### PR TITLE
ROC 2024 Mod Upload

### DIFF
--- a/static/mods/2024ROC_Gou-Lai.json
+++ b/static/mods/2024ROC_Gou-Lai.json
@@ -1,0 +1,4020 @@
+campaignTrail_temp.questions_json = [
+    {
+        "model": "campaign_trail.question",
+        "pk": 12761,
+        "fields": {
+            "priority": 0,
+            "description": "\nAs of January 2023, Chairman Terry Gou, Happy New Year! This year is an election year. With the DPP's significant defeat in last year's county and city mayor elections, you may have the opportunity to become the Kuomintang (KMT) presidential candidate for 2024. In this year, what are your primary political objectives?\n",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12762,
+        "fields": {
+            "priority": 0,
+            "description": "\nOn March 22nd, the Kuomintang (KMT) Central Committee decided to use a draft system to determine the presidential candidate for 2024. It was announced that you and Mayor Hou You-yi would compete in the primary, with the final winner to be decided based on party opinions and the highest results in public opinion polls. What is your assessment of this decision?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12763,
+        "fields": {
+            "priority": 0,
+            "description": "On May 17th, the Kuomintang will announce the results of the presidential nomination. In the final sprint phase, it is crucial for you to enhance your grassroots support and approval in specific regions. Otherwise, your non-party membership status will naturally impact how the KMT's grassroots perceives you. Returning to party membership also requires certain procedures and measures. Which areas do you hope to visit?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12764,
+        "fields": {
+            "priority": 0,
+            "description": "Today is May 17th, and Chairman Eric Chu would like to invite you to the central party headquarters to hear the final results of the primary. You get into your private car and drive to the Kuomintang (KMT) central party headquarters. The candidate to be officially announced today for drafting is...",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12765,
+        "fields": {
+            "priority": 0,
+            "description": "Chairman Guo, with the conclusion of the primary elections, you currently find yourself without any political standing or attention. Perhaps it's time to return to managing your personal business or embark on a foreign journey. However, if your political ambitions persist, maybe you could consider running as an independent candidate...?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12766,
+        "fields": {
+            "priority": 0,
+            "description": "With the failed of your candidacy, many polls have ceased to consider you, but as long as you continue to make moves, the media will refocus on you. What statements do you plan to make during this period to capture attention?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12767,
+        "fields": {
+            "priority": 0,
+            "description": "With your decision not to publicly endorse Hou You-yi but rather to focus on your own schedule in various locations, many media outlets have shifted their attention to your campaign activities. Meanwhile, the Kuomintang is currently occupied with handling Hou's kindergarten incident, temporarily overlooking your presence. During this period, what should we do to enhance your influence and bring back your staunch supporters?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12768,
+        "fields": {
+            "priority": 0,
+            "description": "Due to Hou You-yi's continuous decline in polls, there are voices within the Kuomintang clamoring to revoke his nomination and replace him with Han Kuo-yu or Terry Gou. Are you willing to continue promoting such discourse?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12769,
+        "fields": {
+            "priority": 0,
+            "description": "\nOn July 23rd, Han Kuo-yu made an appearance to endorse Hou You-yi, announcing his support to oust the Democratic Progressive Party. Although the effort was modest, it has already started to draw back some of Han's supporters and deep-blue voters to the Kuomintang. The good news is that many polls have reintroduced you, with your support rating hovering around 10% to 15%. This suggests that you could significantly influence the fate of opposition candidates.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12770,
+        "fields": {
+            "priority": 0,
+            "description": "Entering August, it's time to prepare for announcing your independent candidacy! But before that, let's engage in some more campaign activities to build momentum. What kind of activities do you prefer to garner attention and votes?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12771,
+        "fields": {
+            "priority": 0,
+            "description": "August 28th, the day has finally arrived! Today, at the 'Mainstream Public Opinion Alliance' press conference, you announced the long-awaited news of your independent candidacy! The announcement you made at the press conference has sent shockwaves across the nation, and now, the election officially has four candidates!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12772,
+        "fields": {
+            "priority": 0,
+            "description": "As you officially declare the start of your independent candidacy, you require a vice-presidential candidate to meet legal requirements. Therefore, before all other candidates announce their running mates, you need to unveil yours. On September 14th, you hold a press conference and announce your running mate as...",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12773,
+        "fields": {
+            "priority": 0,
+            "description": "With your announcement of independent candidacy and the confirmation of your vice presidential candidate, the law stipulates that the number of citizen signatures must reach 1.5% of the total number of eligible voters in the most recent legislative election. This means you need over 290,000 citizen signatures to qualify for independent candidacy. Your finances are certainly not an issue, but in which major areas should we set up signature collection sites to gather the most signatures?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12774,
+        "fields": {
+            "priority": 0,
+            "description": "\nThroughout September and October, you've been busy setting up more citizen signature collection sites, investing a significant amount of time in the process. Fortunately, you quickly reached the threshold for citizen signatures. In an effort to showcase strength, you're attempting to garner even more signatures. Unfortunately, discussions of blue-green cooperation between Hou and Ke have started to gradually lower your poll numbers. This isn't a good sign...",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12775,
+        "fields": {
+            "priority": 0,
+            "description": "ww",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12776,
+        "fields": {
+            "priority": 0,
+            "description": "put description here",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12777,
+        "fields": {
+            "priority": 0,
+            "description": "put description here",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12778,
+        "fields": {
+            "priority": 0,
+            "description": "put description here",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12779,
+        "fields": {
+            "priority": 0,
+            "description": "put description here",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12780,
+        "fields": {
+            "priority": 0,
+            "description": "put description here",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12781,
+        "fields": {
+            "priority": 0,
+            "description": "put description here",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12782,
+        "fields": {
+            "priority": 0,
+            "description": "put description here",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12783,
+        "fields": {
+            "priority": 0,
+            "description": "put description here",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12784,
+        "fields": {
+            "priority": 0,
+            "description": "put description here",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12785,
+        "fields": {
+            "priority": 0,
+            "description": "put description here",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12786,
+        "fields": {
+            "priority": 0,
+            "description": "put description here",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12787,
+        "fields": {
+            "priority": 0,
+            "description": "put description here",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12788,
+        "fields": {
+            "priority": 0,
+            "description": "It's November 2023, and you've obtained over a million citizen signatures, which you can now submit to the CEC to formalize your candidacy. However, despite the increase in signatures, it hasn't improved your polling numbers. Since the blue-white coalition further united, your polling numbers have consistently been below 10% and even lower. On November 15th, the blue-white coalition decided to jointly nominate a presidential ticket. What do you need to do now?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12789,
+        "fields": {
+            "priority": 0,
+            "description": "\nOn November 23rd, you invited Mayor Hou and Chairman Ke to the Taipei Grand Hyatt Hotel to discuss polling margin of error and final candidate issues. However, Mayor Hou unexpectedly brought former President Ma Ying-jeou and KMT Chairman Eric Chu, which was an unexpected development, as you did not invite these two individuals. What statement would you like to make?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12790,
+        "fields": {
+            "priority": 0,
+            "description": "\nToday is November 24th, and with yesterday's negotiations ending in no resolution, you have reached a moment where you must make a decision. Will you continue to run with the current ultra-low polling support, or will you choose to withdraw and facilitate a rotation of power between the KMT and TPP parties?",
+            "likelihood": 1
+        }
+    }
+]
+
+campaignTrail_temp.answers_json = [
+    {
+        "model": "campaign_trail.answer",
+        "pk": 12903,
+        "fields": {
+            "question": 12761,
+            "description": "I am now announcing my participation in the Kuomintang (KMT) presidential primary, and I hope Chairman Eric Chu can nominate me as the presidential candidate!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 12904,
+        "fields": {
+            "question": 12761,
+            "description": "I aim to strengthen my image among mayors and legislators across various counties and cities. Gaining their support would be highly beneficial for my campaign!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 12905,
+        "fields": {
+            "question": 12761,
+            "description": "\nCertainly, my top priority is to boost my poll numbers! In politics, high poll ratings can make a significant impact, and with strong public support, I am confident that the Kuomintang will nominate me for the presidency!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 12915,
+        "fields": {
+            "question": 12762,
+            "description": "I can contribute a significant amount of campaign funds to the Kuomintang, merely by allocating a portion of the profits from my stock holdings. This would enable us to organize substantial campaign activities, allowing us to invest heavily in promotional efforts!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 12916,
+        "fields": {
+            "question": 12762,
+            "description": "Mayor Hou is a pragmatic and capable individual, and I am pleased to compete with him in the primary. However, I hope he does not relinquish his position as the Mayor of New Taipei City."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 12917,
+        "fields": {
+            "question": 12762,
+            "description": "Mayor Hou manages New Taipei City, which is also my hometown. I was born in Banqiao District, so I hope Mayor Hou can stay and continue serving the people of New Taipei City. As for the presidency, let me take care of that!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13101,
+        "fields": {
+            "question": 12763,
+            "description": "Of course, it would be in my hometown of New Taipei City! It's also the area where Mayor Hou is in office, allowing me to shape an image of direct confrontation with him!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13102,
+        "fields": {
+            "question": 12763,
+            "description": "Let me connect with the elderly members of the Blue Camp in the capital city Taipei. In this blue stronghold, we must prevail over Mayor Hou You-yi!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13103,
+        "fields": {
+            "question": 12763,
+            "description": "We must showcase our strength in the vulnerable southern region of the KMT. Let's organize a gathering in Kaohsiung, and it would be even better if I could speak a few sentences in Taiwanese!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13104,
+        "fields": {
+            "question": 12763,
+            "description": "Why not organize events in Taoyuan, a city with a thriving high-tech industry and a significant population? We will compete with Mayor Hou in the Hakka region!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13115,
+        "fields": {
+            "question": 12764,
+            "description": "...Why isn't the drafting for me?!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13116,
+        "fields": {
+            "question": 12764,
+            "description": "...Why isn't the drafting for me?!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13117,
+        "fields": {
+            "question": 12764,
+            "description": "...Why isn't the drafting for me?!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13121,
+        "fields": {
+            "question": 12764,
+            "description": "...Why isn't the drafting for me?!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13130,
+        "fields": {
+            "question": 12765,
+            "description": "I have decided to run for president as an independent candidate, but let's not announce it too early. Currently, polls indicate that the KMT candidate is a clear favorite, so I am excluded from the polls. We need to reach out to local factions, legislators, and influential figures within the blue camp, building momentum for the independent candidacy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13153,
+        "fields": {
+            "question": 12766,
+            "description": "Let me take a stroll in Kinmen, allowing me to appear alongside Legislator Chen Yu-chen, who has always supported me. I want everyone to know that my political journey is not over yet!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13154,
+        "fields": {
+            "question": 12766,
+            "description": "Let me head to the southern part of the country to meet with former county mayors, speakers, and local factions within the Kuomintang. They could provide valuable support and attract media attention for me!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13155,
+        "fields": {
+            "question": 12766,
+            "description": "Hey, let's showcase my vision for the nation! I can bring peace across the strait, prosperity to the economy, and justice to society. As an innovative entrepreneur, an unconventional political figure, a political outsider, I have the capability to bring the best future for Taiwan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13168,
+        "fields": {
+            "question": 12767,
+            "description": "Let's continue to make emotional appeals to the deep-blue mainlanders. I, too, came from the mainland, born in 1950 when Taiwan was still underdeveloped. However, the Republic of China has empowered Taiwan to become a formidable player on the world stage. Our nation is truly great!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13169,
+        "fields": {
+            "question": 12767,
+            "description": "I want to emphasize my identity as a successful entrepreneur. I was once the wealthiest person in Taiwan and remain one of the wealthiest individuals in the country. I intend to bring my leadership style and track record of success from the business world into politics, contributing to the prosperity of Taiwan's economy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13170,
+        "fields": {
+            "question": 12767,
+            "description": "Let's recruit some young, dynamic individuals with strong public images and absorb those who have faced setbacks and underutilization within the broader blue camp. Since my campaign still revolves around the blue color, I need them for support!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13171,
+        "fields": {
+            "question": 12767,
+            "description": "Let me showcase our diplomatic experience. Have you seen this photo? That's me with President Trump. I can assure you, I have better international connections than any other candidate here. Even Lai Ching-te wouldn't get a foot in white house!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13182,
+        "fields": {
+            "question": 12768,
+            "description": "Let's vigorously promote this discourse! Terry Gou is the best KMT candidate. It's best to have some local faction leaders come out and speak up in support of Gou!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13183,
+        "fields": {
+            "question": 12768,
+            "description": "We don't want to waste time on such impossible matters. Anyway, Han Kuo-yu might be more inclined to support Hou rather than me. Perhaps Hou didn't assist him back in 2019, but I am Han's direct competitor. I don't want to undermine Hou too much to the point where Han taking stage."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13193,
+        "fields": {
+            "question": 12769,
+            "description": "Let's continue our efforts towards an independent candidacy! Reappearing in the polls is just the first step. The next step is to announce my independent candidacy. That's when our true rise will begin!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13208,
+        "fields": {
+            "question": 12770,
+            "description": "\"Let's release a book specifically targeted at young people! The book could be titled '30 Pieces of Advice from Gou Dad to Young People.' Many young individuals aspire to the lives and experiences of successful figures, and who better than me to offer them that?\""
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13209,
+        "fields": {
+            "question": 12770,
+            "description": "Instead of wasting time on these useless online activities, let's focus on grassroots campaigning offline. We'll hold a rally in Pingtung to boost our momentum and snatch votes away from the Kuomintang!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13210,
+        "fields": {
+            "question": 12770,
+            "description": "I want everyone to hear the story of 'The Three Little Pigs.' We can't defeat the DPP without unity. I invite Ko Wen-je and Hou You-yi to sit down for a 'coffee chat,' hoping to have a constructive discussion on cooperation within the mainstream public opinion framework and work together to oust the DPP."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13211,
+        "fields": {
+            "question": 12770,
+            "description": "I want to start directing the criticism towards the current DPP government. In recent years, the DPP has heavily suppressed freedom of speech and exhibited arrogance and incompetence. Their flawed energy policies, along with Lai Ching-te and Tsai Ing-wen, should not forget the original intention of the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13226,
+        "fields": {
+            "question": 12771,
+            "description": "I know you media folks love to nitpick and amplify the flaws in my words, but today, I'm announcing my independent candidacy and garnering enough citizen signatures to achieve our goal of unity in the opposition!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13227,
+        "fields": {
+            "question": 12771,
+            "description": "I announce my candidacy for president and officially launch a comprehensive citizen coalition signature drive to qualify as a candidate, representing the mainstream consensus of both the blue and white parties.  I firmly believe that public opinion always surpasses party interests, and the public good always outweighs personal gain.  "
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13236,
+        "fields": {
+            "question": 12772,
+            "description": "I have chosen Ms. Lai Pei-hsia, who has American heritage, as my vice president. She possesses excellent image, eloquence, and is a respected woman. Additionally, being a political outsider, she can strengthen and complement my shortcomings. She has a background in acting and now is the vice presidential candidate!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13240,
+        "fields": {
+            "question": 12772,
+            "description": "Do you remember Wave Makers? That's right, in that TV series, Lai Pei-hsia played the role of the female president! Now, she transitions from the stage to reality to serve as my vice president. It's truly surreal"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13244,
+        "fields": {
+            "question": 12773,
+            "description": "We will set up signature collection sites in places like Changhua, Yunlin, Pingtung, and Nantou, where powerful local factions reside. We'll leverage the discord between these local factions and the Kuomintang to boost the number of signatures."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13245,
+        "fields": {
+            "question": 12773,
+            "description": "I will directly confront the Kuomintang in the northern regions, strengthening my influence in New Taipei, Taipei, and Keelung. I want the Kuomintang to know that my financial power is exceptionally strong!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13246,
+        "fields": {
+            "question": 12773,
+            "description": "Let's garner some support in the southern regions of Tainan, Chiayi, and Kaohsiung! I've heard there are many deep-green individuals here willing to help with my signature collection... Regardless of their intentions, I can boost my number of signatures!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13247,
+        "fields": {
+            "question": 12773,
+            "description": "Let's gather signatures in Miaoli, Hsinchu, Hualien, Taitung, Kinmen, and Matsu, where the Kuomintang holds significant influence. People in these areas are likely to shift their support to me easily, as I am a candidate bluer than Hou!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13270,
+        "fields": {
+            "question": 12774,
+            "description": "... It seems like my independent candidacy doesn't have much hope after all? Poll numbers are declining more and more..."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13275,
+        "fields": {
+            "question": 12775,
+            "description": "Let's wait and see. Perhaps there will be a turn of events?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13280,
+        "fields": {
+            "question": 12788,
+            "description": "Let's wait and see. Perhaps there will be a turn of events?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13285,
+        "fields": {
+            "question": 12789,
+            "description": "I only invited Mayor Hou, so it was unexpected to have former President Ma Ying-jeou and Chairman Eric Chu attend. President Ma has been a benefactor to me, but today they both are heavyweight unexpected guests..."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13286,
+        "fields": {
+            "question": 12789,
+            "description": "\nSince both Chairman Ko Wen-je and Mayor Hou believe that integration needs to go through me and have asked me to be a mediator, then I will step up. I am willing to pay any price to facilitate the victory of mainstream public opinion."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13287,
+        "fields": {
+            "question": 12789,
+            "description": "What? Are you going to discuss statistics and polling issues? Sorry, I'll go to the restroom. Grabbing a cup of coffee on the way."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13288,
+        "fields": {
+            "question": 12789,
+            "description": "\nMayor Hou, Chairman Ko, I've booked the pricey Room 2538. If you have any consensus or issues to discuss, you can go upstairs. I'll leave this space for the reporters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13297,
+        "fields": {
+            "question": 12790,
+            "description": "\nI will continue to run and persevere until January 13th. I want the KMT to know that I am not someone to be trifled with. Even if I don't win, they won't win either!\n\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13298,
+        "fields": {
+            "question": 12790,
+            "description": "\nSigh, I'll withdraw from this election. I don't want to burden the blue and white camps anymore. Let them compete on their own. I hope the DPP can be defeated."
+        }
+    }
+]
+
+campaignTrail_temp.states_json = [
+    {
+        "model": "campaign_trail.state",
+        "pk": 251,
+        "fields": {
+            "name": "Tainan City",
+            "abbr": "Tainancity",
+            "electoral_votes": 1,
+            "popular_votes": 1120238,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 252,
+        "fields": {
+            "name": "Kaohsiung City",
+            "abbr": "Kaohsiungcity",
+            "electoral_votes": 1,
+            "popular_votes": 1636962,
+            "poll_closing_time": 180,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 253,
+        "fields": {
+            "name": "Pingtung County",
+            "abbr": "Pingtung",
+            "electoral_votes": 1,
+            "popular_votes": 475927,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 254,
+        "fields": {
+            "name": "Taidong County",
+            "abbr": "Taidong",
+            "electoral_votes": 1,
+            "popular_votes": 109941,
+            "poll_closing_time": 75,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 255,
+        "fields": {
+            "name": "Hualien County",
+            "abbr": "Hualien",
+            "electoral_votes": 1,
+            "popular_votes": 174157,
+            "poll_closing_time": 90,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 256,
+        "fields": {
+            "name": "Chiayi County",
+            "abbr": "ChiayiCounty",
+            "electoral_votes": 1,
+            "popular_votes": 292534,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 257,
+        "fields": {
+            "name": "Chiayi City",
+            "abbr": "ChiayiCity",
+            "electoral_votes": 1,
+            "popular_votes": 157656,
+            "poll_closing_time": 80,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 258,
+        "fields": {
+            "name": "Nantou County",
+            "abbr": "Nantou",
+            "electoral_votes": 1,
+            "popular_votes": 287296,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 259,
+        "fields": {
+            "name": "Yunlin County",
+            "abbr": "Yunlin",
+            "electoral_votes": 1,
+            "popular_votes": 380619,
+            "poll_closing_time": 130,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 260,
+        "fields": {
+            "name": "Changhua County",
+            "abbr": "Changhua",
+            "electoral_votes": 1,
+            "popular_votes": 741368,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 261,
+        "fields": {
+            "name": "Penghu County",
+            "abbr": "Penghu",
+            "electoral_votes": 1,
+            "popular_votes": 49277,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 262,
+        "fields": {
+            "name": "Taichung City",
+            "abbr": "Taichung",
+            "electoral_votes": 1,
+            "popular_votes": 1707203,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 263,
+        "fields": {
+            "name": "Yilan County",
+            "abbr": "Yilan",
+            "electoral_votes": 1,
+            "popular_votes": 267129,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 264,
+        "fields": {
+            "name": "Hsinchu County",
+            "abbr": "HsinchuCounty",
+            "electoral_votes": 1,
+            "popular_votes": 340310,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 265,
+        "fields": {
+            "name": "Hsinchu City",
+            "abbr": "HsinchuCity",
+            "electoral_votes": 1,
+            "popular_votes": 266389,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 266,
+        "fields": {
+            "name": "Miaoli County",
+            "abbr": "Miaoli",
+            "electoral_votes": 1,
+            "popular_votes": 318665,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 267,
+        "fields": {
+            "name": "New Taipei City",
+            "abbr": "Newtaipei",
+            "electoral_votes": 1,
+            "popular_votes": 2458480,
+            "poll_closing_time": 225,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 268,
+        "fields": {
+            "name": "Taipei City",
+            "abbr": "Taipei",
+            "electoral_votes": 1,
+            "popular_votes": 1542009,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 269,
+        "fields": {
+            "name": "Taoyuan City",
+            "abbr": "Taoyuan",
+            "electoral_votes": 1,
+            "popular_votes": 1350792,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 270,
+        "fields": {
+            "name": "Keelung City",
+            "abbr": "Keelung",
+            "electoral_votes": 1,
+            "popular_votes": 218781,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 271,
+        "fields": {
+            "name": "Kinmen County",
+            "abbr": "Kinmen",
+            "electoral_votes": 1,
+            "popular_votes": 45612,
+            "poll_closing_time": 70,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 272,
+        "fields": {
+            "name": "Lienchiang County",
+            "abbr": "Matsu",
+            "electoral_votes": 1,
+            "popular_votes": 6159,
+            "poll_closing_time": 50,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.issues_json = [
+    {
+        "model": "campaign_trail.issue",
+        "pk": 32,
+        "fields": {
+            "name": "Party coalition",
+            "description": 0,
+            "stance_1": "Deep Green",
+            "stance_desc_1": 0,
+            "stance_2": "Green",
+            "stance_desc_2": 0,
+            "stance_3": "Light Green",
+            "stance_desc_3": 0,
+            "stance_4": "Neutral",
+            "stance_desc_4": 0,
+            "stance_5": "Light Blue",
+            "stance_desc_5": 0,
+            "stance_6": "Blue",
+            "stance_desc_6": 0,
+            "stance_7": "Deep Blue",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 33,
+        "fields": {
+            "name": "Provincial differences",
+            "description": 0,
+            "stance_1": "Mostly Taiwanese",
+            "stance_desc_1": 0,
+            "stance_2": "Taiwanese and Hakka mixed",
+            "stance_desc_2": 0,
+            "stance_3": "Taiwanese,Hakka,Mainlanders mixed",
+            "stance_desc_3": 0,
+            "stance_4": "mixing of ethnic groups",
+            "stance_desc_4": 0,
+            "stance_5": "Aboriginal",
+            "stance_desc_5": 0,
+            "stance_6": "Taiwanese Hakka(Northern)",
+            "stance_desc_6": 0,
+            "stance_7": "Mostly Mainlanders",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 34,
+        "fields": {
+            "name": "Urban/rural differences",
+            "description": 0,
+            "stance_1": "Townships Rural",
+            "stance_desc_1": 0,
+            "stance_2": "Small towns and large towns",
+            "stance_desc_2": 0,
+            "stance_3": "Small cities and towns",
+            "stance_desc_3": 0,
+            "stance_4": "Medium-sized city",
+            "stance_desc_4": 0,
+            "stance_5": "Groups of Small Cities",
+            "stance_desc_5": 0,
+            "stance_6": "Large Cities",
+            "stance_desc_6": 0,
+            "stance_7": "Capitals",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 35,
+        "fields": {
+            "name": "Young population",
+            "description": 0,
+            "stance_1": "Very little",
+            "stance_desc_1": 0,
+            "stance_2": "Little",
+            "stance_desc_2": 0,
+            "stance_3": "Less",
+            "stance_desc_3": 0,
+            "stance_4": "Normal level",
+            "stance_desc_4": 0,
+            "stance_5": "Relatively much more",
+            "stance_desc_5": 0,
+            "stance_6": "Large young population",
+            "stance_desc_6": 0,
+            "stance_7": "Younger society",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 36,
+        "fields": {
+            "name": "Feelings about DPP Government",
+            "description": 0,
+            "stance_1": "DPP is the best!",
+            "stance_desc_1": 0,
+            "stance_2": "That's what we like!",
+            "stance_desc_2": 0,
+            "stance_3": "Pro-DPP",
+            "stance_desc_3": 0,
+            "stance_4": "no feelings for the DPP",
+            "stance_desc_4": 0,
+            "stance_5": "Hate green governance",
+            "stance_desc_5": 0,
+            "stance_6": "Mosquitoes, cockroaches, and the DPP",
+            "stance_desc_6": 0,
+            "stance_7": "Never support the Taiwan Independence Party!!",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.state_issue_score_json = []
+
+campaignTrail_temp.candidate_issue_score_json = [
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 12977,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 32,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 12978,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 33,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 12979,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 34,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 12980,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 35,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 12981,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 36,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13005,
+        "fields": {
+            "candidate": 12982,
+            "issue": 32,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13006,
+        "fields": {
+            "candidate": 12982,
+            "issue": 33,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13007,
+        "fields": {
+            "candidate": 12982,
+            "issue": 34,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13008,
+        "fields": {
+            "candidate": 12982,
+            "issue": 35,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13009,
+        "fields": {
+            "candidate": 12982,
+            "issue": 36,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13033,
+        "fields": {
+            "candidate": 13010,
+            "issue": 32,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13034,
+        "fields": {
+            "candidate": 13010,
+            "issue": 33,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13035,
+        "fields": {
+            "candidate": 13010,
+            "issue": 34,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13036,
+        "fields": {
+            "candidate": 13010,
+            "issue": 35,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13037,
+        "fields": {
+            "candidate": 13010,
+            "issue": 36,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13061,
+        "fields": {
+            "candidate": 13038,
+            "issue": 32,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13062,
+        "fields": {
+            "candidate": 13038,
+            "issue": 33,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13063,
+        "fields": {
+            "candidate": 13038,
+            "issue": 34,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13064,
+        "fields": {
+            "candidate": 13038,
+            "issue": 35,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 13065,
+        "fields": {
+            "candidate": 13038,
+            "issue": 36,
+            "issue_score": 0
+        }
+    }
+]
+
+campaignTrail_temp.running_mate_issue_score_json = []
+
+campaignTrail_temp.candidate_state_multiplier_json = [
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12955,
+        "fields": {
+            "candidate": 2001653,
+            "state": 251,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12956,
+        "fields": {
+            "candidate": 2001653,
+            "state": 252,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12957,
+        "fields": {
+            "candidate": 2001653,
+            "state": 253,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12958,
+        "fields": {
+            "candidate": 2001653,
+            "state": 254,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12959,
+        "fields": {
+            "candidate": 2001653,
+            "state": 255,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12960,
+        "fields": {
+            "candidate": 2001653,
+            "state": 256,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12961,
+        "fields": {
+            "candidate": 2001653,
+            "state": 257,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12962,
+        "fields": {
+            "candidate": 2001653,
+            "state": 258,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12963,
+        "fields": {
+            "candidate": 2001653,
+            "state": 259,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12964,
+        "fields": {
+            "candidate": 2001653,
+            "state": 260,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12965,
+        "fields": {
+            "candidate": 2001653,
+            "state": 261,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12966,
+        "fields": {
+            "candidate": 2001653,
+            "state": 262,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12967,
+        "fields": {
+            "candidate": 2001653,
+            "state": 263,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12968,
+        "fields": {
+            "candidate": 2001653,
+            "state": 264,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12969,
+        "fields": {
+            "candidate": 2001653,
+            "state": 265,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12970,
+        "fields": {
+            "candidate": 2001653,
+            "state": 266,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12971,
+        "fields": {
+            "candidate": 2001653,
+            "state": 267,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12972,
+        "fields": {
+            "candidate": 2001653,
+            "state": 268,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12973,
+        "fields": {
+            "candidate": 2001653,
+            "state": 269,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12974,
+        "fields": {
+            "candidate": 2001653,
+            "state": 270,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12975,
+        "fields": {
+            "candidate": 2001653,
+            "state": 271,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12976,
+        "fields": {
+            "candidate": 2001653,
+            "state": 272,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12983,
+        "fields": {
+            "candidate": 12982,
+            "state": 251,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12984,
+        "fields": {
+            "candidate": 12982,
+            "state": 252,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12985,
+        "fields": {
+            "candidate": 12982,
+            "state": 253,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12986,
+        "fields": {
+            "candidate": 12982,
+            "state": 254,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12987,
+        "fields": {
+            "candidate": 12982,
+            "state": 255,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12988,
+        "fields": {
+            "candidate": 12982,
+            "state": 256,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12989,
+        "fields": {
+            "candidate": 12982,
+            "state": 257,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12990,
+        "fields": {
+            "candidate": 12982,
+            "state": 258,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12991,
+        "fields": {
+            "candidate": 12982,
+            "state": 259,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12992,
+        "fields": {
+            "candidate": 12982,
+            "state": 260,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12993,
+        "fields": {
+            "candidate": 12982,
+            "state": 261,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12994,
+        "fields": {
+            "candidate": 12982,
+            "state": 262,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12995,
+        "fields": {
+            "candidate": 12982,
+            "state": 263,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12996,
+        "fields": {
+            "candidate": 12982,
+            "state": 264,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12997,
+        "fields": {
+            "candidate": 12982,
+            "state": 265,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12998,
+        "fields": {
+            "candidate": 12982,
+            "state": 266,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 12999,
+        "fields": {
+            "candidate": 12982,
+            "state": 267,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13000,
+        "fields": {
+            "candidate": 12982,
+            "state": 268,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13001,
+        "fields": {
+            "candidate": 12982,
+            "state": 269,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13002,
+        "fields": {
+            "candidate": 12982,
+            "state": 270,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13003,
+        "fields": {
+            "candidate": 12982,
+            "state": 271,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13004,
+        "fields": {
+            "candidate": 12982,
+            "state": 272,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13011,
+        "fields": {
+            "candidate": 13010,
+            "state": 251,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13012,
+        "fields": {
+            "candidate": 13010,
+            "state": 252,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13013,
+        "fields": {
+            "candidate": 13010,
+            "state": 253,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13014,
+        "fields": {
+            "candidate": 13010,
+            "state": 254,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13015,
+        "fields": {
+            "candidate": 13010,
+            "state": 255,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13016,
+        "fields": {
+            "candidate": 13010,
+            "state": 256,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13017,
+        "fields": {
+            "candidate": 13010,
+            "state": 257,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13018,
+        "fields": {
+            "candidate": 13010,
+            "state": 258,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13019,
+        "fields": {
+            "candidate": 13010,
+            "state": 259,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13020,
+        "fields": {
+            "candidate": 13010,
+            "state": 260,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13021,
+        "fields": {
+            "candidate": 13010,
+            "state": 261,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13022,
+        "fields": {
+            "candidate": 13010,
+            "state": 262,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13023,
+        "fields": {
+            "candidate": 13010,
+            "state": 263,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13024,
+        "fields": {
+            "candidate": 13010,
+            "state": 264,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13025,
+        "fields": {
+            "candidate": 13010,
+            "state": 265,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13026,
+        "fields": {
+            "candidate": 13010,
+            "state": 266,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13027,
+        "fields": {
+            "candidate": 13010,
+            "state": 267,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13028,
+        "fields": {
+            "candidate": 13010,
+            "state": 268,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13029,
+        "fields": {
+            "candidate": 13010,
+            "state": 269,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13030,
+        "fields": {
+            "candidate": 13010,
+            "state": 270,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13031,
+        "fields": {
+            "candidate": 13010,
+            "state": 271,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13032,
+        "fields": {
+            "candidate": 13010,
+            "state": 272,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13039,
+        "fields": {
+            "candidate": 13038,
+            "state": 251,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13040,
+        "fields": {
+            "candidate": 13038,
+            "state": 252,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13041,
+        "fields": {
+            "candidate": 13038,
+            "state": 253,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13042,
+        "fields": {
+            "candidate": 13038,
+            "state": 254,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13043,
+        "fields": {
+            "candidate": 13038,
+            "state": 255,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13044,
+        "fields": {
+            "candidate": 13038,
+            "state": 256,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13045,
+        "fields": {
+            "candidate": 13038,
+            "state": 257,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13046,
+        "fields": {
+            "candidate": 13038,
+            "state": 258,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13047,
+        "fields": {
+            "candidate": 13038,
+            "state": 259,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13048,
+        "fields": {
+            "candidate": 13038,
+            "state": 260,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13049,
+        "fields": {
+            "candidate": 13038,
+            "state": 261,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13050,
+        "fields": {
+            "candidate": 13038,
+            "state": 262,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13051,
+        "fields": {
+            "candidate": 13038,
+            "state": 263,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13052,
+        "fields": {
+            "candidate": 13038,
+            "state": 264,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13053,
+        "fields": {
+            "candidate": 13038,
+            "state": 265,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13054,
+        "fields": {
+            "candidate": 13038,
+            "state": 266,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13055,
+        "fields": {
+            "candidate": 13038,
+            "state": 267,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13056,
+        "fields": {
+            "candidate": 13038,
+            "state": 268,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13057,
+        "fields": {
+            "candidate": 13038,
+            "state": 269,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13058,
+        "fields": {
+            "candidate": 13038,
+            "state": 270,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13059,
+        "fields": {
+            "candidate": 13038,
+            "state": 271,
+            "state_multiplier": 1
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 13060,
+        "fields": {
+            "candidate": 13038,
+            "state": 272,
+            "state_multiplier": 1
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_global_json = [
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 12910,
+        "fields": {
+            "answer": 12905,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": 0.0185
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 12914,
+        "fields": {
+            "answer": 12903,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13094,
+        "fields": {
+            "answer": 12917,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13097,
+        "fields": {
+            "answer": 12915,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13099,
+        "fields": {
+            "answer": 12916,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": -0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13123,
+        "fields": {
+            "answer": 13115,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": -50
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13125,
+        "fields": {
+            "answer": 13116,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": -50
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13126,
+        "fields": {
+            "answer": 13117,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": -50
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13128,
+        "fields": {
+            "answer": 13121,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": -50
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13133,
+        "fields": {
+            "answer": 13130,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": -0.25
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13181,
+        "fields": {
+            "answer": 13171,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13184,
+        "fields": {
+            "answer": 13153,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13186,
+        "fields": {
+            "answer": 13154,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13187,
+        "fields": {
+            "answer": 13155,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13189,
+        "fields": {
+            "answer": 13182,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13191,
+        "fields": {
+            "answer": 13183,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13196,
+        "fields": {
+            "answer": 13193,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": 49.9
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13207,
+        "fields": {
+            "answer": 13193,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13215,
+        "fields": {
+            "answer": 13209,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13220,
+        "fields": {
+            "answer": 13211,
+            "candidate": 2001653,
+            "affected_candidate": 12982,
+            "global_multiplier": -0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13224,
+        "fields": {
+            "answer": 13210,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": -0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13225,
+        "fields": {
+            "answer": 13210,
+            "candidate": 2001653,
+            "affected_candidate": 13038,
+            "global_multiplier": -0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13229,
+        "fields": {
+            "answer": 13226,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13231,
+        "fields": {
+            "answer": 13227,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13232,
+        "fields": {
+            "answer": 13226,
+            "candidate": 2001653,
+            "affected_candidate": 12982,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13233,
+        "fields": {
+            "answer": 13227,
+            "candidate": 2001653,
+            "affected_candidate": 12982,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13238,
+        "fields": {
+            "answer": 13236,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": 0.022
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13242,
+        "fields": {
+            "answer": 13240,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13272,
+        "fields": {
+            "answer": 13270,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.25
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13273,
+        "fields": {
+            "answer": 13270,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13274,
+        "fields": {
+            "answer": 13270,
+            "candidate": 2001653,
+            "affected_candidate": 13038,
+            "global_multiplier": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13278,
+        "fields": {
+            "answer": 13275,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13279,
+        "fields": {
+            "answer": 13275,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13283,
+        "fields": {
+            "answer": 13280,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13284,
+        "fields": {
+            "answer": 13280,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13290,
+        "fields": {
+            "answer": 13285,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13293,
+        "fields": {
+            "answer": 13286,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13294,
+        "fields": {
+            "answer": 13287,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.8
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13295,
+        "fields": {
+            "answer": 13288,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.55
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13301,
+        "fields": {
+            "answer": 13297,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13302,
+        "fields": {
+            "answer": 13298,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "global_multiplier": -99999
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13303,
+        "fields": {
+            "answer": 13285,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": 0.19
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13304,
+        "fields": {
+            "answer": 13286,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13305,
+        "fields": {
+            "answer": 13286,
+            "candidate": 2001653,
+            "affected_candidate": 13038,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13306,
+        "fields": {
+            "answer": 13287,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13307,
+        "fields": {
+            "answer": 13287,
+            "candidate": 2001653,
+            "affected_candidate": 13038,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13308,
+        "fields": {
+            "answer": 13288,
+            "candidate": 2001653,
+            "affected_candidate": 13010,
+            "global_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13309,
+        "fields": {
+            "answer": 13288,
+            "candidate": 2001653,
+            "affected_candidate": 13038,
+            "global_multiplier": -0.04
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_issue_json = [
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 12909,
+        "fields": {
+            "answer": 12903,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 12912,
+        "fields": {
+            "answer": 12904,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 12913,
+        "fields": {
+            "answer": 12904,
+            "issue": 36,
+            "issue_score": 0.045,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13095,
+        "fields": {
+            "answer": 12917,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13098,
+        "fields": {
+            "answer": 12915,
+            "issue": 34,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13100,
+        "fields": {
+            "answer": 12916,
+            "issue": 34,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13134,
+        "fields": {
+            "answer": 13130,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13157,
+        "fields": {
+            "answer": 13153,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13164,
+        "fields": {
+            "answer": 13155,
+            "issue": 34,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13165,
+        "fields": {
+            "answer": 13155,
+            "issue": 36,
+            "issue_score": 0.02,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13166,
+        "fields": {
+            "answer": 13154,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13167,
+        "fields": {
+            "answer": 13154,
+            "issue": 34,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13176,
+        "fields": {
+            "answer": 13170,
+            "issue": 35,
+            "issue_score": 0.12,
+            "issue_importance": 0.125
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13177,
+        "fields": {
+            "answer": 13169,
+            "issue": 34,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13178,
+        "fields": {
+            "answer": 13169,
+            "issue": "32",
+            "issue_score": 0.03,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13179,
+        "fields": {
+            "answer": 13168,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13180,
+        "fields": {
+            "answer": 13168,
+            "issue": 33,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13192,
+        "fields": {
+            "answer": 13183,
+            "issue": "32",
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13213,
+        "fields": {
+            "answer": 13208,
+            "issue": 35,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13223,
+        "fields": {
+            "answer": 13211,
+            "issue": 36,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13234,
+        "fields": {
+            "answer": 13227,
+            "issue": "32",
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13235,
+        "fields": {
+            "answer": 13226,
+            "issue": 36,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13239,
+        "fields": {
+            "answer": 13236,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13243,
+        "fields": {
+            "answer": 13240,
+            "issue": 35,
+            "issue_score": 0.15,
+            "issue_importance": 0.1
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_state_json = [
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13111,
+        "fields": {
+            "answer": 13104,
+            "state": 269,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.0167
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13112,
+        "fields": {
+            "answer": 13103,
+            "state": 252,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.0144
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13113,
+        "fields": {
+            "answer": 13102,
+            "state": 268,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13114,
+        "fields": {
+            "answer": 13101,
+            "state": 267,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13135,
+        "fields": {
+            "answer": 13115,
+            "state": 267,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13136,
+        "fields": {
+            "answer": 13115,
+            "state": 268,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13137,
+        "fields": {
+            "answer": 13116,
+            "state": 266,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13138,
+        "fields": {
+            "answer": 13116,
+            "state": 267,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13139,
+        "fields": {
+            "answer": 13116,
+            "state": 268,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13140,
+        "fields": {
+            "answer": 13115,
+            "state": 266,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13141,
+        "fields": {
+            "answer": 13117,
+            "state": 266,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13142,
+        "fields": {
+            "answer": 13117,
+            "state": 267,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13143,
+        "fields": {
+            "answer": 13117,
+            "state": 268,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13144,
+        "fields": {
+            "answer": 13121,
+            "state": 266,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13145,
+        "fields": {
+            "answer": 13121,
+            "state": 268,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13146,
+        "fields": {
+            "answer": 13121,
+            "state": 267,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13147,
+        "fields": {
+            "answer": 13130,
+            "state": 269,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13148,
+        "fields": {
+            "answer": 13130,
+            "state": 264,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13149,
+        "fields": {
+            "answer": 13130,
+            "state": 265,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13150,
+        "fields": {
+            "answer": 13130,
+            "state": 270,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13151,
+        "fields": {
+            "answer": 13130,
+            "state": 254,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13152,
+        "fields": {
+            "answer": 13130,
+            "state": 255,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13158,
+        "fields": {
+            "answer": 13153,
+            "state": 271,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13160,
+        "fields": {
+            "answer": 13154,
+            "state": 253,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13161,
+        "fields": {
+            "answer": 13154,
+            "state": 258,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13162,
+        "fields": {
+            "answer": 13154,
+            "state": 260,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13197,
+        "fields": {
+            "answer": 13193,
+            "state": 270,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13198,
+        "fields": {
+            "answer": 13193,
+            "state": 255,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13199,
+        "fields": {
+            "answer": 13193,
+            "state": 254,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13200,
+        "fields": {
+            "answer": 13193,
+            "state": 267,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13201,
+        "fields": {
+            "answer": 13193,
+            "state": 268,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13202,
+        "fields": {
+            "answer": 13193,
+            "state": 269,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13203,
+        "fields": {
+            "answer": 13193,
+            "state": 266,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13204,
+        "fields": {
+            "answer": 13193,
+            "state": 265,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13205,
+        "fields": {
+            "answer": 13193,
+            "state": 264,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13216,
+        "fields": {
+            "answer": 13209,
+            "state": 253,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.011
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13249,
+        "fields": {
+            "answer": 13247,
+            "state": 264,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13250,
+        "fields": {
+            "answer": 13247,
+            "state": 265,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13251,
+        "fields": {
+            "answer": 13247,
+            "state": 271,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13252,
+        "fields": {
+            "answer": 13247,
+            "state": 272,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13253,
+        "fields": {
+            "answer": 13247,
+            "state": 254,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13254,
+        "fields": {
+            "answer": 13247,
+            "state": 255,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13256,
+        "fields": {
+            "answer": 13246,
+            "state": 257,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13257,
+        "fields": {
+            "answer": 13246,
+            "state": 256,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13258,
+        "fields": {
+            "answer": 13246,
+            "state": 251,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13259,
+        "fields": {
+            "answer": 13246,
+            "state": 252,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13261,
+        "fields": {
+            "answer": 13245,
+            "state": 268,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13262,
+        "fields": {
+            "answer": 13245,
+            "state": 267,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.0075
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13263,
+        "fields": {
+            "answer": 13245,
+            "state": 270,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13264,
+        "fields": {
+            "answer": 13244,
+            "state": 260,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13265,
+        "fields": {
+            "answer": 13244,
+            "state": 259,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13266,
+        "fields": {
+            "answer": 13244,
+            "state": 253,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13267,
+        "fields": {
+            "answer": 13244,
+            "state": 258,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13269,
+        "fields": {
+            "answer": 13247,
+            "state": 266,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13310,
+        "fields": {
+            "answer": 13298,
+            "state": 251,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13311,
+        "fields": {
+            "answer": 13298,
+            "state": 254,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13312,
+        "fields": {
+            "answer": 13298,
+            "state": 252,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13313,
+        "fields": {
+            "answer": 13298,
+            "state": 253,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13314,
+        "fields": {
+            "answer": 13298,
+            "state": 255,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13315,
+        "fields": {
+            "answer": 13298,
+            "state": 256,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13316,
+        "fields": {
+            "answer": 13298,
+            "state": 257,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13317,
+        "fields": {
+            "answer": 13298,
+            "state": 258,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13318,
+        "fields": {
+            "answer": 13298,
+            "state": 259,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13319,
+        "fields": {
+            "answer": 13298,
+            "state": 260,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13320,
+        "fields": {
+            "answer": 13298,
+            "state": 261,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13321,
+        "fields": {
+            "answer": 13298,
+            "state": 262,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13322,
+        "fields": {
+            "answer": 13298,
+            "state": 263,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13323,
+        "fields": {
+            "answer": 13298,
+            "state": 264,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13324,
+        "fields": {
+            "answer": 13298,
+            "state": 265,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13325,
+        "fields": {
+            "answer": 13298,
+            "state": 266,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13326,
+        "fields": {
+            "answer": 13298,
+            "state": 267,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13327,
+        "fields": {
+            "answer": 13298,
+            "state": 268,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13328,
+        "fields": {
+            "answer": 13298,
+            "state": 269,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13329,
+        "fields": {
+            "answer": 13298,
+            "state": 271,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13330,
+        "fields": {
+            "answer": 13298,
+            "state": 272,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13333,
+        "fields": {
+            "answer": 13298,
+            "state": 270,
+            "candidate": 2001653,
+            "affected_candidate": 2001653,
+            "state_multiplier": -100
+        }
+    }
+]
+
+campaignTrail_temp.answer_feedback_json = [
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 12906,
+        "fields": {
+            "answer": 12903,
+            "candidate": 2001653,
+            "answer_feedback": "\nImmediately announcing your participation in the primary election has exposed your political ambitions. Currently, you have not restored your membership with the KMT, and there is a need to repair the strained relationship with the KMT that resulted from the unpleasant incidents after the 2019 primary.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 12907,
+        "fields": {
+            "answer": 12904,
+            "candidate": 2001653,
+            "answer_feedback": "the majority of legislators and county/city leaders from the KMT are not particularly supportive of you. However, you can leverage support for Hou in certain areas. Perhaps you could garner the backing of a group of staunch party members within the KMT and encourage them to act as representatives on your behalf.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 12908,
+        "fields": {
+            "answer": 12905,
+            "candidate": 2001653,
+            "answer_feedback": "In opinion polls, your figures are not particularly high. When compared individually with Lai Ching-te, you lose in all six polls, while Hou can secure victory in two of them."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 12923,
+        "fields": {
+            "answer": 12916,
+            "candidate": 2001653,
+            "answer_feedback": "Since a large portion of the Kuomintang's party assets has been confiscated, the party has been in a financially strained state. Your monetary offensive will undoubtedly be effective, but please be aware that politics isn't solely about having money; you must accumulate some political capital to make a difference.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 12924,
+        "fields": {
+            "answer": 12917,
+            "candidate": 2001653,
+            "answer_feedback": "\nCurrently, you still lag behind Mayor Hou in the polls, and the majority of legislators and local leaders do not support you. After all, the harm you caused to the Kuomintang in 2019 persists to this day, and they still don't have much trust in you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 12925,
+        "fields": {
+            "answer": 12915,
+            "candidate": 2001653,
+            "answer_feedback": "Since a large portion of the Kuomintang's party assets has been confiscated, the party has been in a financially strained state. Your monetary offensive will undoubtedly be effective, but please be aware that politics isn't solely about having money; "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13105,
+        "fields": {
+            "answer": 13101,
+            "candidate": 2001653,
+            "answer_feedback": "You and Mayor Hou appearing at the temple in New Taipei City at the same time has sparked media attention and speculation. What will the outcome of this primary be?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13106,
+        "fields": {
+            "answer": 13102,
+            "candidate": 2001653,
+            "answer_feedback": "The media has noticed your connection with the traditional Mainlander community and the blue stronghold of Taipei City. They are speculating whether you are strengthening your mainland Chinese identity to gain more support from the deep-blue voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13107,
+        "fields": {
+            "answer": 13103,
+            "candidate": 2001653,
+            "answer_feedback": "You know, your Taiwanese is quite mediocre. Anyone who knows a bit can speak better than you. However, it's just one way for you to increase your affability."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13109,
+        "fields": {
+            "answer": 13104,
+            "candidate": 2001653,
+            "answer_feedback": "Taoyuan is an area with a significant presence of high-tech industries, aligning well with your identity as a tech tycoon. This will enhance your appeal in this blue-leaning region!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13118,
+        "fields": {
+            "answer": 13115,
+            "candidate": 2001653,
+            "answer_feedback": "Mayor Hou You-yi has been drafted as the KMT presidential candidate. All your efforts and attempts over the past few months seem to have been in vain. Despite publicly declaring your support for Mayor Hou on Facebook, there's a myriad of reluctance in your heart to fully endorse him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13119,
+        "fields": {
+            "answer": 13116,
+            "candidate": 2001653,
+            "answer_feedback": "Mayor Hou You-yi has been drafted as the KMT presidential candidate. All your efforts and attempts over the past few months seem to have been in vain. Despite publicly declaring your support for Mayor Hou on Facebook, there's a myriad of reluctance in your heart to fully endorse him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13120,
+        "fields": {
+            "answer": 13117,
+            "candidate": 2001653,
+            "answer_feedback": "Mayor Hou You-yi has been drafted as the KMT presidential candidate. All your efforts and attempts over the past few months seem to have been in vain. Despite publicly declaring your support for Mayor Hou on Facebook, there's a myriad of reluctance in your heart to fully endorse him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13122,
+        "fields": {
+            "answer": 13121,
+            "candidate": 2001653,
+            "answer_feedback": "Mayor Hou You-yi has been drafted as the KMT presidential candidate. All your efforts and attempts over the past few months seem to have been in vain. Despite publicly declaring your support for Mayor Hou on Facebook, there's a myriad of reluctance in your heart to fully endorse him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13132,
+        "fields": {
+            "answer": 13130,
+            "candidate": 2001653,
+            "answer_feedback": "Media reports suggest that Chairman Chu Li-lun is highly dissatisfied with your association with local factions within the blue camp, creating an image of internal disunity and factionalism. There are even reports claiming that Chairman Chu referred to those local factions as 'demons and monsters.'"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13156,
+        "fields": {
+            "answer": 13153,
+            "candidate": 2001653,
+            "answer_feedback": "You met with Legislator Chen Yu-chen, participated in local folk activities in Kinmen, and had a photo opportunity alongside Vice President Lai Ching-te. Both of you shook hands in greeting."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13159,
+        "fields": {
+            "answer": 13154,
+            "candidate": 2001653,
+            "answer_feedback": "This is precisely what Chairman Eric Chu dislikes about you: your close connections with those local factions have created an image of opposition to the central party and disruption of internal unity. However, many of them are willing to temporarily oppose the central party to gain more benefits."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13163,
+        "fields": {
+            "answer": 13155,
+            "candidate": 2001653,
+            "answer_feedback": "These words have caught the attention of many media outlets, and many are pondering whether this is a precursor to your independent candidacy. Currently, numerous media sources are speculating that you may not be willing to concede to Hou..."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13172,
+        "fields": {
+            "answer": 13168,
+            "candidate": 2001653,
+            "answer_feedback": "\nThis is a strong appeal to deep-blue voters, avoiding direct attacks on the mainstream KMT candidate Hou You-yi while reminding voters of the differences between you and him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13173,
+        "fields": {
+            "answer": 13169,
+            "candidate": 2001653,
+            "answer_feedback": "Many believe that you have been influenced by U.S. President Trump. However, venturing into politics across different domains is not an easy feat. Moreover, whether your company is truly favored and admired by the Taiwanese people is still a matter for discussion."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13174,
+        "fields": {
+            "answer": 13170,
+            "candidate": 2001653,
+            "answer_feedback": "You have plenty of money, enabling you to recruit numerous staff to work for you, thereby increasing your political influence."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13175,
+        "fields": {
+            "answer": 13171,
+            "candidate": 2001653,
+            "answer_feedback": "President Trump's wealth doesn't even come close to yours. However, in politics, having money alone isn't enough. While you can showcase your diplomatic credentials, you're still a political novice."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13188,
+        "fields": {
+            "answer": 13182,
+            "candidate": 2001653,
+            "answer_feedback": "\nThis will continue to undermine Hou's poll numbers and the internal unity of the KMT. Many media outlets believe that you are gearing up for an independent candidacy, even though you haven't announced it yet."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13190,
+        "fields": {
+            "answer": 13183,
+            "candidate": 2001653,
+            "answer_feedback": "Focusing on your own campaign strategy might be the best approach. Hou's decline in the polls could benefit you, but it may not last long."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13206,
+        "fields": {
+            "answer": 13193,
+            "candidate": 2001653,
+            "answer_feedback": "This marks the beginning of Kuomintang voters rallying around Hou. Fortunately, his increase in the polls is not significant, leaving ample opportunity for you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13212,
+        "fields": {
+            "answer": 13208,
+            "candidate": 2001653,
+            "answer_feedback": "You may be stuck in the past era. Nowadays, young people either don't read books or prefer e-books. How many votes do you think you can win over with this?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13214,
+        "fields": {
+            "answer": 13209,
+            "candidate": 2001653,
+            "answer_feedback": "This is a tangible threat and a fact of your close ties with local factions. It can indeed increase your share of votes, but strategically, a couple of events won't change much."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13217,
+        "fields": {
+            "answer": 13210,
+            "candidate": 2001653,
+            "answer_feedback": "If you truly want unity, then you shouldn't run independently... Oh, I forgot, I'm your campaign aide! Of course, unity is the most important thing!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13218,
+        "fields": {
+            "answer": 13211,
+            "candidate": 2001653,
+            "answer_feedback": "You're finally focusing on targeting the DPP. Although this may not help you win the election, it can strengthen your support base."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13228,
+        "fields": {
+            "answer": 13226,
+            "candidate": 2001653,
+            "answer_feedback": "We've heard enough of this talk about unity. What's crucial now for the opposition camp is to have a clear, strongest candidate emerge."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13230,
+        "fields": {
+            "answer": 13227,
+            "candidate": 2001653,
+            "answer_feedback": "After your independent candidacy announcement, many media outlets and commentators believe it's a sign that Lai Ching-te will win effortlessly, as you'll only divert more pan-blue votes.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13237,
+        "fields": {
+            "answer": 13236,
+            "candidate": 2001653,
+            "answer_feedback": "Lai is a seasoned actress. However, her possession of American citizenship disqualifies her from becoming vice president. Nevertheless, if she applies to renounce her citizenship by November 24th, she would be eligible, as ROC law stipulates that only ROC citizens can hold the position of vice president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13241,
+        "fields": {
+            "answer": 13240,
+            "candidate": 2001653,
+            "answer_feedback": "Lai is a seasoned actress. However, her possession of American citizenship disqualifies her from becoming vice president. Nevertheless, if she applies to renounce her citizenship by November 24th, she would be eligible, as ROC law stipulates that only ROC citizens can hold the position of vice president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13248,
+        "fields": {
+            "answer": 13247,
+            "candidate": 2001653,
+            "answer_feedback": "These areas are indeed strongholds of the Kuomintang, and leveraging support here would be beneficial. However, their population and voter numbers are relatively low."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13255,
+        "fields": {
+            "answer": 13246,
+            "candidate": 2001653,
+            "answer_feedback": "A group known as 'Deep Green Gou Fans' are actively campaigning for you in the south. These individuals seem to have ties to the Democratic Progressive Party."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13260,
+        "fields": {
+            "answer": 13245,
+            "candidate": 2001653,
+            "answer_feedback": "These areas are advantageous for you as they are in the northern region, where you can strengthen your support base. Additionally, these areas have the highest population density."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13268,
+        "fields": {
+            "answer": 13244,
+            "candidate": 2001653,
+            "answer_feedback": "You continue to forge close connections with local factions, which undoubtedly provide you with significant support. Just ensure that you can provide them with enough benefits, such as funding, in return."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13271,
+        "fields": {
+            "answer": 13270,
+            "candidate": 2001653,
+            "answer_feedback": "That's okay, we, your staff, are still here with you, Chairman Gou. We'll stand by you until the very end!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13277,
+        "fields": {
+            "answer": 13275,
+            "candidate": 2001653,
+            "answer_feedback": ""
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13282,
+        "fields": {
+            "answer": 13280,
+            "candidate": 2001653,
+            "answer_feedback": "The constant attacks between the KMT and TPP regarding polling victories and margins of error suggest that their fragile alliance may be disintegrating from within....."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13289,
+        "fields": {
+            "answer": 13285,
+            "candidate": 2001653,
+            "answer_feedback": "\nThis has sparked dissatisfaction among the Blue camp... They believe that the esteemed former President Ma Ying-jeou should not be referred to as an unexpected guest by you. If you did this intentionally, then they will only be more determined to support the KMT."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13291,
+        "fields": {
+            "answer": 13287,
+            "candidate": 2001653,
+            "answer_feedback": "\nYou posted on Facebook, mentioning that you were in a statistics class, while outside, Lai Pei-hsia and you was enjoying expensive coffee."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13292,
+        "fields": {
+            "answer": 13286,
+            "candidate": 2001653,
+            "answer_feedback": "\nAs Hou You-yi mentioned that Ko Wen-je wants you to withdraw from the election, you feel very uncomfortable. However, it seems there is no way around it. Do you need to find a reason to withdraw from the election...?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13296,
+        "fields": {
+            "answer": 13288,
+            "candidate": 2001653,
+            "answer_feedback": "\nMayor Hou rejected your proposal and demanded to have the discussion publicly in front of the media rather than behind closed doors."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13299,
+        "fields": {
+            "answer": 13298,
+            "candidate": 2001653,
+            "answer_feedback": "\nThis is the right choice, and you don't need to worry about election matters anymore. Now you can just hop on a plane and go travel abroad!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13300,
+        "fields": {
+            "answer": 13297,
+            "candidate": 2001653,
+            "answer_feedback": "\nLet's see how low your current polling support is, and how much support you can get on election day... Hopefully, you can secure one million votes!"
+        }
+    }
+]
+
+
+
+campaignTrail_temp.jet_data = [{}
+]
+

--- a/static/mods/2024ROC_Hou-Han.json
+++ b/static/mods/2024ROC_Hou-Han.json
@@ -1,0 +1,9281 @@
+e=campaignTrail_temp // this is redundant, but Decstar uses this because it looks nicer in the code.
+campaignTrail_temp.multiple_endings=true
+campaignTrail_temp.cyoa = true
+campaignTrail_temp.questions_json = [
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950011,
+        "fields": {
+            "priority": 0,
+            "description": "it's January 2023, congratulations on successfully securing re-election as the Mayor of New Taipei a month ago, with an impressive 62% of the votes. It appears that there is a high likelihood of your candidacy in the 2024 presidential election. According to Formosa's polls, you lead with a support rate of 39.9%, surpassing Lai Ching-te's 34.1%. Do you wish to participate in the 2024 election and potentially lead the KMT to regain the lost governance after 8 years?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950015,
+        "fields": {
+            "priority": 0,
+            "description": "More than a month after the Chinese New Year, on March 22nd, the KMT Central Standing Committee passed a resolution authorizing the party chairman, Eric Chu, to Drafting the party's presidential candidate. However, a primary election is scheduled before that. Your opponent in the primary is Terry Gou. Do you have any specific campaign strategies for the upcoming primary?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950016,
+        "fields": {
+            "priority": 0,
+            "description": "Currently, the primary have begun, and as the most popular candidate, your poll numbers are ahead of Terry Gou. What specific areas do you plan to focus on during the preliminary election competition?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950017,
+        "fields": {
+            "priority": 0,
+            "description": "Congratulations! In today's Central Standing Committee meeting, Chairman Eric Chu announced that you will be the Kuomintang (KMT) presidential candidate for 2024. Terry Gou also congratulated you on Facebook for receiving the party's draft. You will represent the KMT in the 2024 election, aiming to take down the incompetent DPP government!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950018,
+        "fields": {
+            "priority": 0,
+            "description": "On the same day you were drafted, Taiwan People's Party Chairman Ko Wen-je was also selected as the party's presidential candidate. This means that the opposition camp is divided into two parts for the election, which could potentially impact the overall prospects of the pan-blue votes. What is your overall strategy about the TPP?\n",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950019,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, it seems we've encountered trouble! A private kindergarten has been exposed for alleged child abuse by teachers, including the shocking revelation of feeding children Class III controlled substances like barbital and Class IV controlled substances like phenobarbital! Some parents have reported this to the police, and this issue has just come to our attention. We need to take immediate action, or the DPP will use this incident to launch a major attack against you!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950020,
+        "fields": {
+            "priority": 0,
+            "description": "In the midst of the kindergarten incident's escalation, your approval ratings have sharply declined, akin to falling off a cliff into the water. After addressing this matter, you engage in face-to-face discussions with students at National Chengchi University and Taiwan University. When students inquire about your stance on the One China Policy and the differences between you and Han Kuo-yu, how will you respond?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950021,
+        "fields": {
+            "priority": 0,
+            "description": "With a significant decline in your polls, your campaign is facing a major crisis. In many polls, your support is trailing behind Ko Wen-je. According to Formosa and TVBS polls in June, you had support rates of 23% and 17.1%, respectively, while Ko Wen-je had 33% and 28.6%. Even legislator Cheng Li-wen suggested replacing you with Han Kuo-yu due to your lower poll numbers. Additionally, there is uncertainty about Terry Gou's support. Some polls suggest that Gou might reconsider running. What measures do you plan to take to prevent further decline?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950022,
+        "fields": {
+            "priority": 0,
+            "description": "Finally, an hot fire in the snow! Former key strategist for Ma Ying-jeou's campaigns and former ROC representative to the U.S., King Pu-tsung, has agreed to serve as the campaign office chairman under your personal visit. He will assist in orchestrating your campaign!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950023,
+        "fields": {
+            "priority": 0,
+            "description": "\nOn July 1st, you were invited to attend a gathering organized by the Kuomintang's 'Huang Fuxing' branch, where you are expected to meet with Han Kuo-yu. Han's supporters have consistently expressed dissatisfaction with your candidacy, believing that Han Kuo-yu is a more suitable candidate. During the gathering, what do you plan to do to win them over and dispel the sentiment of 'Replacing Hou with Han'?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950024,
+        "fields": {
+            "priority": 0,
+            "description": "On July 3rd, you participated in an interview with Zhao Shao-kang, discussing the election strategy and campaign situation after being Drafted by the KMT. The aim was to gain more media exposure. Zhao mentioned that Han's supporters feel you were not actively supportive in 2020, and many of his fans do not favor you. the promised support from Terry Gou seems to be elusive, and there are rumors of him considering an independent run. What message would you like to convey during this interview?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950025,
+        "fields": {
+            "priority": 0,
+            "description": "On July 23rd, the KMT held a National Party Convention, officially nominating you as the candidate. This signifies that any rumors of replacement are baseless. During the event, Han Kuo-yu expressed his formal support, stating one of his three wishes for this year is for the KMT, under your leadership, to oust the corrupt and incompetent DPP.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950026,
+        "fields": {
+            "priority": 0,
+            "description": "Since the official commencement of your campaign, you have the first opportunity to visit various locations and boost support in specific areas. Where do you intend to concentrate your efforts primarily?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950027,
+        "fields": {
+            "priority": 0,
+            "description": "After 7 years of rule, DPP has left many vulnerable points for you to attack. From restricting freedom of speech to tense relations with the mainland, the widening wealth gap, rising prices, and numerous scandals highlighting incompetence and corruption. How do you plan to launch your strongest attacks against your main opponent?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950028,
+        "fields": {
+            "priority": 0,
+            "description": "As the election has passed its midpoint, you need to present more and better specific policies to attract KMT voters. Currently, your performance in opinion polls is still not favorable, and many are concerned that you might end up as the third in this election. How do you plan to consolidate your support base?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950029,
+        "fields": {
+            "priority": 0,
+            "description": "Some very bad news just came in... Business tycoon Terry Gou, who has been hesitant to support you since you officially entered the race, announced today that he is running for president as an independent candidate! He made this announcement during a press conference for the \"Mainstream Opinion Alliance.\" It seems like the pan-blue's voter base is being further divided. What should we do?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950030,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, it seems that the People's Party has proactively proposed a united plan: they hope to select the sole opposition candidate through comparative candidate polling, and whoever loses will withdraw from the election. What is your opinion on this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950031,
+        "fields": {
+            "priority": 0,
+            "description": "Among the voters, there is a significant portion who lack trust in your abilities and qualifications, with many expressing doubts about your diplomatic skills. A considerable number believe that you lack experience in handling international relations. To address this concern, the KMT Central Committee has decided to send you on an official visit to the United States. In This Trip,What key messages would you like to emphasize?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950032,
+        "fields": {
+            "priority": 0,
+            "description": "Since entering October, legislators nationwide have gradually intensified their activities, and your campaign may be entering its most critical period! At this juncture, Han Kuo-yu is putting aside all previous reservations and actively supporting your candidacy. Now, let's pass the microphone to Mayor Han. What are your thoughts on Mayor Hou?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950033,
+        "fields": {
+            "priority": 0,
+            "description": "Entering November, the joint ticket decision between the KMT and TPP remains undecided. Despite polls indicating that the opposition alliance consistently outperforms Lai Ching-te, both the KMT and the TPP are reluctant to take on a mere preparatory role as vice president, as they both aspire to wield the executive power of the presidency. As time gradually slips away, former President Ma Ying-jeou and Han Kuo-yu propose settling the matter through a nationwide poll, with the loser becoming the vice president. What are your thoughts on this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950034,
+        "fields": {
+            "priority": 0,
+            "description": "On November 15th, waking up in the morning, Taiwan's media and political circles were shocked by a piece of news: KMT-TPP has confirmed the formation of a joint ticket, endorsing a single presidential candidate. This is expected to severely impact Lai Ching-te's support. Chairman Zhu, Mayor Hou, former President Ma, and Chairman Ko have reached an agreement to introduce a set of candidates using the cumulative results of previous polls. This is considered a very intense competition... but due to the selection of fixed-time polls, your current efforts may not be of much use...The final results will be announced on the 18th.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950035,
+        "fields": {
+            "priority": 0,
+            "description": "Damn it... With Ko Wen-je's backtracking, there are only a few days left until the deadline for presidential candidate registration! We must complete the integration within these few days... or find our own vice presidential candidate! Terry Gou and Ko Wen-je invite you to the Taipei Grand Hyatt to discuss the last hope for Joint Tickets... We must rise to the challenge!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950036,
+        "fields": {
+            "priority": 0,
+            "description": "\nWith the breakdown of Joint Tickets, you must now find a vice presidential candidate! Otherwise, the KMT cannot continue participating in this election! Lai Ching-te has already chosen Hsiao Bi-Khim as the vice president, and Ko Wen-je is still undecided about his choice. You must now find a vice presidential candidate willing to sacrifice themselves to join you in this challenging battle!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12762,
+        "fields": {
+            "priority": 0,
+            "description": "What the Democratic Progressive Party fears is the arrival of that man with a massive fan base and influence! Wherever Mayor Han Kuo-yu goes, he brings media exposure to you, strengthening your foundation. His level of animosity is not as high as it was four years ago. So, do you have any special sentiments towards Mayor Han Kuo-yu?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950038,
+        "fields": {
+            "priority": 0,
+            "description": "As the presidential election enters its final stage, it has been discovered that Lai Ching-te's ancestral home is found to have violated building regulations. Although this issue has been known for quite some time, it has only recently been sensationalized. This could be our only opportunity to undermine Lai Ching-te before the election. Do you want to pursue this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950039,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, we have our own troubles. The Democratic Progressive Party (DPP) is attacking the Triumph Apartments owned by your wife, highlighting the high rent and claiming it exploits young people for your personal gain. They argue that you, appearing as a landlord, are unfit to discuss housing justice and social housing. How do you respond?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950040,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, at the final stretch of the election, we might need some advertisements or policies to boost our polling numbers. What policies or advertisements would you most like us to release?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950041,
+        "fields": {
+            "priority": 0,
+            "description": "As 2023 enters its final days, the presidential debates have commenced. Facing Lai Ching-te and Ko Wen-je in this intense battle, what is the most important message you want to convey to the people of Taiwan?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950042,
+        "fields": {
+            "priority": 0,
+            "description": "\nIt seems there is discord within our camp. Former President Ma Ying-jeou, in an interview with Deutsche Welle, mentioned that in the context of cross-strait relations, it is necessary to trust Xi Jinping. The media has widely circulated this, which may be a significant blow to the Kuomintang's electoral prospects. How do you respond to this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950851,
+        "fields": {
+            "priority": 0,
+            "description": "Today is the last day of the election. In which specific area of Taiwan do you plan to campaign to make a final push in these last stages?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950411,
+        "fields": {
+            "priority": 0,
+            "description": "Today is the last day before the election, and your polls have been consistently declining since your nomination. The deadlock with Ko Wen-je and the lead by Lai Ching-te have not been broken, and the situation persists until the registration of presidential candidates in November. There are hardly any individuals willing to be your vice president, until Hung Hsiu-chu, whose nomination was abolished in 2016, volunteered. It is only then that you have a vice presidential candidate to appear on the ballot. On the final day before the election, where do you plan to conduct your campaign activities?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950424,
+        "fields": {
+            "priority": 0,
+            "description": "Today is the last day before the election, On the final day before the election, \nAccording to the latest polls conducted 10 days before the election, your and Lai Ching-te's polls are within the margin of error. In other words, the presidential position hinges on a difference of just 500,000 votes.where do you plan to conduct your campaign activities?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950687,
+        "fields": {
+            "priority": 0,
+            "description": "On November 15th, waking up in the morning, Taiwan's media and political circles were shocked by a piece of news: KMT-TPP has confirmed the formation of a joint ticket, endorsing a single presidential candidate. This is expected to severely impact Lai Ching-te's support. Chairman Zhu, Mayor Hou, former President Ma, and Chairman Ko have reached an agreement to introduce a set of candidates using the cumulative results of previous polls. The terms include a provision that, if the polls fall within the margin of error, it will be considered a victory for Hou You-yi. This is widely seen as a sign that Hou You-yi is likely to win. The final results will be announced on the 18th.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950890,
+        "fields": {
+            "priority": 0,
+            "description": "With the formation of the Joint Tickets, Ko Wen-je has officially become your vice president, marking a political tornado in Taiwan. It's highly likely that Lai Ching-te will lose the presidential position. On the day of the presidential candidate registration, what capabilities of Ko Wen-je would you like to highlight?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950900,
+        "fields": {
+            "priority": 0,
+            "description": "In order to achieve cooperation between the blue and white camps, the cost you have to pay is to accept some reform demands and positions of the TPP. Among these proposals, which ones do you favor more and consider most likely to reach an agreement?\n",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950911,
+        "fields": {
+            "priority": 0,
+            "description": "\nIn this presidential election, facing a one-on-one debate with Lai Ching-te, although you are widely regarded as not the most eloquent, and even your proficiency in Mandarin is limited, your grassroots image in stark contrast to Lai Ching-te's elite image creates a strong juxtaposition. In the debate, what content do you want to emphasize?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950398,
+        "fields": {
+            "priority": 0,
+            "description": "Since you have withdrawn from the primary and essentially paved the way for Terry Gou to secure the presidential candidate position, how do you plan to support him in the upcoming electoral campaign?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950927,
+        "fields": {
+            "priority": 0,
+            "description": "Now, you are in a one-on-one battle with Lai Ching-te in the later stages of the election. Polls indicate that you currently have a lead by several percentage points, but this could be lost due to inappropriate campaign strategies or visiting mistakes. We must stabilize our current position!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950933,
+        "fields": {
+            "priority": 0,
+            "description": "This year's presidential debate has an unprecedented presence of four presidential candidates: yourself, Lai Ching-te, Ko Wen-je, and the former Chairman of Hon Hai Precision Industry, Terry Gou, who does not support you. In this year's presidential debate, what main points do you want to convey?\n",
+            "likelihood": 1
+        }
+    }
+]
+
+campaignTrail_temp.answers_json = [
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950012,
+        "fields": {
+            "question": 1950011,
+            "description": "I will steadfastly continue my course and move forward. Currently, my mission is to serve the citizens of New Taipei City, as they are my top priority and the ones I am most concerned about at the moment."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950013,
+        "fields": {
+            "question": 1950011,
+            "description": "Regardless of any challenges we may face, we will approach them earnestly. If in the future, the party central has any tasks to assign to me, I am more than willing to accept. However, at the moment, my primary focus is on doing things well in New Taipei City."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950014,
+        "fields": {
+            "question": 1950011,
+            "description": "At present, my sole intention is to diligently fulfill my role as the mayor and strive towards constructing a beautiful hometown. To make New Taipei City a great city, we must undertake significant initiatives. By connecting the development of Northern Taiwan through New Taipei, we can contribute to the betterment of Taiwan. A better Taiwan leads to shared prosperity, ensuring peace and stability for the Republic of China."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950388,
+        "fields": {
+            "question": 1950015,
+            "description": "In fact, I do not wish to participate in the primary election. Firstly, I've observed the outcome for Han Kuo-yu, and I believe it's not appropriate for me to run for president while holding my current position . Secondly, I believe Mr.Gou is a more suitable candidate than me. He is a devoted supporter of the Republic of China and can take good care of the country."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950389,
+        "fields": {
+            "question": 1950015,
+            "description": "Chairman Terry Gou is a steadfast supporter of the Republic of China and a patriot. I am pleased to compete alongside him, and if he emerges as the candidate, I will gracefully accept the outcome."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950390,
+        "fields": {
+            "question": 1950015,
+            "description": "I am deeply grateful to Chairman Eric Chu and the party central for giving me this opportunity. In the primary election, I will enhance myself and showcase a broader perspective on international affairs. I recognize the need to develop a more presidential demeanor as I progress."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950399,
+        "fields": {
+            "question": 1950398,
+            "description": "No. My intention in withdrawing from the primary was to focus on effectively managing the city. I didn't want to run for president before completing my term. Therefore, I plan to assist Chairman Terry Gou in his campaign during the later intense stages of the election."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950400,
+        "fields": {
+            "question": 1950398,
+            "description": "Absolutely! I will support him in the campaign, including rallying support for him in New Taipei City and endorsing him for legislative candidates nationwide after his official nomination. I hope he can bring down the Democratic Progressive Party!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950412,
+        "fields": {
+            "question": 1950411,
+            "description": "We have no choice but to stay in Taipei. We cannot afford to let Taipei, this stronghold of the blue camp, be lost!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950413,
+        "fields": {
+            "question": 1950411,
+            "description": "I don't want to lose my hometown. Please allow me to campaign in New Taipei City, and I hope Mayor Hou You-yi can come forward to assist us!\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950414,
+        "fields": {
+            "question": 1950411,
+            "description": "We must secure Taoyuan, the stronghold and vote bank of the Hakka people and the Kuomintang!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950415,
+        "fields": {
+            "question": 1950411,
+            "description": "On the final day, I must drive around the entire Taiwan! Let more people see us!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950425,
+        "fields": {
+            "question": 1950424,
+            "description": "We aim to secure victory in my hometown, New Taipei! Let's conduct the final day of the campaign activities in New Taipei City!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950426,
+        "fields": {
+            "question": 1950424,
+            "description": "Of course, it's in Taipei City. We will declare to all Taipei citizens that tomorrow, we are marching towards the Presidential Office!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950430,
+        "fields": {
+            "question": 1950424,
+            "description": "We plan to hold our last campaign event in Kaohsiung to counter Lai Ching-te and appeal to his support base!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950432,
+        "fields": {
+            "question": 1950424,
+            "description": "The swing state of Taichung is crucial for us, and we aim to secure victory in Taichung."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950441,
+        "fields": {
+            "question": 1950016,
+            "description": "I will visit various counties and cities across Taiwan and establish good relationships with local mayors. I hope to garner more support from these mayors."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950442,
+        "fields": {
+            "question": 1950016,
+            "description": "Let's make some friends in the Legislative Yuan! I will meet with current legislators and discuss campaign matters with them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950443,
+        "fields": {
+            "question": 1950016,
+            "description": "I should appear in the media to share my insights and future prospects in the mayoral election. This can bring me positive media exposure!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950444,
+        "fields": {
+            "question": 1950016,
+            "description": "Anyway, votes come from the voters, and I plan to participate in more offline events to increase my visibility among the electorate. Voters tend to prefer someone familiar and present in their communities!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950454,
+        "fields": {
+            "question": 1950017,
+            "description": "I appreciate Chairman Eric Chu's favor and the support of all the voters. I also want to thank Chairman Terry Gou for his full support. In 2024, we will return to governance, and I am honored to have the opportunity to run for the Kuomintang!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950460,
+        "fields": {
+            "question": 1950018,
+            "description": "Chairman Ko Wen-je has the authority to run for election on his own, and I just need to follow my own path. It's like two brothers climbing a mountain – each making their own effort. Currently, there is no need to discuss coalition votes to avoid affecting the unity and loyalty within our party."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950461,
+        "fields": {
+            "question": 1950018,
+            "description": "I must criticize Ko Wen-je and the TPP. It's widely known that the division within the opposition alliance will only pave the way for the DPP to secure the next term. Chairman Ko Wen-je should seriously consider whether he should indeed continue to run for the presidency!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950462,
+        "fields": {
+            "question": 1950018,
+            "description": "Everyone knows that 60% of the voters want a party alternation. We cannot afford to be divided into two camps. I will extend an olive branch to Chairman Ko . We should work together to bring down the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950463,
+        "fields": {
+            "question": 1950018,
+            "description": "Rather than concerning with Ko, let's focus on targeting Lai Ching-te! Over the past eight years, the DPP government has numerous vulnerabilities we can exploit. Let's concentrate our efforts on the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950477,
+        "fields": {
+            "question": 1950019,
+            "description": "The immediate priority is to investigate and determine what happened. We will promptly send the police to the kindergarten to inspect surveillance footage and search the teachers' personal computers for evidence."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950478,
+        "fields": {
+            "question": 1950019,
+            "description": "\nThe safety and health of the children are our top priorities. We will immediately arrange for them to undergo medical examinations to check if their health has been compromised in any way."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950479,
+        "fields": {
+            "question": 1950019,
+            "description": "The key priority is to calm the parents' emotions. I must hold private meetings with the parents, exchange views and information, and discuss the latest developments and concerns regarding their children."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950487,
+        "fields": {
+            "question": 1950020,
+            "description": "I hope I can handle things well. Let me explain to you why doing things properly is important; it's a matter of attitude because..."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950488,
+        "fields": {
+            "question": 1950020,
+            "description": "When I was a child, I used to hide under the desk and read comic books. My mom would ask, 'What are you doing?' and I would say, 'Studying knowledge by reading comic books.'....."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950489,
+        "fields": {
+            "question": 1950020,
+            "description": "When I was a criminal investigator in the past, combating crime involved collaborating with Interpol, but I always hoped for the exchange of intelligence....."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950490,
+        "fields": {
+            "question": 1950020,
+            "description": "The cross-strait relationship, regardless of the consensus, is entirely based on the Cross-Strait Act. and Only the Constitution of the ROC can bring stability to both sides. I am against Taiwan independence and the One Country, Two Systems!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950502,
+        "fields": {
+            "question": 1950021,
+            "description": "I must seek the recognition of party bosses.and arrange a meeting with the Lien Chan family to request their support. This would be a symbolic move."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950503,
+        "fields": {
+            "question": 1950021,
+            "description": "Allow me to seek the assistance of former party chairman Wu Poh-hsiung of Hakka descent, I need to strengthen my support in Hakka-dominant areas. I hope to gain his recognition!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950504,
+        "fields": {
+            "question": 1950021,
+            "description": "\nI will invite former President Ma Ying-jeou to serve as the Honorary Chairman of my campaign headquarters and request his endorsement and favorable statements for my candidacy."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950513,
+        "fields": {
+            "question": 1950021,
+            "description": "\nI am heading south to Kaohsiung to visit former Legislative Yuan Speaker Wang Jin-ping. I will seek his advice on campaign strategies and solutions to the current situation. I must secure his assistance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950521,
+        "fields": {
+            "question": 1950022,
+            "description": "I am delighted to have King Pu-tsung as a valuable aide in my campaign. He has a strong track record in dealing with the Democratic Progressive Party and will assist me in handling negotiations!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950523,
+        "fields": {
+            "question": 1950023,
+            "description": "I will formally apologize to Han during the gathering and appeal to his supporters to rally behind me. I will acknowledge my mistake in not accepting the position of campaign chairman for New Taipei City in 2020, as I was too focused on municipal affairs and neglected to assist him. I sincerely apologize."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950524,
+        "fields": {
+            "question": 1950023,
+            "description": "I do not need to apologize. Han Kuo-yu's popularity is not at a level where I must pull him back. Furthermore, getting too close to him might harm my image among moderate voters. There is no need to lower my own standing at this point."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950525,
+        "fields": {
+            "question": 1950023,
+            "description": "\nI don't need a formal apology, but let me build a rapport with Han Kuo-yu, present a very familiar and friendly appearance. We don't harbor any dislike for each other; we are good brothers. Let's move past this matter!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950535,
+        "fields": {
+            "question": 1950024,
+            "description": "I support the 1992 Consensus that aligns with the Constitution of the Republic of China. I have made my stance clear! I am against the \"One Country, Two Systems\" and Taiwan independence. I also oppose the Democratic Progressive Party's attempt to stigmatize the 1992 Consensus. It's that simple!\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950536,
+        "fields": {
+            "question": 1950024,
+            "description": "I am not against nuclear power, but rather, I support having nuclear power with proper nuclear safety measures. I assure you that I will ensure the end of the DPP's anti-nuclear policy, and I will restart nuclear power plants to guarantee stable electricity supply and lower electricity prices in Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950537,
+        "fields": {
+            "question": 1950024,
+            "description": "I hope Chairman Terry Gou, being the son of a police officer and a devout follower of Guan Gong, values loyalty and keeps his promises. I believe he will definitely assist me!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950550,
+        "fields": {
+            "question": 1950025,
+            "description": "I sincerely appreciate Mayor Han Kuo-yu's affirmation. I apologize for any previous actions towards him. Now, let's collaborate and work together to win the 2024 election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950558,
+        "fields": {
+            "question": 1950026,
+            "description": "Certainly, I will focus on strengthening my stronghold, Taipei, New Taipei, and Keelung. The northern region is the KMT's most solid base and a crucial vote bank for us!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950559,
+        "fields": {
+            "question": 1950026,
+            "description": "I hope to make efforts in the central region, particularly in Changhua, Taichung, and Nantou. These three areas are crucial in every election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950560,
+        "fields": {
+            "question": 1950026,
+            "description": "I must pay special attention to my hometown, Chiayi County and City. As a southerner, I aim to achieve victory in this deep-green states!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950561,
+        "fields": {
+            "question": 1950026,
+            "description": "\nBeing a southerner myself and proficient in Taiwanese, even though I am from the Kuomintang, I hope to achieve significant results in Tainan, Kaohsiung, and Pingtung. Perhaps, I can turn the tide in these areas!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950579,
+        "fields": {
+            "question": 1950027,
+            "description": "The DPP government has proven incapable of addressing the issue of fraud. Taiwan, once known for its hospitality, is now dubbed the \"Fraud Island.\" I am committed to taking strong measures to tackle the problem of fraud head-on."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950580,
+        "fields": {
+            "question": 1950027,
+            "description": "Under the rule of the Tsai government, we have witnessed increased pressure from the CCP on Taiwan. The median line in the Taiwan Strait has disappeared, and despite the DPP government claiming to resist China and protect Taiwan.we say no to war and yes to dialogue, no to warplanes and yes to business opportunities, no to crises and yes to diplomatic solutions!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950581,
+        "fields": {
+            "question": 1950027,
+            "description": "DPP government is corrupt and plagued by graft. Their digital development sector has squandered 20 billion NT dollars, achieving nothing substantial. In the end, all they managed to do was order takeout!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950582,
+        "fields": {
+            "question": 1950027,
+            "description": "Under the DPP's rule, dissenting voices are suppressed, and even after a court ruled in favor of CTiTV, the NCC continues to deny them the right to resume broadcasting on television. This is the authoritarian oppression of the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950593,
+        "fields": {
+            "question": 1950028,
+            "description": "We must restore law and order. there has been a rampant increase in firearms, drugs, and violent incidents on the streets. Only two death row inmates were executed in the past eight years. The DPP leans towards abolishing the death penalty, but due to public opinion, they refrain from doing so. This is not beneficial for Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950597,
+        "fields": {
+            "question": 1950028,
+            "description": "I will revive the Special Investigation Division. The DPP abolished this institution, responsible for investigating political corruption and official misconduct, as soon as they took office. Was it for their own convenience? I will revive the SPD, and regardless of political affiliation, if any official dares to engage in corruption, we will apprehend them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950599,
+        "fields": {
+            "question": 1950028,
+            "description": "I support housing justice and propose the implementation of a property hoarding tax targeting those with a significant number of properties. This is to ensure that more young people can afford homes. I also commit to continuing the construction of more public housing!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950600,
+        "fields": {
+            "question": 1950028,
+            "description": "My energy policy is clear: Green Sustainability, Reduce Coal with Nuclear, Move towards Coal-free, Transition with Gas. I never been against nuclear power and will include nuclear energy in carbon reduction efforts. If elected, I will complete the inspection and maintenance work for nuclear plants, ensuring safety and extending their operation."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950609,
+        "fields": {
+            "question": 1950029,
+            "description": "This damn Terry Gou! In 2019, he harmed Han Kuo-yu, and now he's doing the same to me this year! We must aggressively attack this untrustworthy guy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950610,
+        "fields": {
+            "question": 1950029,
+            "description": "I hope Chairman Gou can return to the blue camp. We can't afford more division. Persisting in this way will only pave the way for Lai Ching-te to become president!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950611,
+        "fields": {
+            "question": 1950029,
+            "description": "Let's not speak. Just release a campaign video featuring Hou Youyi and Guan Gong, emphasizing the loyalty, benevolence, and integrity of Guan Yu. This will naturally contrast with the untrustworthy behavior of Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950615,
+        "fields": {
+            "question": 1950030,
+            "description": "Polls are only based on phone inquiries and may not accurately reflect actual voting preferences. Let's propose a method for a democratic primary, allowing people across Taiwan to cast their votes to determine the opposition candidate with the highest support!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950616,
+        "fields": {
+            "question": 1950030,
+            "description": "The TPP should not make excessive demands. The KMT is a party with 14+1 county/city mayors and is the second-largest party in the legislature. Our party strength should be taken into account rather than solely relying on individual candidate polls. More people are consider giving their party vote to the KMT!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950617,
+        "fields": {
+            "question": 1950030,
+            "description": "Our current performance in various polls is not very good, but we cannot outright reject the proposal. Refusing it would shift the responsibility for the opposition's inability to integrate onto us. Let's not deny it for now, But we will delay the actual implementation!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950647,
+        "fields": {
+            "question": 1950031,
+            "description": "Everyone knows that the Three Principles of the People, particularly the democratic ideals of government by the people, for the people, and of the people, are closely related. Let's work together to advance these great principles and ensure that the system of liberal democracy continues to thrive in Taiwan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950648,
+        "fields": {
+            "question": 1950031,
+            "description": "Are you... Little Chuck? I didn't expect you to have grown so much. I'm happy to see you again! When I rescued you from the kidnappers all those years ago, you were just a baby. Now, I can hardly recognize you!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950649,
+        "fields": {
+            "question": 1950031,
+            "description": "I would say is my encounters with Mayor Adams of New York City. I even met with legislators from both the Democratic and Republican parties in Washington. AIT Chairman Rosenberger also had a meeting with me. This highlights the strength of the KMT and me in international relations!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950658,
+        "fields": {
+            "question": 1950032,
+            "description": "People have misunderstood Mayor Hou deeply. He genuinely cares about me! Please stop spreading rumors about our supposed discord. After my removal, he was the first to call and offer his comfort, asking if I needed any assistance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950659,
+        "fields": {
+            "question": 1950032,
+            "description": "Mayor Hou is a real man, someone who helped maintain public order in the midst of gunfire and chaos. Such individuals are what Taiwan needs the most—no flashy rhetoric, just someone dedicated to doing good things. I recommend him wholeheartedly!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 2950659,
+        "fields": {
+            "question": 1950032,
+            "description": "Do you remember in 2018 when we campaigned together for mayor? We emphasized unity back then. Now, I'm not sure who is causing division among us, but it's a big mistake. If we want to win, we must stand united with Hou!"
+        }
+    },
+    {
+
+        "model": "campaign_trail.answer",
+        "pk": 1950660,
+        "fields": {
+            "question": 1950032,
+            "description": "I want everyone to recognize that the DPP is corrupt, not only engaging in financial malfeasance but also steering Taiwan towards the deadly path of war. Only the Kuomintang and Mayor Hou can help Taiwan emerge from the shadows of conflict and restore normal relations with the mainland!\""
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950670,
+        "fields": {
+            "question": 1950033,
+            "description": "We have no choice but to accept the challenge, as time is running out. Even if our poll numbers are not high, we must face the battle. Otherwise, it may be perceived as a display of timidity."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950671,
+        "fields": {
+            "question": 1950033,
+            "description": "We must accept the challenge, and we believe we can surpass Ko Wen-je. We have to outperform him to ensure the Kuomintang's dominant position in the joint ticket alliance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950688,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950691,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950692,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950693,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950721,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950722,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950723,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950724,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950737,
+        "fields": {
+            "question": 1950035,
+            "description": "After receiving a text from Chairman Ko, he mentioned that he believes Terry Gou should find a reason to withdraw from the election, to avoid further disrupting the pan-blue camp. Can I read into this, Chairman Ko?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950738,
+        "fields": {
+            "question": 1950035,
+            "description": "I also brought Chairman Eric Chu and former President Ma Ying-jeou to witness this moment. There is no demand for the TPP to concede a 6% margin in the polls; instead, we will determine the outcome based on the respective margins of error in each poll, alright?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950739,
+        "fields": {
+            "question": 1950035,
+            "description": "Today is a crucial day that determines the future destiny of Taiwan and its people. I hope Chairman Terry Gou and President Ko can prioritize the overall situation. We must unite forces to bring down the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950740,
+        "fields": {
+            "question": 1950035,
+            "description": "Today is a crucial day that determines the future destiny of Taiwan and its people. I hope Chairman Terry Gou and President Ko can prioritize the overall situation. We must unite forces to bring down the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950751,
+        "fields": {
+            "question": 1950036,
+            "description": "...We need to strengthen our base! Let Han Kuo-yu as running mate, if we can achieve the performance of his 5.5 million votes, then we will win, won't we?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950755,
+        "fields": {
+            "question": 1950036,
+            "description": " At this point, we can't allow our deep blue supporters to continue leaning towards Ko Wen-je and Terry Gou. We must bring them all back, and Han Kuo-yu will be my partner!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950764,
+        "fields": {
+            "question": 1950037,
+            "description": "(Zhao speaking to the media) The DPP likened Mayor Hou to Adou, but I disagree! I just like Zhao Zilong, loyal to Liu Bei. How could he be compared to a Adou? Just Like Zhao yun'ssteadfast and patriotic, with courage running through my veins."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950765,
+        "fields": {
+            "question": 1950037,
+            "description": "I feel that the DPP lacks professionalism, resorting to divisive tactics to win elections. This kind of maneuver seems quite low-level. If I am elected, Mayor Hou You-yi is the leader, the president, and I am the vice president - merely in a preparatory role!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950766,
+        "fields": {
+            "question": 1950037,
+            "description": "I won't give any attention to such tags. DPP has been in power for a considerable time, yet their election strategies seem to rely on questionable tactics. Can the people of Taiwan still believe in a party that governs without progress but resorts to such tactics during elections?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950781,
+        "fields": {
+            "question": 1950038,
+            "description": "Let's aggressively pursue this issue! Lai Ching-te is truly a candidate who disregards the law, even ignoring illegal construction on his own property. Can someone who disregards the law in such a manner be fit for the presidency?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950782,
+        "fields": {
+            "question": 1950038,
+            "description": "Launching a series of ads attacking Lai Ching-te would be an effective strategy to convey that he is an untrustworthy and arrogant candidate. Emphasize how he has tolerated illegal activities even within his own home, highlighting his lack of integrity. Portray him as someone not deserving of trust and as the people's greatest concern."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950783,
+        "fields": {
+            "question": 1950038,
+            "description": "Hold on, let's not get too carried away! Lai Ching-te's unauthorized construction has been years ago, and according to legal provisions, there is no requirement for demolition. It only needs to be documented and registered through photographs. Let's issue a statement acknowledging that Lai Ching-te's illegal actions technically violate the law, but we have chosen to show leniency and not pursue further action against him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950784,
+        "fields": {
+            "question": 1950038,
+            "description": "An excavator? Yes, right in the Zhongfu neighborhood of Wanli District. Go ahead and demolish his ancestral home for me!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950796,
+        "fields": {
+            "question": 1950039,
+            "description": "Firstly, this property is a legitimate part of my family's assets, and you have no right to interfere. Secondly, I have the right to set the rent at whatever amount I deem appropriate; it's determined by the free market!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950797,
+        "fields": {
+            "question": 1950039,
+            "description": "You're right. I'll discuss it with my wife immediately. I will reduce the rent by half, and after the contract expires, I will convert it into social housing. Is that satisfactory for you?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950798,
+        "fields": {
+            "question": 1950039,
+            "description": "you guys like to attack? Well, then I'll respond with an attack. Lai Ching-te, when will you tear down the unauthorized construction? You dare criticize me; have I committed any crimes? And attacking my wife? That property belongs to her, not me. Please refrain from involving my family in this matter."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950799,
+        "fields": {
+            "question": 1950039,
+            "description": "I won't give this fire any more oxygen. Don't respond to these issues, as it's all legal business operations. Voters will see through it naturally."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950814,
+        "fields": {
+            "question": 1950040,
+            "description": "We want to revisit President Ma Ying-jeou's classic campaign ad from 2008. Our formidable team of county and city mayors is making a comeback to support my campaign, symbolizing unity among ROC's local leaders from across the country. This ad aims to bring hope to the people!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950815,
+        "fields": {
+            "question": 1950040,
+            "description": "Han Kuo-yu is my best attack dog; he is very skilled at criticizing and attacking the DPP. Let him fiercely attack the DPP and Hsiao Bi-khim in the vice presidential debate!    His powerful eloquence will dismantle the candidates from the TPP and DPP."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950816,
+        "fields": {
+            "question": 1950040,
+            "description": "I will propose policies that appeal to young people. Many can't afford homes, so we will offer low-interest loans of up to 15 million, waiving the down payment. As long as young people are willing to borrow, we can provide them with this policy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950817,
+        "fields": {
+            "question": 1950040,
+            "description": "I will emphasize our various policies. If you dislike the NCC restricting free speech, despise opaque governance, and are against the DPP's one-party dominance, then join us because we aim to dismantle all of them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950818,
+        "fields": {
+            "question": 1950031,
+            "description": "I will deliver a speech in Washington, emphasizing the importance of the 3D strategy. Which 3Ds? Deterrence, Dialogue, and De-escalation. This can construct peace and stability across the Taiwan Strait while upholding our sovereignty."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950838,
+        "fields": {
+            "question": 1950041,
+            "description": "I understand that scams cause you concern, and the threat of war makes you worry. However, let's not be afraid. You deserve a better future! In the future, I will definitely stand with you!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950839,
+        "fields": {
+            "question": 1950041,
+            "description": "I declare to the people of Taiwan that I am committed to initiating a new era of democratic political reform. Advocating for a cabinet system is not something that can be achieved by one person or one party alone, but it is a task we must accomplish. Our shared goal is peace, integrity, fairness, and justice in governance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950840,
+        "fields": {
+            "question": 1950041,
+            "description": "Candidates, do you truly oppose or support the abolition of the death penalty? All I hear are ambiguous answers, but let me be clear—I am against the abolition of the death penalty. It is a significant harm to the families of the victims. Candidates, please make your stance clear!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950841,
+        "fields": {
+            "question": 1950041,
+            "description": "January 13th marks the day of Mr. Chiang Ching-kuo's passing. Fellow patriots, on this day, it is crucial to come out and vote, exercising your democratic rights. Mr. Chiang Ching-kuo once said, \"What you don't do today, you'll regret tomorrow!\" I am committed to safeguarding Taiwan's democratic system with my life!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950852,
+        "fields": {
+            "question": 1950042,
+            "description": "\nWe must distance ourselves from him. I have a different perspective, and our views do not align with those of President Ma Ying-jeou. To penalize him and minimize the impact, we must reject his attendance at our pre-election night event!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950853,
+        "fields": {
+            "question": 1950042,
+            "description": "I will strongly criticize President Ma Ying-jeou's remarks, as they diverge from the mainstream thoughts of the Taiwanese people! Under the leadership of Mayor Hou You-yi, the Kuomintang will establish new relations with the mainland, and we don't need to blindly trust anyone."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950858,
+        "fields": {
+            "question": 1950042,
+            "description": "Don't pay attention to him. In the critical situation of this election, addressing this issue will only bring about greater division among us!We cannot afford to take risks at this time!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950863,
+        "fields": {
+            "question": 1950851,
+            "description": "I will conduct campaign activities in my home turf, New Taipei and Taipei. At the New Taipei Sports Stadium, we will gather a crowd and defeat the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950864,
+        "fields": {
+            "question": 1950851,
+            "description": "\nI want to conduct activities in the deeply green cities of Tainan and Kaohsiung, engage in a battle in Lai Ching-te's stronghold, and show him that people in the southern region won't blindly support the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950865,
+        "fields": {
+            "question": 1950851,
+            "description": "We will drive through the Hakka region and finally organize our pre-election night event in Taoyuan City!\nThe Hakka and youth votes have been taken away by Ko Wen-je, and we must retain them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950866,
+        "fields": {
+            "question": 1950851,
+            "description": "We must focus on areas with fewer voters and less competition. Hualien, Taitung, Yilan, and Pingtung are our key areas of concern. We must secure the entire east coast!\n\n\n\n\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950891,
+        "fields": {
+            "question": 1950890,
+            "description": "Ko Wen-je is very popular among the youth, and we must emphasize this. Our alliance lacks support from the younger generation the most. Let Ko Wen-je campaign for our alliance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950892,
+        "fields": {
+            "question": 1950890,
+            "description": "The alliance between the KMT and TPP is a shared aspiration of the Taiwanese people, as evidenced by the polls. We are confident in defeating Lai Ching-te. Let's strengthen the unity and cooperation between the two parties and jointly overcome the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950893,
+        "fields": {
+            "question": 1950890,
+            "description": "\nCertainly, Chairman Ko's eloquence and formidable abilities will provide excellent support for me. In the vice presidential debate, I hope he can defeat Hsiao Mei-chin, while I will confront Lai Ching-te. Together, let's advance progress in Taiwan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950901,
+        "fields": {
+            "question": 1950900,
+            "description": "\nWe will create goals for the third wave of democratic reforms in Taiwan. We will promote a Parliamentary system instead of a presidential system where power is concentrated in one party's hands. This change will benefit the future of Taiwan, as democracy requires a system of checks and balances!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950902,
+        "fields": {
+            "question": 1950900,
+            "description": "In the future coalition government, KMT will take the lead in economic and developmental responsibilities, while the TPP will be responsible for oversight and checks and balances. This is much better than the authoritarian rule of the DPP. Our future government will be free from corruption, and anyone who dares to engage in corruption will be held accountable!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950903,
+        "fields": {
+            "question": 1950900,
+            "description": "\nNow, we represent the greatest consensus of the Taiwanese people. Let's unite and launch a full-scale attack on the DPP! The opposition alliance will surge and break through the DPP's base!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950912,
+        "fields": {
+            "question": 1950911,
+            "description": "Lai Ching-te has claimed to be a pragmatic advocate for Taiwan independence. Now he says Taiwan is already an independent country. This is just the opportunistic behavior of a politician without integrity.I has been loyal to the Republic of China  throughout his life, and I will sacrifice my life to protect it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950913,
+        "fields": {
+            "question": 1950911,
+            "description": "Taiwan cannot afford to be ruled by the DPP anymore. The past 8 years of their governance have exposed the rapid pace of corruption and moral decay within your political regime, making it impossible for the people to trust you any longer. Please believe in the Taiwan United Government under the KMT-TPP alliance; we will do better!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950914,
+        "fields": {
+            "question": 1950911,
+            "description": "\nWhat I insist on is the democratic freedom of the 23 million people in Taiwan. We must strengthen national defense, deter war, and hold the key to peace, security, and stability in the Taiwan Strait. The DPP's approach cannot help Taiwan achieve true peace!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950915,
+        "fields": {
+            "question": 1950911,
+            "description": "\nMy father is a veteran, and I am the son of a pork vendor from the rural areas of Chiayi. I understand the hardships of life and have climbed up from being the lowest-ranking police officer to my current position. I am grateful for the support and assistance from each and every one of you!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950928,
+        "fields": {
+            "question": 1950927,
+            "description": "Now it's a one-on-one battle between me and Lai Ching-te! We must rally our base to come back!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950934,
+        "fields": {
+            "question": 1950933,
+            "description": "Lai Ching-te has claimed to be a pragmatic advocate for Taiwan independence. Now he says Taiwan is already an independent country. This is just the opportunistic behavior of a politician without integrity.I has been loyal to the Republic of China throughout his life, and I will sacrifice my life to protect it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950935,
+        "fields": {
+            "question": 1950933,
+            "description": "Chairman Ko had once promised to pursue a blue-white coalition, but now he has backtracked. This proves that Chairman Ko is someone who prioritizes political interests over integrity. He changed his decision to personally sign the agreement due to opposition from his staff and family, which is truly embarrassing."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950936,
+        "fields": {
+            "question": 1950933,
+            "description": "Chairman Guo had once promised to support me, but the subsequent results are well known. Now the opposition is divided into three parts. Where is the benefit in that? I am the strongest candidate. On election day, we should abandon Guo and support Hou!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950946,
+        "fields": {
+            "question": 1950933,
+            "description": "\nI and Mr. Guo both advocate for the ROC, and we both love this country. However, he is not a viable winner. Please concentrate your votes on me; I am the only one with the potential to defeat the Democratic Progressive Party."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 12763,
+        "fields": {
+            "question": 12762,
+            "description": "Mayor Han Kuo-yu is my close brother and my best campaign partner. I am more than willing to choose him as the Vice President. Let's work together to rescue the Republic of China!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 12764,
+        "fields": {
+            "question": 12762,
+            "description": "(Han Kuo-yu says) I'm telling you, Ko Wen-je won't win! His current popularity and influence are all fake because he has almost no support from the elderly. The women supporting me have already gone through menopause, and they have a higher voter turnout!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 12765,
+        "fields": {
+            "question": 12762,
+            "description": "I chose him to strengthen my deep-blue base and support. Without them, I would never be able to win. I hope Han Kuo-yu can change his performance a bit, just be more composed."
+        }
+    }
+
+]
+
+
+campaignTrail_temp.states_json = [
+    {
+        "model": "campaign_trail.state",
+        "pk": 251,
+        "fields": {
+            "name": "Tainan City",
+            "abbr": "Tainancity",
+            "electoral_votes": 1,
+            "popular_votes": 1120238,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 252,
+        "fields": {
+            "name": "Kaohsiung City",
+            "abbr": "Kaohsiungcity",
+            "electoral_votes": 1,
+            "popular_votes": 1636962,
+            "poll_closing_time": 180,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 253,
+        "fields": {
+            "name": "Pingtung County",
+            "abbr": "Pingtung",
+            "electoral_votes": 1,
+            "popular_votes": 475927,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 254,
+        "fields": {
+            "name": "Taidong County",
+            "abbr": "Taidong",
+            "electoral_votes": 1,
+            "popular_votes": 109941,
+            "poll_closing_time": 75,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 255,
+        "fields": {
+            "name": "Hualien County",
+            "abbr": "Hualien",
+            "electoral_votes": 1,
+            "popular_votes": 174157,
+            "poll_closing_time": 90,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 256,
+        "fields": {
+            "name": "Chiayi County",
+            "abbr": "ChiayiCounty",
+            "electoral_votes": 1,
+            "popular_votes": 292534,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 257,
+        "fields": {
+            "name": "Chiayi City",
+            "abbr": "ChiayiCity",
+            "electoral_votes": 1,
+            "popular_votes": 157656,
+            "poll_closing_time": 80,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 258,
+        "fields": {
+            "name": "Nantou County",
+            "abbr": "Nantou",
+            "electoral_votes": 1,
+            "popular_votes": 287296,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 259,
+        "fields": {
+            "name": "Yunlin County",
+            "abbr": "Yunlin",
+            "electoral_votes": 1,
+            "popular_votes": 380619,
+            "poll_closing_time": 130,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 260,
+        "fields": {
+            "name": "Changhua County",
+            "abbr": "Changhua",
+            "electoral_votes": 1,
+            "popular_votes": 741368,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 261,
+        "fields": {
+            "name": "Penghu County",
+            "abbr": "Penghu",
+            "electoral_votes": 1,
+            "popular_votes": 49277,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 262,
+        "fields": {
+            "name": "Taichung City",
+            "abbr": "Taichung",
+            "electoral_votes": 1,
+            "popular_votes": 1707203,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 263,
+        "fields": {
+            "name": "Yilan County",
+            "abbr": "Yilan",
+            "electoral_votes": 1,
+            "popular_votes": 267129,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 264,
+        "fields": {
+            "name": "Hsinchu County",
+            "abbr": "HsinchuCounty",
+            "electoral_votes": 1,
+            "popular_votes": 340310,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 265,
+        "fields": {
+            "name": "Hsinchu City",
+            "abbr": "HsinchuCity",
+            "electoral_votes": 1,
+            "popular_votes": 266389,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 266,
+        "fields": {
+            "name": "Miaoli County",
+            "abbr": "Miaoli",
+            "electoral_votes": 1,
+            "popular_votes": 318665,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 267,
+        "fields": {
+            "name": "New Taipei City",
+            "abbr": "Newtaipei",
+            "electoral_votes": 1,
+            "popular_votes": 2458480,
+            "poll_closing_time": 225,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 268,
+        "fields": {
+            "name": "Taipei City",
+            "abbr": "Taipei",
+            "electoral_votes": 1,
+            "popular_votes": 1542009,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 269,
+        "fields": {
+            "name": "Taoyuan City",
+            "abbr": "Taoyuan",
+            "electoral_votes": 1,
+            "popular_votes": 1350792,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 270,
+        "fields": {
+            "name": "Keelung City",
+            "abbr": "Keelung",
+            "electoral_votes": 1,
+            "popular_votes": 218781,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 271,
+        "fields": {
+            "name": "Kinmen County",
+            "abbr": "Kinmen",
+            "electoral_votes": 1,
+            "popular_votes": 45612,
+            "poll_closing_time": 70,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 272,
+        "fields": {
+            "name": "Lienchiang County",
+            "abbr": "Matsu",
+            "electoral_votes": 1,
+            "popular_votes": 6159,
+            "poll_closing_time": 50,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.issues_json = [
+    {
+        "model": "campaign_trail.issue",
+        "pk": 32,
+        "fields": {
+            "name": "Party coalition",
+            "description": 0,
+            "stance_1": "Deep Green",
+            "stance_desc_1": 0,
+            "stance_2": "Green",
+            "stance_desc_2": 0,
+            "stance_3": "Light Green",
+            "stance_desc_3": 0,
+            "stance_4": "Neutral",
+            "stance_desc_4": 0,
+            "stance_5": "Light Blue",
+            "stance_desc_5": 0,
+            "stance_6": "Blue",
+            "stance_desc_6": 0,
+            "stance_7": "Deep Blue",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 33,
+        "fields": {
+            "name": "Provincial differences",
+            "description": 0,
+            "stance_1": "Mostly Taiwanese",
+            "stance_desc_1": 0,
+            "stance_2": "Taiwanese and Hakka mixed",
+            "stance_desc_2": 0,
+            "stance_3": "Taiwanese,Hakka,Mainlanders mixed",
+            "stance_desc_3": 0,
+            "stance_4": "mixing of ethnic groups",
+            "stance_desc_4": 0,
+            "stance_5": "Aboriginal",
+            "stance_desc_5": 0,
+            "stance_6": "Taiwanese Hakka(Northern)",
+            "stance_desc_6": 0,
+            "stance_7": "Mostly Mainlanders",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 34,
+        "fields": {
+            "name": "Urban/rural differences",
+            "description": 0,
+            "stance_1": "Townships Rural",
+            "stance_desc_1": 0,
+            "stance_2": "Small towns and large towns",
+            "stance_desc_2": 0,
+            "stance_3": "Small cities and towns",
+            "stance_desc_3": 0,
+            "stance_4": "Medium-sized city",
+            "stance_desc_4": 0,
+            "stance_5": "Groups of Small Cities",
+            "stance_desc_5": 0,
+            "stance_6": "Large Cities",
+            "stance_desc_6": 0,
+            "stance_7": "Capitals",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 35,
+        "fields": {
+            "name": "Young population",
+            "description": 0,
+            "stance_1": "Very little",
+            "stance_desc_1": 0,
+            "stance_2": "Little",
+            "stance_desc_2": 0,
+            "stance_3": "Less",
+            "stance_desc_3": 0,
+            "stance_4": "Normal level",
+            "stance_desc_4": 0,
+            "stance_5": "Relatively much more",
+            "stance_desc_5": 0,
+            "stance_6": "Large young population",
+            "stance_desc_6": 0,
+            "stance_7": "Younger society",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 36,
+        "fields": {
+            "name": "Feelings about DPP Government",
+            "description": 0,
+            "stance_1": "DPP is the best!",
+            "stance_desc_1": 0,
+            "stance_2": "That's what we like!",
+            "stance_desc_2": 0,
+            "stance_3": "Pro-DPP",
+            "stance_desc_3": 0,
+            "stance_4": "no feelings for the DPP",
+            "stance_desc_4": 0,
+            "stance_5": "Hate green governance",
+            "stance_desc_5": 0,
+            "stance_6": "Mosquitoes, cockroaches, and the DPP",
+            "stance_desc_6": 0,
+            "stance_7": "Never support the Taiwan Independence Party!!",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.state_issue_score_json = [
+    //台北市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191111,
+        "fields": {
+            "state": 268,
+            "issue": 32,
+            "state_issue_score": 0.22,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191112,
+        "fields": {
+            "state": 268,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191113,
+        "fields": {
+            "state": 268,
+            "issue": 34,
+            "state_issue_score": 1,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191114,
+        "fields": {
+            "state": 268,
+            "issue": 35,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191115,
+        "fields": {
+            "state": 268,
+            "issue": 36,
+            "state_issue_score": 0.1,
+            "weight": 0.5
+        }
+    },
+    //新北市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191116,
+        "fields": {
+            "state": 267,
+            "issue": 32,
+            "state_issue_score": 0.15,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191117,
+        "fields": {
+            "state": 267,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191118,
+        "fields": {
+            "state": 267,
+            "issue": 34,
+            "state_issue_score": 0.65,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191119,
+        "fields": {
+            "state": 267,
+            "issue": 35,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191120,
+        "fields": {
+            "state": 267,
+            "issue": 36,
+            "state_issue_score": 0.0,
+            "weight": 0.5
+        }
+    },
+    //桃园市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191121,
+        "fields": {
+            "state": 269,
+            "issue": 32,
+            "state_issue_score": 0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191122,
+        "fields": {
+            "state": 269,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191122,
+        "fields": {
+            "state": 269,
+            "issue": 34,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191123,
+        "fields": {
+            "state": 269,
+            "issue": 35,
+            "state_issue_score": 0.75,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191124,
+        "fields": {
+            "state": 269,
+            "issue": 36,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    //新竹市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191125,
+        "fields": {
+            "state": 265,
+            "issue": 32,
+            "state_issue_score": 0.4,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191126,
+        "fields": {
+            "state": 265,
+            "issue": 33,
+            "state_issue_score": -0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191127,
+        "fields": {
+            "state": 265,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191128,
+        "fields": {
+            "state": 265,
+            "issue": 35,
+            "state_issue_score": 0.65,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191129,
+        "fields": {
+            "state": 265,
+            "issue": 36,
+            "state_issue_score": 0.35,
+            "weight": 0.5
+        }
+    },
+    //基隆市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191130,
+        "fields": {
+            "state": 270,
+            "issue": 32,
+            "state_issue_score": 0.5,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191131,
+        "fields": {
+            "state": 270,
+            "issue": 33,
+            "state_issue_score": 0.1,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191132,
+        "fields": {
+            "state": 270,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191133,
+        "fields": {
+            "state": 270,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191134,
+        "fields": {
+            "state": 270,
+            "issue": 36,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    //新竹县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191135,
+        "fields": {
+            "state": 264,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191136,
+        "fields": {
+            "state": 264,
+            "issue": 33,
+            "state_issue_score": 0.45,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191137,
+        "fields": {
+            "state": 264,
+            "issue": 34,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191138,
+        "fields": {
+            "state": 264,
+            "issue": 35,
+            "state_issue_score": 0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191139,
+        "fields": {
+            "state": 264,
+            "issue": 36,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    //苗栗縣
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191140,
+        "fields": {
+            "state": 266,
+            "issue": 32,
+            "state_issue_score": 0.85,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191141,
+        "fields": {
+            "state": 266,
+            "issue": 33,
+            "state_issue_score": 0.55,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191142,
+        "fields": {
+            "state": 266,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191143,
+        "fields": {
+            "state": 266,
+            "issue": 35,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191144,
+        "fields": {
+            "state": 266,
+            "issue": 36,
+            "state_issue_score": 0.85,
+            "weight": 0.5
+        }
+    },
+    //宜兰县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191145,
+        "fields": {
+            "state": 263,
+            "issue": 32,
+            "state_issue_score": -0.45,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191146,
+        "fields": {
+            "state": 263,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191147,
+        "fields": {
+            "state": 263,
+            "issue": 34,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191148,
+        "fields": {
+            "state": 263,
+            "issue": 35,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191149,
+        "fields": {
+            "state": 263,
+            "issue": 36,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    //台中市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191150,
+        "fields": {
+            "state": 262,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191151,
+        "fields": {
+            "state": 262,
+            "issue": 33,
+            "state_issue_score": 0,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191152,
+        "fields": {
+            "state": 262,
+            "issue": 34,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191154,
+        "fields": {
+            "state": 262,
+            "issue": 35,
+            "state_issue_score": 0.35,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191155,
+        "fields": {
+            "state": 262,
+            "issue": 36,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    //南投县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191156,
+        "fields": {
+            "state": 258,
+            "issue": 32,
+            "state_issue_score": 0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191157,
+        "fields": {
+            "state": 258,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191158,
+        "fields": {
+            "state": 258,
+            "issue": 34,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191159,
+        "fields": {
+            "state": 258,
+            "issue": 35,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191160,
+        "fields": {
+            "state": 258,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //花莲县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191161,
+        "fields": {
+            "state": 255,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191162,
+        "fields": {
+            "state": 255,
+            "issue": 33,
+            "state_issue_score": 0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191163,
+        "fields": {
+            "state": 255,
+            "issue": 34,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191164,
+        "fields": {
+            "state": 255,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191165,
+        "fields": {
+            "state": 255,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //台东县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191166,
+        "fields": {
+            "state": 254,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191167,
+        "fields": {
+            "state": 254,
+            "issue": 33,
+            "state_issue_score": 0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191168,
+        "fields": {
+            "state": 254,
+            "issue": 34,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191169,
+        "fields": {
+            "state": 254,
+            "issue": 35,
+            "state_issue_score": -0.33,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191170,
+        "fields": {
+            "state": 254,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //彰化县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191171,
+        "fields": {
+            "state": 260,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191172,
+        "fields": {
+            "state": 260,
+            "issue": 33,
+            "state_issue_score": -0.85,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191173,
+        "fields": {
+            "state": 260,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191174,
+        "fields": {
+            "state": 260,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191175,
+        "fields": {
+            "state": 260,
+            "issue": 36,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    //云林县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191176,
+        "fields": {
+            "state": 259,
+            "issue": 32,
+            "state_issue_score": -0.4,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191177,
+        "fields": {
+            "state": 259,
+            "issue": 33,
+            "state_issue_score": -0.85,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191178,
+        "fields": {
+            "state": 259,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191179,
+        "fields": {
+            "state": 259,
+            "issue": 35,
+            "state_issue_score": -0.85,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191180,
+        "fields": {
+            "state": 259,
+            "issue": 36,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    //澎湖
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191181,
+        "fields": {
+            "state": 261,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191182,
+        "fields": {
+            "state": 261,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191183,
+        "fields": {
+            "state": 261,
+            "issue": 34,
+            "state_issue_score": -0.9,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191184,
+        "fields": {
+            "state": 261,
+            "issue": 35,
+            "state_issue_score": -0.75,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191185,
+        "fields": {
+            "state": 261,
+            "issue": 36,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    //嘉义县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191186,
+        "fields": {
+            "state": 256,
+            "issue": 32,
+            "state_issue_score": -0.75,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191187,
+        "fields": {
+            "state": 256,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191188,
+        "fields": {
+            "state": 256,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191189,
+        "fields": {
+            "state": 256,
+            "issue": 35,
+            "state_issue_score": -0.9,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191190,
+        "fields": {
+            "state": 256,
+            "issue": 36,
+            "state_issue_score": -0.75,
+            "weight": 0.5
+        }
+    },
+    //嘉义市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191191,
+        "fields": {
+            "state": 257,
+            "issue": 32,
+            "state_issue_score": -0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191192,
+        "fields": {
+            "state": 257,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191193,
+        "fields": {
+            "state": 257,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191194,
+        "fields": {
+            "state": 257,
+            "issue": 35,
+            "state_issue_score": -0.6,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191195,
+        "fields": {
+            "state": 257,
+            "issue": 36,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+     //台南市
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191196,
+            "fields": {
+                "state": 251,
+                "issue": 32,
+                "state_issue_score": -0.85,
+                "weight": 1
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191197,
+            "fields": {
+                "state": 251,
+                "issue": 33,
+                "state_issue_score": -0.15,
+                "weight": 2
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191198,
+            "fields": {
+                "state": 251,
+                "issue": 34,
+                "state_issue_score": 0.55,
+                "weight": 0.5
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191199,
+            "fields": {
+                "state": 251,
+                "issue": 35,
+                "state_issue_score": 0.15,
+                "weight": 0.5
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191200,
+            "fields": {
+                "state": 251,
+                "issue": 36,
+                "state_issue_score": -0.75,
+                "weight": 0.5
+            }
+        },
+         //高雄市
+             {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191201,
+                "fields": {
+                    "state": 252,
+                    "issue": 32,
+                    "state_issue_score": -0.55,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191202,
+                "fields": {
+                    "state": 252,
+                    "issue": 33,
+                    "state_issue_score": -0.15,
+                    "weight": 2
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191203,
+                "fields": {
+                    "state": 252,
+                    "issue": 34,
+                    "state_issue_score": 0.65,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191204,
+                "fields": {
+                    "state": 252,
+                    "issue": 35,
+                    "state_issue_score": 0.15,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191205,
+                "fields": {
+                    "state": 252,
+                    "issue": 36,
+                    "state_issue_score": -0.75,
+                    "weight": 0.5
+                }
+            },
+            //屏东县
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191206,
+                "fields": {
+                    "state": 253,
+                    "issue": 32,
+                    "state_issue_score": -0.5,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191207,
+                "fields": {
+                    "state": 253,
+                    "issue": 33,
+                    "state_issue_score": -0.25,
+                    "weight": 2
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191208,
+                "fields": {
+                    "state": 253,
+                    "issue": 34,
+                    "state_issue_score": 0.25,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191209,
+                "fields": {
+                    "state": 253,
+                    "issue": 35,
+                    "state_issue_score": 0,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191210,
+                "fields": {
+                    "state": 253,
+                    "issue": 36,
+                    "state_issue_score": -0.55,
+                    "weight": 0.5
+                }
+            },
+              //金门县
+              {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191211,
+                "fields": {
+                    "state": 271,
+                    "issue": 32,
+                    "state_issue_score": 1,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191212,
+                "fields": {
+                    "state": 271,
+                    "issue": 33,
+                    "state_issue_score": 1,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191213,
+                "fields": {
+                    "state": 271,
+                    "issue": 34,
+                    "state_issue_score": -0.75,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191214,
+                "fields": {
+                    "state": 271,
+                    "issue": 35,
+                    "state_issue_score": -0.25,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191215,
+                "fields": {
+                    "state": 271,
+                    "issue": 36,
+                    "state_issue_score": 1,
+                    "weight": 0.5
+                }
+            },
+                //连江县
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191216,
+                    "fields": {
+                        "state": 272,
+                        "issue": 32,
+                        "state_issue_score": 1,
+                        "weight": 1
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191217,
+                    "fields": {
+                        "state": 272,
+                        "issue": 33,
+                        "state_issue_score": 1,
+                        "weight": 1
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191218,
+                    "fields": {
+                        "state": 272,
+                        "issue": 34,
+                        "state_issue_score": -1,
+                        "weight": 0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191219,
+                    "fields": {
+                        "state": 272,
+                        "issue": 35,
+                        "state_issue_score": 0.25,
+                        "weight": 0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191220,
+                    "fields": {
+                        "state": 272,
+                        "issue": 36,
+                        "state_issue_score": 1,
+                        "weight": 0.5
+                    }
+                },
+]
+campaignTrail_temp.candidate_issue_score_json = [
+    //赖清德
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 328,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 32,
+            "issue_score": -0.85 //深绿
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 329,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 33,
+            "issue_score": -0.75 //台湾本省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 330,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 34,
+            "issue_score": -0.35 //矿工之子
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 331,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 35,
+            "issue_score": 0.25 //年轻人支持度还行
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 332,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 36,
+            "issue_score": -1 //我就是现任副总统啊
+        }
+    },
+    //侯友谊
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 333,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 32,
+            "issue_score": 0.15 //浅蓝，甚至蓝皮绿谷
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 334,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 33,
+            "issue_score": -0.9 //比赖清德更本省
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 335,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 34,
+            "issue_score": -0.5 //嘉义乡下卖猪肉的
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 336,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 35,
+            "issue_score": -0.25 //年轻人不喜欢的老蓝男
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 337,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 36,
+            "issue_score": 0.25 //攻击性不强
+        }
+    },
+    //柯文哲
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 338,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 32,
+            "issue_score": -0.5 //我内心本质还是深绿的
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 339,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 33,
+            "issue_score": -0.75 //本省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 340,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 34,
+            "issue_score": 0.15 //家庭条件还可以
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 341,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 35,
+            "issue_score": 0.8 //阿北阿北我爱你
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 342,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 36,
+            "issue_score": 0.5 //攻击性很强，但并不把下架民进党当第一目标
+        }
+    },
+     //郭台铭
+     {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 343,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 32,
+            "issue_score": 0.7 //深蓝
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 344,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 33,
+            "issue_score": 0.75 //外省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 345,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 34,
+            "issue_score": 0.75 //城里人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 346,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 35,
+            "issue_score": -0.25 //老蓝男
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 347,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 36,
+            "issue_score": 0.4 //攻击性一般，下架民进党是说说听得口号
+        }
+    },
+]
+campaignTrail_temp.running_mate_issue_score_json = [
+  //萧美琴
+  {
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9343,
+    "fields": {
+        "candidate": 1002,
+        "issue": 32,
+        "issue_score": -0.7
+    }
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9344,
+    "fields": {
+        "candidate": 1002,
+        "issue": 33,
+        "issue_score": -0
+    }
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9345,
+    "fields": {
+        "candidate": 1002,
+        "issue": 34,
+        "issue_score": -0.25
+},
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9346,
+    "fields": {
+        "candidate": 1002,
+        "issue": 35,
+        "issue_score": 0.25 
+    }
+},
+    {
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9347,
+    "fields": {
+        "candidate": 1002,
+        "issue": 36,
+        "issue_score": -0.5
+    }
+    },
+    //蓝白联票
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9348,
+        "fields": {
+            "candidate": 50001,
+            "issue": 32,
+            "issue_score": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9349,
+        "fields": {
+            "candidate": 50001,
+            "issue": 33,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9350,
+        "fields": {
+            "candidate": 50001,
+            "issue": 34,
+            "issue_score": 0
+    },
+},
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9351,
+        "fields": {
+            "candidate": 50001,
+            "issue": 35,
+            "issue_score": 0.15 
+        }
+    },
+        {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9352,
+        "fields": {
+            "candidate": 50001,
+            "issue": 36,
+            "issue_score": 0.4
+        }
+        },
+        //赵少康
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93481,
+            "fields": {
+                "candidate": 50000,
+                "issue": 32,
+                "issue_score": 0.95
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93491,
+            "fields": {
+                "candidate": 50000,
+                "issue": 33,
+                "issue_score": 0.95
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93501,
+            "fields": {
+                "candidate": 50000,
+                "issue": 34,
+                "issue_score": 0.55
+        },
+    },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93511,
+            "fields": {
+                "candidate": 50000,
+                "issue": 35,
+                "issue_score": 0.1
+            }
+        },
+            {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93521,
+            "fields": {
+                "candidate": 50000,
+                "issue": 36,
+                "issue_score": 0.5
+            }
+            },
+            //韩国瑜
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 934812,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 32,
+                    "issue_score": 0.95
+                }
+            },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 934912,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 33,
+                    "issue_score": 0.95
+                }
+            },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935013,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 34,
+                    "issue_score": -0.25
+            },
+        },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935114,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 35,
+                    "issue_score": 0
+                }
+            },
+                {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935215,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 36,
+                    "issue_score": 0.65
+                }
+                },
+                //柯志恩
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9348121,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 32,
+                        "issue_score": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9349121,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 33,
+                        "issue_score": -0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9350131,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 34,
+                        "issue_score": -0.15
+                },
+            },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9351141,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 35,
+                        "issue_score": 0.55
+                    }
+                },
+                    {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9352151,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 36,
+                        "issue_score": 0.42
+                    }
+                    },
+                    //赖佩霞
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93481211,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 32,
+                            "issue_score": 0.1
+                        }
+                    },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93491211,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 33,
+                            "issue_score": 0
+                        }
+                    },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93501311,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 34,
+                            "issue_score": 0.25
+                    },
+                },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93511411,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 35,
+                            "issue_score": 0.15
+                        }
+                    },
+                        {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93521511,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 36,
+                            "issue_score": 0.15
+                        }
+                        },
+                        //白蓝联票
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410110,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 32,
+                                "issue_score": -0.1
+                            }
+                        },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410111,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 33,
+                                "issue_score": 0
+                            }
+                        },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410112,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 34,
+                                "issue_score": 0
+                        },
+                    },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410113,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 35,
+                                "issue_score": 0.75
+                            }
+                        },
+                            {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410114,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 36,
+                                "issue_score": 0.25
+                            }
+                            },
+                            //吴欣盈
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241000,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 32,
+                                    "issue_score": 0
+                                }
+                            },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241001,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 33,
+                                    "issue_score": 0
+                                }
+                            },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241002,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 34,
+                                    "issue_score": 0
+                            },
+                           },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241003,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 35,
+                                    "issue_score": 0.75
+                                }
+                            },
+                                {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241004,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 36,
+                                    "issue_score": 0.25
+                                }
+                        }
+    ]
+
+campaignTrail_temp.candidate_state_multiplier_json = [
+       //台南市
+       {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25191,
+        "fields": {
+            "candidate": 2001557,
+            "state": 251,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25192,
+        "fields": {
+            "candidate": 2001591,
+            "state": 251,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25693,
+        "fields": {
+            "candidate": 2001622,
+            "state": 251,
+            "state_multiplier": 0.17
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25694,
+        "fields": {
+            "candidate": 2001653,
+            "state": 251,
+            "state_multiplier": 0.07
+        }
+    },
+    //嘉义县
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25691,
+        "fields": {
+            "candidate": 2001557,
+            "state": 256,
+            "state_multiplier": 0.28
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25692,
+        "fields": {
+            "candidate": 2001591,
+            "state": 256,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25693,
+        "fields": {
+            "candidate": 2001622,
+            "state": 256,
+            "state_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25694,
+        "fields": {
+            "candidate": 2001653,
+            "state": 256,
+            "state_multiplier": 0.07
+        }
+    },
+      //花莲县
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25591,
+        "fields": {
+            "candidate": 2001557,
+            "state": 255,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25592,
+        "fields": {
+            "candidate": 2001591,
+            "state": 255,
+            "state_multiplier": 0.366
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25593,
+        "fields": {
+            "candidate": 2001622,
+            "state": 255,
+            "state_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25594,
+        "fields": {
+            "candidate": 2001653,
+            "state": 255,
+            "state_multiplier": 0.1
+        }
+    },
+      //屏东
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25391,
+        "fields": {
+            "candidate": 2001557,
+            "state": 253,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25392,
+        "fields": {
+            "candidate": 2001591,
+            "state": 253,
+            "state_multiplier": 0.22
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25393,
+        "fields": {
+            "candidate": 2001622,
+            "state": 253,
+            "state_multiplier": 0.14
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25294,
+        "fields": {
+            "candidate": 2001653,
+            "state": 253,
+            "state_multiplier": 0.07
+        }
+    },
+    //高雄
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25291,
+        "fields": {
+            "candidate": 2001557,
+            "state": 252,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25292,
+        "fields": {
+            "candidate": 2001591,
+            "state": 252,
+            "state_multiplier": 0.22
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25293,
+        "fields": {
+            "candidate": 2001622,
+            "state": 252,
+            "state_multiplier": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25294,
+        "fields": {
+            "candidate": 2001653,
+            "state": 252,
+            "state_multiplier": 0.07
+        }
+    },
+    //台东
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252912,
+        "fields": {
+            "candidate": 2001557,
+            "state": 254,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252922,
+        "fields": {
+            "candidate": 2001591,
+            "state": 254,
+            "state_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252932,
+        "fields": {
+            "candidate": 2001622,
+            "state": 254,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252942,
+        "fields": {
+            "candidate": 2001653,
+            "state": 254,
+            "state_multiplier": 0.1
+        }
+    },
+        //嘉义市
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114514,
+            "fields": {
+                "candidate": 2001557,
+                "state": 257,
+                "state_multiplier": 0.28
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114515,
+            "fields": {
+                "candidate": 2001591,
+                "state": 257,
+                "state_multiplier": 0.23
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114516,
+            "fields": {
+                "candidate": 2001622,
+                "state": 257,
+                "state_multiplier": 0.15
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114517,
+            "fields": {
+                "candidate": 2001653,
+                "state": 257,
+                "state_multiplier": 0.05
+            }
+        },
+        //南投
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 566666,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 258,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 666666,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 258,
+                        "state_multiplier": 0.31
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 6666666,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 258,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 66666666,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 258,
+                        "state_multiplier": 0.08
+                    }
+                },
+                //彰化
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 114514123,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 260,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1145141234,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 260,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 11451414,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 260,
+                        "state_multiplier": 0.19
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 21412412,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 260,
+                        "state_multiplier": 0.06
+                    }
+                },
+                //云林
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1111,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 259,
+                        "state_multiplier": 0.32
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2222,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 259,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 3333,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 259,
+                        "state_multiplier": 0.19
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 4444,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 259,
+                        "state_multiplier": 0.04
+                    }
+                },
+                //澎湖
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 5555,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 261,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 6666,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 261,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 7777,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 261,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 8888,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 261,
+                        "state_multiplier": 0.05
+                    }
+                },
+                //台中
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412241,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 262,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412411,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 262,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412412,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 262,
+                        "state_multiplier": 0.22
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412511,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 262,
+                        "state_multiplier": 0.05
+                    }
+                },
+                //新竹县
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101001,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 264,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101002,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 264,
+                        "state_multiplier": 0.29
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101003,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 264,
+                        "state_multiplier": 0.26
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101004,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 264,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //新竹市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010012,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 265,
+                        "state_multiplier": 0.285
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010022,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 265,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010032,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 265,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010042,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 265,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //苗栗
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2194,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 266,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2195,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 266,
+                        "state_multiplier": 0.35
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2196,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 266,
+                        "state_multiplier": 0.22
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2197,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 266,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //新北市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12194,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 267,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12195,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 267,
+                        "state_multiplier": 0.26
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12196,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 267,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12197,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 267,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //台北市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 268,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 268,
+                        "state_multiplier": 0.34
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 268,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 268,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //桃园
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 269,
+                        "state_multiplier": 0.26
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 269,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 269,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 269,
+                        "state_multiplier": 0.13
+                    }
+                },
+                //基隆
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 270,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 270,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 270,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 270,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //金门
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19581,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 271,
+                        "state_multiplier": 0.05
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19582,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 271,
+                        "state_multiplier": 0.55
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19583,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 271,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19584,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 271,
+                        "state_multiplier": 0.15
+                    }
+                },         
+                 //宜兰
+                 {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195813,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 263,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195823,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 263,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195833,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 263,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195843,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 263,
+                        "state_multiplier": 0.08
+                    }
+                },       
+                  //连江
+                  {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195812,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 272,
+                        "state_multiplier": 0.05
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195822,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 272,
+                        "state_multiplier": 0.55
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195832,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 272,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195842,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 272,
+                        "state_multiplier": 0.15
+                    }
+                },      
+]
+
+
+campaignTrail_temp.answer_score_global_json = [
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 12767,
+        "fields": {
+            "answer": 12763,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.14
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 12770,
+        "fields": {
+            "answer": 12764,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 127701,
+        "fields": {
+            "answer": 12764,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 12773,
+        "fields": {
+            "answer": 12765,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.14
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13413,
+        "fields": {
+            "answer": 13408,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13415,
+        "fields": {
+            "answer": 13409,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950382,
+        "fields": {
+            "answer": 1950012,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950384,
+        "fields": {
+            "answer": 1950013,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950387,
+        "fields": {
+            "answer": 1950014,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950393,
+        "fields": {
+            "answer": 1950388,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950395,
+        "fields": {
+            "answer": 1950389,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950397,
+        "fields": {
+            "answer": 1950390,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950403,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950404,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950405,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950406,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950407,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.45
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950408,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950409,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.23
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950410,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950423,
+        "fields": {
+            "answer": 1950415,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950437,
+        "fields": {
+            "answer": 1950425,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950438,
+        "fields": {
+            "answer": 1950426,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950439,
+        "fields": {
+            "answer": 1950430,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950440,
+        "fields": {
+            "answer": 1950432,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950451,
+        "fields": {
+            "answer": 1950443,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.021
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950459,
+        "fields": {
+            "answer": 1950454,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950465,
+        "fields": {
+            "answer": 1950463,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950466,
+        "fields": {
+            "answer": 1950463,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950469,
+        "fields": {
+            "answer": 1950462,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950470,
+        "fields": {
+            "answer": 1950462,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950472,
+        "fields": {
+            "answer": 1950461,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950473,
+        "fields": {
+            "answer": 1950461,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950475,
+        "fields": {
+            "answer": 1950460,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950480,
+        "fields": {
+            "answer": 1950454,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950482,
+        "fields": {
+            "answer": 1950477,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.37
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950484,
+        "fields": {
+            "answer": 1950478,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.37
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950486,
+        "fields": {
+            "answer": 1950479,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.37
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950492,
+        "fields": {
+            "answer": 1950487,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950495,
+        "fields": {
+            "answer": 1950488,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950498,
+        "fields": {
+            "answer": 1950489,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950500,
+        "fields": {
+            "answer": 1950490,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950506,
+        "fields": {
+            "answer": 1950502,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.0354
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950508,
+        "fields": {
+            "answer": 1950503,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.005
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950516,
+        "fields": {
+            "answer": 1950504,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.0354
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950528,
+        "fields": {
+            "answer": 1950525,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950531,
+        "fields": {
+            "answer": 1950524,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950533,
+        "fields": {
+            "answer": 1950523,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950539,
+        "fields": {
+            "answer": 1950535,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950541,
+        "fields": {
+            "answer": 1950521,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950542,
+        "fields": {
+            "answer": 1950521,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": 5.3
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950545,
+        "fields": {
+            "answer": 1950536,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950547,
+        "fields": {
+            "answer": 1950537,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950548,
+        "fields": {
+            "answer": 1950537,
+            "candidate": 2001591,
+            "affected_candidate": 1950365,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950552,
+        "fields": {
+            "answer": 1950550,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950595,
+        "fields": {
+            "answer": 1950593,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950601,
+        "fields": {
+            "answer": 1950597,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950606,
+        "fields": {
+            "answer": 1950600,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950622,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950623,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950624,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.17
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950626,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950627,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950629,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950635,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950636,
+        "fields": {
+            "answer": 1950615,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950637,
+        "fields": {
+            "answer": 1950615,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950638,
+        "fields": {
+            "answer": 1950579,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950639,
+        "fields": {
+            "answer": 1950580,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950640,
+        "fields": {
+            "answer": 1950581,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950641,
+        "fields": {
+            "answer": 1950582,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950642,
+        "fields": {
+            "answer": 1950616,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950644,
+        "fields": {
+            "answer": 1950617,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950654,
+        "fields": {
+            "answer": 1950647,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950655,
+        "fields": {
+            "answer": 1950648,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950656,
+        "fields": {
+            "answer": 1950649,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950663,
+        "fields": {
+            "answer": 1950658,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950665,
+        "fields": {
+            "answer": 1950659,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 2950665,
+        "fields": {
+            "answer": 2950659,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 2950666,
+        "fields": {
+            "answer": 2950659,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950668,
+        "fields": {
+            "answer": 1950660,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.056
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950674,
+        "fields": {
+            "answer": 1950658,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.14
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950675,
+        "fields": {
+            "answer": 1950659,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.14
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950676,
+        "fields": {
+            "answer": 1950660,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.14
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950677,
+        "fields": {
+            "answer": 1950670,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950678,
+        "fields": {
+            "answer": 1950671,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950681,
+        "fields": {
+            "answer": 1950600,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950682,
+        "fields": {
+            "answer": 1950599,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950684,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950685,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950686,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950698,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950699,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950700,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950701,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950702,
+        "fields": {
+            "answer": 1950692,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950703,
+        "fields": {
+            "answer": 1950692,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950704,
+        "fields": {
+            "answer": 1950693,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950705,
+        "fields": {
+            "answer": 1950693,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950729,
+        "fields": {
+            "answer": 1950721,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950730,
+        "fields": {
+            "answer": 1950721,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950731,
+        "fields": {
+            "answer": 1950722,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950732,
+        "fields": {
+            "answer": 1950722,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950733,
+        "fields": {
+            "answer": 1950723,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950734,
+        "fields": {
+            "answer": 1950723,
+            "candidate": 2001591,
+            "affected_candidate": 0,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950735,
+        "fields": {
+            "answer": 1950724,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950736,
+        "fields": {
+            "answer": 1950724,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950742,
+        "fields": {
+            "answer": 1950737,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950744,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950745,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950748,
+        "fields": {
+            "answer": 1950739,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950749,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950750,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950758,
+        "fields": {
+            "answer": 1950751,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950759,
+        "fields": {
+            "answer": 1950755,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950760,
+        "fields": {
+            "answer": 1950751,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950761,
+        "fields": {
+            "answer": 1950755,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950768,
+        "fields": {
+            "answer": 1950766,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950769,
+        "fields": {
+            "answer": 1950766,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950772,
+        "fields": {
+            "answer": 1950765,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950773,
+        "fields": {
+            "answer": 1950765,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950775,
+        "fields": {
+            "answer": 1950764,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950776,
+        "fields": {
+            "answer": 1950764,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950777,
+        "fields": {
+            "answer": 1950737,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950778,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950779,
+        "fields": {
+            "answer": 1950739,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950780,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950786,
+        "fields": {
+            "answer": 1950784,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950787,
+        "fields": {
+            "answer": 1950784,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950791,
+        "fields": {
+            "answer": 1950782,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950792,
+        "fields": {
+            "answer": 1950782,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950793,
+        "fields": {
+            "answer": 1950783,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950794,
+        "fields": {
+            "answer": 1950781,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950795,
+        "fields": {
+            "answer": 1950781,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950801,
+        "fields": {
+            "answer": 1950796,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950802,
+        "fields": {
+            "answer": 1950796,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950806,
+        "fields": {
+            "answer": 1950797,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950810,
+        "fields": {
+            "answer": 1950799,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950811,
+        "fields": {
+            "answer": 1950798,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950812,
+        "fields": {
+            "answer": 1950798,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950820,
+        "fields": {
+            "answer": 1950818,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950823,
+        "fields": {
+            "answer": 1950814,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950826,
+        "fields": {
+            "answer": 1950815,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950827,
+        "fields": {
+            "answer": 1950815,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.034
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950830,
+        "fields": {
+            "answer": 1950816,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950831,
+        "fields": {
+            "answer": 1950816,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950835,
+        "fields": {
+            "answer": 1950817,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950836,
+        "fields": {
+            "answer": 1950814,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950844,
+        "fields": {
+            "answer": 1950838,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950848,
+        "fields": {
+            "answer": 1950840,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.021
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950855,
+        "fields": {
+            "answer": 1950852,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950860,
+        "fields": {
+            "answer": 1950858,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950861,
+        "fields": {
+            "answer": 1950853,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950883,
+        "fields": {
+            "answer": 1950863,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950884,
+        "fields": {
+            "answer": 1950864,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950885,
+        "fields": {
+            "answer": 1950865,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950886,
+        "fields": {
+            "answer": 1950866,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950887,
+        "fields": {
+            "answer": 1950863,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950888,
+        "fields": {
+            "answer": 1950864,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950906,
+        "fields": {
+            "answer": 1950903,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950909,
+        "fields": {
+            "answer": 1950901,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950925,
+        "fields": {
+            "answer": 1950914,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950930,
+        "fields": {
+            "answer": 1950928,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950931,
+        "fields": {
+            "answer": 1950928,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950938,
+        "fields": {
+            "answer": 1950936,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950939,
+        "fields": {
+            "answer": 1950936,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.059
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950941,
+        "fields": {
+            "answer": 1950935,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950942,
+        "fields": {
+            "answer": 1950935,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950944,
+        "fields": {
+            "answer": 1950934,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950945,
+        "fields": {
+            "answer": 1950934,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950949,
+        "fields": {
+            "answer": 1950946,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950950,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950951,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -5
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_issue_json = [
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 12768,
+        "fields": {
+            "answer": 12763,
+            "issue": 32,
+            "issue_score": 0.15,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 12771,
+        "fields": {
+            "answer": 12764,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 12774,
+        "fields": {
+            "answer": 12765,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950385,
+        "fields": {
+            "answer": 1950013,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950446,
+        "fields": {
+            "answer": 1950441,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.155
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950448,
+        "fields": {
+            "answer": 1950442,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950467,
+        "fields": {
+            "answer": 1950463,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950476,
+        "fields": {
+            "answer": 1950460,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950493,
+        "fields": {
+            "answer": 1950487,
+            "issue": 35,
+            "issue_score": -0.15,
+            "issue_importance": 0.3
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950496,
+        "fields": {
+            "answer": 1950488,
+            "issue": 35,
+            "issue_score": -0.15,
+            "issue_importance": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950499,
+        "fields": {
+            "answer": 1950489,
+            "issue": 35,
+            "issue_score": -0.15,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950501,
+        "fields": {
+            "answer": 1950490,
+            "issue": 35,
+            "issue_score": -0.1,
+            "issue_importance": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950527,
+        "fields": {
+            "answer": 1950525,
+            "issue": 32,
+            "issue_score": -0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950532,
+        "fields": {
+            "answer": 1950524,
+            "issue": 32,
+            "issue_score": -0.06,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950534,
+        "fields": {
+            "answer": 1950523,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950540,
+        "fields": {
+            "answer": 1950535,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950546,
+        "fields": {
+            "answer": 1950536,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950549,
+        "fields": {
+            "answer": 1950537,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950553,
+        "fields": {
+            "answer": 1950550,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950555,
+        "fields": {
+            "answer": 1950550,
+            "issue": 36,
+            "issue_score": 0.12,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950584,
+        "fields": {
+            "answer": 1950579,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950587,
+        "fields": {
+            "answer": 1950580,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950588,
+        "fields": {
+            "answer": 1950580,
+            "issue": 36,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950589,
+        "fields": {
+            "answer": 1950581,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950591,
+        "fields": {
+            "answer": 1950582,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950592,
+        "fields": {
+            "answer": 1950582,
+            "issue": 36,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950596,
+        "fields": {
+            "answer": 1950593,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950602,
+        "fields": {
+            "answer": 1950597,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950604,
+        "fields": {
+            "answer": 1950599,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950607,
+        "fields": {
+            "answer": 1950600,
+            "issue": 34,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950608,
+        "fields": {
+            "answer": 1950600,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950625,
+        "fields": {
+            "answer": 1950609,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950628,
+        "fields": {
+            "answer": 1950610,
+            "issue": 32,
+            "issue_score": 0.02,
+            "issue_importance": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950630,
+        "fields": {
+            "answer": 1950611,
+            "issue": 32,
+            "issue_score": 0.03,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950631,
+        "fields": {
+            "answer": 1950559,
+            "issue": 33,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950632,
+        "fields": {
+            "answer": 1950560,
+            "issue": 33,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950633,
+        "fields": {
+            "answer": 1950561,
+            "issue": 33,
+            "issue_score": -0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950634,
+        "fields": {
+            "answer": 1950513,
+            "issue": 33,
+            "issue_score": -0.03,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950643,
+        "fields": {
+            "answer": 1950616,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950645,
+        "fields": {
+            "answer": 1950617,
+            "issue": 32,
+            "issue_score": 0.02,
+            "issue_importance": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950653,
+        "fields": {
+            "answer": 1950647,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950657,
+        "fields": {
+            "answer": 1950649,
+            "issue": 32,
+            "issue_score": 0.15,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950662,
+        "fields": {
+            "answer": 1950658,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950666,
+        "fields": {
+            "answer": 1950659,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950669,
+        "fields": {
+            "answer": 1950660,
+            "issue": 36,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950679,
+        "fields": {
+            "answer": 1950671,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950680,
+        "fields": {
+            "answer": 1950670,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950762,
+        "fields": {
+            "answer": 1950751,
+            "issue": 35,
+            "issue_score": 0.2,
+            "issue_importance": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950763,
+        "fields": {
+            "answer": 1950755,
+            "issue": 35,
+            "issue_score": 0.2,
+            "issue_importance": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950770,
+        "fields": {
+            "answer": 1950766,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950804,
+        "fields": {
+            "answer": 1950796,
+            "issue": 35,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950805,
+        "fields": {
+            "answer": 1950797,
+            "issue": 35,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950809,
+        "fields": {
+            "answer": 1950799,
+            "issue": 35,
+            "issue_score": -0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950813,
+        "fields": {
+            "answer": 1950798,
+            "issue": 35,
+            "issue_score": -0.15,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950821,
+        "fields": {
+            "answer": 1950818,
+            "issue": 32,
+            "issue_score": 0.015,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950824,
+        "fields": {
+            "answer": 1950814,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950829,
+        "fields": {
+            "answer": 1950816,
+            "issue": 35,
+            "issue_score": 0.12,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950833,
+        "fields": {
+            "answer": 1950817,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950834,
+        "fields": {
+            "answer": 1950817,
+            "issue": 36,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950846,
+        "fields": {
+            "answer": 1950839,
+            "issue": 32,
+            "issue_score": 0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950850,
+        "fields": {
+            "answer": 1950841,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950857,
+        "fields": {
+            "answer": 1950852,
+            "issue": 32,
+            "issue_score": -0.04,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950862,
+        "fields": {
+            "answer": 1950853,
+            "issue": 32,
+            "issue_score": -0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950897,
+        "fields": {
+            "answer": 1950891,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950898,
+        "fields": {
+            "answer": 1950892,
+            "issue": 32,
+            "issue_score": 0.07,
+            "issue_importance": 0.11
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950899,
+        "fields": {
+            "answer": 1950893,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950910,
+        "fields": {
+            "answer": 1950902,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950917,
+        "fields": {
+            "answer": 1950912,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950919,
+        "fields": {
+            "answer": 1950913,
+            "issue": 35,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950921,
+        "fields": {
+            "answer": 1950913,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950924,
+        "fields": {
+            "answer": 1950915,
+            "issue": 33,
+            "issue_score": -0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950926,
+        "fields": {
+            "answer": 1950914,
+            "issue": 32,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950932,
+        "fields": {
+            "answer": 1950928,
+            "issue": 32,
+            "issue_score": 0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950948,
+        "fields": {
+            "answer": 1950946,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_state_json = [
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950420,
+        "fields": {
+            "answer": 1950412,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950421,
+        "fields": {
+            "answer": 1950413,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950422,
+        "fields": {
+            "answer": 1950414,
+            "state": 269,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950428,
+        "fields": {
+            "answer": 1950425,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950434,
+        "fields": {
+            "answer": 1950426,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950435,
+        "fields": {
+            "answer": 1950430,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950436,
+        "fields": {
+            "answer": 1950432,
+            "state": 262,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950452,
+        "fields": {
+            "answer": 1950444,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950453,
+        "fields": {
+            "answer": 1950444,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950509,
+        "fields": {
+            "answer": 1950503,
+            "state": 264,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950510,
+        "fields": {
+            "answer": 1950503,
+            "state": 266,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950511,
+        "fields": {
+            "answer": 1950503,
+            "state": 269,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950512,
+        "fields": {
+            "answer": 1950503,
+            "state": 265,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950517,
+        "fields": {
+            "answer": 1950513,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950518,
+        "fields": {
+            "answer": 1950513,
+            "state": 260,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950519,
+        "fields": {
+            "answer": 1950513,
+            "state": 259,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950520,
+        "fields": {
+            "answer": 1950513,
+            "state": 255,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950563,
+        "fields": {
+            "answer": 1950558,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950564,
+        "fields": {
+            "answer": 1950558,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950565,
+        "fields": {
+            "answer": 1950558,
+            "state": 270,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950568,
+        "fields": {
+            "answer": 1950559,
+            "state": 262,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950569,
+        "fields": {
+            "answer": 1950559,
+            "state": 258,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950570,
+        "fields": {
+            "answer": 1950559,
+            "state": 260,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950572,
+        "fields": {
+            "answer": 1950560,
+            "state": 256,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950573,
+        "fields": {
+            "answer": 1950560,
+            "state": 257,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950575,
+        "fields": {
+            "answer": 1950561,
+            "state": 253,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950576,
+        "fields": {
+            "answer": 1950561,
+            "state": 251,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950577,
+        "fields": {
+            "answer": 1950561,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950871,
+        "fields": {
+            "answer": 1950863,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950872,
+        "fields": {
+            "answer": 1950863,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950873,
+        "fields": {
+            "answer": 1950864,
+            "state": 251,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950874,
+        "fields": {
+            "answer": 1950864,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.034
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950875,
+        "fields": {
+            "answer": 1950865,
+            "state": 264,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950876,
+        "fields": {
+            "answer": 1950865,
+            "state": 265,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950877,
+        "fields": {
+            "answer": 1950865,
+            "state": 269,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950878,
+        "fields": {
+            "answer": 1950865,
+            "state": 266,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950879,
+        "fields": {
+            "answer": 1950866,
+            "state": 254,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950880,
+        "fields": {
+            "answer": 1950866,
+            "state": 263,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950881,
+        "fields": {
+            "answer": 1950866,
+            "state": 255,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950882,
+        "fields": {
+            "answer": 1950866,
+            "state": 253,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950889,
+        "fields": {
+            "answer": 1950560,
+            "state": 259,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.06
+        }
+    },
+
+]
+
+campaignTrail_temp.answer_feedback_json = [
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950381,
+        "fields": {
+            "answer": 1950012,
+            "candidate": 2001591,
+            "answer_feedback": "Over the past few months, you have consistently employed vague municipal rhetoric when addressing the media. Whether it's to manage troublesome press interactions or conceal your true intentions, you should start preparing for the presidential election sooner rather than later."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950383,
+        "fields": {
+            "answer": 1950013,
+            "candidate": 2001591,
+            "answer_feedback": "Even though you claim to be focusing on municipal affairs at the moment, your statement 'Regardless of any challenges' has been interpreted by the media as a precursor hinting at your intention to run for president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950386,
+        "fields": {
+            "answer": 1950014,
+            "candidate": 2001591,
+            "answer_feedback": "While you consistently emphasize your current focus on municipal affairs, a presidential election demands a significant amount of time and energy. Do you believe you can effectively balance your responsibilities in local governance while engaging in a campaign?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950392,
+        "fields": {
+            "answer": 1950388,
+            "candidate": 2001591,
+            "answer_feedback": "On May 17th, Terry Gou was drafted as the KMT's presidential candidate, and your qualification for the primary elections came to an end. In the time ahead, you can now focus exclusively on handling municipal affairs in New Taipei City."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950394,
+        "fields": {
+            "answer": 1950389,
+            "candidate": 2001591,
+            "answer_feedback": "While polite words may suggest otherwise, it's worth noting that you currently enjoy a leading advantage in the polls, and Terry Gou has yet to fully regain his Kuomintang membership."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950396,
+        "fields": {
+            "answer": 1950390,
+            "candidate": 2001591,
+            "answer_feedback": "The media spotlight has now turned towards you, with headlines from China Times and United Daily News: 'Mayor Hou Youyi Officially Announces Presidential Bid?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950401,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "answer_feedback": "Understood. It seems you have chosen to continue focusing on municipal affairs, but I hope you won't acquire a reputation for being indifferent to party matters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950402,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "answer_feedback": "Terry Gou is very grateful for your assistance and promises that he will bring down the Democratic Progressive Party. He assures you a position in the cabinet once elected."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950416,
+        "fields": {
+            "answer": 1950415,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950417,
+        "fields": {
+            "answer": 1950414,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950418,
+        "fields": {
+            "answer": 1950413,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950419,
+        "fields": {
+            "answer": 1950412,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950427,
+        "fields": {
+            "answer": 1950425,
+            "candidate": 2001591,
+            "answer_feedback": "You spent the final day in your hometown. Wishing you good luck and hoping that you will be elected as the president tomorrow!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950429,
+        "fields": {
+            "answer": 1950426,
+            "candidate": 2001591,
+            "answer_feedback": "On Ketagalan Boulevard, amidst the bustling crowd of voters hoping for a political change, best of luck tomorrow!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950431,
+        "fields": {
+            "answer": 1950430,
+            "candidate": 2001591,
+            "answer_feedback": "You held the final event near the military dependents' village next to Kaohsiung Harbor, hoping that this would impact Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950433,
+        "fields": {
+            "answer": 1950432,
+            "candidate": 2001591,
+            "answer_feedback": "Absolutely, Taichung City serves as the dividing line between northern and southern Taiwan, making it a crucial region. Wishing you good luck!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950445,
+        "fields": {
+            "answer": 1950441,
+            "candidate": 2001591,
+            "answer_feedback": "\nYou are rallying support from mayors across the country, and with the impressive lineup of 14+1 KMT-supported mayors this year, it will be a significant boost to your campaign."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950447,
+        "fields": {
+            "answer": 1950442,
+            "candidate": 2001591,
+            "answer_feedback": "Building good relationships with legislators is also a wise choice. If elected, you will rely on their support in the Legislative Yuan. Regional legislators can also positively influence your campaign in different areas."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950449,
+        "fields": {
+            "answer": 1950443,
+            "candidate": 2001591,
+            "answer_feedback": "In your interview on TVBS's Situation Room with Zhao Shao-kang, you spoke confidently and it brought you some media exposure. You also appeared on this program before the 2018 mayoral election.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950450,
+        "fields": {
+            "answer": 1950444,
+            "candidate": 2001591,
+            "answer_feedback": "Your participation in the completion events of various construction projects and local festivals in New Taipei City and Taipei City has increased your exposure and familiarity among the voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950458,
+        "fields": {
+            "answer": 1950454,
+            "candidate": 2001591,
+            "answer_feedback": "Terry Gou stated on Facebook: 'Mayor Hou is the most solid popular support within the Kuomintang. It is only natural and the best choice for him to take on greater responsibilities. He will keep his promises and exert utmost effort to support Mayor Hou's victory'."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950464,
+        "fields": {
+            "answer": 1950463,
+            "candidate": 2001591,
+            "answer_feedback": "\nFocusing your energy primarily on the DPP can shape a blue-green confrontation atmosphere, but be cautious. Balance your critiques, as the public is weary of excessive attacks rather than positive campaigning."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950468,
+        "fields": {
+            "answer": 1950462,
+            "candidate": 2001591,
+            "answer_feedback": "As now, Ko Wen-je has not supported your request. He mentioned that it is difficult to cooperate due to differences in policy and ideology between him and the Kuomintang."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950471,
+        "fields": {
+            "answer": 1950461,
+            "candidate": 2001591,
+            "answer_feedback": "Initiating infighting within the opposition camp this early is not good news. It will only benefit the DPP and create a negative impression of the KMT, portraying it as solely focused on attacks without a clear vision.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950474,
+        "fields": {
+            "answer": 1950460,
+            "candidate": 2001591,
+            "answer_feedback": "Currently, this strategy ensures the independence of your party. However, there will come a day when you need to discuss collaboration against the DPP, so please be prepared."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950481,
+        "fields": {
+            "answer": 1950477,
+            "candidate": 2001591,
+            "answer_feedback": "\nUnfortunately, parents cannot wait until the slow administrative and police investigations conclude. Taking advantage of the situation, DPP legislators, along with some parents, held a press conference attacking the efficiency of Mayor Hou's government in handling the case. Your Polls have plummeted as if falling from a skyscraper."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950483,
+        "fields": {
+            "answer": 1950478,
+            "candidate": 2001591,
+            "answer_feedback": "With children claiming they were fed 'colorful potions,' and some showing signs of barbital, awaiting confirmation through hair tests, the credibility of the city government has been damaged. It is essential to conduct a thorough investigation into other kindergartens to prevent any potential issues. This incident has left parents across Taiwan concerned."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950485,
+        "fields": {
+            "answer": 1950479,
+            "candidate": 2001591,
+            "answer_feedback": "You and your city government are facing severe criticism for this incident. Parents are questioning why they reported the case in mid-May and attempted to contact through the mayor's mailbox, but did not receive a response from the government at that time."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950491,
+        "fields": {
+            "answer": 1950487,
+            "candidate": 2001591,
+            "answer_feedback": "Your response at National Chengchi University was disliked by young people; they feel you didn't directly answer the questions. Your standard-style responses are derogatorily referred to as HOHOGPT."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950494,
+        "fields": {
+            "answer": 1950488,
+            "candidate": 2001591,
+            "answer_feedback": "The video of your evasive answers at National Chengchi University has been widely circulated on various news media platforms, drawing a lot of mockery from young people. Even legislator Ko Chih-en believes that this has caused significant damage to your image.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950497,
+        "fields": {
+            "answer": 1950490,
+            "candidate": 2001591,
+            "answer_feedback": "\nBefore to this, you spoke about housing prices for ten minutes, and even your more normal responses were drowned out by online ridicule and the attacks from opponents on the kindergarten incident."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950505,
+        "fields": {
+            "answer": 1950502,
+            "candidate": 2001591,
+            "answer_feedback": "Lien Chan, despite his 87-year-old frame, has released an open letter in his own name, urging all members of the Kuomintang to support Hou You-yi."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950507,
+        "fields": {
+            "answer": 1950503,
+            "candidate": 2001591,
+            "answer_feedback": "\nWu Poh-hsiung, leaning on his cane, strongly supports Hou You-yi, referring to him as \"brothers in adversity.\" He mentioned that the more people get to know him, the more they like him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950514,
+        "fields": {
+            "answer": 1950504,
+            "candidate": 2001591,
+            "answer_feedback": "Ma Ying-jeou has agreed to assist you, and he will recruit a highly valuable individual to support your campaign. As for the specific person, it cannot be disclosed at this moment."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950515,
+        "fields": {
+            "answer": 1950513,
+            "candidate": 2001591,
+            "answer_feedback": "Speaker Wang Jin-ping has successfully organized a legislative support group for you. At the very least, you have the support of the party organization and legislative members, and they have decided to fully support Hou You-yi in the upcoming campaign."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950522,
+        "fields": {
+            "answer": 1950521,
+            "candidate": 2001591,
+            "answer_feedback": "With this news, the media has begun discussing the impact and assistance that 'Little Knife King' (金小刀) might bring to your campaign. After all, he played a crucial role in helping Ma defeat Tsai in 2012, and at that time, Tsai was already a formidable opponent who would become the president in 2016."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950526,
+        "fields": {
+            "answer": 1950525,
+            "candidate": 2001591,
+            "answer_feedback": "You might think it's a clever move, but in reality, the keen-eyed media has caught onto your subtle actions. They interpret your move of pulling a chair next to Han Kuo-yu as a deliberate attempt to cozy up to him, and this has been met with mockery."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950529,
+        "fields": {
+            "answer": 1950523,
+            "candidate": 2001591,
+            "answer_feedback": "While Han Kuo-yu accepted your apology, Han's supporters are mistakenly spreading a video in which you stated in 2019 that you shouldn't leave the mayor position to run for president. This is considered a sarcastic reference to Han Kuo-yu."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950530,
+        "fields": {
+            "answer": 1950524,
+            "candidate": 2001591,
+            "answer_feedback": "As expected, Han Kuo-yu's supporters are interpreting your actions in an exaggerated manner and are determined not to support you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950538,
+        "fields": {
+            "answer": 1950535,
+            "candidate": 2001591,
+            "answer_feedback": "\nIt seems like your campaign has finally returned to the right track. Many people find it difficult to accept KMT candidates who do not adhere to the 1992 Consensus, while others simply do not accept the consensus at all."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950543,
+        "fields": {
+            "answer": 1950537,
+            "candidate": 2001591,
+            "answer_feedback": "Businessmen worship Guan Gong just to seek his blessings for them to earn more money."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950544,
+        "fields": {
+            "answer": 1950536,
+            "candidate": 2001591,
+            "answer_feedback": "There are several nuclear power plants in New Taipei, However, due to concerns about safety, you have not allowed them to insert nuclear fuel rods, and there is no particularly specific and feasible plan for nuclear waste."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950551,
+        "fields": {
+            "answer": 1950550,
+            "candidate": 2001591,
+            "answer_feedback": "After this, a portion of Han's supporters has shifted their support towards you, solidifying unity within the party!However, if you need them to come back completely, this is far from enough."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950562,
+        "fields": {
+            "answer": 1950558,
+            "candidate": 2001591,
+            "answer_feedback": "Strengthening our base is always essential, but we must be cautious as Ko Wen-je and Terry Gou may divert crucial pan-blue votes!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950566,
+        "fields": {
+            "answer": 1950559,
+            "candidate": 2001591,
+            "answer_feedback": "\nCapturing the crucial central region is indeed a priority, especially focusing on Changhua, where a significant number of Minnan people reside. You might have a good chance to perform well there!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950571,
+        "fields": {
+            "answer": 1950560,
+            "candidate": 2001591,
+            "answer_feedback": "It seems like you must secure victory in your hometown; otherwise, it might not look good. At least ensure that Puzi City stays blue, alright?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950574,
+        "fields": {
+            "answer": 1950561,
+            "candidate": 2001591,
+            "answer_feedback": "Although holding a KMT membership in the south often means not winning, your southern identity and local Taiwanese flavor could work in your favor."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950578,
+        "fields": {
+            "answer": 1950489,
+            "candidate": 2001591,
+            "answer_feedback": "Angry students demand direct answers from you... Shifting topics here is not a good move."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950583,
+        "fields": {
+            "answer": 1950579,
+            "candidate": 2001591,
+            "answer_feedback": "The DPP government indeed lacks effective measures against fraud, and their anti-fraud task force is seen as a waste of time and money. However, it remains questionable how many votes you can sway on this issue."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950585,
+        "fields": {
+            "answer": 1950580,
+            "candidate": 2001591,
+            "answer_feedback": "Since 2022, the military threat from the mainland towards Taiwan has intensified. The DPP government, however, has yet to proactively ease the situation. Nevertheless, this can stir up the green base and anti-China sentiments."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950586,
+        "fields": {
+            "answer": 1950581,
+            "candidate": 2001591,
+            "answer_feedback": "While the digital development department, led by Tang Feng, is widely seen as a failure, the current government is reluctant to replace him. Moreover, this issue is not a top concern for the voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950590,
+        "fields": {
+            "answer": 1950582,
+            "candidate": 2001591,
+            "answer_feedback": "This strategy aims to strengthen your deep blue support base. However, many green supporters in Taiwan see CTiTV as pro-China media that could undermine Taiwan's free and democratic system."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950594,
+        "fields": {
+            "answer": 1950593,
+            "candidate": 2001591,
+            "answer_feedback": "death penalty is a sensitive point for the DPP. They have to moderate their stance on this issue. They might argue that Taiwan has not abolished the death penalty, but the number of executions during the DPP's term is significantly lower than during Ma Ying-jeou's presidency."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950598,
+        "fields": {
+            "answer": 1950597,
+            "candidate": 2001591,
+            "answer_feedback": "DPP criticizes your approach, claiming that it aims to return to the era of one-party rule, and they argue that there would be no oversight for the SPD. However, this is undoubtedly well-received among supporters of the blue camp!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950603,
+        "fields": {
+            "answer": 1950599,
+            "candidate": 2001591,
+            "answer_feedback": "This is your attempt to attract young people, but it doesn't seem to be effective. All candidates support the construction of public housing and a property hoarding tax, so it may not have a unique appeal."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950605,
+        "fields": {
+            "answer": 1950600,
+            "candidate": 2001591,
+            "answer_feedback": "on this issue, the KMT and DPP have completely opposite policies, with significant differences. Nuclear power also offers the advantage of generating electricity at a lower cost."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950612,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "answer_feedback": "Hey, isn't your attack a bit too much? You might be angry with him, but opposition voters don't want to see more attacks and divisions. This will only help Ko Wen-je gain more support."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950613,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "answer_feedback": "These are empty words and useless statements; Terry Gou has already announced his independent candidacy, and he won't stop now.\n\n\n\n\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950614,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "answer_feedback": "This is a very interesting advertisement that has caught the media's attention. Many believe that you released this video to satirize Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950618,
+        "fields": {
+            "answer": 1950615,
+            "candidate": 2001591,
+            "answer_feedback": "This is a favorable proposal for you, but it's evident that TPP won't accept it as their party members and support base are lower than yours. Anyway, you've tossed the ball back to them."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950620,
+        "fields": {
+            "answer": 1950616,
+            "candidate": 2001591,
+            "answer_feedback": "While what you say is true, it might create an image of you overpowering a smaller party, and TPP supporters may perceive you as timid, hiding behind the strength of the KMT."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950621,
+        "fields": {
+            "answer": 1950617,
+            "candidate": 2001591,
+            "answer_feedback": "Certainly, negotiations will continue, but you must reach an agreement before November 24th; otherwise, this election will turn into a three-way competition!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950650,
+        "fields": {
+            "answer": 1950649,
+            "candidate": 2001591,
+            "answer_feedback": "\nCompared to Vice President Lai Ching-te, you have indeed met with more important figures. This will be helpful for you and add more points to your international diplomatic efforts."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950651,
+        "fields": {
+            "answer": 1950647,
+            "candidate": 2001591,
+            "answer_feedback": "\nThree Principles of the People encompass nationalism, democracy, and people's livelihood. However, it also has a complex historical relationship with by the people, for the people.and of the people.Unfortunately, in modern times, few Taiwanese can comprehend your political discourse."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950652,
+        "fields": {
+            "answer": 1950648,
+            "candidate": 2001591,
+            "answer_feedback": "In November 1997, when criminals broke into the home of a South African military attaché and kidnapped his entire family, you helped rescue the baby. The infant, who was in your arms back then, has grown up, touching the hearts of many."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950661,
+        "fields": {
+            "answer": 1950658,
+            "candidate": 2001591,
+            "answer_feedback": "Han Kuo-yu's endorsement of you will be remembered by his fans, and the vast majority of them have already decided to forgive your actions and return to the KMT."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950664,
+        "fields": {
+            "answer": 1950659,
+            "candidate": 2001591,
+            "answer_feedback": "This can enhance Mayor Hou's image in terms of law and order, helping boost his scores in public safety. It will contribute to an improvement in Mayor Hou You-yi's standings in the polls."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950667,
+        "fields": {
+            "answer": 1950660,
+            "candidate": 2001591,
+            "answer_feedback": "Stirring up hatred against the DPP and instilling fear of war is a common tactic. However, here, you mentioned that Mayor Hou You-yi will unite more people who believe in these ideas around him!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950672,
+        "fields": {
+            "answer": 1950670,
+            "candidate": 2001591,
+            "answer_feedback": "From now on, polls will begin to assess your specific data. This will determine the fate of Taiwan. Good luck, Mayor Hou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950673,
+        "fields": {
+            "answer": 1950671,
+            "candidate": 2001591,
+            "answer_feedback": "From now on, polls will begin to assess your specific data. This will determine the fate of Taiwan. Good luck, Mayor Hou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950694,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "answer_feedback": "Tremble, Lai Ching-te, for the opposition alliance is united! President Hou You-yi, hello! Vice President Ko Wen-je, hello!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950695,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "answer_feedback": "After calculations by polling experts, it is not surprising that you emerge victorious and become the presidential candidate, with Ko Wen-je as your running mate for the vice presidency. On January 13th next year, you have a high likelihood of winning!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950696,
+        "fields": {
+            "answer": 1950692,
+            "candidate": 2001591,
+            "answer_feedback": "Damn... Under the interference of Ko Wen-je, his staff, and family, on the 18th, TPP's polling experts suggested excluding all indoor phone polls, and the margin of error in other polls became a contentious issue... "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950697,
+        "fields": {
+            "answer": 1950693,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je's supporters and TPP immediately started spreading online that the margin of error the KMT needs to concede is not the commonly perceived 3% but rather a range of plus or minus 3%. This implies that the KMT is asking Ko Wen-je to concede a margin of error of 6%."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950725,
+        "fields": {
+            "answer": 1950721,
+            "candidate": 2001591,
+            "answer_feedback": "It seems there's a big problem... Both sides are in constant dispute over the margin of error and which poll each side won. No decision was made on the 18th... Is this reaching a breaking point?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950726,
+        "fields": {
+            "answer": 1950722,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je's supporters and TPP immediately started spreading online that the margin of error the KMT needs to concede is not the commonly perceived 3% but rather a range of plus or minus 3%. This implies that the KMT is asking Ko Wen-je to concede a margin of error of 6%."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950727,
+        "fields": {
+            "answer": 1950723,
+            "candidate": 2001591,
+            "answer_feedback": "It seems there's a big problem... Both sides are in constant dispute over the margin of error and which poll each side won. No decision was made on the 18th... Is this reaching a breaking point?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950728,
+        "fields": {
+            "answer": 1950724,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je's supporters and TPP immediately started spreading online that the margin of error the KMT needs to concede is not the commonly perceived 3% but rather a range of plus or minus 3%. This implies that the KMT is asking Ko Wen-je to concede a margin of error of 6%."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950741,
+        "fields": {
+            "answer": 1950737,
+            "candidate": 2001591,
+            "answer_feedback": "Ko agrees but immediately counterattacks, stating that revealing private conversations is something only internet trolls and unscrupulous media outlets would do. Fortunately, this ensures Terry Gou's withdrawal as they announce that he will not register as a presidential candidate."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950743,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "answer_feedback": "Regardless of how you explain it, it's too late. Joint tickets have already failed since the time when the polls became controversial."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950746,
+        "fields": {
+            "answer": 1950739,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je refuses to withdraw from the election, declaring that as long as his supporters don't give up, he won't either. The only consolation is that Terry Gou has withdrawn from the election and stated that he will not continue to participate."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950747,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "answer_feedback": "both Ko Wen-je and Gou believe they have the right to independently continue their candidacies. Despite Gou's low polling numbers, he still managed to gather 940,000 citizen signatures. With the situation completely collapsing, you might need to prepare for a concession speech."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950756,
+        "fields": {
+            "answer": 1950751,
+            "candidate": 2001591,
+            "answer_feedback": "Han Kuo-yu might have originally prepared to become the President of the Legislative Yuan, but due to the crisis in your election campaign, he had to withdraw from the legislative list and assume the role of your Vice President."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950757,
+        "fields": {
+            "answer": 1950755,
+            "candidate": 2001591,
+            "answer_feedback": "Han Kuo-yu might have originally prepared to become the President of the Legislative Yuan, but due to the crisis in your election campaign, he had to withdraw from the legislative list and assume the role of your Vice President."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950767,
+        "fields": {
+            "answer": 1950766,
+            "candidate": 2001591,
+            "answer_feedback": "This is a direct criticism of the DPP. Considering that the Kuomintang might be perceived as too focused on attacks, you must offer the people a new hope to have a chance at winning.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950771,
+        "fields": {
+            "answer": 1950765,
+            "candidate": 2001591,
+            "answer_feedback": "Unfortunately, during the policy statement event, you mistakenly referred to \"Hou You-yi\" as \"Lai Ching-te,\" turning it into a big joke. Damn it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950774,
+        "fields": {
+            "answer": 1950764,
+            "candidate": 2001591,
+            "answer_feedback": "We understand that the story of the Three Kingdoms is popular and interesting, but the DPP continues to question the relationship between you and Hou. They still portray Hou as your puppet..."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950785,
+        "fields": {
+            "answer": 1950784,
+            "candidate": 2001591,
+            "answer_feedback": "You might think it's cool, but the news of violent demolition of Lai Ching-te's ancestral home has triggered a backlash among swing voters and the green base. The public is showing even more sympathy towards him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950788,
+        "fields": {
+            "answer": 1950783,
+            "candidate": 2001591,
+            "answer_feedback": "\nThat's the correct choice. Lai Ching-te's unauthorized construction was built a long time ago and hasn't posed any safety hazards. Most people aren't very concerned about this issue, so it's best not to overreact."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950789,
+        "fields": {
+            "answer": 1950782,
+            "candidate": 2001591,
+            "answer_feedback": "\nPerhaps Lai Ching-te hasn't handled this issue well, but regardless, many local residents support him. Your ads have inadvertently backfired, generating a negative impact with excessive aggression. It might be more beneficial to reconsider the tone and approach to avoid alienating potential supporters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950790,
+        "fields": {
+            "answer": 1950781,
+            "candidate": 2001591,
+            "answer_feedback": "\nLai may indeed lack transparency in this matter, and his teary performance may not garner much sympathy. However, pursuing an attack specifically targeting personal and family matters may not be the best choice, as such tactics are generally unpopular. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950800,
+        "fields": {
+            "answer": 1950796,
+            "candidate": 2001591,
+            "answer_feedback": "This response is indeed very good. it further enhance the negative image among young people and the DPP. While these are facts, it seems that the Taiwanese public might not be receptive to such a stance.nice try."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950803,
+        "fields": {
+            "answer": 1950797,
+            "candidate": 2001591,
+            "answer_feedback": "\nThis helps to immediately stop the bleeding. However, your image as a landlord has already become disliked by some young people, and they won't easily change their minds because of this."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950807,
+        "fields": {
+            "answer": 1950798,
+            "candidate": 2001591,
+            "answer_feedback": "Mutual attacks will only make things worse and strengthen the support bases on both sides. If that's what you prefer, then let it be."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950808,
+        "fields": {
+            "answer": 1950799,
+            "candidate": 2001591,
+            "answer_feedback": "While your image among young people may have further deteriorated, fortunately, most pan-blue and swing voters seem to understand. They recognize that this issue doesn't involve personal character but rather legal business operations."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950819,
+        "fields": {
+            "answer": 1950818,
+            "candidate": 2001591,
+            "answer_feedback": "This will strengthen the Kuomintang's image in national defense and help alleviate concerns among Americans about KMT's pro-China stance."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950822,
+        "fields": {
+            "answer": 1950814,
+            "candidate": 2001591,
+            "answer_feedback": "The effectiveness of this advertisement may not match the one from 2008, but it still resonates and is quite impactful. Well done!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950825,
+        "fields": {
+            "answer": 1950815,
+            "candidate": 2001591,
+            "answer_feedback": "Without a doubt, Han Kuo-yu turned the Vice Presidential debate into his personal show. If it weren't for time constraints, the other two candidates had almost no opportunity to speak."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950828,
+        "fields": {
+            "answer": 1950816,
+            "candidate": 2001591,
+            "answer_feedback": "This policy is not considered very favorable. While the loan amount is flexible, the substantial monthly repayments pose a heavy burden for young people. Failing to repay could potentially ruin their lives."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950832,
+        "fields": {
+            "answer": 1950817,
+            "candidate": 2001591,
+            "answer_feedback": "This will solidify your base, as most of the opposition voters are reluctant to vote for the DPP. However, winning will still depend on the preferences of swing voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950843,
+        "fields": {
+            "answer": 1950838,
+            "candidate": 2001591,
+            "answer_feedback": "Mayor Hou, you and your supporters sincerely hope for your victory.They hope you can address Taiwan's public safety and fraud issues!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950845,
+        "fields": {
+            "answer": 1950839,
+            "candidate": 2001591,
+            "answer_feedback": "This is a very ambitious goal, and if it involves amending the constitution, it will require bipartisan cooperation. But at least you have set a clear objective."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950847,
+        "fields": {
+            "answer": 1950840,
+            "candidate": 2001591,
+            "answer_feedback": "Over 80% of Taiwanese people support the death penalty, while the DPP has been ambiguous on this issue, reducing the number of executions. Ko believes that if the death penalty is to be abolished, life imprisonment must be maintained."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950849,
+        "fields": {
+            "answer": 1950841,
+            "candidate": 2001591,
+            "answer_feedback": "This will rally your deep-blue supporters and boost their voter turnout. Hopefully, on the anniversary of Mr. Chiang Ching-kuo's passing, you can achieve victory!\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950854,
+        "fields": {
+            "answer": 1950852,
+            "candidate": 2001591,
+            "answer_feedback": "\nWhether it's good or bad, this highlights internal divisions and ideological issues within the Kuomintang. Hopefully, this won't cause you too much harm."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950856,
+        "fields": {
+            "answer": 1950853,
+            "candidate": 2001591,
+            "answer_feedback": "As a light-blue presidential candidate, attacking our only former president is a very serious matter. You may risk losing some core support base votes. Is it really worth it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950859,
+        "fields": {
+            "answer": 1950858,
+            "candidate": 2001591,
+            "answer_feedback": "\nWhile this avoids the emergence of internal party disputes, it may lead to disapproval from the moderate voters. Hopefully, your base is solid enough."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950867,
+        "fields": {
+            "answer": 1950866,
+            "candidate": 2001591,
+            "answer_feedback": "After the final campaign event with our native friends, you had a good night's sleep and am ready to cast you vote tomorrow."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950868,
+        "fields": {
+            "answer": 1950865,
+            "candidate": 2001591,
+            "answer_feedback": "In Taoyuan, you have connected well with the Hakka community, strengthening your support base. Best of luck to you in tomorrow's election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950869,
+        "fields": {
+            "answer": 1950864,
+            "candidate": 2001591,
+            "answer_feedback": "If Lai Ching-te were to fall from grace over one thing, it would be the loss of his stronghold. You and Han Kuo-yu have delivered speeches in Tainan and Kaohsiung using Taiwanese, snatching away votes!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950870,
+        "fields": {
+            "answer": 1950863,
+            "candidate": 2001591,
+            "answer_feedback": "\nStrengthening your own stronghold is always a good move. New Taipei City is an enormously important vote bank, equivalent to four Changhua Counties. Any presidential candidate cannot afford to lose here."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950894,
+        "fields": {
+            "answer": 1950891,
+            "candidate": 2001591,
+            "answer_feedback": "\nHe can attract many young votes for you; however, since he formed an alliance with the KMT, some of the lightly green-leaning young people have distanced themselves from him. He cannot transfer all of his votes to you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950895,
+        "fields": {
+            "answer": 1950892,
+            "candidate": 2001591,
+            "answer_feedback": "At present, you are leading in the polls, but you must be cautious about unforeseen events. It's best not to make significant moves at this time!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950896,
+        "fields": {
+            "answer": 1950893,
+            "candidate": 2001591,
+            "answer_feedback": "To achieve this alliance, you must accept some of the TPP's political positions and reform demands. If this is the collective will of the Taiwanese people, then you will be elected on January 13 next year."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950905,
+        "fields": {
+            "answer": 1950903,
+            "candidate": 2001591,
+            "answer_feedback": "In the last presidential election, the Democratic Progressive Party (DPP) secured 8.17 million votes. Can you, with the consensus of the majority of the Taiwanese people, surpass this historical record?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950907,
+        "fields": {
+            "answer": 1950902,
+            "candidate": 2001591,
+            "answer_feedback": "The checks and balances between political parties could be the optimal way to ensure a democratic system, but the downside is that your governance may face constraints.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950908,
+        "fields": {
+            "answer": 1950901,
+            "candidate": 2001591,
+            "answer_feedback": "The Parliamentary system is indeed a challenging goal. Even if you win, amending the constitution or pushing through extensive reforms will require cooperation from the DPP. Gaining more seats in the parliament becomes crucial in this context.\n\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950916,
+        "fields": {
+            "answer": 1950912,
+            "candidate": 2001591,
+            "answer_feedback": "Lai Ching-te may be a flip-flopper, but you have to understand that his base will tolerate him no matter what. The room for maneuvering among the swing voters in the center has diminished considerably."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950918,
+        "fields": {
+            "answer": 1950913,
+            "candidate": 2001591,
+            "answer_feedback": "This is a direct confrontation between the blue and green camps, and we hope you can emerge victorious here!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950922,
+        "fields": {
+            "answer": 1950914,
+            "candidate": 2001591,
+            "answer_feedback": "This will weaken the DPP's red-baiting tactics against you and help restore the KMT's anti-communist image. Moreover, being a true local, your Taiwan-centric image is even stronger than that of Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950923,
+        "fields": {
+            "answer": 1950915,
+            "candidate": 2001591,
+            "answer_feedback": "Lai Ching-te also comes from a humble background; however, his current image carries more of an elite vibe, while you appear similar to an ordinary uncle on the street.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950929,
+        "fields": {
+            "answer": 1950928,
+            "candidate": 2001591,
+            "answer_feedback": "The current lead you have in the polls may easily disappear due to scandals or failed strategies; public opinion is fluid, so proceed with caution!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950937,
+        "fields": {
+            "answer": 1950936,
+            "candidate": 2001591,
+            "answer_feedback": "Guo is definitely trailing in this election, and your appeal to his voters will not be ignored!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950940,
+        "fields": {
+            "answer": 1950935,
+            "candidate": 2001591,
+            "answer_feedback": "Although some in the TPP doubt whether you are only aiming to defeat Ko Wen-je and secure the second position, rather than focusing on attacking Lai Ching-te, the votes are likely to flow significantly between opposition parties."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950943,
+        "fields": {
+            "answer": 1950934,
+            "candidate": 2001591,
+            "answer_feedback": "Lai Ching-te may be a flip-flopper, but you have to understand that his base will tolerate him no matter what. The room for maneuvering among the swing voters in the center has diminished considerably."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950947,
+        "fields": {
+            "answer": 1950946,
+            "candidate": 2001591,
+            "answer_feedback": "\nHe indeed cannot win this election, so the hope for the Pan-Blue Coalition's victory lies here: whoever can secure the support of Terry Gou's voters will be able to win!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 12766,
+        "fields": {
+            "answer": 12763,
+            "candidate": 2001591,
+            "answer_feedback": "So far, the vast majority of loyal deep-blue supporters have returned, but there are still a few parasitic ones attached to Ko Wen-je and Terry Gou. You need to pull them all out, and Han Kuo-yu is the key to that!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 12769,
+        "fields": {
+            "answer": 12764,
+            "candidate": 2001591,
+            "answer_feedback": "Han Kuo-yu's supporters burst into laughter, as he has always been a figure who can make people laugh heartily."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 12772,
+        "fields": {
+            "answer": 12765,
+            "candidate": 2001591,
+            "answer_feedback": "This is your most pragmatic choice. Many of Han Kuo-yu's fans have stated that if he is not on the ticket, they won't vote for you as president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 29506591,
+        "fields": {
+            "answer": 2950659,
+            "candidate": 2001591,
+            "answer_feedback": "Referring to the past positive memories will help you gain more party unity. Hopefully, Han Kuo-yu's endorsement can assist you in improving your standings in the polls."
+        }
+    }
+    
+]
+
+cyoAdventure = function (a) {
+    ans = campaignTrail_temp.player_answers[campaignTrail_temp.player_answers.length-1];
+    if (ans == 13019 || 13020 || 13021 ){
+        campaignTrail_temp.election_json[0]["fields"].advisor_url = "https://i.imgur.com/BZlgvel.jpeg";
+    }
+    if (ans == 1950388 ){
+        campaignTrail_temp.questions_json[2] = {
+            "model": "campaign_trail.question",
+            "pk": 1950398,
+            "fields": {
+              "priority": 1,
+              "description": "Since you have withdrawn from the primary and essentially paved the way for Terry Gou to secure the presidential candidate position, how do you plan to support him in the upcoming electoral campaign?",
+              "likelihood": 1
+            }
+          }
+        }
+        if (ans == 1950399 ){
+            campaignTrail_temp.candidate_json[2]["fields"].first_name = "";
+            campaignTrail_temp.candidate_json[2]["fields"].last_name = "Terry Gou";
+            campaignTrail_temp.candidate_json[6]["fields"].last_name = "None";
+            campaignTrail_temp.candidate_last_name = 'Terry Gou';
+            campaignTrail_temp.candidate_image_url = 'https://www.foxconn.com/img/about/group-profile/founder-m.png?5f65a';
+            campaignTrail_temp.running_mate_image_url = 'https://img.ltn.com.tw/Upload/news/600/2015/10/07/phpbfQCOW.jpg';
+            campaignTrail_temp.running_mate_last_name = 'Hong Xiuzhu';
+            campaignTrail_temp.question_number = 28;
+            campaignTrail_temp.questions_json[29] = {
+                "model": "campaign_trail.question",
+                "pk": 1950411,
+                "fields": {
+                  "priority": 1,
+                  "description": "Today is the last day before the election, and your polls have been consistently declining since your nomination. The deadlock with Ko Wen-je and the lead by Lai Ching-te have not been broken, and the situation persists until the registration of presidential candidates in November. There are hardly any person willing to be your vice president, until Hong Xiu-Zhu, whose nomination was abolished in 2016, volunteered. It is only then that you have a vice presidential candidate to appear on the ballot. On the final day before the election, where do you plan to conduct your campaign activities?",
+                  "likelihood": 1
+                }
+              }
+        }
+        if (ans == 1950400 ){
+            campaignTrail_temp.candidate_json[2]["fields"].first_name = "";
+            campaignTrail_temp.candidate_json[2]["fields"].last_name = "Terry Gou";
+            campaignTrail_temp.candidate_json[6]["fields"].last_name = "None";
+            campaignTrail_temp.candidate_last_name = 'Terry Gou';
+            campaignTrail_temp.candidate_image_url = 'https://www.foxconn.com/img/about/group-profile/founder-m.png?5f65a';
+            campaignTrail_temp.running_mate_image_url = 'https://i.imgur.com/ZmWU9KE.png';
+            campaignTrail_temp.running_mate_last_name = 'Lai Pei-hsia';
+            campaignTrail_temp.question_number = 28;
+            campaignTrail_temp.questions_json[29] = {
+                "model": "campaign_trail.question",
+                "pk": 1950424,
+                "fields": {
+                  "priority": 1,
+                  "description": "Today is the last day before the election, On the final day before the election,  According to the latest polls conducted 10 days before the election, your and Lai Ching-te's approval ratings are within the margin of error. In other words, the presidential position hinges on a difference of just 500,000 votes.where do you plan to conduct your campaign activities?",
+                  "likelihood": 1
+                }
+              }
+        }      
+        if (ans == 1950740 ){
+            campaignTrail_temp.questions_json[27] = {
+                "model": "campaign_trail.question",
+                "pk": 1950933,
+                "fields": {
+                  "priority": 1,
+                  "description": "This year's presidential debate has an unprecedented presence of four presidential candidates: yourself, Lai Ching-te, Ko Wen-je, and the former Chairman of Hon Hai Precision Industry, Terry Gou, who does not support you. In this year's presidential debate, what main points do you want to convey?                  ",
+                  "likelihood": 1
+                }
+              }
+        }
+        
+        if (ans == 1950751 || ans == 1950755 ){
+            campaignTrail_temp.running_mate_image_url = 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/%E7%AB%8B%E6%B3%95%E9%99%A2%E9%95%B7%E9%9F%93%E5%9C%8B%E7%91%9C.jpg/640px-%E7%AB%8B%E6%B3%95%E9%99%A2%E9%95%B7%E9%9F%93%E5%9C%8B%E7%91%9C.jpg';
+            campaignTrail_temp.running_mate_last_name = 'Han';
+        }
+        //三民主义
+            getResults = function (out, totv, aa, quickstats) {
+           if( aa[0].candidate === 2001591 && e.player_answers.includes(1950647) && e.player_answers.includes(1950740) ) {
+               unlockAchievement("Three Principles of People");
+                 }
+                }
+           //果冻获胜
+            getResults = function (out, totv, aa, quickstats) {
+           if( aa[0].candidate === 2001591 && e.player_answers.includes(1950388) && e.player_answers.includes(1950400)){
+               unlockAchievement("New Taipei Has A Mayor");
+                 }
+                }
+            //嘉义之子
+            getResults = function (out, totv, aa, quickstats) {
+                let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 256);
+                let stateResulttwo = campaignTrail_temp.final_state_results.find((x) => x.state == 257);
+                let stateResultthree = campaignTrail_temp.final_state_results.find((x) => x.state == 267);
+            if( aa[0].candidate === 2001591 && stateResult.result[0].candidate == 2001591 && stateResulttwo.result[0].candidate == 2001591 && stateResultthree.result[0].candidate == 2001591) {
+                unlockAchievement("Chiayi favorite son");
+            }
+        }
+     //主流民意获胜
+     getResults = function (out, totv, aa, quickstats) {
+                    if( aa[0].candidate === 2001591 && quickstats[1] > 59.9) {
+                        unlockAchievement("Main Stream Opinion Wins");
+                    }
+                }
+     //南部孩子回家了
+     getResults = function (out, totv, aa, quickstats) {
+        let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 256);
+        let stateResulttwo = campaignTrail_temp.final_state_results.find((x) => x.state == 257);
+        let stateResultthree = campaignTrail_temp.final_state_results.find((x) => x.state == 259);
+        let stateResultfour = campaignTrail_temp.final_state_results.find((x) => x.state == 260);
+        let stateResultfive = campaignTrail_temp.final_state_results.find((x) => x.state == 263);
+        let stateResultsix = campaignTrail_temp.final_state_results.find((x) => x.state == 253);
+        
+        if( aa[0].candidate === 2001591 && stateResult.result[0].candidate == 2001591 && stateResulttwo.result[0].candidate == 2001591 && stateResultthree.result[0].candidate == 2001591 && stateResultfour.result[0].candidate == 2001591 && stateResultfive.result[0].candidate == 2001591 && stateResultsix.result[0].candidate == 2001591) {
+            unlockAchievement("Southern Boys Returning Home");
+        }
+    }
+
+    getResults = function (out, totv, aa, quickstats) {
+        if( aa[1].candidate === 2001591 && quickstats[1] < 31.04) {
+            unlockAchievement("Challenge the Bottom Line");
+        }
+    }
+    //侯韩限定：
+getResults = function (out, totv, aa, quickstats) {
+    let stateResulttwo = campaignTrail_temp.final_state_results.find((x) => x.state == 267);
+    if( aa[0].candidate === 2001591 && stateResult.result[0].candidate == 2001591 && stateResulttwo.result[0].candidate == 2001591) {
+        unlockAchievement("Southern Vegetable Vendor Northern Detective");
+    }
+} 
+getResults = function (out, totv, aa, quickstats) {
+    if( aa[0].candidate === 2001591 && quickstats[1] > 39.59 ) {
+        unlockAchievement("Not a single one less");
+    }
+    }
+        //各党标题
+        if ( ans == 1950012 || ans == 1950013 || ans == 1950014 ){    
+            nct_stuff.themes[nct_stuff.selectedTheme].coloring_window = "#f4f4ee" 
+            nct_stuff.themes[nct_stuff.selectedTheme].coloring_title = "#13366e" 
+            $(".container")[0].style.backgroundColor = "#6848ff" 
+            $("#game_window")[0].style.borderColor = "#99A0A8" 
+            $(".container")[0].style.backgroundColor = "#F4F4EE" 
+            $("#game_window")[0].style.borderColor = "#f4f4ee" 
+            $("#game_window")[0].style.backgroundImage = "url(https://imgur.com/3praAwi.jpg)" 
+            document.getElementById("header").src = "https://i.imgur.com/I7YpjTe.jpeg" 
+            document.body.background = "https://i.imgur.com/LXrWSNp.jpeg"
+        }
+    }
+
+campaignTrail_temp.jet_data = [{}
+]
+
+campaignTrail_temp.candidate_image_url = "https://i.imgur.com/GCeTdoX.png";
+campaignTrail_temp.running_mate_image_url = "https://i.imgur.com/KLN8hlP.jpeg";
+campaignTrail_temp.candidate_last_name = "Hou";
+campaignTrail_temp.running_mate_last_name = "For KMT 2024";
+campaignTrail_temp.running_mate_state_id = '253';
+campaignTrail_temp.player_answers = [];
+campaignTrail_temp.player_visits = [];
+campaignTrail_temp.answer_feedback_flg = 1;
+campaignTrail_temp.game_start_logging_id = '3660822';
+
+const style_overwrite = document.createElement("style");
+style_overwrite.innerHTML = 
+`#campaign_sign {
+    background-color: #13366e;
+    border-color: #b22525;
+}
+#menu_container {
+  background-color: #c3c3c3;
+}
+#overall_result_container {
+  background-color: #c3c3c3;
+}
+#state_info h3 {
+  background-color: #ffffff;
+}
+#overall_result h3 {
+  background-color: #ffffff;
+}`
+;
+document.head.appendChild(style_overwrite);
+
+
+let style = document.createElement('style');
+style.type = 'text/css';
+style.id = 'dynamic-style';
+
+style.innerHTML = `
+  .inner_window_question h3 {
+    background-color: #e1e1e1;
+  }
+  .overlay_window h3 {
+    background-color: #b4b4b4;
+  }
+`;
+
+document.head.appendChild(style);
+
+
+function checkIfCanAddMap() {
+    map = document.getElementById("map_container");
+    
+    if(map) {
+        map.style.backgroundImage = "url('https://images.rawpixel.com/image_800/czNmcy1wcml2YXRlL3Jhd3BpeGVsX2ltYWdlcy93ZWJzaXRlX2NvbnRlbnQvbHIvdjk5Ni0wMDlfMS1rcm9pcjRkay5qcGc.jpg')"; 
+    }
+}
+
+setInterval(checkIfCanAddMap, 250);
+
+(function(e, t, n, r, i) {
+    function s(e, t, n, r) {
+        r = r instanceof Array ? r : [];
+        var i = {};
+        for (var s = 0; s < r.length; s++) {
+            i[r[s]] = true
+        }
+        var o = function(e) {
+            this.element = e
+        };
+        o.prototype = n;
+        e.fn[t] = function() {
+            var n = arguments;
+            var r = this;
+            this.each(function() {
+                var s = e(this);
+                var u = s.data("plugin-" + t);
+                if (!u) {
+                    u = new o(s);
+                    s.data("plugin-" + t, u);
+                    if (u._init) {
+                        u._init.apply(u, n)
+                    }
+                } else if (typeof n[0] == "string" && n[0].charAt(0) != "_" && typeof u[n[0]] == "function") {
+                    var a = Array.prototype.slice.call(n, 1);
+                    var f = u[n[0]].apply(u, a);
+                    if (n[0] in i) {
+                        r = f
+                    }
+                }
+            });
+            return r
+        }
+    }
+    var o = 1010,
+        u = 500,
+        a = 50;
+    var f = {
+        stateStyles: {
+            fill: "#333",
+            stroke: "#666",
+            "stroke-width": 1,
+            "stroke-linejoin": "round",
+            scale: [1, 1]
+        },
+        stateHoverStyles: {
+            fill: "#33c",
+            stroke: "#000",
+            scale: [1.1, 1.1]
+        },
+        stateHoverAnimation: 500,
+        stateSpecificStyles: {},
+        stateSpecificHoverStyles: {},
+        click: null,
+        mouseover: null,
+        mouseout: null,
+        clickState: {},
+        mouseoverState: {},
+        mouseoutState: {},
+        showLabels: true,
+        labelWidth: 20,
+        labelHeight: 15,
+        labelGap: 6,
+        labelRadius: 3,
+        labelBackingStyles: {
+            fill: "#333",
+            stroke: "#666",
+            "stroke-width": 1,
+            "stroke-linejoin": "round",
+            scale: [1, 1]
+        },
+        labelBackingHoverStyles: {
+            fill: "#33c",
+            stroke: "#000"
+        },
+        stateSpecificLabelBackingStyles: {},
+        stateSpecificLabelBackingHoverStyles: {},
+        labelTextStyles: {
+            fill: "#fff",
+            stroke: "none",
+            "font-weight": 300,
+            "stroke-width": 0,
+            "font-size": "10px"
+        },
+        labelTextHoverStyles: {},
+        stateSpecificLabelTextStyles: {},
+        stateSpecificLabelTextHoverStyles: {}
+    };
+    var l = {
+        _init: function(t) {
+            this.options = {};
+            e.extend(this.options, f, t);
+            var n = this.element.width();
+            var i = this.element.height();
+            var s = this.element.width() / o;
+            var l = this.element.height() / u;
+            this.scale = Math.min(s, l);
+            this.labelAreaWidth = Math.ceil(a / this.scale);
+            var c = o + Math.max(0, this.labelAreaWidth - a);
+            this.paper = r(this.element.get(0), c, u);
+            this.paper.setSize(n, i);
+            this.paper.setViewBox(-500, 0, c, u, false);
+            this.stateHitAreas = {};
+            this.stateShapes = {};
+            this.topShape = null;
+            this._initCreateStates();
+            this.labelShapes = {};
+            this.labelTexts = {};
+            this.labelHitAreas = {};
+            if (this.options.showLabels) {
+                this._initCreateLabels()
+            }
+        },
+        _initCreateStates: function() {
+            var t = this.options.stateStyles;
+            var n = this.paper;
+            var r = {
+                Tainancity:"m178.94 309.54c1.821 0.85976 1.9013 1.8004 3.9722 1.3601 0.52002 1.6719-1.5712 1.0502-1.4009 2.6113 0.8704 0.21983 2.3913 0.20091 2.5009 1.2003 2.4514 1.3001-0.0196 1.501 0.46065 3.6413 2.191-0.12068 3.2917 1.4299 5.2733 1.8898 0.13963 1.4005-0.8306 1.1807-1.6207 1.8011-1.0903 0.85976-1.1105 1.2309-1.181 2.6706-0.0698 1.411-0.89063 5.8318 0.97023 6.032 0.0496 0.85128 0.0496 1.7515 0 2.6008-0.82081 0.37966-1.1705 1.4814-1.1105 2.3405 0.5807 0.0202 1.2006 0.03 1.7806 0.06 0.17029 0.33986 0.2897 0.71103 0.39083 1.0607 1.7114-0.20939 1.8902 1.5512 3.2813 1.8904 0.16051-0.81019 1.3415-1.1305 1.7219-0.3503 0.0692 0 0.55983-0.0104 0.61072 0 0.84039-1.4103 2.5114-1.3803 2.8611-3.2414 0.73077 1.1709 1.2312 1.6308 2.6314 1.7411 1.4909 0.10959 2.4716-0.39988 3.8418-0.0998 0.76079 1.1598 1.6618 0.69994 1.8817-0.36074 0.39931 0.31051 0.63942 0.76061 0.63029 1.3007-0.15986 0.0398-0.30014 0-0.45021 0.06-0.12984 1.3803-0.89063 1.4599-1.6501 2.4606-0.97023 1.2694-0.14094 1.9498-0.3804 3.1696-0.3308 1.6608-3.2924 3.1214-4.3331 4.6817-1.5007 2.2616-2.7815 3.6608-3.7217 6.3217-0.85083 2.4208-1.6612 4.5519-3.9122 5.5415-2.3711 1.0496-3.1919 3.0013-4.8727 4.8018-0.71055 0.74886-1.9209 1.7593-2.8317 2.1696-1.4204 0.63993-2.4814 0.69081-3.1815 2.3412-0.21009 0.50098-0.16051 1.4899-0.4502 1.8611-0.53047 0.68038-0.94022 0.39009-1.581 0.75996-1.0707 0.62036-1.4707 1.6112-2.281 2.6217-1.0505 1.291-1.0603 2.12-1.6906 3.5917-0.52068 1.2303-1.5509 2.2799-2.2915 3.3706-0.74056 1.0711-1.4707 2.1814-2.0312 3.1312-0.46065 0.77953 0.15007 1.1905-0.97088 1.3197-0.79015 0.0998-1.1705-0.12916-1.0603-0.96936-0.64008-0.0307-1.3108-0.0307-1.9509 0-1.2006 1.4703-2.7515 1.5004-4.0323 2.7711-1.0707 1.0705-0.46065 1.2303-2.0011 1.5695-0.89062 0.21005-2.3809 0.51991-2.1812-0.84019-1.8008-0.15982-3.432-0.77039-5.4827-0.69081-1.3604 0.0502-3.862-0.33008-4.8531 0.43053-1.3708-0.99153-4.3024-0.48011-4.8524-2.9113-1.641 0.95044-6.023-1.3503-7.784 0.42923-0.26034-1.9707-0.0803-4.4417-0.65052-5.7913-0.99045-2.3803-1.2103-4.501-3.1619-6.2114-2.0612-1.8102-4.8929-2.9609-6.513-5.122-1.4009-1.8806-2.9916-3.0216-5.3731-3.8415-5.5428-1.9009-6.4536-7.8024-2.5009-11.954 1.1608-1.2198 1.4811-1.2603 1.5007-3.2107 0.01-1.4606-0.20031-3.1207 0.15985-4.501 0.63029-2.3901 3.1521-3.9714 4.0225-6.3817 0.98067-2.7208-0.42019-5.6817 0.86062-8.4522 0.65051-1.4005 0.52002-2.7606 0.97022-4.1612 0.35038-1.1305 0.68053-0.7306 1.331-1.6308 0.52002-0.72016 0.39018-0.96087 0.49001-1.8813 0.21009-1.9198 0.97022-2.3601 1.7806-3.7815 1.4609 0.61123 2.4911 1.8709 4.0323 2.3008 0.1703 0.8702 0.81037 1.561 1.0603 2.4508 0.51024-0.0404 1.0903 0.09 1.611 0.0502 0.15007 1.9707 3.6819 4.7417 3.5618 1.1598 0.2499 0.3503 0.49001 0.45989 0.6603 0.96935 0.77057 0.0802 1.6012 1.1814 2.3111 1.0202 0.50045-0.11025 0.80059-1.1814 1.1608-1.6713 0.86062-1.1807 2.1108-1.7711 2.3613-3.4704 1.4211-1.5701 4.8028 0.42988 4.2822-2.8311-1.121-0.58122-0.30014-1.8513 0.65052-1.9113 0.98066-0.06 1.271 1.1403 2.6914 0.55121-0.30993-1.3614-1.2808-2.4221 0.31058-3.5512 1.4811-1.0405 2.8513 0.25897 2.7417-2.261 0.84038 0.0404 1.731 0.27006 2.6412 0.14025 1.5405-0.21984 0.94022-0.34965 1.9907-1.3001 1.3806-1.261 3.1521-1.0907 5.013-1.3705 1.611-0.24005 2.9316-1.0007 4.6626-1.0007 1.4707 0 3.9618 1.1102 5.0025-0.34965 0.97936 0.81476 2.5198 1.3144 3.6708 1.8546z",
+                Kaohsiungcity:"m156.17 440.89c0.0502 0.35029 0.20031 0.66993 0.12984 1.0502-0.0803-0.0111-0.15985 0-0.23032-0.0111-0.27991-0.50033-0.60027-0.33986-1.0309-0.58905-0.39996-0.24006-0.4502-0.63014-0.67009-0.96152-0.44042-0.67973-1.1105-1.3301-1.6312-1.9498-1.0707-1.291-2.0612-2.6908-3.0516-4.002-0.20031-0.27006-0.29035-0.8004-0.56047-0.93021-0.0202-0.06 0.01-0.12003-0.0202-0.17026-0.2499-0.34964-0.93043-0.3803-1.2404-0.63993 0.48022-0.15916 1.1608-0.0691 1.6808-0.0489-0.0202 0.17874 0.0803 0.30007 0.0803 0.47881 0.73077-0.0998 0.16051 0.93086 0.85083 0.96152 0.0202 0.0489-0.0104 0.12916 0.0202 0.17026 0.16964 0.14938 0.42998 0.17873 0.57026 0.30007 0.13963 0.12981 0.2897 0.47032 0.42998 0.63014 0.4502 0.49055 0.67009 0.78018 0.93043 1.3307 0.10961 0.2394 0.18986 0.5199 0.39017 0.72995 0.23033 0.24984 0.45021 0.2805 0.66031 0.47033 0.39018 0.36986 0.55068 0.78996 1.0603 1.06 0.12984 0.51012 0.52002 1.1103 0.78035 1.5408 0.0503 0.01 0.0998 0.01 0.15986 0.0196 0.0515 0.37052 0.29166 0.62036 0.69162 0.56035zm102.79-136.88c-0.15007 0-0.25968 0.0104-0.27012 0.0496-0.24011 0.69082-0.0502 1.1409 0.77057 1.3307 0.30992 1.6406 0.55982 2.8402 0.33994 4.6113-1.5203 0.24984-4.1014-0.3503-4.3226 1.5395-0.03 0.28116 0.51023 0.45011 0.51023 0.82063 0 0.77952-0.28969 0.71038-0.47043 1.2101-0.35038 0.93934-0.79014 1.5401-0.67009 2.6002 1.8015-0.20092 1.0309 0.68037 2.0109 1.3307 0.79015 0.53947 1.8413 0.33986 2.7717 0.39009-0.0692 0.3503 0.20096 0.81019 0.19052 1.0705 1.4609-0.61057 3.342 2.9113 3.1417 4.0412-1.0205 0.36987-1.1705 1.0705-0.95065 1.7704-0.8704 0.52056-2.052 0.29029-2.9818 0.6308-1.2006 0.42988-2.0409 1.3803-3.2115 1.9302-1.331 0.61122-2.4716 0.88129-3.832 1.2009-1.731 0.41031-2.2615 1.1507-3.3315 2.3412-0.7497 0.8291-1.4511 2.291-2.3411 2.9609-0.82929 0.61906-2.7012 0.25897-3.3113 1.2303-0.57026 0.92043 0.14028 3.2114-0.0202 4.3106-0.0698 0.54012-0.45021 0.92043-0.5011 1.4906-0.06 0.75996 0.29035 1.4514 0.17095 2.1703-0.28056 1.6204-1.6716 1.2616-2.3515 2.6608-0.30014 0.63014 0.21009 1.1807-0.35038 1.8011-0.39018 0.42075-1.4211 0.53034-1.9411 0.57013-0.27012 1.03 0.81037 1.291 1.611 1.5004 0.14028 2.6504 0.4104 5.9629-0.0998 8.5135-0.1703 0.91912-0.77057 2.0294-1.3604 2.8311-0.47043 0.63928-0.88997 0.75996-1.0498 1.5904-0.2101 1.0907 0.21988 0.88128 0.54025 1.5316 0.33015 0.66929 1.7604 2.621 0.96044 3.4808-0.89063 0.96087-2.9414-0.47098-3.462 1.1898-0.44108 1.4103 1.3108 2.0711 0.30013 3.6308-0.6205 0.95044-2.2419 1.6406-3.0118 2.4208-1.9809 2.0105-3.1514 6.702-1.6005 9.2728 0.24011-0.0189 0.55982 0.0802 0.79014 0.0502 0.53046 1.3999-0.06 3.1312 0.18009 4.6322 0.27012 1.6608 2.1212 2.0796 2.0305 3.651 1.9711-0.24005 1.7408 0.76061 1.8315 2.3308 2.0305 0.0189 1.3911 1.0705 0.28056 1.6497-0.0502-0.12916-0.11027-0.2394-0.18008-0.3503-0.74056-1.0796-3.5012-2.3901-4.7924-2.2799-1.4609 0.12916-2.3215 1.1298-3.5116 1.6797-1.2103 0.56035-2.1714 0.19048-2.0214 2.1409-2.251 0.10959-4.1125-0.60079-4.5021-3.1214-1.641-1.0705-2.9218-2.3105-4.8126-3.0209-1.1307-0.4201-1.7206-0.54012-2.9916-0.33007-1.2404 0.20091-1.5007 0.60013-2.4716 1.0202-0.30014 0.8702-1.4909 1.7293-2.071 2.5408-2.0011-2.0907-2.8122-4.2303-5.9936-3.561-1.38 0.28963-2.4409 1.2205-3.8013 1.7-1.1307 0.39074-2.9224 0.27006-3.8431 1.0802-0.90042 0.79062-1.0309 1.9707-1.8308 2.7104-0.71055 0.64972-1.791 1.9204-2.6314 2.3803-2.0312 1.1005-5.9232 0.28898-7.724-0.50098-1.0505-0.46054-2.3913-0.88064-3.6519-0.55056-1.5712 0.4214-1.4309 1.1703-1.3408 2.8409 0.0502 0.91064 0.73012 3.1996 0.33994 4.0014-0.45999 0.93021-1.1705 0.17874-1.6808 0.77887-0.35038 0.41097-0.15986 1.4814-0.15986 2.0516 0.01 2.7815 0 5.5617 0 8.3321 0 1.2101 0.2499 2.9309-0.36995 3.972-0.84038 1.4097-1.4707 1.079-1.4609 3.1996v4.3327c0 1.5604-0.39996 2.3706-0.68053 3.6602-0.58005 2.7815 0.28057 5.4221 0.64008 8.0118 0.18008 1.2407 0.39018 2.7411 0.2101 4.0014-0.32037 2.1514-1.2606 1.0007-2.3411 2.1709-1.3604 1.4814-0.50045 6.3817-0.50045 8.3321v0.21005c-0.92064-0.63993-1.301-0.42141-2.6614-0.54013-2.4213-0.23092-3.0118-2.5806-5.043-3.6308-1.4211-0.72995-2.1316-0.82911-3.2519-1.9107-0.96044-0.93086-2.4416-2.2009-3.2617-3.1918-0.2499-0.52055-0.8704-1.291-1.4309-1.5206 0.11027-0.53034 0.39018-0.50034 0.93043-0.47033 0.01 0.06 0 0.11024 0.0202 0.15982 0.03 0.0104 0.0698 0.0196 0.0998 0.03 0.0502 0.18982 0.15986 0.2805 0.2101 0.47032 0.2499 0.11024 0.69032 0.21005 0.86061 0.3914 0.24011 0.2394 0.2101 0.69994 0.50045 0.85911 0.28056 0.15982 0.91085-0.0189 1.1908-0.0496 0.46065-0.0404 0.72034 0.0404 1.181 0.14025 0.0104 0.69929 0.90041 0.25049 1.2508 0.7306 0.15007-0.97066-1.2208-1.2407-1.8713-1.7006-0.33994-0.24005-0.82016-0.45988-1.1105-0.74038-0.39997-0.39075-0.36995-0.78997-0.57026-1.2401-0.40976-0.8702-1.7108-0.54012-2.3809-1.3105-0.38039-0.42988-0.24011-0.88064-0.5807-1.3001-0.25968-0.33008-0.71054-0.60014-0.99045-0.93935-0.30993-0.36986-0.75035-0.66993-1.1307-1.0111-0.42019-0.39074-0.7001-0.91064-1.0303-1.3797-0.61071-0.83041-1.2006-1.6504-2.0116-2.231 0.42019-0.0307 1.331-0.17091 1.6912 0.03 0.40975 0.23027 0.36995 0.93086 0.55982 1.3803 0.38039 0.17026 1.4106 0.63015 1.3708 1.06 0.81037 0-0.35038-1.1011-0.56048-1.1898-0.19052-0.42075-0.23032-0.82975-0.49-1.1703-0.25969-0.33072-0.61007-0.48011-0.82995-0.86041-0.2499-0.44945-0.23032-0.57992-0.80058-0.84998-0.46-0.22048-0.86062-0.16047-1.3408-0.29028-0.81037-0.24006-1.5307-1.15-2.1714-1.6993-0.94021-0.81018-0.88084-1.3999-0.88084-2.6217v-2.1807c0-0.33073-0.0698-0.71038 0.1305-0.94 0.15985-0.19048 0.6603-0.23092 0.89062-0.42075 0.36017-0.31964 0.81037-1.06 0.91086-1.5206 0.15985-0.80105-0.29036-1-0.63029-1.6106-0.06-0.0307-0.12985-0.0496-0.18009-0.0698 0.39997-0.24984 0.70011 0.12981 0.96044 0.36073 0.40976 0.34965 0.47044 0.40966 1.1007 0.37965 0.0502-0.88976-0.0502-1.8891-0.38039-2.6706-0.97023-0.0907-0.88084 0.31051-1.1203 1.0405-0.50045 0.06-0.59049-1.3196-0.69032-1.73-0.16051-0.68103-0.74056-1.261-0.8704-1.9413-0.0698-0.39987 0.0698-0.77039-0.12984-1.1207-0.1703-0.30007-0.61072-0.45989-0.79015-0.75996-0.35037-0.61123 0.11027-1.2701-0.48022-1.8206 0.23033-1.4103-1.5307-2.2505-2.1616-3.1612-0.57026-0.82128-0.7001-1.6915-0.82995-2.6608-0.29035-2.0405-0.54024-1.5904-1.8713-2.9713-0.88084-0.91064-0.64008-1.3301-0.8306-2.6713-0.32036-2.2505-1.4811-4.1716-1.5105-6.4919-0.0202-2-0.53046-3.8911-1.3604-5.6517-1.1405-0.27006-1.581-1.4508-1.7806-2.9002 1.761-1.7802 6.1437 0.52055 7.784-0.42988 0.55003 2.4312 3.4816 1.9198 4.8524 2.9113 0.99046-0.76061 3.492-0.38031 4.8531-0.43054 2.0514-0.0796 3.6819 0.53034 5.4827 0.69147-0.20031 1.3601 1.2906 1.0496 2.1812 0.84019 1.5405-0.33986 0.93043-0.50098 2.0011-1.5701 1.2808-1.2707 2.8317-1.3007 4.0323-2.7711 0.64008-0.03 1.3108-0.03 1.9509 0-0.10962 0.84019 0.27012 1.0705 1.0603 0.97 1.121-0.12981 0.51023-0.54012 0.97088-1.3203 0.55982-0.94978 1.2906-2.06 2.0312-3.1312 0.74055-1.09 1.7708-2.1403 2.2915-3.3706 0.63029-1.471 0.64008-2.3008 1.6906-3.591 0.81037-1.0111 1.2103-2.0007 2.281-2.6223 0.64008-0.36922 1.0505-0.0796 1.5809-0.75996 0.29035-0.36922 0.24011-1.3601 0.45021-1.8611 0.7001-1.6504 1.761-1.7 3.1815-2.3405 0.91085-0.41031 2.1212-1.4214 2.8317-2.1703 1.6808-1.8011 2.5009-3.7515 4.8727-4.8018 2.251-0.99023 3.0614-3.1207 3.9122-5.5415 0.94021-2.6608 2.221-4.0614 3.7217-6.321 1.0407-1.561 4.0023-3.0216 4.3324-4.6824 0.24011-1.2198-0.58984-1.9002 0.38104-3.1696 0.76013-1.0007 1.5203-1.0802 1.6501-2.4606 0.15007-0.06 0.29035-0.0202 0.4502-0.06 0.0104-0.54012-0.23097-0.99088-0.63028-1.3007 0.01-0.0496 0.0189-0.10959 0.03-0.17026 0.12919-1.0496-0.43063-2.4306-0.71054-3.3308-0.65052-2.0509-1.3911-4.9316-0.64008-7.1521 0.8704-0.14025 2.8115-0.12916 3.6519 0.14025 1.5209 0.51012 0.67009 1.8513 1.9809 2.5114 2.8715 1.4508 2.482-2.7013 4.0121-3.8409 1.1405-0.85128 1.9809-0.11089 3.171-0.66145 0.35038-0.15982 1.9509-1.8402 2.1714-2.1305 0.65052-0.85063 0.5011-2.1207 1.4909-2.7515 0.98066-0.61971 2.6516-0.25963 3.8124-0.31964 0.28056-1.4306 0.39996-2.5506 1.821-3.1918 0.96109-0.42075 3.3315 0.25049 4.0519-0.39922 0.36995-0.33986 0.77122-2.8918 1.1105-3.6015 0.53046-1.1103 0.86061-2 1.2103-3.1514 0.38039-1.3105 0.82081-2.2805 2.1714-2.7593 1.2006-0.43053 3.0908 0.23941 4.0114-0.70059 0.21009-0.21983 0.36995-1.3601 0.6205-1.7202 0.27991-0.41031 0.93043-1.0802 1.3206-1.3418 1.0302-0.66928 2.4011-0.8004 3.5514-0.94978 1.1816-0.14025 1.9914-0.2094 2.6914-1.1298 0.79015 0.0802 1.821-0.27984 2.4018-0.88977 0.24989-0.0691 0.50044-0.12981 0.74055-0.18004 1.2208-0.24984 1.0903-0.11024 2.1714 0.36987 1.5509 0.69081 2.9316 0.59035 4.8022 0.69994 0.0104 0.33008 0.25055 0.55056 0.2101 0.93087 0.35037-0.0104 0.74055 0.27985 1.1307 0.23027 0.14942 0.98109-0.26033 1.7104-0.29035 2.6217 0.14028-0.0104 0.32037 0.0104 0.46065 0.0404 0.0176 0.12981-0.0124 0.30986-0.0124 0.45924z",
+                Pingtung:"m166.08 473.61c0.38039 0.47033 0.52002 0.84019 0.50045 1.4403-0.0398 0-2.1408 2.4514-2.3515 2.681-0.8704 0.88912-2.5212 1.7104-2.9016-0.16047 1.2808-0.74952 0.64008-2.0405 1.3206-3.1116 0.71054-1.1279 2.2615-0.91913 3.432-0.84933zm69.867-77.268c0.47044 1.2205-0.3693 2.9909 0.65052 4.0907 0.52002 0.57013 2.9218 1.4305 3.7119 1.7906 1.121 0.51012 1.121-0.18982 1.5007 1.1598 0.19052 0.6608 0.10961 1.9198 0.12984 2.5414 0.0692 1.8611-0.53046 2.5806-2.1016 3.4912 0.61137 1.8317 1.1307 5.6928-0.85017 7.1521-1.0107 0.75017-2.7613-0.18983-4.0121 0.32029-0.88997 0.36074-1.6605 1.4814-2.5414 2.1207-1.4106 1.0411-1.9607 1.03-3.802 1.2205-1.0603 0.10959-2.822-0.19047-3.5318 0.78997-0.73077 0.99153 0.25968 2.6413-0.1305 3.8722-0.39018 1.2205-1.6312 2.06-2.0005 3.3412-0.35038 1.2094-0.2499 1.8806-1.0002 2.9498-0.73077 1.0405-1.2906 1.76-1.701 2.8807-0.77057 2.0907-1.0303 4.201-1.1601 6.4828-3.0314 0.03 0.39932 5.3817 0.74056 6.1919 0.7001 1.6797 1.1608 5.4508 0.63029 7.0425-0.32037 0.96935-1.2006 2.1507-0.51024 3.4612 0.76079 1.4299 1.8015 0.21004 2.9616 1.0404 1.2704 0.90021 1.9013 5.1312 1.6808 6.6022-1.6612 0.0698-4.0114 0.74039-4.472 2.3601-0.25055 0.87085-0.0411 2.1011-0.18008 3.0013-0.10962 0.77105-0.46 1.6915-0.30014 2.471 0.48022-0.0802 0.8704 0.21983 1.2808 0.21983 0.45021 2.0516 2.0011 1.5401 3.5318 2.6419 1.671 1.1807 1.581 2.4808 1.4707 4.6406-2.2412 0.03-2.3711 1.6902-2.2817 3.5004 0.86061-0.0685 2.9414 0.40053 3.6421 0.82063 1.9711 1.1703-0.77058 1.8017-0.47044 3.1807 0.90042-0.12003 1.1908 0.50163 1.0002 1.3418 1.8511 0.0992 2.1212 0.57013 3.4712 1.1807 1.1908 0.53947 3.2421-0.0307 3.5318 1.6412 1.8008-0.23092 1.5907 1.9498 3.4418 0.99936 0.73077-0.38031 1.9711-1.7208 2.681-2.4508 0.33081 1.1598 0.67009 2.3608 0.39997 3.3608-0.2101 0.82062-0.6205 1.0907-0.71055 2.1207-0.09 0.91977-0.12984 1.7208-0.30013 2.5506-0.56048 2.7398 0.29035 6.411 0.0998 9.5931-0.98066 0.4201-1.2612 1.8206-0.97022 2.8611 0.38039 1.3601 0.94021 1.4292 2.4716 1.3601 0.09 0.48011 0.09 1.1403 0 1.6106-0.73077 0.6608-1.4511 0.59035-1.8113 1.531-0.33015 0.8702 0.0111 2.5617 0.0111 3.501 0 0.98044-0.27012 2.4103-0.0111 3.3406 0.32036 1.1011 1.2508 1.2101 0.98067 2.6308-0.61985 0.12981-1.2006 0.24006-1.7806 0.39988-0.0411 0.55056-0.21989 1.0404-0.21989 1.6002-1.5509 0.40966-0.93042 0.77104-1.4707 1.8702-0.70076 1.3908-0.68053 0.85976-2.3013 1.2003-2.5212 0.53034-2.0409 2.4814-2.0409 4.8011 0 1.8506-0.60028 4.9218 0.72033 6.2923 0.67988 0.69994 1.151 0.45989 1.6207 1.3712 0.29035 0.58971 0.38039 2.4808 0.30014 3.1507-1.7708 0.45989-1.8106-1.2309-2.7606-2.1905-0.51024-0.51991-0.95066-0.4899-1.3911-1.1207-0.34972-0.5199-0.4104-1.2198-0.82994-1.8004-1.0603-1.4703-1.8811-0.78018-3.5018-1.3608-0.71054-0.25962-1.2906-0.91977-1.9907-1.1814-0.59048-0.21983-1.3506-0.18982-1.9711-0.36008-0.79014-1.5003-4.5021-2.561-5.3327-0.44032-0.49001 1.2401 0.79014 1.6008 0.63029 2.8011-0.16965 1.3203-1.6606 1.3705-2.6712 1.8206-0.53046-0.78018-1.6605-1.4606-2.0011-2.1507-0.47956-0.97001-0.1592-2.7208-0.1592-3.8311 0-1.3007 0.1703-2.7208 0-4.0014-0.23097-1.7606-0.99111-1.5401-1.962-2.711-0.83973-1-0.69945-1.8891-1.0798-3.0809-0.20096-0.63079-0.65052-0.79061-0.63029-1.5506 0.03-0.82976 0.50958-0.75996 0.66944-1.501 0.12071-0.55056-0.25903-1.5095 0-2 0.51023-0.96087 0.56047-0.12068 1.331-0.66081 0.81038-0.55056 1.8511-2.1311 0.53046-2.8611-0.24011-0.39987-0.43063-0.99088-0.50109-1.4508 0.44041 0.0802 1.0107-0.12982 1.4518-0.0496 0.20944-1.2505 0.42933-2.4814 0.36016-3.8115-0.0998-1.8806-0.36995-1.8206-1.4707-3.0411-1.6906-1.8904-0.35038-4.8911-1.0309-7.2923-0.35038-1.2309-1.4909-1.8402-1.8008-3.1709-0.30013-1.291-0.13962-2.4599-0.54024-3.6608-0.8704-2.5695-3.1521-3.0007-4.3722-5.3014-0.60027-1.1292-0.46064-2.471-0.46064-3.8715 0-1.6112-0.46065-2.3608-1.0009-3.6713-0.84038-2.0405-2.0409-3.6817-3.7217-5.291-0.85082-0.82063-1.7304-1.2805-2.1108-2.381-0.54025-1.5395-0.65051-1.79-1.7108-3.1612-1.6508-2.1403-3.1019-2.7208-5.4632-4.0105-1.0714-0.5897-2.7117-0.83954-3.5018-1.8311-1.3904-0.17939-3.3518-0.50034-4.3722-1.2903-0.89063-0.7006-1.3108-1.8409-2.131-2.6719-1.7708-1.7906-4.8531-2.3797-6.0034-4.3706-0.72033-1.2401-0.95065-1.8617-2.1212-2.8709-0.2101-0.17026-0.39018-0.31051-0.55004-0.42075v-0.2094c0-1.9504-0.86061-6.852 0.50045-8.3321 1.0805-1.1703 2.0214-0.0202 2.3411-2.1709 0.18008-1.2603-0.03-2.7593-0.2101-4.0014-0.36017-2.591-1.2208-5.2316-0.64008-8.0118 0.28057-1.291 0.68053-2.1011 0.68053-3.6602v-4.3327c-0.0104-2.1207 0.62051-1.79 1.4609-3.1996 0.6205-1.0411 0.36995-2.7606 0.36995-3.972 0-2.7711 0.01-5.5519 0-8.3321 0-0.57013-0.19052-1.6412 0.15986-2.0516 0.51023-0.60014 1.2208 0.15003 1.6808-0.77888 0.39018-0.8017-0.2897-3.0907-0.33994-4.002-0.09-1.6712-0.23032-2.4208 1.3408-2.8402 1.2606-0.33007 2.6014 0.09 3.6519 0.55056 1.8008 0.78997 5.6935 1.6002 7.724 0.50099 0.84039-0.45989 1.9209-1.7306 2.6314-2.3803 0.80123-0.74039 0.93042-1.9198 1.8308-2.7111 0.92064-0.80953 2.7117-0.69016 3.8431-1.0796 1.3604-0.47946 2.4213-1.4103 3.802-1.7 3.1815-0.66994 3.9912 1.4703 5.993 3.561 0.58071-0.81019 1.7708-1.6706 2.071-2.5408 0.97022-0.4214 1.2306-0.82127 2.4716-1.0202 1.271-0.21005 1.8615-0.09 2.9916 0.33008 1.8909 0.71038 3.1717 1.9504 4.8126 3.0209 0.39083 2.5206 2.251 3.231 4.5021 3.1214-0.15007-1.9504 0.81037-1.5806 2.0214-2.1409 1.1908-0.54991 2.052-1.5506 3.5116-1.6797 1.2912-0.1109 4.0519 1.2003 4.7931 2.2799 0.0672 0.10763 0.12789 0.21787 0.17747 0.34703z",
+                Taidong:"m327.47 304.02c-0.32036 0.81019-0.64007 1.6302-0.96044 2.5004-0.7001 1.9204-0.23097 3.9309-0.55068 5.9518-0.27013 1.7417-1.1601 3.3412-1.4407 5.0627-0.25055 1.5904-0.0196 4.8415-1.181 6.0614-1.0903 1.1598-3.1417 1.2309-4.3122 2.6908-1.3108 1.6412-1.6508 2.9713-1.761 5.2519-0.0803 1.5708 0.36995 4.6217-0.50045 5.8116-0.76079 1.0607-2.852 0.77105-3.5723 2.3712-0.63095 1.4208-0.0698 3.651 0.0692 5.0712 0.29035 2.8611-0.1703 8.1527 3.7322 7.8129-1.0798 0.39009-1.35 1.6002-2.2308 2.1403-0.63029 0.39922-1.3004-0.0496-2.0116 0.50033-0.47956 0.36073-0.58983 1.1403-0.93042 1.3608-1.8211 1.1598-5.4827 0.12981-4.8126 3.9413 0.0502 1.7104-0.68053 3.561-1.331 4.8311-0.61072 1.1703-0.32037 2.4599-0.71055 3.621-0.42998 1.2805-1.4909 2.441-1.9607 3.732-0.44042 1.1807-0.36995 2.2199-1.0407 3.3216-1.301 2.1305-4.1621 2.5108-4.9229 4.8716-0.4502 1.3803-0.0907 2.3405-0.88084 3.591-0.59048 0.93021-1.0498 1.9504-1.7003 2.8611-0.42085 0.60013-0.98067 0.85063-1.2912 1.4814-0.25968 0.51991-0.10048 1.319-0.3693 1.8304-0.70075 1.2707-2.1114 0.97001-1.992 2.8409-2.2204 0.12003-6.4138-0.59035-7.4441 2.0607-1.0798 2.7698 0.82082 4.9603 1.6312 7.1319 0.71054 1.8898-0.31971 2.0411-1.5007 2.7111-1.5607 0.88063-1.1301 1.1403-1.331 2.9609-0.24989 2.2799-3.1619 3.1696-4.5223 5.1605-0.03 0.0502 0.01 0.39139-0.0104 0.48011-0.97023 0.75995-2.3913 1.1298-3.312 1.8904-0.93042 0.75996-1.2006 2.321-2.3313 2.9707-1.0107 0.59035-2.5212 0.14938-3.7021 0.6308-1.2208 0.50098-1.6312 1.5199-2.5009 2.5004-1.6012 1.8102-4.4022 2.1109-5.9232 3.9218-0.64008 0.74104-0.90041 2.3803-1.2103 3.2916-0.39931 1.2003-0.57026 2.4006-0.63029 3.7013-0.12005 2.5004-0.17029 4.3712-2.2014 5.8116-1.1203 0.78996-1.9202 0.91064-2.6308 1.9909-0.66095 0.99023-1.1908 2.1605-1.6716 3.3301-0.52003 1.2609-0.4202 2.5206-0.8704 3.8011-0.44042 1.2401-1.181 2.2805-1.5105 3.5408-0.63942 2.4821-0.44042 5.0327-1.181 7.4724-1.8308 0.47098-1.5607 4.6824-2.2713 6.203-0.88997 1.9002-1.2997 3.651-1.9111 5.5904-0.57026 1.8108-1.2208 4.4123-2.8017 5.5722-0.85017 0.6308-0.43977 2.3405-0.8293 3.6608-0.28121 0.91978 0.33016 7.2023 0.33016 8.1723 0 0.69016 0.24011 1.5004 0.47956 2.351-0.71054 0.72995-1.9502 2.0705-2.681 2.4508-1.8511 0.95043-1.6416-1.2303-3.4418-0.99936-0.28969-1.6719-2.3411-1.1011-3.5318-1.6412-1.35-0.61058-1.6201-1.0802-3.4712-1.1807 0.19052-0.84019-0.0998-1.4606-1.0002-1.3418-0.30013-1.379 2.4409-2.0105 0.47044-3.1807-0.70076-0.42009-2.7815-0.88911-3.6421-0.82062-0.09-1.8096 0.0411-3.4704 2.2817-3.5004 0.10962-2.1612 0.20031-3.4612-1.4707-4.6406-1.5307-1.1011-3.0816-0.59035-3.5318-2.6419-0.41041 0-0.80059-0.30007-1.2808-0.21983-0.15985-0.77953 0.19052-1.7 0.30014-2.471 0.14028-0.90021-0.0698-2.1305 0.18008-3.0014 0.46-1.6197 2.8115-2.2903 4.472-2.3601 0.21989-1.471-0.4104-5.702-1.6808-6.6022-1.1601-0.8291-2.2014 0.39074-2.9616-1.0405-0.69032-1.3105 0.18987-2.4906 0.51023-3.4612 0.53046-1.5904 0.0698-5.3628-0.63029-7.0425-0.33994-0.81019-3.772-6.1618-0.74056-6.1919 0.12919-2.2805 0.39018-4.3908 1.1601-6.4828 0.41041-1.1207 0.97023-1.8396 1.701-2.8807 0.75034-1.0705 0.65052-1.7404 1.0002-2.9498 0.3693-1.2805 1.611-2.1207 2.0005-3.3412 0.39083-1.2309-0.60028-2.8807 0.13049-3.8722 0.70989-0.98044 2.4716-0.68037 3.5318-0.78996 1.8406-0.19048 2.3913-0.17939 3.802-1.2205 0.88084-0.63927 1.6508-1.76 2.5414-2.1207 1.2508-0.50947 3.0027 0.42988 4.012-0.31964 1.9809-1.4599 1.4609-5.321 0.85018-7.1527 1.5712-0.91064 2.1714-1.6302 2.101-3.4912-0.0196-0.62036 0.0607-1.8806-0.12919-2.5414-0.38039-1.3497-0.38039-0.64971-1.5007-1.1598-0.79079-0.36008-3.1926-1.2205-3.7119-1.7906-1.0205-1.1011-0.18008-2.8702-0.65051-4.0907 1.1105-0.58057 1.7512-1.6308-0.28057-1.6497-0.0907-1.5701 0.14028-2.5708-1.8315-2.3308 0.0907-1.5701-1.7604-1.9902-2.0305-3.6511-0.24011-1.501 0.35038-3.231-0.18008-4.6322-0.23032 0.03-0.55069-0.0691-0.79015-0.0502-1.5509-2.5695-0.38039-7.2623 1.6005-9.2728 0.77057-0.77952 2.3913-1.4703 3.0118-2.4208 1.0107-1.561-0.74121-2.2205-0.30014-3.6302 0.52002-1.6615 2.5708-0.23092 3.462-1.1905 0.80059-0.85976-0.63028-2.8115-0.96044-3.4808-0.32036-0.65037-0.75034-0.44097-0.54024-1.5317 0.15985-0.8291 0.58004-0.94978 1.0498-1.5904 0.59048-0.80171 1.1908-1.9113 1.3604-2.8311 0.51024-2.5506 0.24011-5.8618 0.0998-8.5135-0.80058-0.2094-1.8811-0.47033-1.611-1.5004 0.52003-0.0404 1.5509-0.14938 1.9411-0.57013 0.55982-0.62036 0.0502-1.1709 0.35038-1.8011 0.67988-1.3999 2.071-1.0405 2.3515-2.6608 0.12005-0.72017-0.23098-1.4103-0.17095-2.1703 0.0502-0.57013 0.43063-0.95044 0.5011-1.4899 0.16051-1.1011-0.55004-3.3908 0.0202-4.3112 0.61072-0.97 2.4814-0.61122 3.3113-1.2303 0.89062-0.66993 1.5907-2.1318 2.3411-2.9609 1.0714-1.1905 1.6012-1.9309 3.3315-2.3405 1.3604-0.32029 2.5009-0.59036 3.832-1.2016 1.1705-0.54991 2.0109-1.5004 3.2115-1.9302 0.93043-0.33986 2.1114-0.11024 2.9818-0.6308 0.17943 0.65037 0.66031 1.3105 1.0309 1.7208 0.99046 1.1103 2.1401 2.0516 2.4905 3.7111 0.36082 1.7404 0.0111 2.8311 1.2508 4.2114 0.97023 1.0705 3.2617 0.81018 3.4118 2.09 1.4002 0.0907 4.1217-0.14938 5.133 0.69081 1.5209 1.2609 0.36016 3.1918 3.0014 3.3412 1.5509 0.09 3.3022-1.4508 4.8531-0.33986 1.3108 0.94979 1.4302 3.1996 1.5098 4.8115 0.81038 0.0489 1.6508 0.01 2.4514 0.06 0.06 1.03-0.03 2.1305 0.19052 3.1312 0.30014 1.3503 2.1414 2.1807 3.4816 2.03-0.33994 1.5095 0.63029 1.561 1.8315 1.501 0.21988 0.94 1.2208 1.4703 1.7408 2.2603 0.52002 0.79061 0.58918 1.9707 1.611 2.3908 2.131 0.89043 4.7226-0.91064 6.6533-1.03 0.11027-1.2694-0.28057-2.3712-0.14094-3.6413 0.0998-0.93934 0.9611-2.0105 0.9611-2.8696 0.0104-1.3203-1.2704-1.7606-1.2912-2.972-0.0196-1.2101 1.0603-2.2407 2.3013-2.0209 0.88084-2.3405 1.671-4.7117 2.8317-7.0118 0.63029-1.2505 0.03-2.6008 0.53046-3.8115 0.47044-1.1605 1.9914-1.3908 2.6308-2.4906 0.70011-1.2094 0.42998-2.6308 0.54025-4.0014 0.12071-1.4703 0.70989-2.2205 1.1705-3.501 0.15007-0.4201 0.0411-1.3503 0.48022-1.6406 0.50045-0.33007 1.5607 0.57013 2.2014-0.06 0.69031-0.69994 0.28969-2.6217 1.1503-3.471 1.0009-0.99153 2.5316-0.66993 1.5007-2.1709-0.30014-0.42988-2.1708-1.8304-2.6412-2.0202-0.10961-1.8709 0.12985-3.3914 0.84039-4.9414 1.2306-0.71038 0.7001-3.6308 2.2713-3.4012 0.68053-0.97001 2.4605-0.45011 2.2308-2.2707 1.0909-0.64972 2.9113-0.31964 3.9722 0.14025 0.41041 0.18004 1.1405 0.85128 1.5307 0.96087 0.62572 0.18004 1.1164-0.10894 1.7564-0.1396zm-3.9279 119.23-0.0202-0.18004c0.23097-0.12003 4.063-0.30985 4.3722-0.0189 1.5209-0.91064 2.4018-0.82975 2.6614 0.99088 0.15986 0.0404 0.29035 0.0196 0.45021 0.06-0.48022 0.80105-0.81037 1.7704-1.0002 2.7815-0.79015 0.12916-0.75035 0.21984-0.95066 0.82911 0.27013-0.0496 0.66031 0.0802 0.94022 0.0502-0.0607 0.78018 0.09 1.6302 0.33994 2.2694-1.5412 0.83041-3.4522-1.6706-5.1128-1.9902-0.21988-0.40053-0.29035-0.98044-0.17029-1.441 1.7003-0.91978-1.5509-2.3301-2.052-3.0307 0.1318-0.3105 0.29231-0.30007 0.5422-0.32029zm19.79 101.38c0.68053 1.6706 0.32037 2.231 0.33994 3.9518-1.301 0.17939-2.3222-0.39922-3.6121-0.33986-1.3611-2.1709-2.5616-3.0307-5.0025-3.171-0.60028-1.2609-2.6112-2.2407-3.573-3.4312-0.70989-0.88064-0.47043-2.1905-0.79014-3.201-0.27013-0.84019-1.7408-2.1005-1.3108-2.8109 0.8704-0.0802 1.5712 0.20026 2.4513 0.15982 0.0405 0.15916 0 0.30006 0.0502 0.44945 1.8106 0.0907 5.5428 0.55969 6.9834-0.41031 0.23098 0.81018 0.11027 0.33007 0.64008 0.8004 0.0104 0.58122 0.03 1.1905 0.0405 1.7802 0.15986 0.0404 0.30014 0.0104 0.46065 0.0502 0.2101 1.09-0.47043 1.1807-0.65052 1.6706-0.21988 0.61122-0.36995 1.1102-0.30014 1.9504 1.0903-0.18005 1.1105 0.85063 1.1608 1.6608 0.82994 0.03 0.68052 0.0496 1.0009 0.66994 0.70076-0.0398 1.4615 0.0307 2.1114 0.22048z",
+                Hualien:"m262.01 324.77c-0.21989-0.69994-0.0698-1.3999 0.95065-1.7704 0.20031-1.1298-1.6808-4.6517-3.1417-4.0411 0.0104-0.25897-0.25903-0.72017-0.19052-1.0705-0.93043-0.0496-1.9809 0.14938-2.7717-0.39009-0.98001-0.65037-0.20944-1.5317-2.0109-1.3307-0.12006-1.06 0.32036-1.6602 0.67009-2.6002 0.18008-0.50098 0.47043-0.43053 0.47043-1.2101 0-0.36921-0.54025-0.53947-0.50958-0.82062 0.21988-1.8898 2.8017-1.291 4.3226-1.5395 0.21988-1.7717-0.0307-2.972-0.33994-4.6113-0.82081-0.18983-1.0107-0.63993-0.77057-1.3307 0.0104-0.0404 0.12005-0.0496 0.27012-0.0496 0.2897-0.0196 0.72033-0.0104 0.84039-0.12981 0.20031-0.2094 0.15985-0.61057 0.47956-0.88977 0.8704-0.74104 0.48022-0.69081 1.7108-0.94978 0.72033-0.15004 1.4707-0.15004 2.1414-0.36987 0.14941-2.4906-2.191-1.9504-1.3108-4.3112 0.61985-1.6497 1.3304-3.3301 2.3802-4.8004 1.8713-2.6413 7.6137-2.561 10.085-0.72016 0.49001-0.7704 1.331-0.90021 2.0116-1.3405 0.10961-1.8311-0.2101-3.5715-0.0998-5.4417 1.6312-0.48011 1.4106-0.72017 1.7806-2.1709-0.27012 0.06-0.68053-0.0998-0.95065-0.0496-0.13963-0.78018-0.24011-1.6308 0.61136-1.8409 0.03-0.12003-0.0307-0.34899 0.06-0.43966 1.1601-0.5597 2.0514 0.60013 2.972 0.31963 0.48022-0.14025 1.4309-1.9002 1.5209-2.321 1.0198-0.71104 1.1908 0.20939 1.9411 0.20026 0.57026-0.0104 1.1014-0.32029 1.6716-0.42988 0.50045-0.71038 0.10961-1.3503 0.3693-2.1311 0.33994-1.0502 0.72033-0.5897 1.1712-1.3803 0.55982-1.0007-0.16051-2.3608 0.2499-3.441 0.39017-1 1.7003-1.7404 1.9111-3.0209 0.16051-0.9002-0.59049-1.5003-0.51023-2.3308 0.0907-0.8291 0.73011-1.2505 0.84038-2.3308 0.09-0.88064 0.0998-1.9707 0.01-2.8402-0.23946-2.1207-1.81-2.2805-2.0109-4.1612-0.2897-2.8213-0.2897-2.651-2.972-3.201-0.27991-1.4808 1.331-3.6113 2.7822-3.8311-0.17095-1.4103-0.24011-2.9211 0.21988-4.2812 0.53046 0 0.77971-0.2805 1.2808-0.39074 0.69031-1.3405 0.51023-3.06 1.1503-4.471 0.23097-0.5199 0.69031-0.65037 0.88083-1.1703 0.14094-0.3803 0.0411-0.93087 0.16051-1.3307 0.27013-0.84019 0.70011-1.2609 1.0303-1.9804 0.21988 0.0404 0.55003-0.0202 0.78036-0.0502 0.0698-1.3803-0.80059-5.8018 1.331-5.6615 0.1703-3.3816 0.51024-6.7822 0.33994-10.124-0.69945-0.0404-1.4204-0.01-2.1205-0.0502-0.12005-2.4808 0.64008-3.4312 1.3206-5.4717 0.42998-1.2903 0.75034-2.0607 1.3708-3.291 0.73011-1.4508 0.47108-2.4006 0.6205-3.8813 0.21988-2.2505 0.96109-1.0196 2.4611-1.8709 0.85996-0.47945 1.5405-1.6706 2.2112-2.4306 1.2912-1.4703 2.1812-4.9414 0.45999-6.1716-0.82994-0.59035-2.3313-0.90021-3.2513-1.5708-1.181-0.8702-1.0707-1.2903-2.8513-1.3105-0.23098-0.72017-0.3308-1.6902-0.0698-2.351 0.30013-0.72995 0.97022-0.77039 1.2208-1.2505 0.3804-0.70973 0.03-1.5304 0.32037-2.2199 0.42019-0.97979 0.4104-0.5199 1.3708-0.95043 1.6012-0.71038 2.4213-1.1814 3.6023-2.2205 1.2201-1.06 1.9411-0.93022 3.6721-1.0196 0.17943-0.80105 0.14028-1.6712-0.78036-1.8408-0.0998-1.1605 0.1305-1.5904 0.55069-2.1612 0.16964-0.21983 0.36995-0.47033 0.60028-0.8004 0.47108-0.67972 0.82994-2.3706 1.5209-2.9707 0.94087-0.82063 2.7326-0.0802 3.312-1.0307 0.59048-0.97979-0.35038-3.0607-0.01-4.1723 0.44042-1.4103 1.7304-1.4201 2.5205-2.4899 0.53046-0.74104-0.01-0.95043 0.82082-1.5108 0.49-0.33986 1.151-0.20026 1.7108-0.66994 0.78036-0.63014 1.7519-1.5095 2.1218-2.3301 0.50045-1.1403-0.30079-2.8317 0.20031-3.972 0.24011-0.54991 1.4504-1.7098 2.2412-2.1807 0.0411 0.0907 0.0907 0.18004 0.15007 0.27006 0.4104 0.60014 0.93956 0.39074 1.5712 0.59035 0.74056 0.23027 1.1705 0.87999 1.8811 1.2003 0.46064 0.21005 1.0009 0.27006 1.4302 0.54012 0.44107 0.27006 0.72033 0.59035 1.0805 0.93022 0.15986 0.15003 0.32037 0.25962 0.5011 0.39074 0.2897 0.18982 0.19052 0.21983 0.41041 0.0992 0.3693-0.19048 0.48022-0.66015 1.0407-0.50033 0.24011 0.0691 0.27013 0.21983 0.58005 0.24984 0.25055 0.0202 0.38039-0.0502 0.59049-0.0802 0.45021-0.0698 0.93043-0.06 1.3715 0.0411 0.61006 0.12916 1.1503 0.30985 1.7904 0.36921 0.41106 0.0404 0.84038 0 1.2508 0.0502 0.98067 0.0998 1.151 1.1905 1.761 1.8206 0.62051 0.63928 0.8306 1.3301 1.8106 1.4606 0.81037 0.10959 1.5809 0.01 2.3613 0.2094 0.39018 0.0998 0.82016 0.26027 1.2397 0.22048 0.26034-0.0307 0.47108-0.12981 0.74121-0.0907 0.23946 0.03 0.42019 0.15003 0.66944 0.12068-0.0998-0.25049-0.0398-0.53034-0.0803-0.82062-0.0502-0.47946-0.23032-0.45924-0.60027-0.80954-0.17943-0.17091-0.33015-0.28963-0.27013-0.55969 0.06-0.29029 0.03-0.14938 0.21989-0.14025 0.12984 0.0202 0.15006 0.18004 0.32036 0.17026 0.18987-0.0104 0.30014-0.19048 0.42998-0.31051 0.20031-0.20092 0.41041-0.65037 0.70076-0.72995 0.28904-0.0802 0.39018 0.21983 0.6205 0.10959 0.23946-0.10959 0.21988-0.63015 0.28904-0.84998 0.0901-0.27006 0.30014-0.53034 0.54025-0.66993 0.0502 0.24005 0.23098 0.48011 0.46065 0.53033 0.42019 0.11025 0.40975-0.1409 0.71054 0.23027 0.15986 0.20027 0.2897 0.78018 0.59049 0.58057 0.16964-0.11024 0.16964-0.61057 0.18987-0.80953 0.03-0.27006 0.0803-0.69994 0.0104-0.96087-0.11027-0.42989-0.44955-0.33986-0.74056-0.66016-0.19052-0.21004-0.19052-0.45988-0.33994-0.67972-0.2003-0.27984-0.55982-0.39009-0.6603-0.77039-0.20031-0.75017 0.49001-1.6308 1.2404-1.1305 0.32037 0.21984 0.68053 0.68038 0.95066 0.96022 0.33015 0.3503 0.63942 0.69995 0.98066 1.0411 1.1503 1.1507 0.0803-1.1011 1.2006-0.76061 0.24011 0.0802 0.36016 0.44032 0.55003 0.63015 0.38039 0.3803 0.90041 0.51011 1.2612 0.92043 0.36017 0.41031 0.66031 0.84997 1.1099 1.1598 0.35038 0.25049 0.66095 0.19048 1.0805 0.25049 0.46064 0.0691 0.53046 0.3105 0.90041 0.50033 0.39996 0.21005 0.96109-0.0404 1.3904 0.12003 0.29035 0.11024 0.59049 0.36073 0.8704 0.5199 0.53046 0.29028 0.99111 0.61123 1.5816 0.79062 0.46 0.14938 0.93043 0.12002 1.4204 0.12002 0.53046-0.01 0.92064 0.12982 1.4106 0.29029 0.61985 0.19048 1.4713 0.0196 2.0514 0.33986 0.33994 0.18983 0.60093 0.54012 0.93108 0.72995 0.2897 0.17026 0.58136 0.23027 0.90042 0.31051 0.49066 0.12981 1.5405 0.7606 2.022 0.3803 0.0196-0.01 0.0405-0.03 0.0405-0.0496 0.0796 0.42988 0.18987 0.96022 0.0411 1.3405-0.15007 0.43053-0.76078 0.27006-0.87105 0.88064-2.0905 1.3112-2.9414 2.9218-3.2219 5.4019-0.18987 1.7104-0.15985 2.2805-1.8811 2.8807-1.3708 0.48011-2.1904 0.8702-3.3518 1.6406 0.06 1.1305-1.0107 2.3908-1.9313 2.8311-0.57027 0.2805-1.2802 0.44032-1.8406 0.68037-0.95065 0.39009-1.0707 0.74952-1.7512 1.4508-0.99111 1.0196-1.4217 1.7606-1.5105 3.4006-0.0404 0.92043-0.33993 3.8011 0.61007 4.1416 0.57091 1.9615 0.39083 4.5115-1.2606 5.702-0.63943 0.4501-1.4707 0.72016-2.0612 1.1514-0.61071 0.44945-1.4511 1.3705-1.9411 1.9707-1.8504 2.2812-1.9307 8.5428-0.0698 10.763 0.39997 0.47032 1.0414 0.91064 1.5809 1.0502 0.97023 1.4508 1.7715 3.5506 0.62051 5.2016-0.36017-0.03-0.62051 0.16047-0.95066 0.17026-0.0496 0.1709-0.12919 0.29028-0.17029 0.46054-0.39997 0.0998-0.81037 0.19047-1.2097 0.29028-0.0998 0.23027-0.18987 0.21983-0.2897 0.45989-3.002 0.20026-1.7512 9.1221-1.8615 11.283-0.0907 1.8304-0.86062 3.8611-1.3611 5.5219-0.60028 1.9602-0.44042 3.8813-0.76079 5.972-0.17943 1.2303-1.0603 2.3706-1.8811 3.351-1.1601 1.4005-1.2397 2.1409-1.2397 4.0314 0 1.7508 0.68053 3.9818 0.12006 5.6322-0.53046 1.5806-1.9711 2.5004-2.4912 4.2512-1.0407 3.5708 0.0698 8.1723-1.5607 11.684-0.91085 1.9707-2.0807 2.2107-2.4513 4.5617-0.32037 2.0405 0.23032 4.2114 0.01 6.2623-0.21009 1.8611-1.4002 3.2805-1.761 4.9909-0.41041 1.9609-0.0796 3.9211-0.74056 5.762-0.59049 1.6706-2.1316 4.0907-0.12006 5.4913-0.57026 2.7411-1.4818 5.0418-2.4416 7.4926-0.64008 0.03-1.1307 0.31898-1.7519 0.13959-0.39018-0.10959-1.1203-0.77952-1.5307-0.96087-1.0603-0.45924-2.8813-0.78996-3.9723-0.14025 0.23097 1.8206-1.5503 1.3007-2.2308 2.2707-1.5712-0.23092-1.0407 2.6908-2.2713 3.4012-0.71054 1.5499-0.95065 3.0705-0.83973 4.9414 0.47043 0.18982 2.3411 1.5904 2.6412 2.0202 1.0309 1.501-0.5011 1.1814-1.5007 2.1709-0.86061 0.85063-0.45999 2.7711-1.151 3.471-0.63943 0.63015-1.7004-0.27006-2.2014 0.06-0.44042 0.28964-0.33015 1.2205-0.47957 1.6406-0.46064 1.2805-1.0505 2.0307-1.1705 3.501-0.11092 1.3712 0.1592 2.7906-0.54025 4.0014-0.64008 1.1011-2.1616 1.3301-2.6314 2.4906-0.5011 1.2094 0.0998 2.561-0.53046 3.8115-1.1601 2.3001-1.9502 4.6713-2.8317 7.0118-1.2397-0.21983-2.3215 0.81019-2.3006 2.0216 0.0196 1.2101 1.3004 1.6497 1.2906 2.9713 0 0.85977-0.86061 1.9302-0.96044 2.8702-0.13963 1.2694 0.25055 2.3712 0.14028 3.6406-1.9307 0.12068-4.5223 1.9204-6.6533 1.03-1.0198-0.4201-1.0903-1.6002-1.611-2.3908-0.52067-0.78996-1.5209-1.319-1.7408-2.2603-1.2006 0.06-2.1714 0.0104-1.8308-1.501-1.3415 0.14938-3.1821-0.67972-3.4822-2.03-0.21988-1.0007-0.12919-2.1011-0.19052-3.1312-0.80059-0.0502-1.641-0.0104-2.4513-0.06-0.0803-1.6112-0.20031-3.8618-1.5098-4.8115-1.5509-1.1102-3.3028 0.42988-4.8531 0.33986-2.6412-0.14938-1.4811-2.0803-3.0014-3.3412-1.0107-0.83954-3.7322-0.60014-5.133-0.69081-0.15007-1.2799-2.4416-1.0196-3.4118-2.09-1.2404-1.3803-0.89063-2.471-1.2508-4.2114-0.35037-1.6608-1.5013-2.6008-2.4911-3.7104-0.37778-0.41814-0.858-1.0783-1.0381-1.7287z",
+                ChiayiCity:"m184.85 297.29c0.06 1.2094-0.28056 1.4703-1.301 1.9994-0.12984 0.89042-0.33994 2.5317-1.6005 1.8017-0.42019-0.24005-0.55069-0.76061-1.0805-0.89042-0.39017-0.10959-1.2808-0.14938-1.671-0.09-0.75034 0.12003-1.4707 1.1005-1.9907 1.6706-0.51023 0.57013-1.4113 1.5506-2.3313 1.4005-0.48022-0.50164-0.2499-1.1709-0.67988-1.711-0.52002-0.64972-0.99046-0.55056-0.93043-1.5904-0.71054-0.0404-1.4309 0.0104-2.1414-0.03-0.0698-1.1011-1.1803-0.61057-1.8308-0.55056-0.98001 0.0992-1.4106-0.69994-0.27012-1.0404 0.0998-0.63993 0.76078-1.5904-0.39997-1.501-0.42019-0.53034-0.53046-1.4899-0.6205-2.1403-0.12984-0.97001-0.01-0.91978 0.94022-1.261 0.4502-0.17025 0.91085-0.42988 1.181-0.82062 0.0998-0.0104 0.21989 0.0104 0.30993 0 0.0502 0.33986 0.12005 0.66081 0.19052 0.98044 0.77057-0.0404 0.99045-0.63014 1.6605-0.82062 0.62051-0.17939 1.3911-0.0698 2.0612-0.0998-0.18009-1.3601 1.2606-0.94979 2.1714-1 0.0196-0.34899 0.17029-0.63014 0.42998-0.8291 0.33994 0.21983 0.26034 0.50033 0.48022 0.78018 0.20031 0.27985 0.63029 0.4488 0.79014 0.70973 0.49001 0.77952 0.03 1.2701 1.3004 1.1709 0.0998-0.29029 0.1703-0.57013 0.19053-0.89042 0.38039 0.03 1.5105 0.24005 1.7512 0.49054 0.32036 0.33008 0.24989 1.2101 0.33993 1.6497 0.93108 0.17026 1.3004 0.84019 2.3013 0.85976 0.03 0.4899 0.0398 0.93087 0.10961 1.3914 0.22967 0.17026 0.33994 0.2805 0.64008 0.36073z",
+                ChiayiCounty:"m205.81 336.38c-0.21988 1.0607-1.1216 1.5206-1.8817 0.36073-1.3708-0.30007-2.3515 0.2094-3.8418 0.0998-1.4002-0.11024-1.9013-0.57013-2.6314-1.741-0.35038 1.8611-2.0207 1.8311-2.8611 3.2414-0.0502-0.0104-0.54025 0-0.61071 0-0.38039-0.78018-1.5614-0.45988-1.7219 0.3503-1.3904-0.33986-1.5705-2.1011-3.2813-1.8904-0.0998-0.34965-0.22053-0.72017-0.39083-1.0607-0.5807-0.03-1.2006-0.0398-1.7806-0.06-0.0607-0.85912 0.2897-1.9609 1.1105-2.3405 0.0496-0.85063 0.0496-1.7508 0-2.6008-1.8615-0.20026-1.0414-4.6211-0.97023-6.032 0.0692-1.4397 0.09-1.8096 1.181-2.6706 0.79014-0.62036 1.761-0.39922 1.6207-1.8011-1.9816-0.45989-3.0816-2.0105-5.2733-1.8898-0.48022-2.1403 1.9914-2.3412-0.46064-3.6413-0.10962-0.99936-1.6312-0.98045-2.5009-1.2003-0.1703-1.561 1.9209-0.93935 1.4009-2.6112-2.071 0.44032-2.1512-0.50033-3.9723-1.3601-1.1503-0.54012-2.6915-1.0404-3.6721-1.8506-1.0407 1.4599-3.5318 0.34965-5.0025 0.34965-1.731 0-3.0516 0.76061-4.6626 1.0007-1.8609 0.27985-3.6317 0.10959-5.013 1.3705-1.0505 0.95044-0.45021 1.0802-1.9907 1.3001-0.91085 0.12982-1.8008-0.0998-2.6412-0.14025 0.10961 2.5206-1.2606 1.2205-2.7417 2.261-1.5907 1.1298-0.6205 2.1905-0.31057 3.5512-1.4204 0.58905-1.7108-0.61123-2.6915-0.55056-0.95065 0.06-1.7708 1.3294-0.65051 1.9106 0.52002 3.261-2.8618 1.2609-4.2822 2.8311-0.24989 1.7-1.5007 2.291-2.3613 3.471-0.36016 0.4899-0.6603 1.5604-1.1608 1.6706-0.71054 0.15982-1.5405-0.93934-2.3111-1.0196-0.17029-0.51012-0.40975-0.61971-0.6603-0.97 0.12005 3.5812-3.4118 0.81018-3.5618-1.1598-0.52003 0.0405-1.1007-0.0907-1.611-0.0502-0.2499-0.88912-0.89063-1.5806-1.0603-2.4508-1.5405-0.42989-2.5714-1.6908-4.0323-2.3001 0.03-0.0607 0.0698-0.12068 0.0998-0.17939 0.74056-1.3607-0.0404-3.7313 1.4811-4.471 0.21988-0.1109 0.48022-0.15982 0.7001-0.24006 0.30014-0.12133 0.42019-0.25962 0.67074-0.39074 0.10962-0.0607 0.76014-0.16047 0.82016-0.23092 0.67988-0.80106-2.3815-1.4201-2.6712-1.5199 1.8909-0.17025 6.6232-0.12068 4.6521-3.1814-0.36995-0.0411-0.55003 0.31051-0.80058 0.55969-0.53046-0.42074-1.2103-1.5506-0.93043-2.1011 0.20031-0.39987 0.58005-0.45989 0.56047-0.96935-0.0202-0.45011-0.33993-0.42988-0.0698-0.93087-0.48022-0.0104-0.86061-0.54012-0.81037-1.0104 0.06-0.62036 0.78036-0.88064 1.0505-1.3196 0.49001-0.79127 0.06-2.4019-1.0505-1.9309-0.44042 0.18983-0.44042 0.85977-1.1203 0.69081-0.53046-0.12981-0.70076-0.76061-0.44042-1.2309 0.35038-0.63993 0.78036-0.34965 1.3108-0.5199 0.7001-0.22114 0.38039-0.82128 0.38039-1.441 0-1.2401 0.88084-1.441 1.5607-2.2499 0.72033-0.86042 0.38039-2.0516-0.99046-1.5506-0.18987 0.0796-0.36995 0.31898-0.57026 0.37965-0.25968 0.0907-0.55003-0.0196-0.82016 0.0496-0.27012 0.0607-0.39996 0.33073-0.60027 0.39075-0.36995 0.11024-0.42019-0.0907-0.70076-0.15982-0.21988-0.06-0.63029 0.0104-0.82016-0.0998-0.42998-0.25049-0.17029-0.39922-0.30992-0.75996-0.20031-0.50098-0.73077-0.54012-0.94087-0.99087-0.27991-0.58971 0.21988-1.1905 0.36995-1.7104 0.0803-0.25962 0.0803-0.55969 0.20031-0.79061 0.13963-0.31051 0.36996-0.40966 0.50045-0.69081 0.47043-0.11025 0.58005 0.20091 0.96044 0.33072 0.33994 0.11025 0.80059 0.0405 1.1608 0.0405 0.58005 0 1.8909 0.25962 1.611-0.62036-0.12006-0.36008-0.66031-0.4201-0.55004-0.87999 0.06-0.27006 0.33994-0.35029 0.48022-0.59035 0.70011 0.45989 1.2006 0.95044 1.0505 2.0607 0.32036-0.0502 0.79014 0.12981 1.1105 0.06 0.42019 0.75996 2.9714 0.95044 3.862 1.1403 1.6508 0.35029 3.2317 0.85063 4.8224 1.1605 2.0312 0.39922 3.8724 0.40966 3.522-2.1709-0.0998-0.66994-0.89063-1.3601-0.98067-1.8617-0.14028-0.78997 0.38039-1.5304 0.50045-2.2805 0.33015-0.01 1.5607-0.21983 1.8113-0.03 0.63029 0.47098 0 1.0913 0.36996 1.6412 0.92064 1.3712 2.221 0.69081 1.9907-0.93021 1.9209-0.63993 1.1705-1.1403 2.101-2.7404 0.85082-1.441 1.6207-0.68038 3.342-0.82063-0.10049-0.63993-0.59049-1.1102-0.61072-1.7802 1.0407-0.09 2.161 0.18983 3.1214 0.4501 0.0405-2.2707 0.15007-2.651 2.3515-2.8122 1.4106-0.0998 3.0314-1.0405 2.7019-2.8004 0.88019-0.36008 1.9809-0.17939 2.9414-0.23027-0.2101-1.6615 1.9013-3.0516 3.3615-2.972 1.5007 0.0698 2.3515 2.9511 4.5125 1.6804 0.77057-0.4501 0.54025-1.3203 1.5307-1.6804 0.76013-0.27006 2.1512 0 2.9616 0 0.90041 0 1.9411 0.14025 2.8017-0.0398 0.96044-0.19048 1.38-0.86041 2.5114-0.60013 0.2499 1.3105 1.6207 1.8806 1.7206 3.1109 0.23098-0.0189 0.55004 0.0802 0.78036 0.06 0.80059 4.1514 4.6123 2.6112 7.694 3.3014 1.7114 0.39074 2.8115 1.291 4.8531 1.1703 1.7519-0.10959 3.1514-0.85976 4.9627-0.81019 0.35038 2.1514 0.06 3.1012 2.6614 2.4514 0.24011-0.49055 0.46064-0.47946 0.82994-0.79062 0.20096 2.0516 2.452 0.69994 3.5423 0.65037 1.4811-0.0692 3.6121 1.4103 5.0025 1 1.1007-0.33008 0.80059-0.71038 0.79015-1.8311 0-0.53034 0.09-2.0209-0.12071-2.5114-0.25903-0.62036-1.2306-0.4899-1.3604-1.3405-0.06-0.42988 0.64007-1.2003 1.1405-1.4305 0.2101 0.12068 0.5011 0.21983 0.89062 0.27006 1.2006 0.17026 2.5714-0.20026 3.9723-0.14025 0.0104 0.32029 0.19053 0.4899 0.2101 0.78018 0.75034 0.0502 1.5307 0.0202 2.2817 0.06 0.92064 0.68038 0.52002 1.4005 1.6906 1.8213 0.79014 0.27006 2.3111 0 3.1521-0.0404 0.0502-0.15004 0.01-0.29029 0.0502-0.45011 0 0 0.47957-0.0202 0.44955 0.0104 0.36995 0.66081 1.0903 1.3908 1.2012 2.1403 0.0692 0.55056-0.31123 1.9204-0.33994 2.6608-0.0502 0.98045-0.12985 1.6908-0.70011 2.4606-0.53046 0.7293-1.5007 0.77953-1.4511 1.8506 0.15986 0.0489 0.30014 0.0104 0.46065 0.0489 0.06 1.5904 0.70989 2.9811 1.01 4.4815 0.25055 1.2309 0.16051 3.7711 1.6508 4.1918 0.06 2.2499 0.52003 2.2805 2.6915 2.3001 1.6201 0.0196 3.0516 0.45011 4.6417 0.31116 0.39997-2.242 7.5844-0.54012 9.1849-0.44097 0 0-0.06 0.30007-0.0802 0.30007 0.0698 0.22049 0.28056 0.36074 0.29035 0.63993 0.45999-0.0698 0.94021-0.21005 1.4002-0.33008-0.58071 0.61058-1.6116 0.97001-2.4018 0.88977-0.7001 0.91978-1.5098 0.99088-2.6914 1.1298-1.151 0.14938-2.5212 0.27985-3.5514 0.94978-0.39084 0.26028-1.0414 0.93087-1.3206 1.3412-0.2499 0.36073-0.41041 1.501-0.6205 1.7208-0.92064 0.93934-2.8115 0.27006-4.0114 0.69994-1.3506 0.47946-1.791 1.4508-2.1714 2.76-0.35038 1.1507-0.67988 2.0411-1.2103 3.1514-0.33994 0.71038-0.74056 3.261-1.1105 3.6015-0.72033 0.64971-3.0908-0.0196-4.0519 0.39987-1.4204 0.63993-1.5398 1.76-1.821 3.1918-1.1601 0.06-2.8317-0.30007-3.8124 0.31899-0.99046 0.63145-0.84039 1.9009-1.4909 2.7522-0.21988 0.28898-1.821 1.9707-2.1714 2.1305-1.1901 0.55056-2.0305-0.18982-3.171 0.66081-1.5307 1.1403-1.1412 5.291-4.0121 3.8415-1.3108-0.6608-0.45999-2-1.9809-2.5114-0.84038-0.27006-2.7815-0.2805-3.6519-0.14025-0.75035 2.2205-0.01 5.1012 0.64008 7.1521 0.27991 0.90086 0.83973 2.2812 0.71054 3.3308-9e-3 0.0626-0.0189 0.12264-0.0287 0.17222zm-22.262-37.091c1.0198-0.53033 1.3604-0.78996 1.301-1.9994-0.30014-0.0802-0.41106-0.19048-0.64008-0.36008-0.0698-0.46054-0.0803-0.90151-0.10961-1.3914-1.0009-0.0196-1.3708-0.69081-2.3013-0.85976-0.09-0.43967-0.0202-1.3196-0.33993-1.6497-0.24012-0.25049-1.3708-0.46054-1.7512-0.49054-0.0202 0.32029-0.09 0.60013-0.19053 0.89042-1.2704 0.0992-0.81037-0.3914-1.3004-1.1709-0.1605-0.25963-0.59048-0.42988-0.79014-0.70973-0.21988-0.28115-0.14028-0.56035-0.48022-0.78018-0.25969 0.20026-0.41041 0.47946-0.42998 0.8291-0.91085 0.0502-2.3515-0.36008-2.1714 1-0.67009 0.03-1.4407-0.0796-2.0612 0.0998-0.67009 0.19048-0.89062 0.77953-1.6605 0.82062-0.0698-0.31963-0.14028-0.63992-0.19052-0.98044-0.09 0.0104-0.2101-0.0104-0.30993 0-0.27012 0.39074-0.73077 0.65037-1.181 0.82063-0.95066 0.33986-1.0707 0.28963-0.94022 1.2603 0.09 0.65037 0.20031 1.6112 0.6205 2.1409 1.1608-0.0907 0.50045 0.85976 0.39997 1.5004-1.1405 0.33986-0.70989 1.1403 0.27012 1.0411 0.65052-0.0607 1.761-0.55121 1.8308 0.55057 0.71055 0.0398 1.4309-0.0104 2.1414 0.03-0.06 1.0405 0.41041 0.94 0.93043 1.5904 0.42998 0.53947 0.20031 1.2094 0.67988 1.7104 0.92064 0.14938 1.821-0.82976 2.3313-1.3999 0.52002-0.57013 1.2404-1.5506 1.9907-1.6706 0.39018-0.0607 1.2808-0.0196 1.671 0.09 0.53047 0.12982 0.66031 0.65037 1.0805 0.89042 1.2606 0.7293 1.4707-0.91194 1.6005-1.8024z",
+                Nantou:"m217.09 275.91c-0.88997-0.5199-0.50958-1.5506-1.671-2.351-1.581-1.0907-0.96044 0.88977-1.7806 1.79-0.74056 0.81019-2.9805-0.4899-3.0314 0.98109-1.4818 0.0692-2.7515-0.20091-4.1125-0.33986-0.39084-0.82975-0.2101-1.8206-0.57027-2.6106-1.121 0.36009-1.7806 2.1905-2.9316 1.9504-0.39997-2.0307-0.12071-3.3308 0.25968-5.1918 0.36082-1.7515 1.4909-2.7906 1.9118-4.4214 0.36017-1.3307-0.35038-1.3001-0.7001-2.2009-0.36017-0.91065-0.27991-1.6504-0.32037-2.6706-0.0404-0.66993-0.58005-2.351-0.18008-3.0013 0.47109-0.77952 1.5209-0.47032 2.4716-0.52055 0.10962-2.0607-0.15986-3.7913-0.63942-5.6406-0.26034-1.0202-0.54025-1.2505-1.0903-1.9805 0.18987 0 0.39997-0.03 0.57027-0.0502-0.0698-0.8004 0.51023-1.2003 0.88997-1.7802 1.7519-0.41031 2.972-0.95043 4.9425-1.0496-0.01-0.0698-0.01-0.39074 0-0.4501-0.49 0-0.82994-0.31051-1.2808-0.39009-0.03-0.4899-0.27991-0.90021-0.21988-1.4403-0.33994-0.33008-0.86062-0.59035-1.2808-0.66994 0.03 1.7515-3.8118 0.54013-4.0519-0.50033-1.6605-0.42988-1.4609-2.9107-2.7815-3.0509 0.50958-1.2707-0.21989-6.3021 1.2697-6.8422 0.0698-1.1403-0.09-2.3308 0.32036-3.351 0.21989-0.55056 0.71055-0.6608 0.8815-1.291 0.12005-0.47032 0-1.1605-0.0307-1.6406-0.23032 0.03-0.55004-0.0802-0.77971-0.0502-0.0907-1.561-0.55003-3.2708-0.33015-4.7815 3.1208 0.12003 3.2806-4.201 1.9411-6.002-0.47043 0.09-0.85017-0.19048-1.2704-0.21983-0.3693-4.1012 4.553-0.39009 5.8931-2.6706 0.28057 0.15982 0.58071 0.29029 0.91086 0.36922 1.2006 0.3105 2.9218-0.0104 4.1726-0.0104 1.8106 0 2.3913 0.31116 3.8424 0.80105 3.342 1.1396 4.6221-0.93086 6.4543-3.1814 0.66944-0.81997 1.5007-1.7704 1.8902-2.7704 0.42085-1.1011 0.62051-2.8813 1.6912-3.6413 0.82081-0.58057 1.9711-0.3503 2.942-0.39987 0.12005-2.4808-0.21989-5.0516 0.65051-7.3119 0.47957-1.2101 1.2906-1.9602 2.7019-1.3203 0.58005 0.25962 0.75034 0.97 1.3004 1.2003 0.73077 0.29029 0.82015-0.03 1.6808-0.17938 0.44955 1.1102-0.33081 2.9211 0.23032 3.9302 0.88084 1.5904 2.4011 0.48011 2.6314-0.96023 0.19052-1.1605-1.1105-3.321 0.84038-3.0007 1.3408 0.20939 1.121 1.8898 2.9616 1.4703 0.54025-1.1814 1.7708-1.1814 2.8409-1.6602 2.3613-1.09 4.4825-0.32029 7.234 0.0196 0.33994-1.0196 0.79015-1.8402 2.052-1.73 0.09-2.291 1.151-4.0111 3.631-4.1012 2.6014-0.09 3.6023-0.40053 5.6635-1.6712 1.8308-1.1298 2.3711-2.8702 3.9618-4.1612 1.5614-1.2799 4.4434-0.58905 6.4738-0.69929 0.12919-1.4814 0.0496-2.7411 1.3604-3.1409 1.0198-0.3105 2.9414-0.63014 4.0023-0.50033 0.55982 0.0802 1.0498 0.60992 1.6312 0.47033 0.42998-0.0998 0.81037-0.95044 1.5398-1.1305 0.70076-0.17939 1.4217-0.12916 2.1714-0.33986 0.66096-0.19048 0.84039-1.2205 1.3604-0.19048 0.72033 0.0404 1.5509 0.10046 2.2713 0.06 1.1405-0.0691 0.48022 0.48011 1.2006-0.69994 0.82016-1.3497 0.99111-2.6406 3.1417-2.3105-0.33994 2.1507 1.6201 1.0411 2.2204 2.1103 0.7001 0.12002 1.4818 0.0502 2.1108-0.15982 0.24011-2.0105 6.0934-0.0202 6.7936 1.0202-0.0802 0.19048-0.0502 0.28963-0.0698 0.47946 0.0196 0 0.03 0.0104 0.0502 0-0.42019 0.57013-0.65052 1-0.55069 2.1612 0.92064 0.17025 0.96044 1.0404 0.78036 1.8402-1.731 0.0907-2.452-0.0404-3.6728 1.0202-1.181 1.0404-2.0005 1.5101-3.6023 2.2205-0.96044 0.42988-0.95065-0.03-1.3708 0.95043-0.29035 0.69016 0.06 1.5101-0.32036 2.2199-0.2499 0.48011-0.92064 0.5199-1.2208 1.2505-0.26033 0.66081-0.16051 1.6308 0.0692 2.351 1.7806 0.0202 1.6716 0.44032 2.852 1.3105 0.92064 0.66993 2.4213 0.98044 3.2513 1.5708 1.7212 1.2303 0.82995 4.7013-0.45999 6.1716-0.67009 0.76061-1.3506 1.9504-2.2112 2.4306-1.5007 0.85128-2.2419-0.38031-2.4611 1.8709-0.14942 1.4814 0.10961 2.4312-0.62051 3.8813-0.61985 1.2303-0.94021 2.0007-1.3708 3.291-0.67988 2.0405-1.4407 2.9909-1.3206 5.4717 0.7001 0.0411 1.4211 0.0104 2.1205 0.0502 0.17095 3.3412-0.16964 6.7418-0.33994 10.124-2.1323-0.14025-1.2612 4.2812-1.331 5.6615-0.23097 0.03-0.56047 0.09-0.78035 0.0502-0.33016 0.72016-0.76079 1.1403-1.0303 1.9804-0.12005 0.39988-0.0202 0.95044-0.16051 1.3307-0.19052 0.5199-0.65051 0.65037-0.88084 1.1703-0.64007 1.4103-0.45999 3.1305-1.1503 4.471-0.5011 0.10959-0.75034 0.39074-1.2815 0.39074-0.45999 1.3608-0.39017 2.8702-0.21988 4.2812-1.4511 0.21983-3.0608 2.351-2.7815 3.8311 2.6817 0.54991 2.6817 0.3803 2.972 3.201 0.20097 1.8806 1.7715 2.0405 2.0109 4.1612 0.0907 0.8702 0.0802 1.9602-0.01 2.8402-0.11027 1.0802-0.75034 1.501-0.84039 2.3308-0.0802 0.83041 0.67009 1.4306 0.51024 2.3308-0.2101 1.2805-1.5209 2.0209-1.9111 3.0209-0.4104 1.0802 0.31058 2.441-0.25055 3.441-0.44955 0.78997-0.82994 0.33008-1.1705 1.3803-0.25904 0.77953 0.13049 1.4208-0.3693 2.1311-0.57092 0.10959-1.1014 0.42075-1.6716 0.42988-0.74969 0.0104-0.92064-0.91064-1.9411-0.20026-0.09 0.42075-1.0407 2.1807-1.5209 2.321-0.92064 0.2805-1.8113-0.88064-2.972-0.31964-0.0907 0.0907-0.03 0.31964-0.0607 0.43966-0.85017 0.21005-0.74969 1.0607-0.61072 1.8409 0.27013-0.0502 0.68053 0.10959 0.95066 0.0496-0.36995 1.4508-0.15007 1.6908-1.7806 2.1709-0.11027 1.8702 0.21009 3.6106 0.0998 5.4417-0.68053 0.44032-1.5209 0.57014-2.0116 1.3405-2.4716-1.8396-8.214-1.9198-10.085 0.72017-1.0498 1.4703-1.761 3.1507-2.3802 4.8004-0.8815 2.3608 1.4602 1.8206 1.3108 4.3112-0.67009 0.21984-1.4217 0.21984-2.1414 0.36987-1.2306 0.25897-0.84039 0.20874-1.7108 0.94978-0.32036 0.2805-0.28056 0.68038-0.48022 0.88977-0.12005 0.12068-0.55003 0.11025-0.84038 0.12981 0-0.14938 0.0307-0.33007 0.0111-0.45988-0.14028-0.03-0.32037-0.0502-0.46065-0.0405 0.03-0.91064 0.44042-1.6412 0.29035-2.6217-0.39083 0.0496-0.78036-0.24005-1.1307-0.23027 0.0411-0.3803-0.20031-0.60079-0.2101-0.93086-1.8713-0.10959-3.2513-0.0104-4.8022-0.69995-1.0805-0.48011-0.95065-0.6197-2.1714-0.36986-0.24011 0.0502-0.49 0.11024-0.74055 0.18004-0.46 0.12003-0.94022 0.25897-1.4002 0.33007-0.0104-0.2805-0.21989-0.42074-0.29035-0.63993 0.0202 0 0.0802-0.30006 0.0802-0.30006-1.6012-0.0992-8.7849-1.8011-9.1849 0.44097-1.5907 0.14025-3.0216-0.29029-4.6417-0.31116-2.1714-0.0196-2.6314-0.0502-2.6915-2.3001-1.4909-0.42074-1.4002-2.9609-1.6508-4.1918-0.30014-1.5003-0.95066-2.8911-1.01-4.4815-0.16051-0.0398-0.30014 0-0.46065-0.0489-0.0502-1.0711 0.92064-1.1213 1.4511-1.8506 0.57026-0.77104 0.65052-1.4814 0.70011-2.4606 0.03-0.74039 0.4104-2.1103 0.33994-2.6608-0.11027-0.74952-0.82995-1.4808-1.2006-2.1403 0.03-0.03-0.44955-0.0104-0.44955-0.0104-0.0411 0.16047 0 0.30007-0.0502 0.4501-0.84039 0.0405-2.3613 0.31051-3.1521 0.0405-1.1705-0.42075-0.77057-1.1409-1.6906-1.8213-0.75034-0.0398-1.5314-0.01-2.2817-0.06-0.0196-0.29028-0.20031-0.46054-0.21009-0.78017-1.4002-0.06-2.7717 0.31115-3.9723 0.14024-0.39083-0.0489-0.68053-0.14873-0.89063-0.26875z",
+                Yunlin:"m204.7 249.7c0.55004 0.72995 0.82929 0.96022 1.0903 1.9805 0.47957 1.8506 0.7497 3.5806 0.63943 5.6406-0.95066 0.0502-2.0005-0.25897-2.4716 0.52055-0.39932 0.65037 0.14028 2.3308 0.18008 3.0014 0.0411 1.0196-0.0405 1.7606 0.32037 2.6706 0.35037 0.90021 1.0603 0.8702 0.7001 2.2009-0.42085 1.6308-1.5503 2.6706-1.9118 4.4214-0.38039 1.8611-0.6603 3.1612-0.25968 5.1918 1.151 0.24006 1.8106-1.5904 2.9316-1.9504 0.36017 0.78997 0.17943 1.7802 0.57026 2.6106 1.3604 0.14025 2.6308 0.41032 4.1125 0.33986 0.0502-1.471 2.2908-0.17025 3.0314-0.98109 0.82147-0.90021 0.20097-2.88 1.7806-1.79 1.1608 0.8004 0.78036 1.8304 1.671 2.351-0.50045 0.23092-1.2006 1.0007-1.1405 1.4305 0.12984 0.84998 1.1014 0.72017 1.3604 1.3405 0.2101 0.49055 0.12071 1.9804 0.12071 2.5114 0.01 1.1207 0.30992 1.501-0.79015 1.8311-1.3904 0.41031-3.522-1.0705-5.0025-1-1.0903 0.0496-3.342 1.3999-3.5416-0.65037-0.36996 0.31116-0.59049 0.30007-0.8306 0.79062-2.6014 0.64971-2.3111-0.30007-2.6614-2.4514-1.8113-0.0496-3.2115 0.7006-4.9627 0.81019-2.0409 0.12068-3.141-0.77953-4.8531-1.1703-3.0816-0.69016-6.8934 0.85063-7.694-3.3008-0.23032 0.0196-0.55003-0.0802-0.78036-0.0607-0.0992-1.2303-1.4707-1.8004-1.7206-3.1109-1.1307-0.25962-1.5509 0.41032-2.5114 0.60014-0.86061 0.17939-1.902 0.0398-2.8017 0.0398-0.81037 0-2.2014-0.27006-2.9616 0-0.9911 0.36009-0.76078 1.2303-1.5307 1.6804-2.1616 1.2707-3.0118-1.6106-4.5125-1.6804-1.4609-0.0802-3.5723 1.3105-3.3615 2.972-0.96044 0.0502-2.0612-0.13046-2.9414 0.23027 0.33015 1.7606-1.2912 2.7013-2.7019 2.8004-2.2014 0.15982-2.3111 0.54012-2.3515 2.8122-0.96044-0.26027-2.0807-0.54012-3.1214-0.4501 0.0202 0.66994 0.51024 1.1403 0.61072 1.7802-1.7212 0.14025-2.4912-0.62036-3.342 0.82063-0.93043 1.6002-0.18009 2.1005-2.101 2.7404 0.23033 1.6197-1.0707 2.3001-1.9907 0.93021-0.36996-0.54991 0.25968-1.1703-0.36996-1.6412-0.25055-0.18982-1.4811 0.0202-1.8113 0.0307-0.12006 0.74952-0.64008 1.4899-0.50045 2.2799 0.09 0.50164 0.88084 1.1905 0.98067 1.8617 0.35038 2.5806-1.4909 2.5708-3.522 2.1709-1.5907-0.31116-3.1717-0.81019-4.8224-1.1605-0.89063-0.18983-3.4418-0.38031-3.862-1.1403-0.32037 0.0698-0.79015-0.11024-1.1105-0.06 0.15006-1.1102-0.35038-1.6008-1.0505-2.0607 0.0405-0.0496 0.06-0.11024 0.0803-0.18004 0.26033-1.0705-0.55004-0.88912-0.95066-1.5304-0.0502-0.0104-0.11026 0-0.1605-0.0196-0.0503-0.87085-0.06-1.8011-0.01-2.6804 0.0405-0.71038 0.27991-0.36987 0.50045-0.81019 0.21988-0.45988-0.21989-0.63993-0.4202-0.88977-0.57026-0.71038-0.38039-1.6908-0.33015-2.621 0.0202-0.52056 0.30014-0.66994 0.36995-1.0607 0.0803-0.40966-0.24011-0.75017-0.31057-1.1403-0.0803-0.48011 0.0202-1.0405-0.01-1.5304-0.36995-0.13047-1.151-0.74104-1.0505-1.2107 0.0998-0.5199 0.85082-0.27006 1.1105-0.80105 0.18008-0.36922 0.0104-1.2505 0.0104-1.6797 0-0.72017 0.32036-0.94 0.50044-1.5708 0.18009-0.62036 0.4202-1.0098 0.88084-1.5101 0.49001-0.53034 0.6205-0.84019 0.85996-1.5095 0.24011-0.66993 0.39018-1.09 0.45021-1.7906 0.0398-0.56035 0.27012-0.89043 0.64008-1.3007 0.57026-0.62036 2.2112-1.6008 1.7206-2.6308-0.21989-0.45989-0.45021-0.48989-0.48022-1.1403-0.03-0.4201 0.0998-0.97979-0.0803-1.3601-0.21009-0.44945-0.48022-0.3803-0.85082-0.30985-0.32037 0.06-0.20031 0.36008-0.57026 0.10959-0.18009-0.12068-0.27992-0.33986-0.26034-0.56034 0.12005-0.97979 1.8413-0.62036 2.5016-0.70973 0.0398-0.8702-0.15007-1.7404-0.18008-2.6008-0.0398-0.99022 0.20031-1.2505 0.70076-2 0.81037-0.0404 2.681 0.30007 3.1214-0.44032-0.0998-0.52055-0.20031-0.99088-0.20031-1.561 0-0.27985-0.0803-0.69016 0.0802-0.93021 0.18009-0.27007 0.55069-0.27007 0.73077-0.50034-0.6603-0.30007-0.88084 0.2505-1.181 0.66994-0.27991 0.39987-0.81037 0.75996-1.0205 1.1905-0.45021 0.12003-0.72033 0.63993-1.121 0.87999-0.32037 0.19047-0.67988 0.12068-0.99046 0.25049-0.24011 0.0998-0.42019 0.30007-0.67987 0.30007-0.09-0.68038-0.59049-1.2101-1.0205-1.7215-0.51024-0.6197-0.47043-1.0796-0.49001-1.8806 0.21988 0.51011 0.70011 1.0307 1.3004 0.93999 0.52002-0.0907 0.59049-0.54991 0.78036-1.0007 0.38039-0.89042 0.47043-1.8904 0.42019-2.8807-0.68053 0.0698-1.0309 0.24984-1.5105 0.74038-0.46065 0.45989-0.78036 0.58057-1.3506 0.8702-0.09-0.50033 0.74055-1.0307 1.1105-1.2903 0.47043-0.33986 0.68053-0.7306 1.1307-1.0711 0.39018-0.28898 0.89063-0.74952 1.3708-0.9002 0.88084-0.28964 1.3206-0.57013 1.9711-1.2094 0.6205-0.62036 1.2906-1.1703 2.1616-1.4005 0.75034-0.21005 3.3015 0.46054 2.9414-1-0.15007-0.60014-0.88084-0.63928-0.24011-1.3001 0.27991-0.2805 0.67009-0.36987 1.0603-0.39075 0.30014 0.12068 0.74056 0.18005 1.1307 0.11025 0.67009 2.0516 3.5919 0.81997 4.3918 2.2805 2.3411 0.66015 4.3226 0.86042 6.9736 0.86042 1.1908 0 2.681 0.24984 3.8418 0.01 1.4009-0.30007 1.9013-1.2903 3.1319-0.20026 0.97023-2.0516 1.7708-1.8102 4.0323-1.8102 0.92064 0 1.8308-0.06 2.6216 0.21005 1.0407 0.35029 1.241 0.9002 2.5212 0.82062-0.0398 0.27006 0.11027 0.66994 0.06 0.94 0.20031 0.20026 0.20031 0.01 0.33015 0.33986 1.581 0.0907 2.4611 0.06 3.6317 0.69081 0.99045 0.53034 1.7212 1.3307 2.6614 1.6608 2.651 0.90999 5.593 0.20939 8.3543 0.33986 0.4104 0.0202 1.4818-0.0189 1.8413 0.16047 0.47043 0.23092 0.73012 1.06 1.1908 1.3105 0.91085 0.47097 2.7417 0.48011 3.802 0.53034 1.6801 0.0802 3.3818 0.17025 5.0626 0.14938 1.9111-0.0189 2.0214-0.0802 3.141 1.4814 0.0215 0.0157 0.0313 0.0359 0.0418 0.0555z",
+                Penghu:"m30.865 336.76c0.46065 0.0698 0.20031 0.18004-0.06003 0.3503-0.51023 0.33986-0.21988 1.15-0.59049 1.6504-0.15007 0.20026-0.32036 0.4788-0.49001 0.64906-0.23032 0.21005-0.47043 0.0907-0.7001 0.25114-0.28056 0.20027-0.14028 0.50947-0.2499 0.8004-0.09004 0.24006-0.27012 0.39988-0.32036 0.66994-0.04045 0.24006 0.0098 0.50033-0.33015 0.50033-0.1703-0.21983-0.40975-0.47032-0.60028-0.69016-0.15986-0.19047-0.56048-0.33072-0.6603-0.53034-0.10962-0.23027 0.1305-0.58904 0.16051-0.80953 0.02023-0.18982 0.02023-0.52055-0.06981-0.69081-0.21988-0.41031-0.76078-0.48989-1.0009-0.90021-0.03001-0.0698-0.05024-0.19047-0.09983-0.24005-0.09983-0.0998-0.18987-0.0405-0.30014-0.11024-0.1703-0.09-0.25968-0.4488-0.47043-0.45989 0.45021 0 0.90041-0.03 1.3506-0.0405 0.32036 0 0.39018-0.0411 0.61072-0.21983 0.23032-0.19048 0.2897-0.18004 0.64008-0.18004 0.48022 0 0.95065 0.0404 1.3708-0.12003 0.20031-0.0698 0.36016-0.0502 0.56047-0.0998 0.27012-0.0607 0.15986-0.22049 0.33994-0.31116 0.10896 0.4214 0.56961 0.48076 0.90955 0.53099zm9.855-23.999c0.12006 0.36008 0.21988 0.66015 0.06981 1.06-0.15986 0.4214-0.55004 0.48011-0.59049 0.96087-0.02023 0.42075 0.24011 0.69994 0.4104 1.0496-0.73077 0.11024-4.3827 0.0907-4.3925-0.78996 0.33015-0.0202 0.60028-0.19048 0.6603-0.50034 0.80058-0.41031 1.3904-1.1905 1.3108-2.0803-0.09983-0.0104-0.2101-0.0307-0.31058-0.0307-0.55982-0.66015-0.09004-0.97-0.09983-1.6497 0-0.54013-0.64008-1.3412 0.26034-1.6713 0.13963-0.03 0.33994 0.17026 0.48022 0.17939 0.11027 0.78997 0.51023 0.0998 0.85082 0.15982 0.81037 0.12981 0.2499 0.25049 0.58005 0.75017 0.1703 0.25898 0.73077 0.42989 0.82016 0.60014 0.24011 0.4201-0.2101 0.85063-0.24011 1.06-0.06916 0.55186 0.03067 0.38226 0.19052 0.90216zm4.2326 0.90021c0.01957 0.25962 0.06981 0.21005-0.1703 0.34964-0.12006 0.0607-0.29035 0.12134-0.43063 0.18004-0.53046 0.25898-0.40975-0.20091-0.85017-0.24983-0.31058-0.0411-0.20031 0.18982-0.33015 0.33986-0.08025 0.11024-0.11027 0.0998-0.2101 0.17025-0.09983 0.0613-0.24011 0.16047-0.36995 0.24006-0.0098 0.22048 0.08025 0.55056-0.1703 0.65036-0.36995 0.12982-0.40975-0.33007-0.45999-0.55056-0.50045 0.03-0.43063-0.69994-0.43063-1.0404 0.33015 0 0.6603 0.0104 0.99046-0.0111 0.09004-0.25898 0.08025-0.57013 0.06003-0.85911-0.11027-0.0111-0.23032-0.0998-0.24011-0.22049-0.04045-0.3105 0.24011-0.14025 0.38039-0.25962 0.11027-0.0998 0.03001-0.27007 0.11027-0.34965 0.10962-0.0907 0.39997 0 0.49001 0.12981 0.20031 0.31051-0.1703 0.55056 0.33994 0.60014 0.19052 0.0196 0.42019-0.12981 0.5807-0.09 0.14028 0.03 0.15007 0.14938 0.2499 0.20874 0.09983 0.0613 0.2101 0.0111 0.30014 0.10046 0.1703 0.15134 0.15072 0.46185 0.16051 0.66146zm0.24011-20.209c-0.21988 0.4201-0.13963 0.91978-0.16964 1.3901-0.90041 0.0502-1.6012 0.2805-2.4213 0.20027-0.42019-0.0489-0.7399-0.16961-1.1503 0-0.32036 0.13046-0.09983 0.63993-0.73077 0.55121-0.0398-0.18004-0.15986-0.21983-0.20031-0.39074-0.21988 0.0411-0.50045-0.0607-0.72033-0.03-0.06003-0.6308 0.71054-0.60079 0.6603-1.1507 0.73012 0.17874 1.7108-0.22048 2.3913-0.42988 0.77057-0.25049 1.4909-0.2107 2.3411-0.14025zm0.26034-23.275c0.19052 0.0998 0.19052 0.8402 0.09004 1.09-0.6603 1.6112-2.3913 0.72016-3.7419 1.2609-0.02023 0.74952-0.0098 0.82975 0.30014 1.4299 0.30014 0.55056 0.36995 0.75017 0.33015 1.4606-0.04045 0.95044 0.15986 2.7019-1.2103 2.6106-0.14028 0.53034 0.98002 1.8011-0.25055 1.8409-0.01957 0.33986-0.12006 0.90021-0.01957 1.2401 0.09983 0.3105 0.43977 0.45989 0.57026 0.75995 0.44042 1.0705-0.38039 1.1807-1.2208 1.1403 0.02023-0.12068-0.0398-0.2805-0.01957-0.39075-0.76078-0.0404-1.7512-0.53034-2.4018-0.09 0.30014 1.3405-1.6207 0.0496-1.611 1.06-0.69032-0.0802-1.0805 0.32029-1.8008 0.25049-0.39997-0.98044 0.06981-1.1102 0.75034-1.5095 0.58005-0.33986 0.27012-0.3803 0.57026-0.81018 0.2101-0.31116 0.1703-0.52056 0.72033-0.58122 0.30992 0.51012 0.51023 0.61971 1.0505 0.60079 0.26034-0.0111 1.1412-0.27006 1.331-0.42075 0.60028-0.50099 0.67009-2.1507 0.38039-2.9211-1.3911 0-1.4009-1.3412-0.08026-0.86041 0.03001-0.61123-0.03001-0.92043 0.32036-1.3803 0.33015-0.44032 0.76078-0.42075 0.85082-1.09-0.14028 0.03-0.33994-0.0502-0.48022-0.03 0.02023-0.11024-0.0398-0.28115-0.02023-0.39074-0.24011-0.0404-0.47043-0.16047-0.73012-0.11024 0.27012-0.8004-0.2499-1.9198 0.09004-2.6406 0.85017-0.0104 0.70989-0.25049 0.98002-0.85063 0.2101-0.44032 0.61072-0.66015 0.75034-1 0.36995-0.8004-0.18008-0.69016 0.75034-1.0802 0.45021-0.19048 0.86061-0.46054 1.3108-0.65037l0.03001 0.0698c0.1305-0.01 0.27012-0.01 0.40062 0.0104-0.2101 0.36074-0.39018 0.6608-0.63029 1.0111-0.29035 0.39922-0.69032 0.39922-0.51024 1.0496 0.77057-0.0502 1.3708 0.57013 2.2412 0.3503 0.21923-0.0587 0.71902-0.52838 0.90955-0.42858zm8.5742-4.4032c-0.23032 1.3803 1.641 2.2205 1.5007 3.8109-0.36995 0.0202-0.76078 0.0104-1.1405 0.0307-0.26034 0.38031-0.32036 1.2401-0.2499 1.7208 0.84039-0.19048 0.82995 0.8004 0.39018 1.1703-0.63029-0.0404-0.50045 0.63014-0.47043 1.0802 1.5307 0.03 1.2912 1.1005 1.2208 2.4208-0.4104 0.03-0.89063-0.2805-1.2306-0.48989-0.7001-0.45011-0.29035-0.48011-0.59049-1.2505-0.39018-1.0411-1.761-0.57013-1.3206-1.9915 0.54025-0.09 0.33015-1.1096 0.31058-1.5806-0.86061 0.0411-0.49001-0.77953-0.75034-1.2603-0.16051-0.29029-0.53046-0.33986-0.65052-0.66994-0.09983-0.24984 0-0.72016-0.01957-0.99023-0.8704-0.26027-2.191-0.63014-2.0814 0.63928-0.53046-0.0196-0.44042 0.52056-0.74056 0.78018-0.50045-0.3803-0.69032-0.93935-1.331-0.65037 0.09004-0.06 0.01044-0.16047 0.08025-0.27984h0.09004c0.31058-0.76061-0.38039-1.1905-0.32036-1.9009 0.56048 0.10959 0.84039-0.36987 1.4009-0.43054 0.54025-0.0691 1.2306 0.0998 1.8211 0.0698-0.04045-0.15982 0.06003-0.39987 0.03001-0.56035 0.41041-0.03 1.0309 0.17026 1.0805-0.33007 0.7001-0.21005 0.84039 0.41031 1.3408 0.63014 0.52981 0.22179 1.0505-0.058 1.6305 0.032zm1.592-17.163c0.09004 0.40966 0.1703 0.78997 0.16051 1.2205-0.18008-0.0411-0.45021 0.0691-0.64008 0.03-0.04045 0.78996-0.31058 0.85976-0.67009 1.3999-0.23032 0.33986-0.15007 1.4606-0.91085 1.2401 0.02023-0.1396-0.08025-0.18004-0.09983-0.24005-0.0098-0.66016-0.10962-1.3503 0.27012-1.9009 0.30014-0.44031 1.1307-0.55056 1.1405-1.1703-0.32036-0.06-0.52002-0.33987-0.59049-0.66994-0.39018 0.0411-0.65052-0.20026-0.64008-0.57992 0.78036-0.21005 1.1803 0.78018 1.9803 0.67059zm0.75687 4.9772c0.27012 0.19048 1.1405 1.0007 1.0009 1.4208-0.14028 0.42988-1.4811 0.24984-1.8511 0.39988-0.5807 0.24005-1.0603 0.92043-1.2306 1.5708-0.39018-0.31116-0.47043-0.78996-0.42998-1.291-0.24011 0.0411-0.43063-0.10959-0.64008-0.10959-0.19052-0.63014 0.40975-0.54012 0.67009-0.9002 0.25968-0.36009 0.23032-0.60014 0.24011-1.0705 0.45999-0.0907 0.78036-0.80105 0.99046-1.1814 0.25968 0.75147 0.64986 0.75147 1.2501 1.1611zm9.1868 29.42c1.0309 0.25049 1.4211 0.16047 1.3904 1.4097-1.1608 0.0913-2.5812 1.0411-2.5009-0.88912-1.3506-0.0698-2.8415-0.14025-4.1523-0.0907-0.82016 0.0307-1.2704 0.22049-1.5007 0.91064-0.2499 0.72017 0.02023 1.1207-0.82995 1.4208-0.30014 0.11024-0.64008-0.0405-0.92064 0.0998-0.35038 0.17939-0.45021 0.52055-0.73012 0.74952-0.46065 0.39074-1.0009 0.33986-1.3408 0.84019-0.75034 1.1103 0.81037 2.8918-0.08026 3.9818-0.30992 0.37965-0.89063 0.25897-1.4204 0.23027-0.43063-1.561-2.0011 0.12068-3.1019 0.17939-0.61072 0.0404-1.4009-0.14939-1.5907-0.82976-0.14028-0.50033 0.42998-1.2394-0.06003-1.7704-0.49001-0.55056-1.2404 0.0998-1.8308-0.50033-0.47043-0.47032-0.21988-1.1605-0.77057-1.5617-0.44042-0.31899-1.5509 0.0698-1.7708-0.64972-0.18987-0.58056 0.55069-0.82062 0.6205-1.3412 0.43063-0.20027 0.30014-0.66015 0.5807-1 1.2103-0.33007-0.02023 2.3412 1.3108 2.1703 0.27991 0.72016 0.75034 1.0104 0.69032 1.8904 0.52002 0.14938 0.8704-0.0998 0.8306-0.63993 1.6207-0.0796 0.81037 0.53034 1.2508 1.6412 1.0407 0.20026 1.2906-0.66994 1.2508-1.561 0.67988 0.0496 2.9616 1.6204 2.5512 0.0111-0.0398-0.19048-0.45999-0.27007-0.48022-0.52121-0.04045-0.47946 0.30014-0.45924 0.50045-0.66929 0.27012-0.30006 0.49001 0.0496 0.51023-0.59035 0-0.12981-0.28056-0.63014-0.36016-0.74039-1.1007-1.3901-2.101 0.20092-3.1417 0.33073-0.97023 0.12003-2.6216-0.76061-2.4911-1.9009 0.68053-0.0691 1.7108 1.2101 2.2412 0.24006 0.65052-1.2101-1.0407-1.4703-1.7408-1.2401-0.09004 0.48011-0.59049 0.31116-1.0107 0.31964 0.15007-0.88977 0.31058-1.1801 1.151-1.6002 0.12006-0.68038-0.98067-1.6106-0.6603-2.0607 0.2499-0.33986 2.0311-0.01 2.4716 0-0.33994-0.90021 0.33994-0.85911 1.0205-0.82911 0.03001 0.66929-0.18008 1.9994 0.36995 2.471 0.09983 0.09 1.0303 0.30007 1.1405 0.26941 0.67009-0.17939 0.39997-0.36987 0.44042-0.94 0.10962-1.6902 0.96044-0.33986 1.5705-1.15 0.64008-0.84084-0.65052-1.4703-0.85017-1.9009-0.12006-0.03-0.1703-0.06-0.2499-0.0998 0.45021-0.12002 0.82016-0.67972 1.4302-0.50033 0.53046 0.16047 0.35038 0.88977 1.2306 0.4899-0.12006-0.74104 0.91085-1.1403 1.2808-0.4899 0.16051 0.28963-0.36016 0.99023-0.42998 1.3405-0.09004 0.4501-0.09983 1.3001 0 1.7508 0.10962 0.48011 0.58005 1.1514 1.0903 0.50099-0.26034-0.36987-0.18008-1.5506-0.06981-1.9413 0.27991-1.0196 0.88084-0.30007 1.8008-0.41031 0.06982-1.3999-0.16051-2.1709 1.5007-1.8898 0.09983 0.67972 0.33015 1.1292 0.36016 1.8898 0.2499-0.03 0.55069 0.0502 0.81037 0.03 0.06981 0.0802 0.09004 0.0907 0.1703 0.17091-0.04045 0.19048 0.02023 0.45989 0.02023 0.72016 0.76078-0.0802 0.23032-1.1605 0.39997-1.6608 0.24011-0.66016 0.76078-0.51991 1.4909-0.48011 0.02023 0.4501-0.15007 1.2205 0.01044 1.6504 0.23032 0.59035 0.52002 0.57991 0.59049 1.3307 0.09722 1.1285-0.05285 2.2884 0.0072 3.409z",
+                Changhua:"m211.1 246.37c-0.01 0.0607-0.01 0.3803 0 0.4501-1.9711 0.0998-3.1919 0.63928-4.9425 1.0496-0.38039 0.58057-0.96044 0.98044-0.88997 1.7802-0.17095 0.0202-0.38039 0.0502-0.57026 0.0502-0.0111-0.0202-0.0202-0.0411-0.0411-0.06-1.1203-1.561-1.2306-1.501-3.141-1.4814-1.6808 0.0202-3.3824-0.0692-5.0632-0.14938-1.0603-0.0502-2.8918-0.0607-3.8013-0.53034-0.46064-0.24984-0.72033-1.0802-1.1908-1.3105-0.36017-0.18004-1.4309-0.14025-1.8413-0.16047-2.7606-0.12981-5.7033 0.57013-8.3543-0.33986-0.94022-0.33008-1.671-1.1298-2.6614-1.6608-1.1705-0.63014-2.0514-0.60014-3.6317-0.69016-0.12984-0.33007-0.12984-0.13959-0.33015-0.33986 0.0502-0.26941-0.0998-0.66928-0.06-0.93934-1.2802 0.0802-1.4805-0.47033-2.5212-0.82063-0.79015-0.27006-1.7004-0.21004-2.6216-0.21004-2.2608 0-3.0614-0.24006-4.0323 1.8102-1.2306-1.0907-1.731-0.0998-3.1319 0.20027-1.1608 0.24005-2.651-0.01-3.8418-0.01-2.6517 0-4.6326-0.20091-6.9736-0.86041-0.80059-1.4606-3.7217-0.23093-4.3918-2.2805-0.39018 0.0698-0.8306 0.01-1.1307-0.11024 0.18009-0.01 0.36996-0.01 0.54025 0 0.60028 0.03 1.4309 0.27006 1.8909-0.21983 0.48022-0.53034-0.18008-0.72017-0.32036-1.3503-0.20031-0.90021 0.59048-1.6008 1.4309-1.561 0.11027-0.69081 0.0803-0.91065 0.8306-0.93022 0.6205-0.0202 1.5105 0.17026 2.0514-0.12981 0.4502-0.25049 0.84038-1.0502 1.0903-1.4814 0.30014-0.53033 0.20031-1.1102 0.42998-1.6406 0.53046-1.2205 1.4309-2.1103 2.2112-3.1312 0.33015-0.43967 0.60028-1.1011 0.77057-1.6204 0.06-0.21004 0.0202-0.57013 0.12984-0.75017 0.19053-0.30985 0.36996-0.23027 0.50045-0.60992 0.10962-0.31051 0.06-0.94 0.06-1.2603-1.1007-0.29028-2.071-0.40053-1.3506-1.6608 0.54025-0.95043 1.3806-1.7 1.731-2.8506 0.27012-0.89042 0.43063-1.8506 1.0009-2.6713 0.15985-0.23027 0.36016-0.36921 0.52002-0.63927 0.12984-0.23093 0.12005-0.48011 0.35037-0.63015 0.50045-0.32029 1.3911 0.30007 1.8811-0.0698 0.33993-0.25049 0.39017-1.0907 0.48022-1.4703 0.15985-0.66994 0.35037-1.3503 0.78035-1.8898 0.58071-0.72016 1.181-1.1807 1.3206-2.1103 0.14028-0.88064 0.7001-1.3712 1.3604-1.9407 0.48022-0.42074 1.9711-0.97 2.131-1.5101 0.88083-0.15004 2.6014-0.66994 2.4213-1.8709-1.0002-0.0802-2.131 0.11024-3.1717 0.0502-0.80058-0.0404-0.78036-0.21983-0.71054-0.95044 0.0502-0.44031-0.0405-1.09 0.0803-1.5506 0.28057-1.1305 1.761-1.1605 2.7613-1.2505 0.57026-0.0502 1.0707-0.26028 1.611-0.31116 0.56047-0.0496 1.1412 0 1.6912 0 0.61071 0 1.5809 0.21005 1.9209-0.42923 0.27991-0.53034 0.0196-1.3412-0.06-1.8709-0.0998-0.65037 0.12984-1.09 0.26034-1.7006 0.13963-0.5897 0.09-1.3196 0.06-1.9302-0.53046-0.0202-1.0309-0.06-1.5607-0.0691-0.77057-0.0104-0.71054 0.0802-0.75034 0.8004-0.06 0.0202-0.11027 0-0.1703 0.0202-0.0202 0.33986 0 0.70059-0.0202 1.0496-0.64007-0.09-0.28056 1.1011-0.44042 1.4906-0.84038 0.0502-1.9914-0.21984-2.8011 0.0111-0.57026 0.1696-0.40061 0.69929-0.95065 0.99022-0.15007 0.0802-0.45021 0.0404-0.61071 0.09-0.2897 0.0907-0.3804 0.33987-0.73012 0.29029 0.21988-1.1703 1.1608-1.4208 1.8511-2.2407 0.76078-0.91065 1.4407-1.8506 2.251-2.7104 0.7001-0.74039 1.5007-1.5108 2.2713-2.2812 0.33015-0.33008 0.67988-0.72017 0.92064-1.1403 0.29035-0.53034 0.36016-1.0502 0.81037-1.4906 1.0205-1.0007 3.0216-0.43053 4.4322-0.51011 0-0.53947 0.06-0.5199-0.12005-0.99023-0.45021-1.2603 0.92064-1.4403 1.4002-2.3608 0.27012-0.53034 0.2003-1.2701 0.71054-1.7202 0.96109-0.85063 2.7913-0.50033 4.0121-0.31116-0.0405-0.12002-0.0803-0.23027-0.12071-0.31963 0.0803 0.03 0.15986 0.0691 0.24011 0.11024 0.0803 1.3497 0.11027 2.2903 0.54025 3.4612 0.42084 1.15 1.0714 1.8402 1.5007 2.8409 0.49001 1.1703 0.0907 2.9002 0.7001 3.9713 0.72033 1.2505 2.0312 0.78997 3.1019 1.2303 0.09 0.68037 0.67009 0.81018 1.331 0.66015-0.0692 0.32029 0.12984 0.80105 0.06 1.1102 1.1405 0.58122 2.0011 1.0502 3.3028 1.2003 1.4106 0.15982 2.6712-0.0802 3.9723 0.36073-0.09 1.8004 0.58005 1.8102 1.2404 3.1012 0.58984 1.15 0.3804 3.0007 2.2706 2.5604-0.11027 0.46054 0.0202 0.21983-0.28056 0.51012-0.0803 0.96022-0.93043 1.5604-1.0303 2.471-0.11027 0.98044 0.33994 2.1005 0.36017 3.1403 0.64007 0.03 1.3108 0.03 1.9509 0-0.0802-0.38031 0.1305-0.91 0.0502-1.2903 2.1512 0.25962 3.2017 2.6106 5.0626 3.621-1.3408 2.2805-6.2631-1.4306-5.8931 2.6706 0.42084 0.03 0.80123 0.30986 1.2704 0.21983 1.3408 1.8004 1.181 6.1221-1.9418 6.002-0.21988 1.5101 0.24011 3.2212 0.3308 4.7815 0.23033-0.03 0.55004 0.0802 0.77971 0.0502 0.03 0.47945 0.15007 1.1703 0.03 1.6406-0.17029 0.63015-0.6603 0.74039-0.88084 1.291-0.4104 1.0196-0.24989 2.2107-0.32036 3.351-1.4909 0.54012-0.76078 5.5715-1.2697 6.8422 1.32 0.14025 1.1203 2.621 2.7815 3.0509 0.24011 1.0404 4.0825 2.2512 4.0519 0.50033 0.42019 0.0802 0.93956 0.33986 1.2808 0.66994-0.06 0.54012 0.19052 0.95043 0.21988 1.4403 0.45151 0.0776 0.79145 0.38813 1.2821 0.38813z",
+                Taichung:"m182.09 177.11c-0.03-0.84997-0.10962-2.0907 0.38039-2.8004 0.42998-0.63015 1.5209-1.4606 2.3515-1.5206-0.0411-0.8004 0.47957-1.09 0.0496-1.8604-0.27012-0.4899-0.80058-0.80106-1.2097-1.1814 1.2397 0.63993 2.5707 0.71038 2.6712 2.4814 0.33015 0.0398 0.57026-0.20092 0.80124-0.36987 0.11027-0.91065 0.26947-1.0202 1.121-1.0705 0.21988-0.97979-0.93108-0.39988-1.0603-1.291-0.74121-0.12982-1.5209-0.21005-2.2817-0.20027 0.82995 0 1.3108-0.48989 1.8713-1 0.3693-0.33986 0.39932-0.29028 0.47957-0.81018 0.06-0.36009 0.0907-0.74039 0.0502-1.1103-0.0692-0.03-0.11027-0.0502-0.18008-0.0802 0.43063 0.0104 1.1307-0.0802 1.701-0.06 0.96044 0.0411 0.76078 0.11024 1.0009 0.8702 0.40975-0.01 0.81037-0.09 1.1705-0.25897 0.0405-0.33073 0.31058-1.1703 0.12005-1.4103-0.0803-0.0998-0.52002-0.15003-0.6603-0.21004-0.24011-0.10959-0.32036-0.32029-0.75034-0.30986 0.41105-0.44097 1.6207 0.0992 1.9809-0.30007 0.56047-0.63079-0.17943-1.9504 0.0411-2.6719 0.2897-0.96936 1.4909-1.5206 2.0801-2.2701 0.97022-1.2205 0.17094-2.591 0.80123-3.8813 0.39018-0.78018 1.1105-1.15 1.761-1.7306 0.60028-0.54012 1.1803-1.2394 1.5698-1.9504 0.32037-0.57991 0.97088-1.1598 1.1816-1.7704 0.24011-0.65036 0.16051-1.1102 0.63942-1.6908 0.8306-1.0104 2.0716-1.4906 2.7019-2.6106 0.0196-0.03 0.0404-0.0691 0.06-0.0998 1.4106 1.1305 1.5105 2.7815 2.5512 4.2114 1.0707 1.4514 2.8709 1.9707 4.0917 3.6217 1.121 1.5003 2.0612 2.351 3.4627 3.591 0.74969 0.66015 1.0407 1.5506 1.9907 1.9602 1.0909 0.47946 1.7212 0.06 2.8017 0.8702 1.7806 1.3405 3.2017 3.2714 5.163 4.4912 2.1212 1.3203 4.9829 0.7006 6.834 2.1807 0.88084 0.70973 1.4609 1.8702 2.4318 2.5806 1.0798 0.78018 2.0605 0.41031 3.4522 0.20092 2.4514-0.36987 5.4821 0.50946 7.6737-0.33073 3.2017-1.2198 0.0998-4.6211 1.6201-6.882 1.4413-2.1096 4.6423 0.0998 6.3831 0.3803 2.2119 0.36008 5.7333-0.30007 7.174 1.8702 0.35038 0.53034 0.15985 1.2505 0.53046 1.7704 0.2499 0.3503 0.93956 0.48011 1.2508 0.74039 1.2306 1.0307 1.4407 1.5708 3.1919 1.4305 0.14028-0.69994 0.63029-1.1507 0.88084-1.7802 1.5907-0.0307 1.5405-1.3803 2.482-1.7006 1.2306-0.41031 1.5712 0.8402 2.6712 0.68038 0.33994-0.0502 2.0514-1.0104 2.3313-1.1703 1.32-0.78997 0.55917-1.0502 1.3708-2.1409 0.36995-0.50033 1.1014-0.33007 1.4609-0.69016 0.38039-0.3803 0.33015-0.8702 0.63029-1.2101 0.89062-1.03 1.151-0.84019 2.542-1.1292 2.3006-0.47098 3.1514-1.2505 4.2013-3.3021 2.221-0.39922 2.052-1.0705 2.1616-3.1703 0.69032-0.12067 1.4602-0.0202 2.1212 0.15917 0.31058 1.501 0.70011 2.8618 2.5205 1.6804 1.1014-0.72995 1.1412-2.03 2.6419-2.561 0.47044-1.1703-0.0802-2.6106 0.39018-3.7809 0.81038 0.0404 1.4106-0.39988 1.9411-0.87999v0.1396c1.6208 0.0802 3.4627 0.0802 5.043-0.15982 1.32-0.20092 2.4905-0.84019 3.4118-1.7802 0.0411 0.03 0.0803 0.0502 0.12071 0.0698 0.2499 0.15982 0.51023 0.28963 0.7001 0.5199 0.20031 0.25962 0.26948 0.60014 0.42998 0.87998 0.33081 0.60014 0.2101 1.1703 0.2101 1.8506-0.01 0.35029-0.0502 0.65036-0.2101 0.92043-0.14941 0.25962-0.35037 0.48011-0.42998 0.78017-0.0607 0.24984-0.18008 0.74039-0.0698 1.0007 0.11027 0.30007 0.49001 0.45989 0.74056 0.63928 0.28056 0.21004 0.44042 0.52055 0.68053 0.78018 0.29035 0.32029 0.42998 0.29028 0.8704 0.29028 0.83059 0 2.0109-0.20092 2.7019 0.17026 0.31971 0.18004 0.91085 0.29028 1.121 0.57991 0.17029 0.23092 0.0998 0.76061 0.0998 1.0411 0 0.82062-0.0202 1.6908 0.82929 2.0111 0.38039 0.14025 0.90041 0.17939 1.3206 0.12003 0.49-0.0691 0.55003-0.3105 0.85017-0.66015 0.2499-0.29028 0.56047-0.3803 0.89062-0.58122 0.41041-0.2394 0.68053-0.21983 1.1412-0.30985 0.50045-0.0998 1.0107-0.12003 1.5607-0.12003 0.35038 0 0.39996 0 0.65051-0.15982 0.16051-0.11024 0.26034-0.28115 0.46065-0.33986 0.48022-0.12981 1.0505-0.12981 1.5307-0.0992 0.73012 0.03 0.85083 0.2094 1.2808 0.76061 0.24011 0.30986 0.25968 0.17939 0.61071 0.30007 0.5807 0.20027 0.70076 0.61971 0.79015 1.1703 0.03 0.20027 0.0802 0.38031 0.14941 0.5597-0.79014 0.47097-2.0005 1.6308-2.2412 2.1814-0.50045 1.1396 0.30014 2.8311-0.20031 3.9713-0.36995 0.81997-1.3415 1.7-2.1212 2.3301-0.56048 0.47098-1.2208 0.33073-1.7114 0.66994-0.82995 0.56035-0.2897 0.77039-0.82081 1.5108-0.79015 1.0705-2.0801 1.0796-2.5205 2.4899-0.33993 1.1103 0.60028 3.1918 0.01 4.1723-0.58005 0.95044-2.3711 0.2094-3.312 1.0307-0.69032 0.60014-1.0498 2.291-1.5209 2.9707-0.23032 0.33007-0.43063 0.58056-0.60028 0.8004-0.0202 0.0104-0.03 0-0.0502 0 0.0196-0.19048-0.0104-0.28963 0.0698-0.47946-0.70011-1.0411-6.5534-3.0307-6.7936-1.0202-0.63029 0.21005-1.4106 0.27985-2.1108 0.15982-0.60027-1.0705-2.5616 0.0411-2.2204-2.1103-2.1512-0.33008-2.3222 0.96087-3.1417 2.3105-0.72033 1.1807-0.06 0.63079-1.2006 0.69994-0.72033 0.0411-1.5509-0.0202-2.2706-0.06-0.52067-1.03-0.70011 0-1.3611 0.19048-0.74969 0.21004-1.4707 0.16047-2.1708 0.33986-0.73012 0.18004-1.1105 1.0307-1.5405 1.1305-0.5807 0.1396-1.0707-0.39009-1.6312-0.47032-1.0603-0.13047-2.9818 0.18982-4.0023 0.50033-1.3115 0.39987-1.2312 1.6602-1.3604 3.1409-2.0312 0.11024-4.9125-0.58057-6.4732 0.69929-1.5907 1.291-2.1323 3.0307-3.9625 4.1618-2.0612 1.2694-3.0614 1.5806-5.6628 1.6706-2.482 0.09-3.5423 1.8102-3.6317 4.1012-1.2606-0.11024-1.7108 0.70973-2.052 1.7306-2.7515-0.33986-4.8727-1.1103-7.234-0.0202-1.0707 0.47945-2.3006 0.47945-2.8409 1.6602-1.8406 0.4201-1.6207-1.2603-2.9616-1.4703-1.9509-0.32029-0.65052 1.8402-0.84039 3.0007-0.23032 1.4403-1.7512 2.5506-2.6314 0.96087-0.55983-1.0111 0.21988-2.8206-0.23033-3.9309-0.86061 0.14938-0.95065 0.47033-1.6808 0.18004-0.55003-0.23092-0.72033-0.93999-1.3004-1.2009-1.4113-0.63928-2.221 0.10959-2.7019 1.3203-0.8704 2.261-0.53046 4.8318-0.65052 7.3119-0.97023 0.0502-2.1212-0.18004-2.9414 0.39988-1.0714 0.76061-1.271 2.5408-1.6919 3.6413-0.39018 0.99936-1.2201 1.9498-1.8902 2.7711-1.8315 2.2499-3.1123 4.3216-6.4543 3.1807-1.4511-0.48989-2.0305-0.80105-3.8424-0.80105-1.2508 0-2.9714 0.32029-4.1726 0.0111-0.3308-0.0802-0.63094-0.21005-0.91085-0.36987-1.8608-1.0104-2.9113-3.3608-5.0625-3.621 0.0803 0.38031-0.12984 0.91064-0.0502 1.2903-0.63943 0.03-1.3108 0.03-1.9509 0-0.0196-1.0405-0.47043-2.1605-0.36016-3.1403 0.0998-0.91064 0.95065-1.5101 1.0302-2.471 0.30014-0.29029 0.1703-0.0502 0.28057-0.51012-1.8902 0.44032-1.6801-1.4103-2.2706-2.5604-0.66096-1.291-1.331-1.3007-1.2404-3.1012-1.301-0.44097-2.5616-0.20091-3.9723-0.36073-1.301-0.14938-2.1616-0.61971-3.3022-1.2003 0.0692-0.3105-0.12984-0.78996-0.0607-1.1102-0.6603 0.15003-1.2404 0.0202-1.331-0.66015-1.0707-0.43967-2.3809 0.0202-3.1019-1.2303-0.61007-1.0711-0.20945-2.8011-0.69946-3.9714-0.43063-1.0007-1.0805-1.6908-1.5013-2.8409-0.42932-1.1703-0.45999-2.1103-0.54024-3.4612-0.0796-0.0411-0.15921-0.0802-0.23946-0.11024-0.60028-1.2303-2.0612-0.78018-3.0614-1.5206-0.55069-0.40053-0.86061-0.63993-1.5007-0.84019-0.60027-0.18004-0.96044-0.33008-1.4811-0.67059 0.33015-0.12003 0.64008-0.25897 0.92064-0.45989 0.50045-0.3803 0.48022-0.58057 0.6205-1.1005 0.11027-0.4501 0.26034-0.72995 0.46065-1.1305 0.15007-0.30985 0.17029-0.8004 0.48022-0.99022-0.06 0.57013-0.0196 1.3999 0.06 1.9811 0.12005 0.7704 0.67987 0.90021 0.88018 0.12003 0.15007-0.57991-0.20031-1.4606 0.44042-1.6902 0.51024-0.18004 1.4217 0.21983 1.9209 0.30985 0.14029-0.57013 0.0502-1.0404 0.0803-1.6197 0.0202-0.56034 0.16051-1.1213 0.17029-1.6804-0.33994-0.0698-0.53046 0.27006-0.72033 0.51012-0.44042 0.55056-0.32036 0.50033-0.90041 0.44031-0.87562-0.10437-0.94609 0.2655-1.2958 1.0359z",
+                Yilan:"m393.17 81.6c0.64987 0.54012 1.0505 1.2003 1.0002 2.0405-0.0404 0.04044-0.0692 0.0698-0.12005 0.12068-1.1014 0.06915-3.342 0.46054-3.2519-1.1011-0.20031-0.06001-0.4104-0.12981-0.60027-0.21005-0.0104-0.03979-0.0104-0.06915-0.0104-0.10959h0.0196c0.36995 0.06067 0.81037 0.12981 1.2103 0.10959 0.18987-0.39922 0.11027-0.87998 0.53046-1.12 0.4613-0.25962 0.89193 0 1.2221 0.27006zm-72.209 76.407c-0.0692-0.17938-0.12006-0.36008-0.14942-0.55969-0.0907-0.55056-0.21009-0.97-0.79014-1.1709-0.35038-0.12003-0.36995 0.0104-0.61072-0.30007-0.43063-0.55056-0.55068-0.72995-1.2808-0.76061-0.48022-0.03-1.0505-0.03-1.5307 0.0998-0.20096 0.06-0.30013 0.23092-0.46064 0.33986-0.2499 0.15982-0.30014 0.15982-0.65052 0.15982-0.55003 0-1.0603 0.0196-1.5614 0.12002-0.45999 0.09-0.73011 0.0692-1.1412 0.30986-0.33015 0.20091-0.63943 0.29028-0.88998 0.58122-0.30013 0.3503-0.36016 0.5897-0.85082 0.66015-0.42019 0.06-0.93956 0.0202-1.32-0.12003-0.85017-0.32029-0.82994-1.1905-0.82994-2.0111 0-0.2805 0.0698-0.81019-0.0992-1.0411-0.21009-0.28898-0.80123-0.39922-1.1216-0.57992-0.69032-0.36986-1.87-0.17025-2.7012-0.17025-0.44042 0-0.58005 0.03-0.8704-0.29029-0.24011-0.25962-0.39996-0.57013-0.68053-0.78018-0.2499-0.17938-0.63029-0.33986-0.74056-0.63927-0.10961-0.26028 0.0104-0.75018 0.0692-1.0007 0.0803-0.30007 0.28056-0.5199 0.43063-0.78018 0.15986-0.27006 0.20096-0.57078 0.2101-0.92043 0-0.67972 0.12005-1.2505-0.2101-1.8506-0.16051-0.27984-0.23032-0.62036-0.43063-0.87998-0.19053-0.23092-0.44956-0.36008-0.69945-0.5199 0.39017-0.73061 0.31971-1.8311 0.79014-2.5708 0.27012-0.41031 0.77057-0.36922 1.0107-0.66015 0.2101-0.24984 0.24011-0.80106 0.39018-1.1305 0.24011-0.57013 0.73012-1.7404 1.2103-2.06 0.47043-0.32029 0.90041-0.0698 1.3904-0.25114 0.63942-0.23027 0.29035-0.5199 0.74056-0.84998 0.0998-0.71038 0.53046-0.62036 1.0107-0.81997 0.75034-0.31116 0.5807-0.17026 0.75034-1.0007 0.30014-1.4103 1.0107-0.84997 2.1616-1.2603 0.31057-1.1011-0.23033-1.7515 0.93108-2.2505 0.91998-0.40966 1.2508-0.33986 1.0798-1.4906-0.15986-1.1103-1.1301-3.7313-0.34973-4.6915 0.39018-0.47946 1.1705-0.44032 1.6312-0.95044 0.74969-0.85911 0.0692-0.95043-0.35038-1.6902-0.16051-0.28963-0.24011-0.66928-0.24011-1.0705-0.0104-1.06 0.50045-2.3105 1.3708-2.6217 0.71054-0.24984 1.1608-0.01 1.7114-0.72017 0.46-0.60013 0.44042-1.3001 0.65052-2.0105 0.41041-1.4208 1.4609-1.8709 2.5714-2.681 0.21988-0.66928 0.57026-1.9009 0.27991-2.5004-0.30993-0.66015-0.72033-0.46054-0.45999-1.2394 0.12005-0.33008 0.47043-0.77105 0.71054-1.0307 0.67009-0.74039 2.3411-0.88129 3.5618-0.95044 0.2101 0 0.39997-0.0111 0.57026-0.0202 0.88149-0.0404 1.2704-0.06 2.0011-0.43053 0.58005-0.28898 1.0805-0.77953 1.7708-0.92043 0.70989-0.14025 1.5307 0.0607 2.1812-0.20026 0.35038-0.14025 0.63029-0.4201 0.98067-0.54991 0.2897-0.0998 0.67988-0.0802 0.92064-0.23093 0.86061-0.50033 0.54025-1.7802 1.0714-2.5108 0.53959-0.76061 2.4905-0.91064 3.432-0.90021 1.2208 0 1.5907-0.40966 1.5098-1.6602 2.7026 0.12003 2.7326-2.0705 1.9711-4.0712-0.33016-0.87998-0.44042-1.7508 0-2.6908 0.33015-0.69016 1.2097-1.8304-0.0503-2.2603 0-0.12068 0.0405-0.26028 0.0503-0.33986 0.0692-1.4299 2.3613-1.6197 3.3518-1.6497 1.1105-0.04045 0.85017-0.20092 1.0002-1.1709 0.0998-0.60014 0.36017-1.1096 0.85083-1.4808 1.0302-0.76061 2.7913-0.69016 4.0721-0.77039 1.3806-0.08024 2.7515-0.02022 4.1524-0.09067 0.0398-0.69016-0.12071-1.5506 0.33015-2.1005 0.36995-0.44945 1.151-0.63014 1.6012-0.97 0.49-0.36922 0.81037-1 1.1705-1.4299 0.65052-0.78018 2.3006-1.7306 3.312-1.9302 1.3408-0.26028 2.7404 0.21983 3.9416-0.48011 1.1601-0.66015 1.6116-1.6106 2.9009-2.0105 0.29035-0.56035 0.86061-0.66994 0.75034-1.3007-0.0998-0.57992-0.7001-0.62036-0.38039-1.4208 1.4009-0.0098 0.94021-1.7202 1.4106-2.5004 1.2097-0.24984 2.3913-0.3503 3.6525-0.3503 0.53047 0 1.2808 0.0698 1.7004-0.23027 0.3693-0.26028 0.68053-0.72016 1.1405-1.0202 0.58071-0.36987 2.0801-1.2003 2.2315-1.9107 0.21989-1.06-1.0805-1.9805-2.1414-1.9413-0.42998-1.4403 0.26033-2.0796 1.1712-3.0711 1.1014-1.1703 2.2608-0.84019 3.8215-0.91064 0.6603-0.04044 1.4296-0.02022 2.0801-0.15004 0.82081-0.14938 1.0805-0.60014 1.5705-1.12 0.84039-0.91064 2.0912-1.5206 3.2722-1.6504 0.46-0.04958 1.4309-0.01957 1.8517-0.23027 0.56961-0.2805 0.60028-0.88064 1.2312-1.1305 1.2006-0.47033 2.2008 0.42988 3.3916 0.36987-0.11027 0.30007-0.15007 0.66015-0.0998 1.1103-1.4106-0.05023-2.882 0.66015-4.1432 1.2094-0.39931 0.17091-1.181 0.32029-1.3708 0.69081-0.19053 0.39009 0.15985 1.0796-0.44042 1.2394-0.0202 0.03001 0 0.0698-0.0104 0.10959-0.4215 0.28115-0.64008 0.6608-1.0303 0.97066-0.36995 0.31051-0.71054 0.91064-1.2103 0.96022-0.42084 0.4899-0.93108 1.0202-1.6312 1.1605-0.39018 0.08024-0.50045 0.08024-0.82929 0.33008-0.25969 0.20092-0.68053 0.42988-0.8306 0.75017-0.2897 0.63014 0.16051 1.4808 0.16051 2.1311-0.0104 0.6608-0.65052 1.3203-1.1705 1.6602-0.24011 0.17091-0.52067 0.30007-0.72033 0.50098-0.18987 0.19048-0.49001 0.41031-0.68053 0.63014-0.4489 0.53034-0.84039 1.1298-1.3604 1.5701-0.47957 0.41031-1.0107 0.98044-1.4413 1.4403-0.47892 0.53034-0.88932 0.8291-1.0407 1.5604-0.12984 0.63014-0.49 1.1103-0.76013 1.6902-0.31058 0.6608-0.53046 1.4103-0.82081 2.0907-0.60028 1.3901-0.47043 2.9811-0.58984 4.5219-0.0502 0.61058-0.09 1.2805-0.25903 1.8402-0.12984 0.45989-0.2512 0.85063-0.3308 1.3301-0.0796 0.50098-0.18987 0.97066-0.28057 1.4305-0.27012 1.3307-0.0502 2.7906-0.0502 4.1514 0 1.2303 0.2101 2.5702 0.51024 3.7509 0.27012 1.0705 1.1014 2.1703 1.6312 3.0901 0.27991 0.46054 0.40976 0.69081 0.44042 1.2101 0.03 0.44945 0.0796 0.85976 0.1703 1.291 0.12984 0.69081 0.36995 1.3999 0.3308 2.1207-0.03 0.60014-0.0411 1.2205-0.0411 1.8402 0 0.60013 0.0496 1.1814 0.0802 1.7802 0.0196 0.48989 0.26947 0.93021 0.31971 1.4208 0.0405 0.36008-0.0998 0.67972-0.0411 1.0496 0.12136 0.74104 0.72033 1.2909 0.93173 1.9915 0.28904 0.93021 0.17878 1.7 0.79014 2.4899 0.47044 0.61057 0.68053 1.501 1.3708 1.9009 0.65052 0.38031 1.1014 0.5199 1.8413 0.66081 0.20879 0.0404 0.39997 0.14024 0.61985 0.17025-0.0111 0.31051 0.23946 1.2205-0.36995 1.1207-0.2101-0.0404-0.33015-0.35029-0.50045-0.47032-0.2101-0.15004-0.30014-0.15004-0.58135-0.16047-0.49001-0.01-1.0407-0.0998-1.4106 0.24984-0.34973 0.33007-0.28057 0.8702-0.2499 1.3307 0.25969 0.12981 0.45999 0.36986 0.74056 0.47032 0.20944 0.0698 0.44107 0.0698 0.66095 0.17091 0.0992 0.15982 0.21989 0.33986 0.30014 0.50033 0.12006-0.0998 0.21989-0.21004 0.30014-0.33986 0.18987-0.0196 0.39083 0.0196 0.57026 0.0907 0.0104 0.28049-0.17943 1.1403 0.12071 1.2094 0.18987 0.32029-0.14028 0.36987-0.3693 0.43054-0.48022 0.12068-0.51024 0.03-0.56048 0.61057-0.0998 1.09-0.03 2.1898 0.03 3.2805 0.68053-0.17026 0.4502 1.4005 0.4502 1.8011 0 0.68038 0.28057 1.7097-0.50109 1.9602-0.72034 0.21983-1.4511 0.06-2.1212 0.57078-0.28904 0.2094-0.52067 0.40966-0.88084 0.47032-0.54024 0.09-1.0407 0.0196-1.3715 0.57992-0.25055 0.42075-0.22054 1.0307-0.1703 1.5101 0.0411 0.33986 0.0998 0.66994 0.30014 0.93935 0.25968 0.35029 0.68053 0.29028 0.95065 0.55121 0.25969 0.24005 0.1703 0.63014 0.25969 0.96022 0.14028 0.53034 0.39018 0.78018 0.82081 1.1207 0.17943 0.14025 0.82016 0.72995 0.84038 0.92043 0.0398 0.31116-0.73077 0.32029-0.99176 0.33008-1.4707 0.0698-2.3606 1.2407-3.4411 2.1318-0.31971 0.25897-0.88084 0.57992-1.0714 0.95044-0.20031 0.3803-0.1703 1.0104-0.30014 1.4208-0.63942 0.06-1.181 1.1807-1.6305 1.6308-0.35038 0.33986-0.63094 0.66993-0.90107 1.0802-0.20031 0.30986-0.53046 0.60014-0.70989 0.91-0.17029 0.32029-0.25968 0.74038-0.39083 1.0907-0.14028 0.36987-0.2101 0.81997-0.24011 1.2101-0.0796 0.96022-0.06 1.9504-0.25968 2.8702-0.18987 0.8702-0.27013 1.7306-0.31058 2.6308-0.0411 0.75017-0.31971 1.3105-0.73012 1.9204-0.49001 0.71038-0.82081 1.3503-0.8704 2.2505-0.0405 0.8702-0.25055 1.6706-0.25055 2.5512 0 0.63015-0.0411 1.2505-0.0496 1.8696-0.0104 0.36074 0.15986 1.0502-0.0998 1.3307 0 0.0202-0.0196 0.0411-0.0405 0.0502-0.48022 0.38031-1.5314-0.24984-2.0214-0.3803-0.31971-0.0802-0.61137-0.14025-0.90107-0.31051-0.33015-0.18983-0.58983-0.54012-0.93108-0.72995-0.58005-0.32029-1.4302-0.15003-2.0514-0.33986-0.49001-0.16047-0.88084-0.30007-1.4106-0.28963-0.49001 0-0.96109 0.03-1.4204-0.12068-0.59048-0.17939-1.0505-0.50033-1.5816-0.78997-0.27991-0.15982-0.58005-0.40966-0.8704-0.5199-0.42933-0.15982-0.99045 0.09-1.3904-0.12003-0.3693-0.18982-0.44042-0.42988-0.90041-0.50098-0.4202-0.06-0.73012 0-1.0805-0.24984-0.44955-0.31051-0.74969-0.75017-1.1099-1.1605-0.36082-0.41032-0.88084-0.54013-1.2612-0.92043-0.18987-0.19048-0.30992-0.55056-0.55003-0.63015-1.1203-0.33986-0.0502 1.9113-1.2006 0.76061-0.33994-0.33986-0.65052-0.69016-0.98067-1.0404-0.27013-0.27985-0.63029-0.74039-0.95066-0.96022-0.75034-0.50099-1.4407 0.3803-1.2404 1.1298 0.0998 0.3803 0.46065 0.48989 0.6603 0.77105 0.15007 0.21983 0.15007 0.47032 0.33994 0.67972 0.2897 0.31964 0.63029 0.23027 0.74056 0.66015 0.0698 0.25962 0.0196 0.69016-0.0104 0.96022-0.0202 0.20092-0.0202 0.69994-0.18987 0.81019-0.30014 0.20026-0.43063-0.38031-0.59049-0.58057-0.30013-0.36987-0.29035-0.12068-0.71054-0.23093-0.23098-0.0502-0.41041-0.28963-0.46065-0.53033-0.24011 0.13959-0.4502 0.39922-0.54024 0.66928-0.0692 0.21983-0.0503 0.74104-0.2897 0.85063-0.23033 0.11024-0.33015-0.19048-0.61985-0.10959-0.29035 0.0802-0.5011 0.53034-0.70076 0.7293-0.12984 0.12068-0.24011 0.30007-0.42998 0.31116-0.17029 0.01-0.19052-0.15004-0.32036-0.17026-0.19053-0.0104-0.16051-0.15004-0.21989 0.14025-0.06 0.27006 0.0907 0.39009 0.27013 0.55904 0.36995 0.3503 0.55003 0.33008 0.60027 0.81019 0.0411 0.29028-0.0202 0.57013 0.0803 0.81997-0.2499 0.03-0.42998-0.09-0.66944-0.12003-0.27013-0.0404-0.48022 0.06-0.74121 0.09-0.42019 0.0411-0.85017-0.12003-1.2397-0.21983-0.78036-0.20027-1.5509-0.0998-2.3613-0.21005-0.98002-0.12981-1.1908-0.81997-1.8106-1.4599-0.61071-0.6308-0.7797-1.7215-1.761-1.8206-0.41041-0.0502-0.83973-0.0111-1.2508-0.0502-0.63943-0.06-1.181-0.24005-1.7904-0.36986-0.44107-0.0992-0.92064-0.11025-1.3715-0.0405-0.2101 0.03-0.33994 0.0992-0.59049 0.0802-0.30992-0.03-0.33994-0.18004-0.58005-0.25049-0.56047-0.15917-0.67009 0.31115-1.0407 0.50098-0.21988 0.12003-0.12071 0.09-0.41041-0.0998-0.18008-0.13047-0.33994-0.24006-0.5011-0.39009-0.36016-0.33986-0.63942-0.66016-1.0798-0.93022-0.42998-0.27006-0.97023-0.33007-1.4309-0.54012-0.71055-0.32029-1.1405-0.97001-1.8811-1.2003-0.63094-0.20091-1.1608 0.01-1.5712-0.59035-0.0574-0.0855-0.10701-0.17548-0.14746-0.2655z",
+                HsinchuCounty:"m293.48 147.63c0.0196-0.71104-0.09-1.4514-0.0502-2.1514 0.03-0.55969 0.18987-1.1807 0.0698-1.73-0.12005-0.56034-0.58005-0.84019-0.91085-1.2707-0.2897-0.38031-0.67009-0.63015-1.0002-0.96023-0.67988-0.71103-1.2312-1.5812-1.9118-2.2805-0.60027-0.61123-1.2704-1.1102-1.7604-1.8011-0.55982-0.80041 0.47043-1.3705 0.19052-2.1403-0.25968-0.66993-1.0002-1.1703-1.5705-0.70973-0.69097 0.57013-1.5509 0.16961-2.2315 0.69016-0.30014 0.23027-0.52002 0.57079-0.88084 0.66015-0.36017 0.0907-0.88997 0.0111-1.2508 0-0.35038-0.01-0.66944-0.03-1.0002 0-0.39997 0.0411-0.58071 0.24006-0.93108 0.32029-0.47044 0.12003-0.61072-0.12981-0.95066-0.30985-0.34972-0.19048-0.72946-0.12068-1.1203-0.14025-0.69032-0.0307-1.0498-0.93086-1.7108-0.48011-0.25968 0.16961-0.38039 0.62036-0.61072 0.73974-0.18008 0.10045-0.82015 0.0502-1.0205 0-0.39018-0.10959-0.43064-0.51012-0.76079-0.69995-0.30014-0.19048-0.6205-0.06-0.90041 0.11025-0.21988 0.12981-0.3693 0.28963-0.55004 0.48011-0.24011 0.26027-0.47043 0.35029-0.79014 0.53033-0.30014 0.16961-0.44042 0.24984-0.67988 0.4899-0.24011 0.23027-0.33015 0.33986-0.6603 0.3803-0.69097 0.0692-1.3604-0.0607-1.8615-0.39074-0.52067-0.3503-1.1705-0.0691-1.791-0.24984-0.15985-0.2805-0.44955-0.47032-0.58005-0.78996-0.14028-0.3503-0.0802-0.75017-0.13049-1.1207-0.0998-0.66994-0.74056-1.3901-0.2499-2.0516 0.23032-0.32029 0.54025-0.36008 0.91085-0.43967 0.53047-0.0998 0.36996-0.18004 0.60093-0.57013 0.20945-0.3503 0.58984-0.55056 0.66031-1.0104 0.0692-0.42009-0.24011-0.4501-0.5011-0.62036-0.2897-0.20026-0.61072-0.48989-0.84039-0.77039-0.23946-0.2805-0.50958-0.5199-0.80058-0.75996-0.3804-0.32029-0.89063-0.74039-1.3604-0.95043-0.0803-0.47033 0.76078-0.33987 1.0407-0.44032 0.32037-0.12068 0.53046-0.36074 0.58136-0.72017 0.10961-0.78018 0.3693-1.5003 0.85996-2.1305 0.35038-0.46054 0.39083-0.9002 0.70989-1.3307 0.27012-0.36008 0.65051-0.66015 0.55134-1.1703-0.15007-0.78018-1.0414-1.0502-1.2808-1.711-0.17095-0.47033 0.12919-0.69994-0.33994-1.0405-0.39018-0.27006-0.73011-0.25049-0.99045-0.66993-0.23098-0.36009-0.29035-0.74039-0.81037-0.59036-0.30014 0.09-0.99111 0.48011-1.0407 0.76061-0.22053-0.0802-0.39996-0.41031-0.55069-0.58057-0.24011-0.27006-0.52002-0.48989-0.7797-0.74038-0.65052-0.6308-1.3115-1.0104-2.2119-1.3301-0.58983-0.21005-0.81037-0.78996-1.4106-1.0111-0.14942-0.0496-0.3693-0.03-0.50045-0.0802-0.2101-0.0991-0.12984-0.0691-0.25968-0.30007-0.19053-0.31964-0.20031-0.39009-0.57027-0.50033-0.19052-0.41031 0-0.89042-0.09-1.3307-0.10961-0.50033-0.60027-0.3503-1.0805-0.36987-0.80059-0.0496-1.1099-0.69016-1.5607-1.2394-0.23098-0.27985-0.54025-0.47033-0.76078-0.76061-0.30993-0.39009-0.43977-0.88129-0.78036-1.2505-0.21989-0.23092-0.54025-0.3105-0.77971-0.51011-0.25968-0.21984-0.35038-0.54013-0.64007-0.69016-0.54025-0.2805-0.91086-0.0411-0.66031-0.81019 0.12984-0.39987 0.50045-0.62036 0.76013-0.96022 0.33016-0.44097 1.2508-1.4814 0.82995-2.1612-0.27012-0.44945-1.4811-0.43053-1.9111-0.29028-0.64008 0.21005-0.33994 1-1.1705 0.8702-0.78036-0.12003-0.76079-1.0104-1.5907-0.5897-0.2897 0.14025-0.39018 0.3105-0.70011 0.0991-0.18008-0.10959-0.39083-0.47946-0.42084-0.66015-0.0196-0.0202-0.0502-0.0404-0.0803-0.06 1.2612-1.0104 0.11027-3.2212 0.85148-4.5213 0.8293-0.29028 1.8008-0.15003 2.7215-0.20092 0.0496-0.97001-0.15007-2.1207 0.65051-2.8206 0.76079-0.66015 2.1408 0.02022 2.6112-0.91064 0.2499-0.4899 0.13963-0.93021 0.47957-1.4403 0.30014-0.4501 0.41041-0.63014 0.94022-0.7306 0.74055-0.15004 1.9711 0.66015 2.1812 1.3203 0.2897 0.01044 0.60028 0.01957 0.89063 0.03001 0.0398 0.20026 0.18987 0.31964 0.18987 0.54991 0.5807 0.46054 0.28056 1.0307 0.49001 1.6804 0.33015 1.0307 0.63029 0.27985 1.2397 0.08024 0.90106-0.28963 1.1712 0.09915 0.91085-1.1403-0.10962-0.53034-0.15986-1.3601-0.33994-1.9204-0.19052-0.60014-0.64986-0.91064-0.98067-1.4305-0.38039-0.60014-0.33015-1.1096-0.33015-1.8396 0-1.5101-0.65051-1.9909-1.84-2.7508-0.64008-0.41031-1.0603-1.0104-1.7519-1.2401-0.89063-0.30007-1.3708-0.0698-1.8406-0.99023-0.88084-0.06067-1.4602-0.21005-2.2204-0.45989-0.73077-0.23092-1.6207 0.0098-2.2921-0.36987-1.35-0.76061-1.4211-2.651-3.0216-2.8311 0.0404-0.06001 0.0698-0.11024 0.0404-0.19048 0.0992-2.471 1.9202-1.6008 2.9218-3.1709 0.4502-0.71038-0.03-1.9107 0.14028-2.7508 0.26034-1.2401 1.0205-2.3105 1.6312-3.3908 0.5011-0.85976 0.66096-1.9805 1.3115-2.6908 0.4202-0.44945 0.93043-0.78996 1.4407-1.12 0.47956 0.12981 1.1705 0.12981 1.5607 0.03979 0.61006-0.1396 0.82995-0.7293 1.4407-0.90021 0.63029-0.17939 1.1908 0.2805 1.8106 0.3803 0.8704 0.13046 1.35-0.24006 2.0807-0.39922 0.61072-0.12981 1.4707-0.01044 1.9907 0.27006 0.41041 0.21983 1.3806 0.8702 1.6606 1.1703 0.81037 0.88977 0.0202 2.9713 0.27012 4.1416 0.26034 1.2205 2.4716 1.09 3.5925 1.5708 0.66944 0.28898 1.0107 0.54991 1.8308 0.5199 0.69032-0.03001 1.3506-0.11024 2.071-0.0698-0.11027 0.54012-0.06 1.2003-0.23032 1.7404 0.0992-0.33008 1.4511 0.63993 1.4602 0.65037 0.70011 0.24006 1.9509 0.01044 2.7019 0.01044 0.71055 0 2.2204 0.33986 2.4213 1 0.0405 0.14025-0.24011 0.36074-0.17029 0.58057 0.0992 0.36008 0.3693 0.19048 0.47957 0.44032 0.15006 0.33986 0.15985 1.12 0.16964 1.5003 0.0111 0.66994-0.0496 0.84998-0.47957 1.3307-0.36995 0.40966-0.82016 0.42075-0.6603 1.1403 0.30014-0.03001 0.47957 0.0698 0.72033 0.19048 0.20031 0.09981 0.52002 0.67972 0.78036 0.85976 0.28969 0.20026 0.74969 0.39987 1.0798 0.5199 0.55069 0.19048 1.7108 0.14938 1.5907 1.0104 0.86061-0.1396 1.181 0.56035 1.331 1.2505 1.0407 0.33008 1.6808 1.5708 2.8918 1.3307 0-0.18004 0.14028-0.33986 0.11027-0.54991 0.53046-0.08024 1.0413 0.09915 1.5614 0.08024 0.03 0.66928-0.26034 1.6706 0.51023 1.8206 0.63942 0.12003 1.2606-0.72016 1.8308-0.75017 0.91085-0.03979 0.57091 0.92043 1.1705 1.3405 0.39018 0.27006 1.4002 0.43053 1.9013 0.51012-0.03 0.59035 0.01 1.3412 0.3693 1.8206 0.45021 0.60014 0.99111 0.29028 1.6312 0.67972 0.0998 0.06001 0.31058 0.3803 0.5011 0.50098 0.30014 0.20026 0.6205 0.33008 0.85082 0.4899 0.65052 0.44945 0.78036 0.55969 1.581 0.74039 1.3004 0.30007 2.2014 1.6706 1.9209 3.0914-0.12984 0.66015-0.67988 0.93021-0.82995 1.5003-0.15985 0.55969 0.0104 1.3803 0.18008 1.9009 0.21989 0.0502 0.12071 0.0802 0.2499 0.17026 0.11027-0.0202 0.27013 0.0202 0.39083 0.0202 0.41041 1.8004-1.3911 2.9707-0.72033 4.8115 0.12984 0 0.2499 0.03 0.38039 0 0.44042-0.48011 1.5509-0.51012 2.2713-0.39988 0.93957 0.1396 0.80059 0.50034 1.3108 1.1905 0.33994 0.45989 0.88084 0.76061 1.0198 1.3901 0.16051 0.71038 0 1.4703 0.18008 2.1507 0.39018 0.0202 1.6312-0.17939 1.9209 0.0802 0.31906 0.2805 0.17943 1.411 0.14942 1.8506-0.03 0.61123-0.14942 1.0502 0.2499 1.5708 0.45999 0.61057 0.80124 0.66994 0.76013 1.5904 1.4609-0.28898 0.30014 3.2812 0.33994 4.002 0.86061 0.50033 0.74056 1.7508 1.5809 2.2512 0.76079 0.01 1.2508 0.77039 1.8413 0.99023 0.73012 0.27984 1.8902 0.0502 2.6712-0.0502 0 0.39987 0.0802 0.78018 0.24011 1.0711 0.42019 0.74039 1.1007 0.82976 0.35038 1.6902-0.46065 0.50947-1.2404 0.47033-1.6312 0.95044-0.78036 0.96022 0.19052 3.5806 0.35038 4.6909 0.1703 1.1507-0.15986 1.0802-1.0805 1.4906-1.1608 0.50098-0.6205 1.1507-0.93042 2.2505-1.1516 0.41031-1.8622-0.15004-2.1616 1.2603-0.17029 0.8304 0 0.69081-0.74969 1.0007-0.48022 0.20026-0.91085 0.10959-1.0113 0.81997-0.44956 0.33008-0.0992 0.62036-0.74056 0.85063-0.49001 0.17939-0.92064-0.0698-1.3904 0.25049-0.48022 0.32029-0.97088 1.4906-1.2103 2.0607-0.14942 0.33008-0.17943 0.88064-0.39018 1.1298-0.24011 0.29028-0.74056 0.24984-1.0107 0.66015-0.47043 0.74104-0.39997 1.8402-0.79015 2.5708-0.0411-0.0202-0.0802-0.0404-0.1207-0.0698-0.91999 0.94-2.0905 1.5812-3.4118 1.7802-1.5809 0.24005-3.4222 0.24005-5.043 0.15982 6.5e-4 -0.0437 6.5e-4 -0.0939 6.5e-4 -0.14351z",
+                HsinchuCity:"m239.48 98.926c0.2101-0.57078 0.27012-0.55121 0.82995-0.91064 0.30013-0.19048 0.85996-0.51012 1.1209-0.81019 0.25904-0.30007 0.20031-0.63014 0.30993-0.98044 0.0803-0.27006 0.24011-0.77953 0.11027-1.0802-0.14942-0.36008-0.63029-0.4201-0.91086-0.60014-0.24989-0.14025-0.58135-0.4899-0.42084-0.8291 0.0998-0.20092 0.28056-0.12068 0.39083-0.29028 0.09-0.14938 0.03-0.46054 0.03-0.63014 0-0.71038-0.0502-1.4501 0-2.1611 0.0196-0.34965 0.10962-0.5897 0.24011-0.8702 0.12006-0.26941 0.39018-0.4201 0.55069-0.66015 0.18987-0.31051 0.21989-0.7006 0.40976-1.0196 0.21988-0.3803 0.47956-0.4501 0.51023-0.91064 0.0196-0.33986-0.03-0.68037 0.0803-1.0007 0.11027-0.30985 0.3693-0.5199 0.5396-0.78996 0.20096-0.30985 0.41106-0.4899 0.64008-0.74039 0.23032-0.24006 0.42019-0.53034 0.6205-0.84019 0.38039-0.55969 0.42019-1.4103-0.25969-1.7306-0.30013-0.14025-0.63029-0.21983-0.95065-0.24984 0.06-0.4899 2.5616-0.16047 3.0314-0.27985 0.03-0.06001 0.0692-0.0998 0.09-0.14025 1.6005 0.17939 1.6716 2.0705 3.0216 2.8311 0.67009 0.3803 1.5614 0.1396 2.2921 0.36987 0.75948 0.24984 1.3408 0.39922 2.2204 0.45989 0.47109 0.91978 0.95066 0.69016 1.8406 0.99023 0.69032 0.23027 1.1105 0.83041 1.7512 1.2401 1.1908 0.76061 1.8406 1.2401 1.8406 2.7508 0 0.72995-0.0502 1.2394 0.33015 1.8396 0.33015 0.52055 0.79014 0.83041 0.98067 1.4305 0.18008 0.56035 0.23097 1.3908 0.33993 1.9204 0.25969 1.2394-0.0104 0.85063-0.91085 1.1403-0.61006 0.20026-0.9102 0.95044-1.2397-0.08024-0.21009-0.65037 0.09-1.2205-0.49001-1.6804 0-0.23092-0.15006-0.3503-0.18986-0.54991-0.29036-0.01109-0.60028-0.02022-0.89063-0.03001-0.2101-0.6608-1.4407-1.4703-2.1812-1.3203-0.53046 0.0998-0.64008 0.27985-0.94021 0.7306-0.33994 0.51012-0.23033 0.95044-0.48022 1.4403-0.47044 0.93021-1.8511 0.24984-2.6112 0.91064-0.80059 0.69994-0.60028 1.8506-0.65052 2.8206-0.91999 0.05023-1.8902-0.09002-2.7215 0.20092-0.74055 1.3001 0.40976 3.5108-0.85082 4.5212-0.42019-0.29028-1.1608-0.33007-1.7206-0.33007-0.8306 0-1.2912-0.14025-1.2808-1.0411 0-0.63928-0.03-1.1298-0.4104-1.6197-0.14094-0.18004-0.41106-0.36986-0.51024-0.54991-0.12984-0.21983-0.0907-0.50098-0.16964-0.74104-0.69097-0.19048-1.1105 1.4103-1.791 1.5401-0.31123 0.06-1.0903 0.03-1.3715-0.09-0.40062-0.15004-0.44955-0.44032-0.91085-0.46054-0.0111-0.06002-0.0202-0.11024 0-0.15004 0.0189-0.20026 0.20944-0.2805 0.3693-0.4201 0.24272-0.2094 0.27273-0.28963 0.37256-0.54926z",
+                Miaoli:"m246.9 103.34c0.03 0.0202 0.06 0.0404 0.0803 0.06 0.03 0.18004 0.24011 0.54991 0.42019 0.66015 0.31123 0.21005 0.41106 0.0411 0.70076-0.0992 0.82994-0.42075 0.81037 0.47032 1.5907 0.5897 0.82994 0.12981 0.53046-0.66015 1.1705-0.8702 0.42998-0.14025 1.641-0.16047 1.9111 0.29028 0.42084 0.67973-0.50045 1.7202-0.82995 2.1612-0.25968 0.33986-0.63094 0.5597-0.76013 0.96022-0.2512 0.7704 0.12005 0.53034 0.6603 0.81019 0.29035 0.14938 0.38039 0.47032 0.63943 0.69016 0.24011 0.20026 0.56047 0.27984 0.78036 0.51011 0.33993 0.36922 0.47043 0.86042 0.78035 1.2505 0.21989 0.29028 0.53046 0.48011 0.76079 0.76061 0.44955 0.54991 0.76078 1.1905 1.5607 1.2394 0.48022 0.0202 0.97088-0.12916 1.0805 0.36987 0.09 0.44032-0.0998 0.92043 0.09 1.3307 0.36995 0.10959 0.38039 0.18004 0.57026 0.50033 0.12985 0.23093 0.0502 0.20092 0.25969 0.30072 0.13049 0.0496 0.35038 0.03 0.50044 0.0796 0.60028 0.22048 0.82016 0.80105 1.4106 1.0111 0.90042 0.31964 1.5607 0.69929 2.2112 1.3301 0.26034 0.25049 0.54025 0.47032 0.78036 0.74039 0.15007 0.17025 0.33015 0.50033 0.55004 0.58056 0.0502-0.27984 0.74121-0.66928 1.0414-0.76061 0.52002-0.14938 0.5807 0.23093 0.80971 0.59036 0.26034 0.42009 0.60093 0.39987 0.99111 0.66993 0.47044 0.33986 0.1703 0.57013 0.33994 1.0405 0.24011 0.66015 1.1307 0.93021 1.2815 1.711 0.0992 0.51012-0.28122 0.81019-0.55134 1.1703-0.31906 0.42988-0.36017 0.8702-0.70989 1.3307-0.49001 0.63015-0.74969 1.3497-0.86062 2.1305-0.0496 0.36009-0.25968 0.60014-0.5807 0.72017-0.27991 0.0991-1.1203-0.03-1.0407 0.44032 0.47043 0.21004 0.98067 0.63014 1.3604 0.95043 0.29035 0.24006 0.55982 0.48011 0.80058 0.75996 0.23098 0.2805 0.55004 0.57013 0.84039 0.77039 0.25968 0.17026 0.57026 0.20092 0.5011 0.62036-0.0698 0.45989-0.45021 0.66015-0.66096 1.0104-0.23032 0.39074-0.0692 0.47033-0.60028 0.57013-0.3693 0.0802-0.68053 0.12068-0.91085 0.43967-0.49001 0.6608 0.14942 1.3803 0.2499 2.0516 0.0502 0.36921-0.01 0.77039 0.13049 1.1207 0.12919 0.32029 0.4202 0.51012 0.58005 0.78996 0.6205 0.18004 1.2704-0.0998 1.791 0.24984 0.50045 0.33008 1.1705 0.46054 1.8609 0.39075 0.3308-0.0411 0.42084-0.15004 0.66095-0.38031 0.24011-0.24005 0.38039-0.32029 0.67988-0.48989 0.31971-0.18005 0.55003-0.27007 0.79014-0.53034 0.17943-0.19048 0.33016-0.3503 0.55004-0.48011 0.28056-0.17026 0.60027-0.30007 0.90041-0.11025 0.33015 0.19048 0.36996 0.59036 0.76079 0.69995 0.20031 0.0502 0.84038 0.10045 1.0205 0 0.23032-0.12003 0.34972-0.57013 0.61071-0.73974 0.6603-0.4501 1.0205 0.44945 1.7108 0.48011 0.39017 0.0196 0.77057-0.0502 1.1203 0.14025 0.33994 0.17939 0.48022 0.42923 0.95066 0.30986 0.35037-0.0802 0.53046-0.27985 0.93042-0.3203 0.33081-0.03 0.65052-0.01 1.0009 0 0.36016 0.0111 0.89062 0.0907 1.2508 0 0.36016-0.09 0.5807-0.42988 0.88084-0.66015 0.68053-0.5199 1.5405-0.12002 2.2315-0.69016 0.57026-0.46054 1.3108 0.0398 1.5698 0.70973 0.28121 0.7704-0.74969 1.3405-0.19052 2.1409 0.49 0.69016 1.1608 1.1898 1.761 1.8004 0.67988 0.69929 1.2306 1.5702 1.9118 2.2805 0.33015 0.33007 0.71054 0.58056 1.0002 0.96022 0.33015 0.43053 0.79015 0.71038 0.91085 1.2707 0.12006 0.54991-0.0404 1.1703-0.0698 1.73-0.0405 0.69995 0.0698 1.4403 0.0502 2.1514-0.53046 0.47946-1.1307 0.91977-1.9411 0.87998-0.47108 1.1703 0.0803 2.6106-0.39083 3.7809-1.5007 0.53034-1.5398 1.8311-2.6412 2.561-1.8211 1.1814-2.2112-0.17939-2.5212-1.6804-0.6603-0.17939-1.4302-0.27985-2.1212-0.15917-0.10962 2.1005 0.0607 2.7704-2.161 3.1703-1.0505 2.0516-1.9013 2.8311-4.2019 3.3021-1.3904 0.28898-1.6501 0.0991-2.5414 1.1292-0.30013 0.33986-0.24989 0.83041-0.63029 1.2101-0.36081 0.36008-1.0903 0.19048-1.4609 0.69016-0.81038 1.0907-0.0502 1.3503-1.3715 2.1409-0.28057 0.16048-1.9914 1.12-2.3306 1.1703-1.1014 0.15982-1.4407-1.0907-2.6719-0.68037-0.93956 0.32029-0.88997 1.6706-2.4814 1.7-0.2499 0.6308-0.74056 1.0802-0.88084 1.7802-1.7519 0.14025-1.9607-0.39988-3.1926-1.4306-0.31058-0.25962-1.0002-0.39009-1.2508-0.74039-0.3693-0.5199-0.17943-1.2401-0.53046-1.7704-1.4407-2.1709-4.9627-1.5101-7.1739-1.8702-1.7408-0.2805-4.9425-2.4899-6.3832-0.3803-1.5209 2.261 1.5809 5.6615-1.6201 6.882-2.191 0.8402-5.2224-0.0404-7.6744 0.33073-1.3911 0.2094-2.3711 0.58057-3.4522-0.20091-0.96958-0.71038-1.5509-1.8709-2.4311-2.5806-1.8511-1.4808-4.7128-0.85976-6.834-2.1807-1.9613-1.2205-3.3824-3.1507-5.163-4.4912-1.0805-0.81019-1.7108-0.39074-2.8017-0.8702-0.95065-0.40966-1.2404-1.3001-1.9913-1.9602-1.4002-1.2401-2.3411-2.0907-3.462-3.5917-1.2208-1.6497-3.0216-2.1696-4.0917-3.621-1.0414-1.4299-1.1405-3.0809-2.5512-4.2114 0.58984-0.96935 1.6312-1.7202 2.5414-2.4599 0.47044-0.39074 1.1908-0.75017 1.5614-1.2003 0.38039-0.46054 0.17943-0.91064 0.33994-1.4305 0.2897-0.92043 1.1705-1.4906 1.5607-2.3608 0.4502-1.0007 0.91085-1.6908 1.5614-2.6008 0.30013-0.42923 0.49-1.15 0.55982-1.6602 0.11027-0.84019 0.11027-1.1403 0.69097-1.8096 0.54025-0.63993 0.63942-0.99088 0.67988-1.8004 0.06-1.2309 0.5807-2.5617 0.88083-3.762 0.36996-1.4703 1.6312-2.1005 2.4109-3.381 0.50045-0.83041 0.61072-1.7906 1.1705-2.651 0.36995-0.55904 0.92064-1.5206 1.5607-1.6602 1.0413-0.24006 4.1928 1 3.7824-1.2394-0.54025-0.22048-0.92064 0.12916-1.4106 0.0992-0.0411-0.23027 0.5807-1.1298 0.74056-1.4103 0.30013-0.53034 0.68053-0.92043 0.86061-1.5304 0.33994-1.1305 0.65051-1.9407 1.6201-2.6706 0.70076-0.53034 1.562-1.3007 2.5218-1.4403 1.1803-0.18004 2.3802-0.39988 3.5618-0.50099 0.59049-0.06 1.2103 0.0202 1.8008-0.01 0.2499-1.3503 1.2208-2.621 2.5009-3.1312 0.0907-0.98045 1.0505-1.1103 1.5809-1.7802 0.49001-0.6197 0.44107-1.2805 0.49001-2.0803 0.0607-0.81997 0.53046-1.4703 1.0805-2.0307 0.44042-0.44032 0.97088-1.3307 1.562-1.5401-0.0202 0.04044-0.0111 0.09067 0 0.15004 0.45999 0.0202 0.50958 0.30985 0.91085 0.46054 0.27991 0.12003 1.0603 0.14938 1.3715 0.09 0.68053-0.12981 1.1007-1.7306 1.7904-1.5401 0.0803 0.24006 0.0404 0.52056 0.17029 0.74104 0.0992 0.17939 0.3693 0.36922 0.50958 0.54991 0.3804 0.4899 0.41106 0.98044 0.41106 1.6204-0.0111 0.90021 0.44956 1.0405 1.2808 1.0405 0.56112-5e-3 1.301 0.0346 1.7212 0.32486z",
+                Taipei:"m351.36 53.383c0.0104 0.32029 0.0104 0.65037 0 0.97066-0.52002-0.02022-1.0407 0.06915-1.5705 0.09915-0.25968 0.01044-0.5807-0.06001-0.82994 0.02022-0.20031 0.0698-0.4202 0.36008-0.56048 0.39987-0.50045 0.14938-0.96044-0.11024-1.5307-0.09067-0.63029 0.03066-0.92064 0.32029-1.4909 0.44097-0.90042 0.19048-2.3313-0.39987-3.141 0.17026-0.20096 0.1396-0.10962 0.44032-0.28056 0.63014-0.15986 0.17026-0.42933-0.05023-0.58984 0.26028-0.35038 0.66928 0.3693 0.87998 0.82016 1.0196 0.0692 1.2805-1.0303 5.092 1.0909 4.8318 0.06 0.3503 1.3004 0.54991 1.6605 0.66994 0.25968 0.96935-0.47043 0.77953-1.151 0.81997-0.82995 0.05023-0.77123 0.41031-1.4106 0.66928-0.59049 0.22048-1.2208-0.2394-1.761-0.31964-0.61071-0.09981-1.3708 0.23027-1.5098-0.59035-0.67009 0.13046-1.0414 0.65037-1.7414 0.57013-0.55004-0.06001-0.85996-0.47032-1.1601-0.92043-0.47108-0.67972-1.3506-1.6804-1.2704-2.5708-0.3804 0.02022-0.8704-0.03001-1.1705-0.2394-0.39997-0.2805-0.25969-0.74104-0.47044-0.94-0.72033-0.66994-1.4609 0.47032-1.9117 0.83041-0.01-1.2009 1.791-2.1905 0.74121-3.3412-0.44107-0.48011-0.97023-0.68037-1.4009-1.1703-0.44042-0.50098-0.60028-0.96087-1.3604-0.90021-0.82016 0.06001-1.0505 0.72016-1.4909 1.2505-0.61072 0.74039-0.79015 0.88977-1.3604 0.09981-0.46065-0.63928-0.42019-0.95044-0.55982-1.681-0.0907-0.43967-0.61137-1.1801-0.59049-1.5904 0.06-1.06 2.2308-1.06 2.8115-2.0209 0.59049-0.94 0.61137-2.8011 0.61137-3.9818 0-1.2205-0.73077-2.1507-1.5816-2.9811-0.41041-0.39922-0.69032-0.8004-1.2501-1.0196-0.57091-0.21983-1.2404-0.10959-1.8315-0.24984-0.52002-0.12981-1.0603-0.20092-1.5607-0.39987-0.84038-0.32029-0.75034-0.42075-0.79014-1.1905-0.0202-0.54991-0.19053-1.2903 0.03-1.8095 0.0992-0.23092 1.2306-1.0202 1.2208-0.69081 0.0405-0.8004-0.2101-1.7606 0.42998-2.2407 0.7001-0.53034 1.331-0.10959 1.2612-1.3999 1.0309-0.06001 1.2097 0.12981 1.4909-0.85063 0.16051-0.57992 0.28056-0.97 0.65052-1.5003 0.28904-0.42075 0.67987-1.1011 1.1803-1.2609 0.54025-0.17026 1.4211 0.01957 1.9914 0 0.19052-1.1703-0.0802-1.8102 1.3415-1.8206 0.5807-0.01044 1.0002-0.06915 1.4902-0.25962 0.24011-0.09067 0.89062-0.3803 1.0205-0.57013 0.2101-0.36008-0.1605-1.06 0.0502-1.4403 0.21989-0.39074 0.89063-0.4899 1.1301-0.80105 0.18008-0.23027 0.36082-1.03 0.64007-1.1703 0.58005-0.28963 0.96045 0.42075 1.3904 0.65037-0.33994 1.6308 0.90041 1.8617 2.191 1.9309 0.60028 1.5003-0.03 3.3308 0.76013 4.822 0.14942 0.27006 0.50958 0.50033 0.61072 0.7293 0.15007 0.36987 0.0202 0.86042 0.06 1.2707 0.0698 0.85063 0.53046 1.2401 1.151 1.7704 0.20944 0.77105 0.85996 0.80105 0.85082 1.8206-0.0111 1.1011-0.69097 0.98044-1.0909 1.8311-0.10962 0.21983-0.13963 0.82976-0.0803 1.0907 0.14029 0.51012 0.0104 0.30007 0.66944 0.40966 0.78036 0.12981 1.3917 0.60014 2.1512 0.68037 0.0307 1.0405 1.1908 0.69994 1.4309 1.6504 0.2499 0.93935-0.48022 2.9707-1.0002 3.6706-0.85083 1.1507-0.63029 1.0705-0.33015 2.4208 0.32036 1.4808 2.0011 2.8011 3.2519 3.3301 0.53047 0.23092 1.1007 0.3803 1.7512 0.42075 0.76666 0.04175 1.1966-0.49838 1.8974-0.23875z",
+                Newtaipei:"m400.14 55.204c1.2012 4.4117-4.7722 2.1905-5.6935 4.7613-1.1901 0.06001-2.1904-0.84019-3.3909-0.36987-0.6316 0.25049-0.66161 0.85063-1.2319 1.1305-0.4202 0.21005-1.3911 0.18004-1.8511 0.23092-1.181 0.12916-2.4318 0.74039-3.2722 1.6497-0.49001 0.5199-0.7497 0.97001-1.5705 1.12-0.65051 0.12981-1.4211 0.1109-2.0801 0.15003-1.562 0.0698-2.7221-0.25962-3.8215 0.91064-0.91085 0.99023-1.6012 1.6308-1.1712 3.0711 1.0609-0.04044 2.3613 0.88064 2.1414 1.9407-0.15007 0.71038-1.6508 1.5401-2.2315 1.9107-0.46 0.30007-0.77122 0.76061-1.1405 1.0202-0.42085 0.30007-1.1705 0.23027-1.7004 0.23027-1.2612 0-2.4416 0.09981-3.6526 0.3503-0.47043 0.78018-0.0104 2.4906-1.4106 2.5004-0.31972 0.80105 0.28056 0.84084 0.38039 1.4208 0.11027 0.6308-0.46 0.74104-0.75035 1.3007-1.2906 0.39988-1.7408 1.3503-2.9009 2.0105-1.2012 0.69994-2.6008 0.21983-3.9416 0.48011-1.0113 0.20026-2.6614 1.15-3.312 1.9302-0.36082 0.42988-0.67988 1.06-1.1705 1.4305-0.4502 0.33986-1.2312 0.5199-1.6012 0.96935-0.4502 0.54991-0.29035 1.4103-0.33015 2.1005-1.4009 0.0698-2.7717 0.01044-4.1523 0.09067-1.2808 0.08024-3.0418 0.0098-4.0721 0.77039-0.49 0.36987-0.75034 0.88064-0.85082 1.4814-0.15007 0.96935 0.11027 1.1298-1.0002 1.1703-0.99046 0.03001-3.282 0.21983-3.3518 1.6497-0.0104 0.08024-0.0502 0.21983-0.0502 0.33986 1.2606 0.42988 0.38039 1.5701 0.0502 2.2603-0.44042 0.94-0.33015 1.8108 0 2.6908 0.76078 2.0007 0.73077 4.1912-1.9711 4.0712 0.0803 1.2505-0.28905 1.6602-1.5098 1.6602-0.94021-0.01-2.8924 0.14025-3.4327 0.9002-0.53046 0.72995-0.20944 2.0105-1.0707 2.5108-0.24011 0.15003-0.63029 0.13046-0.92064 0.23092-0.35038 0.12981-0.63029 0.40966-0.98066 0.54991-0.65052 0.26027-1.4707 0.06-2.1812 0.20026-0.69097 0.1409-1.1908 0.6308-1.7708 0.92043-0.73077 0.36987-1.1203 0.39074-2.0011 0.43053-0.1703 0.0104-0.36017 0.0202-0.57026 0.0202 0.01-0.92043 0.0398-1.8409-0.0104-2.7508-0.94022 0.11024-0.91086-0.74039-1.6312-1.1814-0.42084-0.24984-0.54024-0.33986-1.0205-0.4201-0.36016-0.0502-0.85017 0.11024-1.151-0.0998-0.64007-0.42989-0.21988-1.3301-0.54025-1.9602-0.26033-0.51011-0.72033-1.0307-1.0407-1.5206-0.75035-1.15-1.4511-2.1605-1.8615-3.501-0.17029-0.57013-0.21988-1.3197-0.33015-1.9198-0.20031-0.98044-0.14028-1.2009 0.60028-1.6412 1.0603-0.63014 1.3715-1.9302 2.7215-2.1201 0.31123-0.2805 0.29035-0.76061 0.2499-1.2205-2.3411 0.1409-0.99959-2.6504-1.7304-3.6811-0.39997-0.57013-1.3004-0.06001-1.6906-0.99023-1.1105 0.12003-1.6612-1.8709-2.2315-2.4514-0.68053-0.69016-2.7019-1.5806-3.5919-0.7306-0.44956 0.43053-0.30014 1.0711-1.1601 1.2505-0.81037 0.17091-1.331-0.58057-1.9209-0.91978-1.3108-0.74104-2.5009-0.59035-3.9918-0.68037-0.21988-1.0502 2.0612-1.3007 2.7319-1.3307 0.03-0.44097 0.0803-0.82976-0.21988-1.1814-0.2101-0.24984-0.91086-0.21983-1.0805-0.57992-0.43063-0.89042 1.6808-1.1403 1.3408-1.9909-0.24989-0.61058-1.1705 0.08024-1.6207-0.23092-0.36017-0.25962-0.38039-1.2303-0.33994-1.6602-0.12005 0-0.28056-0.04044-0.39018-0.03001-0.35038-0.30007-0.39083-1.0007-0.76078-1.2407-0.31123-0.20026-1.0205 0.01109-1.3415-0.24006-0.69031-0.53034 0.0405-1.4808-0.0104-2.4103-0.30992-0.01044-0.63029-0.01044-0.91085-0.0698 0.0202-0.14025 0.0411-0.90021 0.11092-0.93021 0.23946-0.09981 0.44956-0.23092 0.72033-0.27006 0.15007-0.3803 0.19052-1.1807 0.01-1.4906-0.30993-0.54012-0.72033-0.14025-1.0707-0.4899-0.42998-0.42988 0-1.1005 0.39997-1.2603 0.36016-0.15003 1.1007 0.01044 1.4909-0.01044 0.12005-0.77953-0.33994-1.2805-0.49001-1.9909-0.14093-0.71038-0.19052-1.5095-0.16051-2.2505 0.0104-0.33986-0.0802-1.0705 0.0992-1.3405 0.30014-0.4501 0.44107-0.21005 0.90041-0.33008 0.74121-0.18983 1.3115-0.30007 2.1016-0.1396 1.1301 0.23027 3.0118 0.57013 4.1523 0.14938 1.1301-0.43053 0.74056-2 2.4011-1.9407 0.19052-0.39987 0.77057-0.82976 1.1705-1 0.0398-0.54012 0.03-0.8702-0.30014-1.2603-0.18987-0.21983-0.72033-0.21005-0.84039-0.57013-0.32036-0.96087 1.3604-1.0307 1.9711-1.0007-0.03-0.92043-0.58984-1.0405-0.88019-1.7606-0.31058-0.74039-0.09-1.8004 0.12984-2.4599-0.0411-0.01044-0.09-0.02022-0.14028-0.03001-0.0405-0.2805-0.0998-0.55056-0.19052-0.81019-0.99111-0.24006-0.94022-0.55969-1.0002-1.5003-0.31123-0.0698-0.54025-0.2805-0.5807-0.58057-1.1712-0.12003-2.052-0.54991-3.2422-0.60014-0.76078-0.02022-1.6012-0.44032-2.071-0.93021-0.30992-0.32029-0.33015-0.63993-0.53046-0.98044-0.32036-0.53034-0.5011-0.44032-0.90041-0.75017-0.68053-0.51012-1.3611-0.90021-1.6808-1.6602-1.0303-0.02022-2.0912-0.05023-3.1417-0.11024-0.0692-0.20026-0.18008-0.24984-0.20031-0.47033-0.36995-0.29028-0.5807-0.67972-1.0714-0.8702-0.47957-0.19048-1.0002-0.0411-1.4407-0.36987-0.66031-0.5199-0.42933-1.9107-0.39932-2.8109 0.21989-0.01044 0.39018-0.02022 0.46065-0.05023 0.42933-0.15003 1.7512-0.15982 2.5505-0.33008 1.8817-0.39074 3.5729-0.15003 5.5128-0.24006 0.86061-0.0411 1.5007-0.17026 2.2419-0.76061 1.0198-0.81019 1.32-1.3705 2.7515-2.0007 0.0404-0.21983 0.90041-0.28963 1.0009-0.50033 1.9809-1.1011 6.8738-4.0509 2.7815-5.702 1.5307-0.33986 0.9102-1.3105 1.4609-2.3105 0.47043-0.86042 1.7512-1.6106 2.2112-2.3007 0.94022-1.4299 1.9509-3.2603 1.8413-5.4006 0-0.13046 2.4311-0.0698 2.6712-0.18004 1.2103-0.60014 1.0002-1.3601 1.7806-2.2603 1.3408-1.5604 3.402-2.561 4.5523-4.3112 1.2508 0.01109 4.703 0.96087 3.4816-1.4899 0.67009 0.33986 0.53046-0.05023 1.0205 0.66015 1.38 0.08024 3.8418 0.53034 4.6521-0.62036 0.80058 0.63014 1.0407 0.69016 2.0214 0.4501 0.12071 0.21983-0.0202 0.44032 0.0803 0.66928 1.2006 0.20092 1.7408 1.0202 2.7117 1.5401 1.2606 0.66994 0.59048 0.66015 2.251 0.74952 0.06 0.97 1.3708 1.6804 1.7003 2.5917 0.42085 1.1801 0.12985 2.8604 0.33994 4.1201 0.55917-0.12003 1.3604 0.20092 1.9202 0.08024-0.25903 2.2805 1.5712 2.6308 1.581 4.6713 0.96109 0.04044 1.962 0.04044 2.9224 0 0.69032-1.0007 2.071-0.93021 2.9916-1.9302 0.1703 2.2603-1.9613 3.1709-2.1616 4.9322 0.0502-0.4899 1.5105 0.7704 2.4716 1.6308-1.1399 0.53034-1.9307 1.0796-2.9505 1.7208-0.47043 0.29028-0.43063 1.2094-1.0505 1.4508-0.66944 0.25962-1.9907-0.01044-2.7215 0.03001-0.65052 1.8409-2.3913 1.4103-4.0023 1.501-0.12984 0.40966-0.12984 1.2603 0 1.6706 0.58071-0.14938 1.3708 0.0411 1.9209-0.17026 0.09 1.711-0.26034 6.0209 2.0005 6.002 0.03 0.27985-0.03 0.65037 0.0802 0.92043 0.42998-0.02022 1.0009 0.14938 1.4211 0.07958 0.42085 1.1403 1.4511 1.5708 2.5512 0.81019-0.21009 0.15982-0.43063 0.55056-0.7797 0.78018 0-0.01957 0.0796 0.55056 0.06 0.58057 1.4504-0.30007 2.5708 0.5199 2.5009 2.0007 2.0801 0.12003 3.5619 1.0405 5.5323 1.2205 0.47108 0.05023 1.0107 0.44945 1.6912 0.33008 0.60027-0.09981 0.48022-1.06 1.0414-1.2101 1.2697-0.34965 2.7515 0.58057 3.2121-1.0405 0.36017-1.2603-0.95065-2.1709-1.9711-2.3001 0.0998-1.8311-0.13963-3.1312-1.4504-4.2218 1.0498-0.24006 1.8406-1.1103 2.9009-1.2505 1.2012-0.16047 2.0605 0.78996 3.4712 0.47098-0.09-0.63993 0.33994-1.1103 0.33015-1.6713 0.3308 0.0698 0.84038-0.12003 1.1705-0.08024 0.0613-0.32029 0.39148-1.09 0.42149-1.4208v-0.03001c0.36017 0.01044 0.73012 0.01957 1.0805 0.03001-0.12136 0.55969 0.20031 1.3607 0.0796 1.9204 1.1099 0.07958 1.6612-0.84019 2.2504-0.92043 1.271-0.15982 1.8622 0.33008 2.7117 0.46054 1.4211 0.23027 4.7526-0.42075 5.043 1.2094 1.1405 0.18983 2.6216 0.39009 2.7515-0.92043 0.53046 0.06001 1.4811-0.28898 1.7108-0.28898-0.42084 0.74039-0.33015 1.5695-0.21009 2.4599 0.23097 0.0698 0.44042 0 0.67074 0.08024 0.36017 1.4299-2.5714 5.9316 0.2499 6.002 0.24011 1.1801 0.7908 1.7202 0.98067 2.9009 0.14028 0.85976-0.2101 2.4899-0.15007 3.5206 2.4115 1.5701 4.2535 0.91064 7.1739 1.0802 0.41106 1.1507 2.512 0.84084 3.6225 0.71038zm-48.785-0.84998c0.0104-0.32029 0.0104-0.65037 0-0.97066-0.69946-0.25962-1.1301 0.2805-1.9013 0.24006-0.65052-0.0411-1.2201-0.19048-1.7512-0.42075-1.2508-0.53034-2.9316-1.8506-3.2519-3.3301-0.30014-1.3503-0.52002-1.2701 0.33015-2.4208 0.52068-0.69994 1.2508-2.7313 1.0002-3.6706-0.24011-0.95044-1.4002-0.61123-1.4302-1.6504-0.76013-0.08024-1.3715-0.55056-2.1512-0.68037-0.66096-0.10959-0.53046 0.09981-0.67009-0.40966-0.06-0.26028-0.03-0.8702 0.0802-1.0907 0.40062-0.85063 1.0805-0.72995 1.0909-1.8311 0.01-1.0196-0.64008-1.0496-0.85083-1.8206-0.6205-0.53034-1.0805-0.91978-1.151-1.7704-0.0405-0.41031 0.0907-0.90021-0.06-1.2707-0.0998-0.23027-0.46064-0.45924-0.61071-0.7293-0.79015-1.4906-0.15986-3.3216-0.76013-4.822-1.2912-0.06915-2.5316-0.30007-2.191-1.9309-0.43063-0.23027-0.81037-0.93935-1.3904-0.65037-0.28056 0.14025-0.46065 0.94-0.64008 1.1703-0.23945 0.31116-0.91085 0.41031-1.1301 0.80105-0.2101 0.3803 0.15986 1.0802-0.0502 1.4403-0.12984 0.19048-0.78036 0.47946-1.0198 0.57013-0.49066 0.19048-0.91085 0.24984-1.4909 0.25962-1.4211 0.01044-1.151 0.65037-1.3415 1.8206-0.57027 0.01957-1.4511-0.17026-1.9914 0-0.50045 0.15982-0.89063 0.84019-1.1803 1.2609-0.36995 0.53034-0.49001 0.92043-0.65051 1.5003-0.28057 0.98044-0.46 0.78996-1.4909 0.85063 0.0692 1.2909-0.56047 0.8702-1.2606 1.3999-0.64008 0.47946-0.39084 1.4403-0.43064 2.2407 0.0104-0.33008-1.1203 0.46054-1.2208 0.69081-0.21989 0.5199-0.0502 1.2603-0.03 1.8095 0.0398 0.77039-0.0502 0.8702 0.79015 1.1905 0.50044 0.20026 1.0407 0.27006 1.5607 0.39988 0.59049 0.14025 1.2612 0.03001 1.8315 0.24984 0.55982 0.21983 0.84038 0.62036 1.2508 1.0196 0.85017 0.83041 1.5809 1.7606 1.5809 2.9811 0 1.1807-0.0202 3.0411-0.61137 3.9818-0.5807 0.96022-2.7515 0.96022-2.8115 2.0209-0.0202 0.41031 0.50044 1.1507 0.59048 1.5904 0.14029 0.7306 0.0992 1.0411 0.55983 1.681 0.57026 0.78996 0.75034 0.63993 1.3604-0.0998 0.44042-0.53034 0.67009-1.1905 1.4909-1.2505 0.76078-0.06067 0.92064 0.39922 1.3604 0.90021 0.43063 0.4899 0.9611 0.69016 1.4009 1.1703 1.0498 1.15-0.75034 2.1396-0.74121 3.3412 0.45021-0.36074 1.1908-1.501 1.9118-0.83041 0.2101 0.20026 0.0692 0.66015 0.47043 0.94 0.30014 0.2094 0.79015 0.25962 1.1705 0.2394-0.0803 0.89042 0.80124 1.8904 1.2704 2.5708 0.30013 0.4501 0.61071 0.86042 1.1608 0.92043 0.7001 0.08024 1.0707-0.43967 1.7408-0.57013 0.13963 0.82062 0.90041 0.4899 1.5098 0.59035 0.54025 0.08024 1.1705 0.54012 1.761 0.31964 0.64008-0.25897 0.58071-0.61971 1.4106-0.66928 0.68053-0.04044 1.4106 0.14938 1.151-0.81997-0.36017-0.12068-1.6012-0.32029-1.6606-0.66994-2.1212 0.25962-1.0198-3.5512-1.0909-4.8318-0.45021-0.14025-1.1705-0.3503-0.82016-1.0196 0.1605-0.31116 0.43063-0.09067 0.58983-0.26028 0.17095-0.18983 0.0803-0.4899 0.28057-0.63014 0.81037-0.57013 2.2412 0.02022 3.141-0.17026 0.57026-0.12068 0.85996-0.41031 1.4909-0.44097 0.57027-0.01957 1.0309 0.24006 1.5307 0.09067 0.14093-0.0411 0.36081-0.33008 0.56047-0.39988 0.2499-0.08024 0.57026-0.01044 0.82995-0.02022 0.53372-0.03066 1.0537-0.12068 1.5744-0.10046z",
+                Taoyuan:"m324.59 106.65c0.0502 0.91065 0.0202 1.8304 0.0104 2.7508-1.2208 0.0691-2.8918 0.21005-3.5619 0.95044-0.24011 0.25962-0.59048 0.69994-0.71054 1.0307-0.26034 0.78018 0.15007 0.57991 0.45999 1.2394 0.29035 0.60079-0.06 1.8311-0.27991 2.5004-1.1105 0.81019-2.1616 1.2609-2.5714 2.681-0.2101 0.71038-0.19053 1.4103-0.65052 2.0105-0.55069 0.71038-1.0009 0.47033-1.7114 0.72017-0.8704 0.3105-1.3806 1.561-1.3708 2.621-0.78035 0.0998-1.9418 0.33008-2.6719 0.0502-0.58984-0.21983-1.0798-0.98044-1.8406-0.99088-0.84039-0.50033-0.72033-1.7508-1.5809-2.2505-0.0405-0.72017 1.1209-4.291-0.33994-4.002 0.0411-0.92043-0.30014-0.97979-0.76013-1.5904-0.39997-0.5199-0.28057-0.96087-0.2499-1.5708 0.03-0.43967 0.16964-1.5701-0.15007-1.8506-0.2897-0.25963-1.5307-0.06-1.9202-0.0802-0.18008-0.67972-0.0202-1.4403-0.18008-2.1507-0.13963-0.63014-0.67988-0.93021-1.0198-1.3901-0.51023-0.69081-0.36995-1.0502-1.3115-1.1905-0.72033-0.11025-1.8308-0.0802-2.2706 0.39987-0.12984 0.03-0.2499 0-0.38039 0-0.67009-1.8409 1.1301-3.0111 0.72033-4.8115-0.12005 0-0.27991-0.0411-0.39018-0.0202-0.12984-0.09-0.03-0.12068-0.2499-0.17026-0.17029-0.52055-0.33993-1.3412-0.18008-1.9009 0.15007-0.57013 0.70011-0.84019 0.82995-1.501 0.28056-1.4208-0.6205-2.79-1.9209-3.0907-0.80059-0.18004-0.93043-0.28963-1.581-0.74104-0.23097-0.15917-0.55068-0.28898-0.85082-0.4899-0.19052-0.12003-0.39997-0.44032-0.5011-0.50033-0.63943-0.39009-1.181-0.08024-1.6312-0.67972-0.36016-0.48011-0.39931-1.2303-0.3693-1.8206-0.50109-0.08024-1.5105-0.24006-1.9013-0.51012-0.60028-0.4201-0.26034-1.3803-1.1705-1.3405-0.57026 0.03001-1.1908 0.8702-1.8315 0.75017-0.77057-0.15004-0.47957-1.1514-0.50958-1.8206-0.52068 0.01957-1.0309-0.16047-1.5614-0.08024 0.03 0.2094-0.11027 0.36922-0.11027 0.54991-1.2097 0.24006-1.8511-1.0007-2.8918-1.3307-0.15007-0.69081-0.47109-1.3901-1.331-1.2505 0.12006-0.86042-1.0414-0.81997-1.5907-1.0104-0.33015-0.12068-0.79015-0.32029-1.0805-0.5199-0.25968-0.18004-0.5807-0.75996-0.7797-0.85976-0.24011-0.12003-0.42085-0.21983-0.72033-0.19048-0.15986-0.72016 0.29035-0.7306 0.66095-1.1403 0.42933-0.48011 0.49001-0.66015 0.47957-1.3307-0.01-0.3803-0.0196-1.1605-0.16964-1.5003-0.11027-0.24984-0.38039-0.08024-0.48022-0.44032-0.0692-0.21983 0.21009-0.44097 0.17095-0.58057-0.20097-0.66015-1.7108-1.0007-2.422-1.0007-0.74969 0-2.0005 0.23092-2.7012-0.0098-0.0104-0.01044-1.3611-0.98044-1.4609-0.65037 0.17094-0.54012 0.1207-1.2003 0.23097-1.7404-0.72033-0.04044-1.3806 0.0411-2.071 0.0698-0.82081 0.03001-1.1608-0.23092-1.8315-0.5199-1.121-0.48011-3.3309-0.3503-3.5919-1.5708-0.2499-1.1703 0.54025-3.2505-0.27012-4.1423-0.27991-0.30007-1.2508-0.95044-1.6606-1.1703-0.52002-0.27985-1.3806-0.39922-1.9907-0.27006-0.73077 0.16047-1.2103 0.53034-2.0814 0.39987-0.61985-0.09981-1.1803-0.55904-1.81-0.3803-0.61137 0.17026-0.8306 0.76061-1.4407 0.90021-0.39083 0.09067-1.0805 0.09067-1.5614-0.03979 0.45999-0.30007 0.92064-0.60014 1.2704-0.99088 0.60028-0.66015 1.9307-2.561 2.2308-3.4514 0.47043-1.3901-0.39018-4.4208 1.271-4.7313 0.49-2.7411 2.2608-4.6909 4.6326-6.002 2.1714-1.2003 5.133-1.0104 5.9532-3.6706 0.66096-0.04958 0.82016-0.44945 1.4217-0.58057 0.0692-4.3014 8.9037-0.39009 9.8347-3.9211 2.512-0.54012 4.6221-2.5708 6.9534-3.6113 3.0118-1.3405 4.6025-0.98044 7.5145-1.9302 0.35038-0.10959 1.3806-0.0998 1.9914-0.12003-0.03 0.90021-0.25968 2.291 0.39931 2.8109 0.44108 0.33008 0.9611 0.18004 1.4407 0.36987 0.49 0.19048 0.7001 0.57992 1.0714 0.8702 0.0202 0.21983 0.12984 0.27006 0.20031 0.47032 1.0505 0.06001 2.1114 0.09002 3.1417 0.11024 0.32036 0.75996 1.0009 1.15 1.6808 1.6602 0.39996 0.30985 0.5807 0.21983 0.90041 0.75017 0.20031 0.33986 0.21988 0.66015 0.53046 0.98044 0.47044 0.4899 1.3108 0.91064 2.071 0.93021 1.1908 0.05023 2.0716 0.48011 3.2421 0.60014 0.0405 0.30007 0.27013 0.51012 0.5807 0.57992 0.06 0.94065 0.01 1.2609 1.0002 1.501 0.09 0.25962 0.14941 0.53034 0.19052 0.80953 0.0502 0.01044 0.0992 0.02022 0.14028 0.03001-0.21988 0.6608-0.44042 1.7215-0.12984 2.4606 0.2897 0.72017 0.85017 0.84019 0.88084 1.7606-0.61137-0.03001-2.2921 0.04044-1.9711 1.0007 0.12006 0.36008 0.65052 0.34965 0.84039 0.57013 0.33015 0.39009 0.33994 0.72017 0.30014 1.2603-0.40062 0.17026-0.98067 0.60014-1.1705 1-1.6605-0.06067-1.2704 1.5095-2.4011 1.9407-1.1405 0.42075-3.0223 0.08024-4.1523-0.14938-0.79015-0.16047-1.3604-0.05023-2.101 0.1396-0.46064 0.12003-0.60092-0.12068-0.90106 0.33008-0.17943 0.27006-0.09 1-0.0992 1.3405-0.03 0.74039 0.0196 1.5401 0.16051 2.2505 0.14942 0.71038 0.61072 1.2094 0.49001 1.9909-0.39083 0.02022-1.1307-0.14025-1.4909 0.01044-0.39997 0.15982-0.82995 0.82976-0.39997 1.2603 0.35038 0.3503 0.76078-0.05023 1.0707 0.4899 0.18008 0.31051 0.14093 1.1103-0.01 1.4906-0.27012 0.03979-0.48022 0.1696-0.72033 0.27006-0.0698 0.03001-0.0907 0.78996-0.11027 0.93021 0.28057 0.06001 0.60028 0.06001 0.91086 0.0698 0.0502 0.93021-0.67988 1.8806 0.0104 2.4103 0.32036 0.24984 1.0302 0.04044 1.3415 0.24006 0.3693 0.24006 0.41041 0.94 0.76078 1.2407 0.10962-0.01109 0.27013 0.03001 0.39018 0.03001-0.0404 0.42988-0.0202 1.3999 0.33994 1.6602 0.44956 0.31051 1.3708-0.3803 1.6201 0.23027 0.33994 0.85128-1.7708 1.1011-1.3408 1.9915 0.1703 0.36008 0.8704 0.33008 1.0805 0.57992 0.30013 0.3503 0.25055 0.74039 0.21988 1.1807-0.67009 0.03001-2.9511 0.28115-2.7319 1.3307 1.4909 0.09067 2.681-0.06001 3.9918 0.68037 0.59049 0.33986 1.1105 1.09 1.9209 0.92043 0.85996-0.17939 0.71054-0.81997 1.1601-1.2505 0.89062-0.84998 2.912 0.0411 3.5925 0.7306 0.56961 0.57992 1.1203 2.5708 2.2308 2.4508 0.39018 0.93021 1.2906 0.42075 1.6906 0.99088 0.73077 1.0307-0.61072 3.8207 1.7304 3.6811 0.0411 0.46054 0.0607 0.94-0.2499 1.2205-1.35 0.18983-1.6605 1.4906-2.7215 2.1201-0.74056 0.44032-0.80059 0.66015-0.60028 1.6406 0.10962 0.60014 0.15986 1.3503 0.33015 1.9204 0.41041 1.3405 1.1105 2.351 1.8615 3.501 0.31971 0.4899 0.7797 1.0104 1.0407 1.5206 0.32037 0.63014-0.0998 1.5304 0.54025 1.9602 0.30014 0.21005 0.79015 0.0502 1.151 0.0998 0.48022 0.0802 0.60028 0.17025 1.0205 0.42009 0.71577 0.44684 0.6851 1.2975 1.626 1.1872z",
+                Keelung:"m354.05 44.801c-1.1007 0.76061-2.131 0.33008-2.5505-0.81019-0.42085 0.0698-0.99176-0.09915-1.4217-0.08024-0.10962-0.26941-0.0502-0.63928-0.0803-0.91978-2.2615 0.01892-1.9111-4.2916-2.0005-6.002-0.55069 0.2094-1.3415 0.01957-1.9209 0.17026-0.12984-0.40966-0.12984-1.2603 0-1.6706 1.611-0.09067 3.3518 0.33986 4.0023-1.501 0.73077-0.04044 2.052 0.23092 2.7215-0.03001 0.6205-0.24006 0.58135-1.1598 1.0505-1.4508 1.0205-0.63993 1.8106-1.1905 2.9511-1.7208 0.46064 0.42988 0.80972 0.76061 0.82016 0.77039 1.4811 1.0502 2.6621 1.0705 4.6326 1.1801 0.4502 1.8617-0.28057 2.7906-0.14942 4.4423 0.68053-0.86042 1.7004-1.4005 1.7304-2.6908 2.4611-1.3203 4.0525 1.6706 6.6742 0.7306-0.11027 0.4899 0.17878 1.2003 0.0796 1.6902 0.52068 0.02022 1.0498 0.03001 1.5907 0.05023v0.03001c-0.03 0.33008-0.36016 1.1005-0.42084 1.4208-0.33015-0.04044-0.84039 0.15004-1.1705 0.08024 0.0104 0.56035-0.42084 1.0307-0.33015 1.6706-1.4106 0.32029-2.2706-0.63014-3.4718-0.47032-1.0603 0.14025-1.8511 1.0104-2.9009 1.2505 1.3108 1.0907 1.5503 2.3908 1.4511 4.2212 1.0198 0.13046 2.3306 1.0411 1.9711 2.3007-0.46064 1.6204-1.9418 0.69016-3.2121 1.0405-0.55982 0.15003-0.44042 1.1103-1.0407 1.2101-0.68053 0.12003-1.2208-0.2805-1.6912-0.33008-1.9711-0.18004-3.4516-1.1011-5.5323-1.2205 0.0698-1.4814-1.0505-2.3007-2.5009-2.0007 0.0196-0.03001-0.06-0.60014-0.06-0.58057 0.34907-0.23027 0.56896-0.62036 0.77971-0.78018z",
+                Kinmen:"m41.675 107.89c-0.0762 4e-3 -0.14595 0.0243-0.18718 0.0468-0.0375 0.0225-0.0711 0.0402-0.0936 0.0702l-0.0468 0.0936c-0.05235 0.16473-0.0159 0.38094-0.0234 0.53817-0.77124 0.0375-1.3965-0.23867-2.1526-0.16379-0.17222 0.015-0.27516 0.0412-0.32758 0.0936-0.015 8e-3 -9e-3 9e-3 -0.0234 0.0234-0.09735 0.11235-0.102 0.2967-0.30418 0.49137-0.21714 0.20217-0.453 0.4034-0.46797 0.72537-0.0075 0.41931 0.2527 0.74409 0.1404 1.1933-0.09735 0.34443-0.40246 0.4268-0.51478 0.74877-0.08985 0.2471 0.015 0.66641 0 0.93596-0.0225 0.3669-0.1095 0.46984-0.49137 0.51477-0.15724 0.0225-0.32666 0.0524-0.49138 0-0.09735-0.0225-0.24522-0.1563-0.32757-0.16379-0.75626-0.0973-0.35661 1.154-0.3042 1.521 0.045 0.34443-0.0135 0.56532-0.1404 0.84236-0.1422 0.32946-0.03375 0.42867-0.0936 0.79557-0.045-7e-3 -0.0795 0-0.117 0-0.03 0.10485-0.1011 0.16098-0.0936 0.28078-0.38936 0.0748-0.53722-0.27891-0.88916-0.23398-0.0225 0.11235 0.07485 0.23959 0.1872 0.37438 0.03 0.0375 0.072 0.0795 0.117 0.117 0.15723 0.1497 0.32384 0.27611 0.42117 0.35097 0.0375 0.0225 0.087 0.0552 0.117 0.0702 0.1422 0.0599 0.26301 0.0468 0.39778 0.0468 0.09735 8e-3 0.20778 0.0328 0.32758 0.0702 0.11235 0.0375 0.21434 0.10485 0.30418 0.1872 0.05235 0.0375 0.1029 0.0954 0.1404 0.1404 0.0375 0.0448 0.0795 0.0954 0.117 0.1404l0.0702 0.0468 0.0468 0.0702c0.1797 0.1797 0.39498 0.30699 0.70197 0.18719 0.35192-0.1347 0.1161-0.47265 0.28078-0.77216 0.22462-0.41182 0.906-0.78433 1.3103-0.88917 0.21789-0.0598 0.66546-0.25176 0.91256-0.117 0.23211 0.1497 0.1104 0.43898 0.1404 0.67857 0.0075 0.0748 0.0411 0.1347 0.0936 0.1872 0.015-0.0225 0.0243-0.0318 0.0468-0.0468 0.1497-0.1497 0.41368-0.27705 0.60837-0.37438 0.25458-0.1347 0.5026-0.33975 0.77217-0.44459 0.07485-0.26206-0.10395-0.43615-0.35098-0.42117-0.11235-0.45675-0.0468-0.63364 0.32758-0.86577 0.31448-0.20965 0.58497-0.3697 0.95936-0.44457 0.36688-0.0823 0.69354-0.0795 1.0529 0.0702 0.2995 0.11985 0.55222 0.34349 0.88916 0.35099 0.1497-0.20966 0.0486-0.47079 0.0936-0.72537 0.015-0.12735-0.04215-0.20685 0.0702-0.30419 0.09735-0.0898 0.25272 0.0206 0.32758-0.0468 0.26208-0.20965 0.045-0.94999 0.1872-1.2869 0.0225-0.0448 0.0243-0.072 0.0468-0.117 0.0375-0.0899 0.0795-0.19842 0.117-0.28078 0.0225-0.0448 0.0477-0.0795 0.0702-0.117 0.03-0.0523 0.072-0.0795 0.117-0.117 0.11985-0.11235 0.24615-0.19374 0.35098-0.35099 0.22462-0.37438 0.0543-1.0389 0.0468-1.4507-0.2471-0.0225-0.57 0.0263-0.77217-0.0936-0.05235-0.03-0.1188-0.072-0.16378-0.117-0.03-0.03-0.0636-0.0561-0.0936-0.0936-0.05985-0.0748-0.09645-0.1591-0.1638-0.23398-0.03-0.0375-0.0795-0.0795-0.117-0.117-0.4268-0.3594-0.98836-0.45674-1.3103-0.93596-0.0225-0.0375-0.0243-0.0881-0.0468-0.1404-0.0225-0.0524-0.0636-0.10395-0.0936-0.16378-0.0375-0.0824-0.0645-0.18158-0.117-0.23399-0.0225-0.0225-0.0477-0.0318-0.0702-0.0468-0.18718-0.11235-0.59433-0.0468-0.81896-0.0468-0.15162 0-0.47348-0.0594-0.70197-0.0468zm32.666-14.206c-0.71882-0.05985 0.19842 0.96028 0.28078 1.1699v0.0234c0.03 0.07485 0.0468 0.17596 0.0468 0.28078 0 0.21714-0.0468 0.45114-0.0468 0.60837 0 0.3669 0.0402 0.51946-0.30418 0.63177-0.20217 0.06735-0.3332 0.08805-0.46798 0.1404-0.05235 0.0225-0.10395 0.0327-0.16378 0.0702-0.03 0.015-0.0561 0.0477-0.0936 0.0702-0.10485 0.06735-0.21526 0.13575-0.32758 0.2106-0.11235 0.08235-0.22276 0.15818-0.32758 0.21058-0.1422 0.06735-0.29482 0.0702-0.44458 0.0702-0.05235 0.0075-0.11145 0-0.16378 0-0.06735 0-0.14325 9e-3 -0.21058 0.0234-0.0375 0.0075-0.0795 9e-3 -0.117 0.0234-0.25458 0.07485-0.44085 0.21058-0.72537 0.21058-0.07485 0.12735-0.1338 0.30513-0.1638 0.51478-0.04485 0.45675 0.06645 1.0408 0.35098 1.3103 0.0375 0.0375 0.072 0.0711 0.117 0.0936 0.0075 0.0075 0.0159 0 0.0234 0 0.04485 0.015 0.0954 0.0393 0.1404 0.0468v-0.117c0-0.015-0.0075-0.0318 0-0.0468v-0.0234c-0.0075-0.0075 0.0075-0.0159 0.0234-0.0234-0.0075-0.0075-0.0075-0.0159 0-0.0234-0.0075-0.0225-0.01515-0.0318 0-0.0468-0.0075-0.03 9e-3 -0.0711 0.0234-0.0936 0.0075-0.03-0.0075-0.0402 0-0.0702 0-0.015 0.01605-0.0234 0.0234-0.0234v-0.0468c0.0225-0.07485 0.04035-0.14325 0.0702-0.2106 0.0225-0.06735 0.0477-0.12735 0.0702-0.18718 0.015-0.0225 0.0159-0.0711 0.0234-0.0936 0.08235-0.0075 0.19281-0.0075 0.32758 0 0.05985 0 0.13575-0.0075 0.2106 0 0.0375 0 0.072 0.0234 0.117 0.0234 0.0225 0 0.0318-0.0075 0.0468 0 0.0375 0 0.0795-0.0075 0.117 0 0.08985 0.0075 0.19936 0.0318 0.30418 0.0468l0.0936 0.0234h0.0234c0.05985 0.0075 0.10395 9e-3 0.16378 0.0234 0.05985 0.015 0.1347 0.0318 0.18718 0.0468 0.05235 0.0225 0.08805 0.0552 0.1404 0.0702 0.04485 0.015 0.1029 0.0402 0.1404 0.0702 0.05985 0.0225 0.0954 0.0561 0.1404 0.0936 0.045 0.03 0.0945 0.07215 0.117 0.117 0.045 0.06735 0.0777 0.12825 0.0702 0.21058v0.0234c-0.0075 0-0.0318-0.0159-0.0468-0.0234h-0.0231c-0.18718-0.015-0.42117 0.0216-0.60837-0.0234-0.22462-0.04485-0.33694-0.19467-0.56157-0.18718h-0.0702c-0.0375 0-0.0795 0.0159-0.117 0.0234-0.015 0.0075-0.0318 0.0234-0.0468 0.0234-0.0375 0.015-0.0636 0.0243-0.0936 0.0468-0.06735 0.05985-0.09735 0.1535 0 0.28078 0.0075 0.015 0.0318 9e-3 0.0468 0.0234 0.08235 0.05985 0.19188 0.0543 0.30418 0.0468 0.10485 0 0.21246 0.0135 0.25738 0.1404 0.0225 0 0.0477 0.01575 0.0702 0.0234 0.0225-0.0075 0.0318-0.0075 0.0468 0 0.10485 0.31448 0.12825 0.45861 0.0234 0.79556l-0.0234 0.0936c-0.03 0.0973-0.04965 0.18345-0.117 0.28079-0.05985 0.0823-0.18999 0.12075-0.25738 0.2106l-0.0468 0.0468c-0.0075 0.015 0 0.0243 0 0.0468-0.0075 0.0448-0.0075 0.0881 0 0.1404 0.04485 0.16473 0.19094 0.32571 0.28078 0.46797 0.11235 0.17221 0.19188 0.46705 0.30418 0.63177l0.0468 0.0468c-0.03-7e-3 -0.0402-0.0159-0.0702-0.0234-0.0375-8e-3 -0.087-9e-3 -0.117-0.0234-0.05985-0.0225-0.11145-0.0561-0.16378-0.0936-0.0375-0.015-0.0636-0.0243-0.0936-0.0468-0.35193-0.25458-0.44178-0.67482-0.56158-1.1465-0.22462-0.0974-0.14595-0.27237-0.28078-0.44459l-0.0702-0.0702-0.0234-0.0468c-0.0375-0.03-0.1029-0.0477-0.1404-0.0702-0.08235-0.0375-0.17595-0.0636-0.28078-0.0936-0.1422-0.0375-0.263-0.0486-0.39778-0.0936-0.04485-0.015-0.08805-0.0243-0.1404-0.0468 0 0-0.0234-0.0157-0.0234-0.0234-0.0225-0.015-0.0477-0.0168-0.0702-0.0468-0.015-0.0075-9e-3 -0.0318-0.0234-0.0468-0.0225-0.03-0.0477-0.04785-0.0702-0.0702-0.015-0.015-0.0318-0.0393-0.0468-0.0468-0.07485-0.04485-0.1769-0.04305-0.30418 0.0468-0.21039 0.1422-0.22725 0.48951-0.0468 0.63177 0.1497 0.11235 0.26114 0.0561 0.35098 0.0936l0.0468 0.0234c0.03 0.03 0.0561 0.058 0.0936 0.1404 0.1422 0.26957 0.2705 0.74034 0.2106 1.0998-0.015 0.0749-0.0477 0.12735-0.0702 0.18718-0.15724 0.015-0.30232 0.0402-0.44458 0.0702-0.1497 0.03-0.29482 0.0795-0.44458 0.117-0.08985 0.03-0.17595 0.0478-0.28078 0.0702-0.05235 8e-3 -0.1029 0.0318-0.1404 0.0468s-0.0636 0.0243-0.0936 0.0468c-0.0375 0.0225-0.0711 0.0402-0.0936 0.0702-0.015 0.0225-0.0318 0.0636-0.0468 0.0936-0.015 0.0448-0.0234 0.10395-0.0234 0.1638-0.0075 0.0748-7.5e-4 0.15255-0.0234 0.25739-0.0075 0.0449-0.0243 0.10395-0.0468 0.16378-0.07485 0-0.16004 8e-3 -0.25738 0h-0.1404c-0.0225 0-0.0552-7e-3 -0.0702 0-0.10485 8e-3 -0.18999 0.0252-0.25738 0.0702-0.03 0.015-0.0552 0.0402-0.0702 0.0702-0.1872 0.29951 0.1011 0.6168 0.28078 0.81897 0.0225 0.015 0.0552 0.0318 0.0702 0.0468 0.37438 0.4268 0.41182 0.96872 0.37438 1.5678-0.0075 0.0973-0.0075 0.18251-0.0234 0.25739-0.0075 0.0748-0.0243 0.14325-0.0468 0.21058-0.045 0.11985-0.11415 0.24803-0.23398 0.39779-0.0375 0.045-0.0795 0.087-0.117 0.117-0.03 0.0375-0.0636 0.0478-0.0936 0.0702-0.03 0.0225-0.0402 0.0552-0.0702 0.0702s-0.07965 0.0159-0.117 0.0234c-0.08235 0.0225-0.20124 0.0234-0.35098 0.0234-0.31448 1e-5 -0.66734-5e-3 -0.95936 0.0702-0.2995 0.0748-0.44739 0.22557-0.70197 0.39778-0.27704 0.19467-0.3126 0.25646-0.70197 0.23399-0.21714-0.32946-0.52881-0.25083-0.86576-0.28079-0.40432-0.03-0.4998-0.33132-0.88916-0.42118-0.08985-0.0225-0.18345-0.0393-0.28078-0.0468-0.23961-0.015-0.49324-1e-3 -0.72537-0.0468-0.61398-0.10485-1.0988-0.2499-1.638-0.63177-0.89103-0.62897-1.5668-1.5612-2.4802-2.1526-0.48669-0.32198-0.94156-0.32384-1.2635-0.79556-0.26206-0.41182-0.46518-0.85921-0.77216-1.2635-0.29952-0.40434-0.69356-0.92566-1.053-1.2402-0.55408-0.47172-0.87138-0.13755-1.0062 0.49138-0.614 0.03-1.1194-0.1236-1.5912 0.28079-0.44176 0.37438-0.8199 0.74782-1.4039 0.91255-0.89852 0.23961-1.856 1.7043-1.4741 2.7376 0.19468 0.48669 0.6065 0.32945 0.93596 0.56157 0.1347 0.0898 0.18532 0.19842 0.32758 0.28079 0.0225 8e-3 0.0477 0.0393 0.0702 0.0468 0.045 0.0225 0.0954 0.0318 0.1404 0.0468 0.045 0.0225 0.08805 0.0318 0.1404 0.0468 0.11235 0.03 0.22276 0.0542 0.32758 0.0468 0.0375-0.20217 6e-3 -0.3566-0.0702-0.49139-0.05235-0.10485-0.1422-0.20778-0.18718-0.32758-0.0075-0.0225-0.0159-0.0402-0.0234-0.0702l-0.0468-0.0936c-0.10485-0.19467-0.27237-0.47358-0.25738-0.60837 0.24708-0.0449 0.44644 0.0786 0.67856 0.0936 0.25458 0.03 0.36783-0.1329 0.58498-0.1404 0.38936-0.015 0.88728 0.73095 0.84236-0.0702h0.21058c0.22464 7e-3 0.44178 0.015 0.56158-0.18719 0.10485-0.1797-0.11235-0.57936 0.18718-0.63177 0.32198-0.0524 0.23025 0.44364 0.32758 0.60837 0.07485 0.11985 0.61866 0.4764 0.117 0.49137-0.18718 0.29202-0.25738 0.30606-0.25738 0.72537 0 0.41183 0.08985 0.68138-0.37438 0.74877h-0.0702c-0.12735 0.0225-0.32384 0.03-0.42118 0-0.1422-0.0524-0.27048-0.32853-0.39777-0.35098-0.1422-0.0225-0.21996 0.0272-0.2574 0.117-0.0075 0.015-0.0234 0.0243-0.0234 0.0468-0.0075 0.015-0.0234 0.0477-0.0234 0.0702-0.0225 0.1347-0.0168 0.28546-0.0468 0.39778-0.25458 0.015-0.51758 8e-3 -0.77216 0.0234-0.015 0.20966 0.16566 0.14505 0.21058 0.25739 0.015 0.03 0.0234 0.0636 0.0234 0.0936 0.0075 0.0225 0.0234 0.0477 0.0234 0.0702 0.0075 0.0523 0.0075 0.10395 0 0.16378v0.117c0 8e-3 0.0075 0.0159 0 0.0234 0.0075 0.0375-0.01575 0.0636-0.0234 0.0936-0.0225 0.23961-0.0711 0.45395-0.0936 0.67857-0.0375 0.5466 0.39966 1.0314 0.63177 1.4507 0.21714 0.39684 0.34443 0.58029 0.37438 1.0296 0.03 0.32196 0.117 0.58309 0.117 0.91255 0 0.26955 0.0162 0.54098 0.0234 0.79556 0.0075 0.35941 0.0234 0.69261 0.0234 1.0296 0 0.20966 0.0972 0.76374 0 0.93596-0.11235 0.19468-0.55408 0.26767-0.74877 0.32758-0.08235 0.0225-0.18344 0.0477-0.28078 0.0702-0.06735 0.015-0.11985 9e-3 -0.18718 0.0234-0.09735 0.0225-0.21434 0.0402-0.30418 0.0702-0.12735 0.0448-0.24522 0.11235-0.32758 0.18719-0.11235 0.11235-0.16098 0.27517-0.0936 0.51478 0.05985 0.23211 0.25458 0.47172 0.18718 0.74876 0 0.015 0.0075 0.0159 0 0.0234 0 0.03-0.0075 0.0477-0.0234 0.0702-0.0225 0.0448-0.07215 0.0954-0.117 0.1404-0.03 0.0225-0.0636 0.0552-0.0936 0.0702-0.0375 0.0225-0.072 0.0477-0.117 0.0702-0.06735 0.0448-0.12735 0.0795-0.18718 0.117-0.03 0.0225-0.0711 0.0477-0.0936 0.0702-0.29202 0.23212-0.33507 0.23961-0.70197 0.1872-0.08235-7e-3 -0.26206-9e-3 -0.37438-0.0234-0.0225 0-0.0318 7e-3 -0.0468 0-0.015-2e-5 -0.0318-0.0157-0.0468-0.0234-0.03-0.015-0.0552-0.0168-0.0702-0.0468-0.0075 7e-3 0-0.0157 0-0.0234-0.05985-0.0599-0.06555-0.11985-0.1404-0.1872-0.20216-0.18719-0.36128-0.27891-0.60837-0.23399-0.04485 8e-3 -0.08805 0.0318-0.1404 0.0468-0.0375 0.0973-0.09645 0.18158-0.16378 0.23399-0.0225 0.0225-0.0402 0.0318-0.0702 0.0468-0.12735 0.0898-0.28827 0.0918-0.46798 0.0468-0.08235-0.015-0.17502-0.0243-0.25738-0.0468-0.0225 0-0.0318-0.0162-0.0468-0.0234-0.08235-0.0225-0.17502-0.0552-0.25738-0.0702h-0.0234c-0.1422-0.0225-0.2939-0.0135-0.42118 0.0234-0.0375 0.015-0.0561 0.0318-0.0936 0.0468-0.0375 0.0225-0.0636 0.0168-0.0936 0.0468-0.04485 0.0375-0.1029 0.0879-0.1404 0.1404-0.15723 0.21715-0.14505 0.33882-0.0702 0.42118 0.05235 0.0524 0.14415 0.1029 0.234 0.1404 0.08985 0.03 0.19094 0.0561 0.28078 0.0936 0.24708 0.11235 0.59994 0.50636 0.77216 0.67857 0.0375 0.015 0.0795 0.0168 0.117 0.0468 0.045 0.03 0.0954 0.072 0.1404 0.117 0.26956 0.23961 0.5438 0.68699 0.67857 0.88916 0.05235 0.0748 0.0636 0.10395 0.0936 0.1638 0.015 0.015 0.0318 0.0402 0.0468 0.0702 0.0225 0.0599 9e-3 0.22836 0.0468 0.28078 0.03 0.03 0.0486 0.0627 0.0936 0.0702 0.04485 0.015 0.11145 0.0159 0.1638 0.0234h0.0234c0.04485 8e-3 0.0954 9e-3 0.1404 0.0234 0.03 7e-3 0.0477 0.0159 0.0702 0.0234 0.0225 7e-3 0.0318 0.0318 0.0468 0.0468 0.10485 0.0973 0.17408 0.23211 0.23398 0.37437 0.0375 0.0898 0.0636 0.20685 0.0936 0.3042 0.045 0.1422 0.08895 0.27704 0.16378 0.37437 0.05985 0.0824 0.16848 0.13485 0.28078 0.1872 0.11985 0.0448 0.23212 0.087 0.37438 0.117 0.13485 0.03 0.28641 0.0552 0.42118 0.0702 0.12735 0.015 0.26114 0.0318 0.35098 0.0468 0.03 0.12735 0.09735 0.23772 0.18718 0.32759 0.07485 8e-3 0.12735 0 0.1872 0 0.06735 0 0.1422 9e-3 0.18718 0.0234 0.0375 8e-3 0.0636-6e-3 0.0936 0.0234 0.05235 0.0375 0.0954 0.10485 0.1404 0.18718 0.0225 0.0448 0.0477 0.088 0.0702 0.1404 0.045 0.10485 0.0795 0.22277 0.117 0.32759 0.015 0.0524 0.0477 0.0954 0.0702 0.1404 0.05235 7e-3 0.087 0.0486 0.117 0.0936 0.09735 0.11985 0.16098 0.34723 0.28078 0.44458 0.25458 0.2396 0.2939 0.1694 0.60837 0.117 0.32946-0.0448 0.86109-0.20122 1.1232 0.0234 0.0225 0.015 0.0552 0.0402 0.0702 0.0702 0.0375 0.0524 0.0552 0.11235 0.0702 0.18719 0.15723 0.11985 0.43054 0.19749 0.65517 0.25738 0.03 0.015 0.0402 0.0159 0.0702 0.0234 0.03 7e-3 0.0711 0.0234 0.0936 0.0234 0.1347 0.03 0.2293 0.03 0.30418 0 0.015 0 0.0393-8e-3 0.0468-0.0234 0.0225-8e-3 0.0318-0.0243 0.0468-0.0468 0.05235-0.0674 0.0795-0.17782 0.117-0.32758 0.0375-0.015 0.0954-0.0234 0.1404-0.0234 0.10485-0.0225 0.19935-0.0309 0.30418-0.0234 0.10485 0 0.20684-7.5e-4 0.30418-0.0234 0.0225 0 0.0477 7e-3 0.0702 0 0.03-8e-3 0.0477-0.0161 0.0702-0.0234 0.0375-0.015 0.0795-0.0477 0.117-0.0702s0.0711-0.0402 0.0936-0.0702c0.20217-0.20216 0.26768-0.51758 0.32758-0.77216 0.15723-0.6664 0.14415-1.0436 0.60837-1.5678 0.39684-0.45675 0.52881-1.096 0.86576-1.5678 0.1497-0.20965 0.23118-0.4839 0.35098-0.67857 0.0375-0.0524 0.0795-0.0954 0.117-0.1404 0.08235-0.0824 0.1591-0.15163 0.23398-0.234 0.04485-0.0375 0.087-0.088 0.117-0.1404 0.0225-0.015 9e-3 -0.0477 0.0234-0.0702 0.1872-0.45673-0.0318-0.7029 0.51478-0.91255 0.23211-0.0974 0.30324-0.1161 0.46797-0.28079 0.43428-0.44176 0.58592-0.64113 1.1699-0.86575 0.32198-0.12735 0.5569-0.31167 0.81897-0.49139 0.17222-0.1347 0.35847-0.23772 0.53817-0.32758 0.35192-0.18719 0.73378-0.34161 1.1232-0.49137 0.61398-0.23961 1.082-0.4764 1.7782-0.49137 0.68138 0 1.3534-0.0748 2.0122-0.1872 0.63645-0.11235 1.183-0.23399 1.8718-0.23399 0.16473 0 0.31072 9e-3 0.46797 0.0234 0.1497 8e-3 0.31822 0.0168 0.46798 0.0468 0.07485 0.015 0.1347 0.0477 0.18718 0.0702 0.17222 0.0598 0.26582 0.13665 0.46798 0.23399 0.32944 0.1497 0.50634 0.1086 0.67856 0.46798 0.09735 0.1797 0.12825 0.41369 0.2106 0.60837 0.03 0.0598 0.0486 0.11145 0.0936 0.16379 0.04485 0.0523 0.10395 0.0795 0.16378 0.117 0.19468 0.0974 0.453 0.1179 0.65517 0.1404 0.15724 0.0225 0.34162-4e-3 0.49138 0.0468 0.1497 0.0598 0.2396 0.20497 0.37437 0.2574 0.15724 0.0523 0.32666 7.3e-4 0.49138 0.0234 0.03 0 0.0636 0.0159 0.0936 0.0234 0.0375 0.015 0.0636 0.0243 0.0936 0.0468 0.06735 0.0448 0.11985 0.0956 0.18718 0.1404 0.03 0.0225 0.0561 0.0552 0.0936 0.0702 0.15724 0.0898 0.31917 0.0824 0.49138 0.18718 0.1497 0.0824 0.20122 0.19749 0.35098 0.25739h0.0234l0.0234 0.1404c0.0075 0.0448 0.01605 0.0795 0.0234 0.117 0.015 0.0824 0.04875 0.17502 0.0936 0.25738 0.11985 0.23961 0.24522 0.36878 0.32758 0.60837 0.11235 0.28454 0.18063 0.52602 0.21058 0.79557 0.0075 0.0448 0.0234 0.0954 0.0234 0.1404 0.015 0.0898 0.0075 0.17595 0 0.28079-0.57656 0.20217-1.8064-0.30699-1.7316 0.56157 0.49419 0.0225 0.97246-0.0459 1.4741-0.0234 0.05985 0.41931-1.0333 0.20685-1.3103 0.30418-0.05235 0.20217 0.1245 0.28266 0.30418 0.32759 0.045 0.1347 0.0702 0.30231 0.0702 0.44458 0.30699-0.0375 0.57374-0.24241 0.86576-0.25738 0.26206-0.015 0.58965 0.1077 0.88916 0.0702 0.55334-0.0524 0.37083-0.1422 0.49138-0.56159 0.11985-0.42679 0.41276-0.29763 0.77216-0.32758 0.60651-0.0448 0.81054-0.70383 1.3571-0.93596 0.29202-0.11985 0.68325-0.0411 0.98276-0.0936 0.05985-8e-3 0.13485-0.0477 0.18718-0.0702 0.1497-0.0749 0.24054-0.19935 0.2106-0.49137-0.0225-0.20965-0.06555-0.30138-0.1404-0.42118-0.03-0.0448-0.0402-0.0647-0.0702-0.117l-0.0234-0.0234c-0.0225-0.0375-0.0318-0.0636-0.0468-0.0936-0.10485-0.16473-0.11235-0.18533 0-0.32759 0.015-0.0225 0.0243-0.0636 0.0468-0.0936 0.03-0.0449 0.0879-0.0954 0.1404-0.1404 0.2396-0.24709 0.61586-0.48201 0.79556-0.0702 0.33694 0.0973 0.57 0.15537 0.95936 0.1404 0.20966-0.24709 0.57375-0.61678 0.49138-1.0062-0.1497-0.0898-0.27986-0.20498-0.44458-0.25739-0.05235-0.12735-0.0375-0.27798 0-0.39778-0.16473-0.12735-0.53444-0.31355-0.63177-0.53817-0.08235-0.19467 7.5e-4 -0.64862 0.0234-0.86576 0.08985-0.74128 0.6636-0.80211 1.2401-0.58497-0.0225 0.22463 0.49138 0.27143 0.67857 0.23399 0.40434-0.0974 0.2527-0.40434 0.32758-0.74877 0.05985-0.25458 0.18158-0.48669 0.23398-0.74876 0.0075-0.03 0-0.0636 0-0.0936 0.0075-0.0748 0.0318-0.15912 0.0468-0.234 0.0075-0.03 9e-3 -0.0636 0.0234-0.0936 0.0075-0.015 0.0159-9e-3 0.0234-0.0234 0.05985-0.0898 0.2106-0.21432 0.2106-0.30418 0-0.45674-1.0923-0.1254-1.4741-0.51477-0.03-0.03-0.0786-0.072-0.0936-0.117-0.09735-0.2471 0.1125-0.54192 0-0.81896-0.09735-0.25458-0.41649-0.4165-0.49137-0.67857-0.1497-0.50916-0.05235-1.4732 0-2.0122 0.045-0.43428 0.28452-1.534 0.74876-1.6614 0.10485-0.23211 0.43522-0.34068 0.39778-0.65517-0.0075-0.10485-0.13005-0.24615-0.25738-0.35097-0.05235-0.0375-0.08805-0.0711-0.1404-0.0936-0.0225-8e-3 -0.0711-0.0159-0.0936-0.0234-0.05985-0.015-0.10395-0.0234-0.16378-0.0234-0.05985 0-0.11145 7e-3 -0.1638 0.0234-0.0225 8e-3 -0.0477 8e-3 -0.0702 0.0234-0.0225 0-0.0477 0.0159-0.0702 0.0234-0.05235 0.0225-0.1188 0.0477-0.16378 0.0702-0.1497 0.0748-0.263 0.1404-0.39778 0.1404-0.11985 0-0.25552-0.0459-0.39778-0.2106-0.06735-0.0824-0.12735-0.16659-0.18718-0.23398-0.05985-0.0824-0.1188-0.15911-0.1638-0.23399-0.05985-0.10485-0.1263-0.21528-0.16378-0.32758-0.03-0.10485-0.0318-0.2237-0.0468-0.35099-0.015-0.10485-0.03075-0.20029-0.0234-0.32758 0.03-0.614 0.25364-1.3272-0.39778-1.5444-0.05235-0.015-0.0954-0.0477-0.1404-0.0702-0.08235-0.0375-0.1422-0.0645-0.18718-0.117-0.20966-0.1872-0.19376-0.46611-0.1638-0.79557l0.0234-0.16379v-0.1872c0.0075-0.20216-0.0075-0.453 0.0234-0.65517 0.0075-0.06735 7.5e-4 -0.10395 0.0234-0.16378 0.11235-0.2995 0.3566-0.3828 0.30418-0.77217-0.05235-0.0075-0.1188-0.0159-0.16378-0.0234-0.0225 0-0.0318-0.0234-0.0468-0.0234-0.26956-0.015-0.51759 0.01785-0.77217 0.0702-0.16473 0.0375-0.31822 0.08055-0.46798 0.1404-0.03 0.015-0.0636 0.0393-0.0936 0.0468-0.05985 0.0225-0.12735 0.0402-0.18718 0.0702l-0.0702 0.0468c-0.11985 0.07485-9e-3 0.23306-0.23398 0.2106-0.1797-0.0075-0.36034-0.39591-0.39778-0.53817-0.03-0.0375-0.0327-0.0411-0.0702-0.0936-0.12735-0.0075-0.26206-0.0159-0.37438-0.0234-0.23211 0-0.43521-0.0135-0.58497-0.1404-0.08235-0.06735-0.1347-0.15351-0.18718-0.2808-0.04485-0.11985-0.0627-0.24708-0.0702-0.37437 0-0.06735 0.0075-0.12735 0-0.1872-0.015-0.06735-0.0318-0.12735-0.0468-0.18718-0.08985-0.28454-0.20498-0.497-0.2574-0.81897-0.0375-0.1797-0.1188-0.3828-0.16378-0.58497-0.015-0.05235-0.0159-0.11145-0.0234-0.16378-0.0075-0.07485-0.0075-0.15912 0-0.234v-0.1404c0.0075-0.11985 0.02265-0.26206 0-0.37437-0.0075-0.04485-0.01605-0.07215-0.0234-0.117-0.0375-0.1347-0.11415-0.26674-0.23398-0.30418-0.03-0.0075-0.072-0.015-0.117 0-0.015-0.0075-0.0318 0.0159-0.0468 0.0234l-0.0702 0.0234c-0.13485 0.08235-0.16473 0.30512-0.37438 0.32758-0.06735-0.16473-0.0243-0.35098-0.0468-0.53818-0.38187-0.1797-1.257 0.09825-1.6614 0.2106h-0.0234c-0.05985 0.0225-0.1029 0.0393-0.1404 0.0468h-0.0234c-0.16473 0.0375-0.24802 0.01785-0.39778-0.117-0.0375-0.03-0.072-0.0645-0.117-0.117h-0.0234c-0.16473-0.1497-0.36876-0.42962-0.60837-0.44458z",
+                Matsu:"m47.89 49.587c-0.5391 0.81864-0.3307 2.5646-0.0312 3.463-0.75874 0.08984-1.3228 0.52164-1.8719 1.0607 0.87854 1.6672-0.22714 1.5961-0.68638 2.9638-0.56906 1.6672 0.4917 2.5258 1.5599 3.2446 0.40934 0.27954 0.76624 0.68512 1.1856 0.90476 1.0383 0.46922 0.98962 0.07608 1.7783-0.09354 0.7288-0.18968 0.60276-0.31948 1.5911-0.24958 0.62896 0.02994 1.2292 0.46298 2.028 0.34318 0.39934-0.75874 1.4738-2.1078 2.4022-2.028 0.51914 1.6772 2.6594-0.27828 3.3382-0.71756 1.4876-0.98836 2.26-1.5712 2.0904-3.5878-1.797 0.08986-3.4904-0.45424-5.3974-0.37438-1.1381 0.04992-1.7571-0.1273-2.2464 0.81116-0.1198 0.22962-0.1572 0.47672-0.1872 0.68636l-0.0312 0.28078c0 0.03994-0.0212 0.08486-0.0312 0.1248-0.01 0.08986-0.012 0.1797-0.0312 0.24958-0.01 0.03994-0.012 0.09484-0.0312 0.1248-0.03 0.0599-0.065 0.10608-0.1248 0.156-0.1798 0.12978-0.52538 0.19468-1.1543 0.1248-0.1398-1.6972-0.2683-4.0908-2.7142-3.6814 0.32944-0.609 0.76498-1.0795 1.4039-1.2791 0.1598-0.16972 0.40708-0.72506 0.46798-0.90476 0.1598-0.32946-2.9376-1.4726-3.307-1.6223zm23.56-17.784c-0.38328 0.04264-0.8218 0.14792-1.2479 0.24958-0.21306 0.05082-0.42916 0.11702-0.62396 0.156-0.1948 0.03894-0.37314 0.05302-0.53038 0.0624-0.34942 0.02-0.85984-0.07238-1.2791-0.0624h-0.0312c-0.1698 0-0.31698 2e-3 -0.43678 0.0624-0.70882 0.26956-0.46922 0.52664-0.99836 0.93596-0.34442 0.24958-0.7213 0.5831-1.1231 0.87356s-0.82864 0.53786-1.2479 0.59278c-1.228 0.13978-1.807-0.80616-2.7454 0.31198-1.0882 1.2679 0.1548 1.9006 0.37438 3.0886 0.1198 0.6689-0.0212 0.95716-0.2808 1.2167-0.0698 0.0599-0.1386 0.12728-0.21838 0.18718-0.31948 0.24958-0.74252 0.54536-1.092 1.1543-0.1398 0.25958-0.2421 0.56532-0.31198 0.90476-0.02 0.1198-0.0524 0.25458-0.0624 0.37438-0.0598 0.58902 8e-3 1.2068 0.1872 1.7159 0.1598 0.04992 0.1872-0.04492 0.1872 0.1248 0.20966-0.02996 0.52914 0.09234 0.74876 0.0624-0.1572 0.84736 0.41046 1.3996 1.1232 1.2167 0.1018-0.02616 0.2059-0.06738 0.31198-0.1248-0.0486-0.1872-0.091-0.41458-0.1248-0.65516-0.23696-1.6842-0.0236-4.4052 1.8719-4.4926-0.0224-0.5441 0.0872-0.94332 0.28078-1.2479 0.0968-0.1523 0.20398-0.30146 0.34318-0.40558 0.69598-0.5206 1.8782-0.47422 3.0574-0.37438-0.0798 0.49918 0.1884 0.94468 0.21838 1.4039 1.797-0.7887 2.9938-1.7147 5.2102-0.93596 0.1872 0.38936-0.093 2.9332 0.49918 3.5254 0.0494 0.04932 0.125 0.07348 0.1872 0.09354s0.1106 0.0138 0.1872 0c0.153-0.02786 0.34192-0.1198 0.56156-0.31198 0.0674-0.0587 0.1122-0.13966 0.156-0.2184 0.0438-0.07876 0.1006-0.1542 0.1248-0.2496 0.1936-0.76316-0.191-2.0002-0.1248-2.839 8e-3 -0.10486 8e-3 -0.22142 0.0312-0.31198 0.024-0.09056 0.0812-0.14556 0.1248-0.2184 0.0436-0.07288 0.089-0.13552 0.156-0.1872 0.20096-0.15502 0.5154-0.22214 0.99836-0.1248 0.0798-0.45924 0.0798-1.1107 0-1.5599-0.76874-0.04992-3.01 0.68512-2.8702-0.34318 0.1598-0.99836 1.6186-0.7238 1.2791-2.371-1.1381 0.24958-1.1656-0.99836-2.184-1.2479-0.1798-0.04742-0.43086-0.0596-0.68636-0.03114z"
+                };
+            var i = {};
+            for (var s in r) {
+                i = {};
+                if (this.options.stateSpecificStyles[s]) {
+                    e.extend(i, t, this.options.stateSpecificStyles[s])
+                } else {
+                    i = t
+                }
+                this.stateShapes[s] = n.path(r[s]).attr(i);
+                this.topShape = this.stateShapes[s];
+                this.stateHitAreas[s] = n.path(r[s]).attr({
+                    fill: "#000",
+                    "stroke-width": 0,
+                    opacity: 0,
+                    cursor: "pointer"
+                });
+                this.stateHitAreas[s].node.dataState = s
+            }
+            this._onClickProxy = e.proxy(this, "_onClick");
+            this._onMouseOverProxy = e.proxy(this, "_onMouseOver"),
+            this._onMouseOutProxy = e.proxy(this, "_onMouseOut");
+            for (var s in this.stateHitAreas) {
+                this.stateHitAreas[s].toFront();
+                e(this.stateHitAreas[s].node).bind("mouseout", this._onMouseOutProxy);
+                e(this.stateHitAreas[s].node).bind("click", this._onClickProxy);
+                e(this.stateHitAreas[s].node).bind("mouseover", this._onMouseOverProxy)
+            }
+        },
+        _initCreateLabels: function() {
+            var t = this.paper;
+            var n = [];
+            var r = 860;
+            var i = 220;
+            var s = this.options.labelWidth;
+            var o = this.options.labelHeight;
+            var u = this.options.labelGap;
+            var a = this.options.labelRadius;
+            var f = s / this.scale;
+            var l = o / this.scale;
+            var c = (s + u) / this.scale;
+            var h = (o + u) / this.scale * .5;
+            var p = a / this.scale;
+            var d = this.options.labelBackingStyles;
+            var v = this.options.labelTextStyles;
+            var m = {};
+            for (var g = 0, y, b, w; g < n.length; ++g) {
+                w = n[g];
+                y = (g + 1) % 2 * c + r;
+                b = g * h + i;
+                m = {};
+                if (this.options.stateSpecificLabelBackingStyles[w]) {
+                    e.extend(m, d, this.options.stateSpecificLabelBackingStyles[w])
+                } else {
+                    m = d
+                }
+                this.labelShapes[w] = t.rect(y, b, f, l, p).attr(m);
+                m = {};
+                if (this.options.stateSpecificLabelTextStyles[w]) {
+                    e.extend(m, v, this.options.stateSpecificLabelTextStyles[w])
+                } else {
+                    e.extend(m, v)
+                }
+                if (m["font-size"]) {
+                    m["font-size"] = parseInt(m["font-size"]) / this.scale + "px"
+                }
+                this.labelTexts[w] = t.text(y + f / 2, b + l / 2, w).attr(m);
+                this.labelHitAreas[w] = t.rect(y, b, f, l, p).attr({
+                    fill: "#000",
+                    "stroke-width": 0,
+                    opacity: 0,
+                    cursor: "pointer"
+                });
+                this.labelHitAreas[w].node.dataState = w
+            }
+            for (var w in this.labelHitAreas) {
+                this.labelHitAreas[w].toFront();
+                e(this.labelHitAreas[w].node).bind("mouseout", this._onMouseOutProxy);
+                e(this.labelHitAreas[w].node).bind("click", this._onClickProxy);
+                e(this.labelHitAreas[w].node).bind("mouseover", this._onMouseOverProxy)
+            }
+        },
+        _getStateFromEvent: function(e) {
+            var t = e.target && e.target.dataState || e.dataState;
+            return this._getState(t)
+        },
+        _getState: function(e) {
+            var t = this.stateShapes[e];
+            var n = this.stateHitAreas[e];
+            var r = this.labelShapes[e];
+            var i = this.labelTexts[e];
+            var s = this.labelHitAreas[e];
+            return {
+                shape: t,
+                hitArea: n,
+                name: e,
+                labelBacking: r,
+                labelText: i,
+                labelHitArea: s
+            }
+        },
+        _onMouseOut: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("mouseout", e, t)
+        },
+        _defaultMouseOutAction: function(t) {
+            var n = {};
+            if (this.options.stateSpecificStyles[t.name]) {
+                e.extend(n, this.options.stateStyles, this.options.stateSpecificStyles[t.name])
+            } else {
+                n = this.options.stateStyles
+            }
+            t.shape.animate(n, this.options.stateHoverAnimation);
+            if (t.labelBacking) {
+                var n = {};
+                if (this.options.stateSpecificLabelBackingStyles[t.name]) {
+                    e.extend(n, this.options.labelBackingStyles, this.options.stateSpecificLabelBackingStyles[t.name])
+                } else {
+                    n = this.options.labelBackingStyles
+                }
+                t.labelBacking.animate(n, this.options.stateHoverAnimation)
+            }
+        },
+        _onClick: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("click", e, t)
+        },
+        _onMouseOver: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("mouseover", e, t)
+        },
+        _defaultMouseOverAction: function(t) {
+            this.bringShapeToFront(t.shape);
+            this.paper.safari();
+            var n = {};
+            if (this.options.stateSpecificHoverStyles[t.name]) {
+                e.extend(n, this.options.stateHoverStyles, this.options.stateSpecificHoverStyles[t.name])
+            } else {
+                n = this.options.stateHoverStyles
+            }
+            t.shape.animate(n, this.options.stateHoverAnimation);
+            if (t.labelBacking) {
+                var n = {};
+                if (this.options.stateSpecificLabelBackingHoverStyles[t.name]) {
+                    e.extend(n, this.options.labelBackingHoverStyles, this.options.stateSpecificLabelBackingHoverStyles[t.name])
+                } else {
+                    n = this.options.labelBackingHoverStyles
+                }
+                t.labelBacking.animate(n, this.options.stateHoverAnimation)
+            }
+        },
+        _triggerEvent: function(t, n, r) {
+            var i = r.name;
+            var s = false;
+            var o = e.Event("usmap" + t + i);
+            o.originalEvent = n;
+            if (this.options[t + "State"][i]) {
+                s = this.options[t + "State"][i](o, r) === false
+            }
+            if (o.isPropagationStopped()) {
+                this.element.trigger(o, [r]);
+                s = s || o.isDefaultPrevented()
+            }
+            if (!o.isPropagationStopped()) {
+                var u = e.Event("usmap" + t);
+                u.originalEvent = n;
+                if (this.options[t]) {
+                    s = this.options[t](u, r) === false || s
+                }
+                if (!u.isPropagationStopped()) {
+                    this.element.trigger(u, [r]);
+                    s = s || u.isDefaultPrevented()
+                }
+            }
+            if (!s) {
+                switch (t) {
+                case "mouseover":
+                    this._defaultMouseOverAction(r);
+                    break;
+                case "mouseout":
+                    this._defaultMouseOutAction(r);
+                    break
+                }
+            }
+            return !s
+        },
+        trigger: function(e, t, n) {
+            t = t.replace("usmap", "");
+            e = e.toUpperCase();
+            var r = this._getState(e);
+            this._triggerEvent(t, n, r)
+        },
+        bringShapeToFront: function(e) {
+            if (this.topShape) {
+                e.insertAfter(this.topShape)
+            }
+            this.topShape = e
+        }
+    };
+    var c = [];
+    s(e, "usmap", l, c)
+})(jQuery, document, window, Raphael)
+
+
+
+endingPicker = (out, totv, aa, quickstats) => {
+    
+    //out = "win", "loss", or "tie" for your candidate
+    //totv = total votes in entire election
+    //aa = all final overall results data
+    //quickstat = relevant data on candidate performance (format: your candidate's electoral vote count, your candidate's popular vote share, your candidate's raw vote total)
+  
+    /*
+    e.header = "<h2></h2>"
+    e.pages = ["<p></p>",
+               "<p></p>"]
+    */
+  
+    // NORMAL ENDINGS
+  e.final_overall_results.sort((a, b) => b.popular_votes - a.popular_votes);
+  map = document.getElementById("map_container");
+
+  //不帮助果冻，果冻失败
+  
+  if (aa[0].candidate === 2001557 && e.player_answers.includes(1950399)) {
+  used=false
+  if (used != true) {
+              setInterval(function () {
+                  used = true;
+                  imgg = document.getElementsByClassName("person_image")[0];
+                  if (imgg != null) {
+                      imgg.src =  "https://cc.tvbs.com.tw/img/upload/2023/05/11/20230511101843-4fbdaa77.jpg";
+                  }
+              }, 100);
+          }
+  return "<div style='overflow-y:scroll;height:250px;'><h3>KMT's Landslide Failure, DPP Re-elected</h3><p>Since the nomination of Terry Gou on May 17, 2023, the Kuomintang (KMT) has made a significant mistake. Gou's campaign encountered numerous issues over the months, ultimately leading to the current outcome. Firstly, Gou's involvement in past scandals resurfaced, severely impacting his and the KMT's image. Many within the KMT were also dissatisfied with the influence he had on the party in 2019, including a considerable number of Han Kuo-yu's supporters, as he competed against Han in 2019 and played a role in his significant defeat.</p><p>Mayor Hou You-yi focused on municipal governance and did not actively support Gou's campaign, lacking the backing of the initially popular presidential candidate Hou You-yi. Gou's campaign suffered from a lack of enthusiasm and support.</p><p>Things took a turn for the worse when Ko Wen-je refused to form a KMT-TPP ticket with Gou. Ko was wary of Gou's extensive business background and unclear ties with Beijing, as Gou had substantial business interests in mainland China. Gou insisted on running for president instead of vice president, refused to let the outcome be decided by polls, and even made statements like 'Let the Older brother go first for four years.' By November 23, Ko Wen-je still refused to communicate with Gou. At this point, Gou's approval ratings had fallen to the level of Eric Chu in 2016, and he still had not found a vice president. Ultimately, on November 24, Hung Hsiu-chu, who had been nominated in 2016 before being abolished, became Gou's vice president in an attempt to salvage his candidacy and keep the KMT in the election. Unfortunately, these efforts were in vain, and Gou's defeat was a reality.</p><p>With Gou's defeat, you have one less opponent to deal with in the next four years. Despite achieving high satisfaction ratings in polls for excellent municipal governance, earning the title of 'Five-Star Mayor,' it came at the cost of the KMT's survival and development. After this election, the KMT's electoral capabilities have once again been undermined. How many years will it take for this party to emerge from the shadow of 2016? Perhaps it will never happen.</p></div>"  
+  
+    } 
+    //帮助果冻，果冻失败
+
+    if (aa[0].candidate === 2001557 && e.player_answers.includes(1950400)) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://image.cache.storm.mg/styles/smg-800x533-fp-wm/s3/media/image/2019/11/23/20191123-114039_U4040_M570673_9ed1.jpg?itok=or7yughm";
+                        }
+                    }, 100);
+                }
+        return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Sets Historic Record, KMT Faces Third Defeat</h3><p>Since the Drafted of Terry Gou, his approval ratings have been consistently unstable, ultimately resulting in the current consequences. Lai Ching-te and the Democratic Progressive Party (DPP) have once again emerged victorious, setting a historical record in Taiwan by securing a third term. Meanwhile, you have also set a historical record of failure, a responsibility that Terry Gou must bear. If it weren't for his mishandling of the KMT-TPP Ticket in the later stages of the election, the KMT might have won by tens of thousands or even hundreds of thousands of votes against the DPP. However, his disdainful remarks towards Ko Wen-je and his supporters led Ko's supporters to refuse to transfer their votes to him, even when he was leading in the polls. He publicly stated that Ko Wen-je would absolutely not win and requested Ko's supporters to vote for him to defeat the DPP. His insistence on Ko Wen-je being the vice president further angered the TPP and its supporters. On registration day, Terry Gou, an outsider in politics, appointed actress Lai Pei-hsia as vice president, who had starred in the Taiwanese TV series Wave Makers, a show that exposed sexual harassment issues within the DPP. Despite her good and excellent image as well as eloquence, she lacked political experience and was questioned for the KMT's governing capabilities. Although Hou You-yi consistently supported Terry Gou, he ultimately faced defeat.</p> <p>With Terry Gou's defeat, you have one less opponent to deal with in the next four years. Despite achieving high satisfaction ratings in polls for excellent municipal governance, earning the title of 'Five-Star Mayor,' and establishing numerous connections and enhancing your strength and network in the local community, this success comes at the cost of the KMT's survival and development. After this election, the KMT's electoral capabilities have once again been undermined, and people are losing confidence in the party. However, due to the relatively small gap in this election, they are now looking towards you as the wise rising star. Can you secure victory in 2028? How many years will it take for the KMT to emerge from the shadow of 2016? Perhaps it will never happen. Perhaps it will be in the next four years.</p></div>"  
+        
+          } 
+
+    //不帮助果冻，果冻获胜
+
+    if (aa[0].candidate === 2001591 && e.player_answers.includes(1950399) ) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/800/20240113/2000x1333_wmky_495863372336_0.jpg";
+                        }
+                    }, 100);
+                }
+        return "You fool! I told you not to support him, to make sure he loses, and then let him give up in four years! Now he's the president, and in 2028, Terry Gou will definitely choose to run for re-election. What are you going to do then? After 2026, you can just go home and sleep. Goodbye, Mayor Hou!"  
+        
+          } 
+
+    //帮助果冻，果冻获胜
+    if (aa[0].candidate === 2001591 && e.player_answers.includes(1950400) ) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://news-data.pts.org.tw/media/149657/cover.jpg";
+                        }
+                    }, 100);
+                }
+        return "<div style='overflow-y:scroll;height:250px;'><h3>Terry Gou and Kuomintang Secure Victory! Political Alternation Achieved</h3><p>Since Terry Gou was drafted on May 17, avoiding the internal primary conflicts, his approval ratings have been neck-and-neck with Lai Ching-te until he was officially confirmed as the candidate in July. Gou gradually gained a stable lead over Lai. However, the rise of Ko Wen-je and the TPP caused a decline in Gou's approval ratings. Gou had to consider the KMT-TPP Tickets, and after sporadic negotiations over several months, a decision was made on November 15 to determine the outcome through polls. However, Ko Wen-je regretted the agreement after signing, leading to a loss of confidence in him. Voters looking to oust the Democratic Progressive Party (DPP) ultimately rallied towards Terry Gou. Gou nominated political outsider Lai Pei-hsia as vice president, bringing a positive media image. In the vice presidential debate, her unique eloquence, speaking skills, and sincere words resonated with many voters. According to polls, a staggering 62% considered Lai Pei-hsia the best in the debate. Ultimately, on January 13, Terry Gou emerged victorious and assumed the presidency.</p> <p>With Terry Gou's victory, your support for him will not go unnoticed. He has promised you a position in the cabinet, and the position of Premier is highly likely to be yours! Additionally, your high satisfaction ratings in municipal governance, earning the title of 'Five-Star Mayor,' and building numerous connections and enhancing strength and relationships in the local community have contributed to the survival and development of the Kuomintang. After this election, the electoral capabilities of the Kuomintang seem to have returned, and people's confidence in the party has been proven at the ballot box. Media and the public are speculating on who the DPP will field in the 2028 or even 2032 elections, while in the Kuomintang camp, attention is now turning to you, the rising star. If Terry Gou is willing to serve only one term, can you secure victory in 2028? Or do you plan to compete in the primaries against the incumbent president at that time? Regardless, you have considerable strength to contend with, and I wish you the best of luck, Mayor Hou!</p></div>"  
+        
+          } 
+          ///侯侯本体结局
+          if (aa[0].candidate === 2001591 && quickstats[1] > 40 && quickstats[1] < 46.0) {
+            used=false
+            if (used != true) {
+                        setInterval(function () {
+                            used = true;
+                            imgg = document.getElementsByClassName("person_image")[0];
+                            if (imgg != null) {
+                                imgg.src =  "https://s.yimg.com/ny/api/res/1.2/3jfyA37ICOF20CUv0IIlHA--/YXBwaWQ9aGlnaGxhbmRlcjt3PTY0MDtoPTQyNw--/https://media.zenfs.com/zh-tw/stormmediagroup.com/fb0e15099976b36c5bfa1068ec596167";
+                            }
+                        }, 100);
+                    }
+            return "<div style='overflow-y:scroll;height:250px;'><h3>Fourth Party Alternation! KMT Victory, DPP Rule Ends</h3><p>I believe Ko Wen-je must be regretting now, why he didn't accept the offer to be the Vice President on November 18. Because if he did, he would have gained many administrative resources for free, the second-highest position in the country, and the expansion of TPP's strength. But he chose to give up. In November, when the opposition alliances parted ways, many predicted that DPP would unprecedentedly enter its third term. However,Han Kuo-yu has brought in passionate fans and the blue base. Since he became the VP, every campaign event has been packed with people.. Faced with the untrustworthy Ko Wen-je and the interesting man who rose to fame 6 years ago, they immediately flocked to the latter. This led to a sharp increase in KMT's poll numbers after November,Han Kuo-yu consolidated your support base and helped secure victory with his charismatic appeal and a large number of dedicated fans., helping you secure victory.Han Kuo-yu firmly supports your policies and believes that you have adopted many of his policies, which makes him very satisfied.</p><p>In terms of this legislative yuan, you witnessed a complete victory. With 57+2 seats in the National Assembly, you will ensure your majority without having to consider DPP and TPP. You can pass any bills you want, ensuring the smooth operation of the Hou You-yi government in the parliament. However, to push for the cabinet system and other reforms you have promised, cooperation between the three parties must be promoted.</p><p>On May 20 this year, you will become the President of the Republic of China, a son of a pork vendor from rural Chiayi, who has been serving the country since entering the police academy, facing countless gunshots, confrontations, and battles against criminals. But if it weren't for Eric Chu promoting you to Deputy Mayor of New Taipei in 2010, you probably wouldn't have entered politics. In just over a decade, you have become the president. Perhaps your Mandarin is not good, perhaps your appearance is not as impressive as others, perhaps you don't even have much personal charm, but you are steadfast and down-to-earth, which has won the favor of the majority of Taiwanese voters. The first thing you will face after taking office is the mayoral by-election in New Taipei, as well as the major elections for mayors across the country in 2026. You must firmly grasp the local base of the blue camp, and in 2028, your prospects for re-election will be very promising! Good luck, President Hou You-yi!</p></div>"  
+            
+          } 
+          else if (aa[0].candidate === 2001591 && quickstats[1] < 40 && quickstats[1] > 35.0 ) {
+            used=false
+            if (used != true) {
+                        setInterval(function () {
+                            used = true;
+                            imgg = document.getElementsByClassName("person_image")[0];
+                            if (imgg != null) {
+                                imgg.src =  "https://cc.tvbs.com.tw/img/upload/2023/10/12/20231012145942-686dd798.jpg";
+                            }
+                        }, 100);
+                    }
+            return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Loses Third Term, 8-Year Curse Continues, Underdog Emerges Victorious</h3> <p>In an intense duel, the one who fights to the end is the true winner. With the possibility of Joint Tickets completely lost, Hou You-yi could only find Han Kuo-yu as the vice presidential candidate. On the positive side,at least Han Kuo-yu's fans can fill your campaign events and hope to get 5.5 million votes..To put it negatively, there is simply no other KMT member willing to be your vice president because polls show you lagging behind Lai Ching-te. No one is willing to waste time and sacrifice their political future to help you. Due to the Han Kuo-yu consolidated your support base and helped secure victory with his charismatic appeal and a large number of dedicated fans,We manage to defeat Lai Ching-te in the final stage of the election. It's truly a thrilling and exciting battle! Ko Wen-je must be regretting now; he could have become vice president, but now he can only be elected as Taipei City citizen. Haha.</p> <p>In terms of this legislative session, you have just obtained a majority, but it's very fragile. The 55+2 seats in the National Assembly will ensure your absolute majority without having to consider the faces of DPP and TPP. You can pass any bills you want, ensuring the smooth operation of the Hou You-yi government in the parliament. However, to push for the cabinet system and other promised reforms, cooperation between the three parties must be promoted. Additionally, if someone in the National Assembly does not vote for you, even one or two people whose party lines are inconsistent, it may lead to you losing the majority. So, you must uphold party discipline. After all, you are now the president, and you might also serve as the party chairman.</p><p>On May 20 next year, you will become the President of the Republic of China, a son of a pork vendor from rural Chiayi, who has been serving the country since entering the police academy, facing countless gunshots, confrontations, and battles against criminals. But if it weren't for Eric Chu promoting you to Deputy Mayor of New Taipei in 2010, you probably wouldn't have entered politics. In just over a decade, you have become the president. Perhaps your Mandarin is not good, perhaps your appearance is not as impressive as others, perhaps you don't even have much personal charm, but you are steadfast and down-to-earth, which has won the favor of the majority of Taiwanese voters. The first thing you will face after taking office is the mayoral by-election in New Taipei, as well as the major elections for mayors across the country in 2026. You must firmly grasp the local base of the blue camp, and in 2028, your prospects for re-election will be very promising! Good luck, President Hou You-yi!</p></div>    "
+          }
+            else if (aa[0].candidate === 2001557 && quickstats[1] <40 && quickstats[1] > 35.0 ) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/1024/20231231/1200x814_wmky_053032638365_202312030108000000.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Unprecedentedly Enters Third Term: KMT Fails to Achieve Party Alternation</h3><p>As predicted, the miracle did not happen. Lai Ching-te maintained his high approval ratings until the last day of the election. Everyone knew that the lack of cooperation between the blue and white camps would benefit Lai Ching-te. As expected, both you and Ko Wen-je lost in the election. However, Lai Ching-te's vote share is not as high as expected, staying below 40%, which means he didn't even secure full support from the DPP base. Han Kuo-Yu's entry brought a strong boost to the blue camp, but the Triumph Apartments incident and the influence of Ma Ying-jeou may have affected your base and votes. You may have also performed poorly in the early stages of the campaign, leading to a drag, but since this was a result that everyone could foresee, it might not be as bad as it seems.</p> <p>Fortunately, we have maintained a relative majority in the Legislative Yuan. The 53+2 seats will ensure that we are the largest party in the legislature. While we didn't achieve an absolute majority, meaning we have to cooperate with the TPP to pass bills, they will become a crucial minority in the parliament.</p> <p>After the election, you must return to the position of Mayor of New Taipei City. Your deputy mayor has been acting on your behalf for the past few months. Your term will continue until 2026. Although some extremists talk about replicating the outcome of Han Kuo-yu in 2020 and attempting to recall you as mayor, their chances of success are unlikely, and you are not particularly disliked. They are not likely to succeed. In 2026, you must step down, and at that time, you will be a free person, able to enjoy retirement and the remaining years of your life. However, if you still have ambitions for 2028, this election is just a stepping stone. Failure is the mother of success. Since the DPP can be re-elected, what reason do you have not to strive for the nomination in 2028?</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Han Kuo-yu for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>    "
+            }
+            else if (aa[0].candidate === 2001557 && quickstats[1] > 40.0 && quickstats[1] < 46.0) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://d1j71ui15yt4f9.cloudfront.net/wp-content/uploads/2023/12/03223725/20231203000125.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>Narrow Defeat with High Votes: KMT Loses to DPP with Over 40%</h3><p>Once, people believed that getting 40% of the votes in a three-way race would guarantee victory. Unfortunately, luck wasn't on your side, and the DPP secured a victory with just a slightly higher vote count. You garnered nearly the same number of votes, yet you have to return to your position as the mayor of New Taipei City. Is there a flaw in our electoral system? Despite securing a substantial 40% of the votes, achieving a party alternation proved elusive. Your supporters blame Ko Wen-je for siphoning off many of your votes, but despite our best efforts, party alternation couldn't be realized.</p><p>For you, the consolation is that Ko Wen-je secured third place. Before the election, he had significant momentum with substantial support from young people, and TPP supporters made their voices heard online. However, these were ultimately futile dreams. Even if Ko Wen-je had said he would let you run alone, you wouldn't have won. You proved that the KMT, with a solid base, wouldn't easily lose to the TPP, which has only been around for a few years. Among the opposition voters, there's a saying: whoever is in third place is the culprit for the opposition's failure. Judging by the voting pattern, he is indeed the third, and he lost by a significant margin. After the election, his Facebook was turned upside down by angry opposition voters.</p><p>Although Lai Ching-te becomes president, his governance won't be smooth. The high satisfaction with the Tsai administration won't be fully inherited by him. He is destined to face a minority government and a parliament where the opposition party is in power. Currently, the KMT has 56+2 seats, making it the largest party in the Legislative Yuan and securing an absolute majority. This means that, barring any surprises, Han Kuo-yu, who supports you, will become the president of the Legislative Yuan. This is a significant payback for him.  However, being selected as the vice president by you, Han Kuo-yu missed the opportunity to become a legislator.In fact, he was very likely to become the President of the Legislative Yuan, but because he had to assist you, he lost that position. In the next four years, she will have no public office, and this is the cost of failure. and you can go back to being the mayor of New Taipei City. You can try running again in 2028, as your performance has at least matched that of Han Kuo-yu in 2020, and this was in a three-way race. If you enter the race in 2028, the presidency could very well be yours. Good luck, Mayor Hou!</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Han Kuo-yu for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>"
+            }
+          else if (aa[0].candidate === 2001557 && quickstats[1] < 35.0 && quickstats[1] > 30.0) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://images.ctee.com.tw/newsphoto/2024-01-13/1024/20240113700644_20240113212416.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Triumphs Again, KMT Faces Another Defeat: When Will the Chapter of 2016 End?</h3> <p>On the night of your defeat, you had a nightmare: perhaps the KMT will never govern again? It's a frightening thought, but since 2016, the KMT has lost the presidential election three times in a row. The last time they won was 12 years ago, a cycle ago, but it feels as distant as a century ago. The DPP has achieved an unprecedented third term, even though their government is a minority one without the support of the majority of the people. The KMT's failure was anticipated, as the DPP had a few percentage points of a lead, and every step forward for you was challenging, ultimately leading to the KMT's defeat.</p><p>For you, the consolation is that Ko Wen-je came in third. Before the election, he had significant momentum, with substantial support from young people and a large voice among internet users, especially TPP supporters. However, these were ultimately futile dreams. Even if Ko Wen-je said he would let you run alone, you wouldn't have won. You proved that the KMT, with a solid base, wouldn't easily lose to the TPP, which has only been around for a few years. Among the opposition voters, there's a saying: whoever is in third place is the culprit for the opposition's failure. Judging by the voting pattern, he is indeed the third, so he might be the culprit?</p> <p>Although Lai Ching-te becomes president, his governance won't be smooth. The high satisfaction with the Tsai administration won't be fully inherited by him. He is destined to face a minority government and a parliament where the opposition party is in power. Currently, the KMT has 52+2 seats, making it the largest party in the Legislative Yuan. This means that, barring any surprises, Han Kuo-yu, who supports you, will become the president of the Legislative Yuan. This is a significant payback for him. However, being selected as the vice president by you, Han Kuo-yu missed the opportunity to become a legislator.In fact, he was very likely to become the President of the Legislative Yuan, but because he had to assist you, he lost that position. In the next four years, she will have no public office, and this is the cost of failure., and you can go back to being the mayor of New Taipei City. The world seems unchanged, just like before! You can try running again in 2028... if the ROC can survive until then.</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Han Kuo-yu for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>"
+              map.style.backgroundImage = "url(https://i.imgur.com/VjbWx3Q.jpeg)"; 
+            }
+          else if (aa[0].candidate === 2001591 && quickstats[1] > 46.0 ) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://www.cmmedia.com.tw/file/85517/1702626663_100072_cropped_46_1702626585_100072_main_393601449_891878185643590_6906418825261982269_n.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>Hou's Crushing Comeback: KMT Triumphs Over DPP in 2024, Regaining Power!</h3><p>As the lights lit up at the KMT campaign headquarters, the audience below had anticipation and anxiety in their eyes. For most of the past year, Lai Ching-te had been leading in the polls, only recently trading victories with Hou You-yi in the last couple of months. In the audience, there were infants in cradles, elderly individuals in their seventies and eighties, and middle-aged people in their forties and fifties, all hoping for a KMT victory to bring them a better future. When the vote counting began, Hou You-yi and Lai Ching-te were neck and neck. However, people noticed that Hou You-yi had a significantly high vote share in deep-blue regions. In battleground areas like Changhua and Taichung, he also performed admirably, gradually widening the gap. In the end, Hou You-yi secured victory in the presidential election with over 46% of the votes, becoming the 16th president.</p><p>Han Kuo-yu's fans cheered for the president, knowing that Han Kuo-yu had finally climbed to one of the highest positions in the country, even if it was under your leadership.. You and your campaign team quickly conducted a simulated inauguration ceremony, preparing for the formal inauguration on May 20.Han Kuo-yu consolidated your support base and helped secure victory with his charismatic appeal and a large number of dedicated fans.The DPP suffered a major defeat in this election, prompting them to reflect on whether their governance over the past eight years had left the people extremely dissatisfied, leading them to choose the strongest candidate even in the face of opposition division, ultimately ousting the DPP. Lai Ching-te's days as vice president were also coming to an end.</p><p>As the president who led the KMT back to power and won a challenging battle, the rewards for you are substantial. The KMT holds 59+2 seats in the Legislative Yuan, becoming the largest party and securing an absolute majority in the legislature. Han Kuo-yu, who supports you, is destined to become the president of the Legislative Yuan, and party chairman Eric Chu can become the premier. According to tradition, the party chairman should be the president, a significant reward for You. Han Kuo-Yu, as vice president, can handle diplomatic affairs and even represent you on foreign visits. Although some people are concerned about his lifestyle affecting diplomatic outcomes and image.Due to the enormous victory you achieved this year, it's almost certain that you will be nominated for re-election by the KMT in 2028. However, the upcoming New Taipei City mayoral by-election and the 2026 county and city mayoral elections will test your governing abilities. If you can navigate them successfully, then you have a great chance of winning re-election in 2028. Good luck, President Hou You-yi!</p></div>"
+            }
+            else if (aa[0].candidate === 2001622 ) {
+            used=false
+            if (used != true) {
+                        setInterval(function () {
+                            used = true;
+                            imgg = document.getElementsByClassName("person_image")[0];
+                            if (imgg != null) {
+                                imgg.src =  "https://d1b8dyiuti31bx.cloudfront.net/NewsPhotos/20231231/109_025527539611.jpg";
+                            }
+                        }, 100);
+                    }
+            return "<div style='overflow-y:scroll;height:250px;'><h3>Taiwan's Political Earthquake: Blue and Green Parties Overturned, Ko Wen-je Emerges Victorious</h3> <p>A year ago, nobody would have believed that Ko Wen-je and his TPP could secure the presidency of the ROC. However, it happened. Ko Wen-je and his People Party (TPP) claimed the presidency, leaving both the blue and green camps and their supporters in shock. Ko Wen-je's young fanbase erupted in joy, filling the internet with their celebrations, contrasting with the disappointment among blue and green supporters.</p><p>The world's attention turned to Ko Wen-je and the TPP. Media outlets from major countries, including China, the United States, South Korea, Japan, Russia, the United Kingdom, and France, featured front-page coverage on the process and outcome of Ko Wen-je and the TPP securing the presidency in Taiwan. However, Ko Wen-je is destined to be a crippled president as the TPP is the smallest party in the parliament. The solid foundations of the KMT and DPP in the legislature cannot be easily shaken. Can you imagine a president from the third-largest party dealing with a parliament full of opponents? It's almost unimaginable, but it happened. Ko Wen-je can choose to collaborate with either the blue or green camp, but he will never have dominance.</p> <p>With Ko Wen-je's election, your campaign turned into a joke. The KMT lost to a small party that had only been established for five years, and the defeat was embarrassing. The only consolation is that the DPP also suffered a severe setback, so you're not alone in this. As for the future, who knows? Ko Wen-je is an unpredictable figure, and the stance of his government remains uncertain. We know nothing at this point.</p></div> "
+               }
+               else if (aa[0].candidate === 2001557 && quickstats[1] > 46.0 ) {
+                  used=false
+                  if (used != true) {
+                              setInterval(function () {
+                                  used = true;
+                                  imgg = document.getElementsByClassName("person_image")[0];
+                                  if (imgg != null) {
+                                      imgg.src =  "https://cdn.hk01.com/di/media/images/dw/20240112/822423439976435712294650.jpeg/DZO8aeGaT0u6zDkTim6YltXgdsj2Ey8DbXl0JW15dCU?v=w1280r16_9";
+                                  }
+                              }, 100);
+                          }
+                  return "<div style='overflow-y:scroll;height:250px;'><h3>Head-to-Head Showdown Upended: DPP Defeats KMT-TPP Alliance</h3><p>In the November polls, most surveys indicated that the KMT-TPP joint ticket, whether led by Ko Wen-je or Hou You-yi, could defeat Lai Ching-te by at least several hundred thousand votes. However, on January 13th, how did things take such a turn? Lai Ching-te has emerged victorious over you, reminiscent of 2004 when the KMT's poll numbers remained high but were caught up and surpassed in the final stages. It was a painful night, with the supporters of the KMT and TPP left speechless, while not far away, the cheers of DPP supporters echoed through the skies.</p><p>In the Legislative Yuan, the KMT only leads the DPP by one seat, and the 51+2 seats will mean that you only need one person to abstain from voting to lose the relative majority. This is not good news for the KMT, and the TPP might consider choosing to cooperate with the DPP because your failure has brought about bitter political consequences. However, at least in the Legislative Yuan, there is some room for cooperation and contention among the three parties, and the election for the Legislative Yuan President on February 1st will be intense.</p><p>Given your lackluster performance in what was considered a sure-win game, you are being blamed as the main culprit for the failure. Your lack of proficiency in Mandarin, running for office while holding another position, and the image of a charmless rural figure have all weighed you down – issues of your own making. More importantly, your failure to handle some crucial issues properly undoubtedly impacted your votes and the likelihood of ultimate victory. You may not even be able to retain the position of New Taipei City Mayor, as some angry and extreme TPP and KMT supporters are planning to recall you as a failed leader. The saying goes,'a drowning man will clutch at a straw', and now you must find a way to return to city governance and regain the favor of the citizens. Good luck, Mayor Hou.</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Han Kuo-yu for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>        "
+                }
+                else if (aa[0].candidate === 2001591 && quickstats[1] < 35.0 ) {
+                  used=false
+                  if (used != true) {
+                              setInterval(function () {
+                                  used = true;
+                                  imgg = document.getElementsByClassName("person_image")[0];
+                                  if (imgg != null) {
+                                      imgg.src =  "https://pgw.udn.com.tw/gw/photo.php?u=https://uc.udn.com.tw/photo/2023/07/21/1/23334907.png&s=Y&x=76&y=0&sw=981&sh=654&exp=3600&w=800";
+                                  }
+                              }, 100);
+                          }
+                  return "<div style='overflow-y:scroll;height:250px;'> <h3>Narrow Victory in the Presidential Race: Hou You-yi Wins Presidency with Less Than 35% of Votes</h3> <p>In this intense multi-candidate competition, the DPP evidently lost its political stronghold, while the KMT's support base remained robust. Although several camps believed they could secure the presidency, the actual results were astonishing. Hou You-yi won the presidency with less than 35% of the vote, with the remaining 65% distributed among other candidates. This marks the lowest presidential vote percentage since the direct election of presidents. Nevertheless, you have secured the presidency, which may be challenging, but you did achieve it. After all, in a multi-candidate election, the support base is the most crucial factor.</p><p>In the Legislative Yuan, you maintain the status of the largest party but only lead the DPP by two seats. The upcoming parliament will undoubtedly involve party cooperation, and Han Kuo-yu is likely to become the next President of the Legislative Yuan without unexpected events. The TPP will inevitably become a crucial third force, and may your dealings with them be smooth! During your presidential term, challenges and opportunities will coexist. The difficulties presented by the challenging parliament and the diplomatic and domestic issues left by the DPP may be bothersome, but a reformed KMT government may gain more support and assistance from the people. The by-election for the mayor of New Taipei City and the 2026 county and city mayor elections will be your test. If you perform well, you may secure the nomination for reelection in 2028. However, if your performance is subpar, the KMT may prefer to nominate a new figure to replace you. Best of luck, President Hou You-yi!</p></div>"
+                }
+                //隐藏结局：2004重演。蓝白合输给民进党
+                else if (aa[0].candidate === 2001557 && quickstats[1] > 49.99 && quickstats[1] < 50.12 && aa[1].candidate === 2001591 ) {
+                  used=false
+                  if (used != true) {
+                              setInterval(function () {
+                                  used = true;
+                                  imgg = document.getElementsByClassName("person_image")[0];
+                                  if (imgg != null) {
+                                      imgg.src =  "https://rwnews.tw/upload/newstemp_13273/wide_j861buk_FotoJet-(72).jpg";
+                                  }
+                              }, 100);
+                          }
+                  return "<div style='overflow-y:scroll;height:250px;'><h3>Taiwan Election Deadlocked!</h3><p>Chairman Lai, something big has happened!</p><p>Your campaign office director, Yao Li-ming, hurriedly entered the hallway, finding you enjoying Taiwan's signature hand-shaken milk tea with extra sugar, evidently influenced by the locals in Tainan.</p><p>'Yao Director, what's the urgency?'</p><p>'Haven't you been watching? The vote count is at 95%, and there's still no winner declared!'</p><p>'I'm concerned about my health; high blood pressure, you know. What's going on?'</p><p>Yao quickly turned on the TV in your office, switching to SETN. Hou You-yi's and Lai Ching-te's images were swapping positions every half-minute, and their rankings kept changing. Each channel showed a different story, with Hou leading more on CTI, while Formosa TV and SETN favored Lai.</p><p>'Isn't there still 5% left? Let's wait until all votes are counted; I believe we'll win.'</p><p>One hour later, at the joint campaign headquarters of Hou You-yi and Ko Wen-je, the roar of car horns shattered the sky and everyone's hearts and ears.</p><p>'Everyone, please be quiet; President Hou can't speak in this noise.'</p><p>Hou You-yi stood silent on the stage.</p><p>'Chairman Ko, you go first.'</p><p>Ko Wen-je stepped forward, took the microphone, revealing an unprecedented solemnity in his expression.</p><p>'This is evidence of the DPP rigging the election. Their election staff used various methods, including disabling cameras, not singing the ballots, and much more. Our TPP and KMT supervisors have discovered many flaws in the electoral process, suspected of cheating... Please, everyone, look at the big screen.'</p><p>Hou You-yi added, 'The gap in our defeat is... very, very marginal. This slight difference is clouded in suspicion, raising many doubts. It gives the impression that this is an unfair election. We are preparing to file a lawsuit for the invalidation of the election.'</p><p>Supporters: 'Invalid! Invalid! Invalid!'</p><p>As the chants subsided, Hou You-yi continued, 'The second request is for the CEC to immediately seal all ballot boxes as a basis for future verification.'</p><p>Supporters: 'Verify! Verify! Verify!'</p><p>'If Taiwan really cannot lose, it's here. Everyone, right?'</p><p>Supporters: 'Yes!'</p><p>'Taiwanese people, democracy is our most effective weapon against the CCP. When we destroy this weapon, what other defenses do we have? Unfair elections not only make us hear about the doubts just mentioned but also clearly witness manipulative actions throughout the election. Everyone knows this, and we are using the most rational and gentle method to expose the deception carried out by Lai Ching-te and the DPP throughout this election. Let the whole world understand, shall we?'</p><p>Supporters: 'Go Hou-Ko! Go Hou-Ko!'</p><p>What happened in the world was unclear, but it was certain that Taiwan would once again enter bitter days of election violence and confrontation.</p></div>"
+                }
+                //白莲教赢过侯，侯大于23%
+                else if (aa[1].candidate === 2001622 && aa[2].candidate === 2001591 && quickstats[1] >= 23.1 && quickstats[1] < 30.0) {
+                    used=false
+                    if (used != true) {
+                                setInterval(function () {
+                                    used = true;
+                                    imgg = document.getElementsByClassName("person_image")[0];
+                                    if (imgg != null) {
+                                        imgg.src =  "https://imgcdn.cna.com.tw/www/webphotos/WebCover/800/20231223/1200x900_118527508580.jpg";
+                                    }
+                                }, 100);
+                            }
+                    return "<div style='overflow-y:scroll;height:250px;'> Is this the result of your self-sabotage? Well, I must say you succeeded because you managed to make a century-old political party lose to a third-party newcomer that has only been around for 5 years. It's quite a failure, and everyone on the internet is mocking you. </div>"
+                  }
+                  else if (aa[1].candidate === 2001622 && aa[2].candidate === 2001591 && quickstats[1] < 23.1 && quickstats[1] < 30.0) {
+                    used=false
+                    if (used != true) {
+                                setInterval(function () {
+                                    used = true;
+                                    imgg = document.getElementsByClassName("person_image")[0];
+                                    if (imgg != null) {
+                                        imgg.src =  "https://img.ltn.com.tw/Upload/news/600/2015/10/21/php4Ic3tg.jpg";
+                                    }
+                                }, 100);
+                            }
+                    return "<div style='overflow-y:scroll;height:250px;'>Your votes is even lower than Lien Chan's in 2000. I'm speechless. Now, Ko Wen-je and his supporters can openly mock the Kuomintang and you!</div>"
+                  }
+}
+
+
+
+setInterval(endingPicker, 250);
+
+//注释代码
+function getTooltips(str) {
+    let matches = [];
+
+    tooltipList.forEach((tooltip, index) => {
+        // Adjust the regex to match searchString potentially surrounded by “ and followed by optional punctuation
+       let regex = new RegExp(`(?<=\\b|\\s|^|“)${tooltip.searchString}(?=[.,;!?]?\\b|\\s|”|$)`, 'g');
+
+
+        let match;
+        while ((match = regex.exec(str)) !== null) {
+            matches.push({
+                start: match.index + (match[0].startsWith('“') ? 1 : 0), // Adjust for potential starting “
+                end: match.index + match[0].length - (match[0].endsWith('”') ? 1 : 0) - (match[2] ? 1 : 0), 
+                tooltipIndex: index
+            });
+        }
+    });
+
+    // Sort by starting position; if two start at the same position, longer match comes first
+    matches.sort((a, b) => a.start - b.start || b.end - b.start - (a.end - a.start));
+
+    // Filter out overlaps
+    for (let i = 0; i < matches.length - 1; ) {
+        if (matches[i + 1].start < matches[i].end) {
+            matches.splice(i + 1, 1); // Remove the next match since it overlaps
+        } else {
+            i++; // Move to next match
+        }
+    }
+
+    return matches;
+}
+function applyTooltips(str) {
+    const matches = getTooltips(str);
+    let result = '';
+    let lastIndex = 0;
+
+    matches.forEach(match => {
+        const tooltip = tooltipList[match.tooltipIndex];
+        result += str.slice(lastIndex, match.start);
+        result += `<span class='mytooltip'>${tooltip.searchString}<span class='mytooltiptext'>${tooltip.explanationText}</span></span>`;
+        lastIndex = match.end;
+    });
+
+    result += str.slice(lastIndex); // Add the remainder of the original string
+    return result;
+}
+
+function applyTooltipsToObject(obj) {
+    for (let key in obj) {
+        if (typeof obj[key] === 'string') {
+            obj[key] = applyTooltips(obj[key]);
+        } else if (typeof obj[key] === 'object') {
+            applyTooltipsToObject(obj[key]); // Recursive call
+        }
+    }
+}
+
+applyTooltipsToObject(campaignTrail_temp.questions_json);
+applyTooltipsToObject(campaignTrail_temp.answers_json);
+applyTooltipsToObject(campaignTrail_temp.answer_feedback_json);

--- a/static/mods/2024ROC_Hou-KoChihen.json
+++ b/static/mods/2024ROC_Hou-KoChihen.json
@@ -1,0 +1,9227 @@
+e=campaignTrail_temp // this is redundant, but Decstar uses this because it looks nicer in the code.
+campaignTrail_temp.multiple_endings=true
+campaignTrail_temp.cyoa = true
+campaignTrail_temp.questions_json = [
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950011,
+        "fields": {
+            "priority": 0,
+            "description": "it's January 2023, congratulations on successfully securing re-election as the Mayor of New Taipei a month ago, with an impressive 62% of the votes. It appears that there is a high likelihood of your candidacy in the 2024 presidential election. According to Formosa's polls, you lead with a support rate of 39.9%, surpassing Lai Ching-te's 34.1%. Do you wish to participate in the 2024 election and potentially lead the KMT to regain the lost governance after 8 years?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950015,
+        "fields": {
+            "priority": 0,
+            "description": "More than a month after the Chinese New Year, on March 22nd, the KMT Central Standing Committee passed a resolution authorizing the party chairman, Eric Chu, to Drafting the party's presidential candidate. However, a primary election is scheduled before that. Your opponent in the primary is Terry Gou. Do you have any specific campaign strategies for the upcoming primary?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950016,
+        "fields": {
+            "priority": 0,
+            "description": "Currently, the primary have begun, and as the most popular candidate, your poll numbers are ahead of Terry Gou. What specific areas do you plan to focus on during the preliminary election competition?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950017,
+        "fields": {
+            "priority": 0,
+            "description": "Congratulations! In today's Central Standing Committee meeting, Chairman Eric Chu announced that you will be the Kuomintang (KMT) presidential candidate for 2024. Terry Gou also congratulated you on Facebook for receiving the party's draft. You will represent the KMT in the 2024 election, aiming to take down the incompetent DPP government!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950018,
+        "fields": {
+            "priority": 0,
+            "description": "On the same day you were drafted, Taiwan People's Party Chairman Ko Wen-je was also selected as the party's presidential candidate. This means that the opposition camp is divided into two parts for the election, which could potentially impact the overall prospects of the pan-blue votes. What is your overall strategy about the TPP?\n",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950019,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, it seems we've encountered trouble! A private kindergarten has been exposed for alleged child abuse by teachers, including the shocking revelation of feeding children Class III controlled substances like barbital and Class IV controlled substances like phenobarbital! Some parents have reported this to the police, and this issue has just come to our attention. We need to take immediate action, or the DPP will use this incident to launch a major attack against you!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950020,
+        "fields": {
+            "priority": 0,
+            "description": "In the midst of the kindergarten incident's escalation, your approval ratings have sharply declined, akin to falling off a cliff into the water. After addressing this matter, you engage in face-to-face discussions with students at National Chengchi University and Taiwan University. When students inquire about your stance on the One China Policy and the differences between you and Han Kuo-yu, how will you respond?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950021,
+        "fields": {
+            "priority": 0,
+            "description": "With a significant decline in your polls, your campaign is facing a major crisis. In many polls, your support is trailing behind Ko Wen-je. According to Formosa and TVBS polls in June, you had support rates of 23% and 17.1%, respectively, while Ko Wen-je had 33% and 28.6%. Even legislator Cheng Li-wen suggested replacing you with Han Kuo-yu due to your lower poll numbers. Additionally, there is uncertainty about Terry Gou's support. Some polls suggest that Gou might reconsider running. What measures do you plan to take to prevent further decline?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950022,
+        "fields": {
+            "priority": 0,
+            "description": "Finally, an hot fire in the snow! Former key strategist for Ma Ying-jeou's campaigns and former ROC representative to the U.S., King Pu-tsung, has agreed to serve as the campaign office chairman under your personal visit. He will assist in orchestrating your campaign!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950023,
+        "fields": {
+            "priority": 0,
+            "description": "\nOn July 1st, you were invited to attend a gathering organized by the Kuomintang's 'Huang Fuxing' branch, where you are expected to meet with Han Kuo-yu. Han's supporters have consistently expressed dissatisfaction with your candidacy, believing that Han Kuo-yu is a more suitable candidate. During the gathering, what do you plan to do to win them over and dispel the sentiment of 'Replacing Hou with Han'?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950024,
+        "fields": {
+            "priority": 0,
+            "description": "On July 3rd, you participated in an interview with Zhao Shao-kang, discussing the election strategy and campaign situation after being Drafted by the KMT. The aim was to gain more media exposure. Zhao mentioned that Han's supporters feel you were not actively supportive in 2020, and many of his fans do not favor you. the promised support from Terry Gou seems to be elusive, and there are rumors of him considering an independent run. What message would you like to convey during this interview?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950025,
+        "fields": {
+            "priority": 0,
+            "description": "On July 23rd, the KMT held a National Party Convention, officially nominating you as the candidate. This signifies that any rumors of replacement are baseless. During the event, Han Kuo-yu expressed his formal support, stating one of his three wishes for this year is for the KMT, under your leadership, to oust the corrupt and incompetent DPP.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950026,
+        "fields": {
+            "priority": 0,
+            "description": "Since the official commencement of your campaign, you have the first opportunity to visit various locations and boost support in specific areas. Where do you intend to concentrate your efforts primarily?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950027,
+        "fields": {
+            "priority": 0,
+            "description": "After 7 years of rule, DPP has left many vulnerable points for you to attack. From restricting freedom of speech to tense relations with the mainland, the widening wealth gap, rising prices, and numerous scandals highlighting incompetence and corruption. How do you plan to launch your strongest attacks against your main opponent?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950028,
+        "fields": {
+            "priority": 0,
+            "description": "As the election has passed its midpoint, you need to present more and better specific policies to attract KMT voters. Currently, your performance in opinion polls is still not favorable, and many are concerned that you might end up as the third in this election. How do you plan to consolidate your support base?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950029,
+        "fields": {
+            "priority": 0,
+            "description": "Some very bad news just came in... Business tycoon Terry Gou, who has been hesitant to support you since you officially entered the race, announced today that he is running for president as an independent candidate! He made this announcement during a press conference for the \"Mainstream Opinion Alliance.\" It seems like the pan-blue's voter base is being further divided. What should we do?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950030,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, it seems that the People's Party has proactively proposed a united plan: they hope to select the sole opposition candidate through comparative candidate polling, and whoever loses will withdraw from the election. What is your opinion on this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950031,
+        "fields": {
+            "priority": 0,
+            "description": "Among the voters, there is a significant portion who lack trust in your abilities and qualifications, with many expressing doubts about your diplomatic skills. A considerable number believe that you lack experience in handling international relations. To address this concern, the KMT Central Committee has decided to send you on an official visit to the United States. In This Trip,What key messages would you like to emphasize?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950032,
+        "fields": {
+            "priority": 0,
+            "description": "Since entering October, legislators nationwide have gradually intensified their activities, and your campaign may be entering its most critical period! At this juncture, Han Kuo-yu is putting aside all previous reservations and actively supporting your candidacy. Now, let's pass the microphone to Mayor Han. What are your thoughts on Mayor Hou?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950033,
+        "fields": {
+            "priority": 0,
+            "description": "Entering November, the joint ticket decision between the KMT and TPP remains undecided. Despite polls indicating that the opposition alliance consistently outperforms Lai Ching-te, both the KMT and the TPP are reluctant to take on a mere preparatory role as vice president, as they both aspire to wield the executive power of the presidency. As time gradually slips away, former President Ma Ying-jeou and Han Kuo-yu propose settling the matter through a nationwide poll, with the loser becoming the vice president. What are your thoughts on this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950034,
+        "fields": {
+            "priority": 0,
+            "description": "On November 15th, waking up in the morning, Taiwan's media and political circles were shocked by a piece of news: KMT-TPP has confirmed the formation of a joint ticket, endorsing a single presidential candidate. This is expected to severely impact Lai Ching-te's support. Chairman Zhu, Mayor Hou, former President Ma, and Chairman Ko have reached an agreement to introduce a set of candidates using the cumulative results of previous polls. This is considered a very intense competition... but due to the selection of fixed-time polls, your current efforts may not be of much use...The final results will be announced on the 18th.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950035,
+        "fields": {
+            "priority": 0,
+            "description": "Damn it... With Ko Wen-je's backtracking, there are only a few days left until the deadline for presidential candidate registration! We must complete the integration within these few days... or find our own vice presidential candidate! Terry Gou and Ko Wen-je invite you to the Taipei Grand Hyatt to discuss the last hope for Joint Tickets... We must rise to the challenge!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950036,
+        "fields": {
+            "priority": 0,
+            "description": "\nWith the breakdown of Joint Tickets, you must now find a vice presidential candidate! Otherwise, the KMT cannot continue participating in this election! Lai Ching-te has already chosen Hsiao Bi-Khim as the vice president, and Ko Wen-je is still undecided about his choice. You must now find a vice presidential candidate willing to sacrifice themselves to join you in this challenging battle!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12762,
+        "fields": {
+            "priority": 0,
+            "description": "With the breakdown of the Joint Tickets, you have chose Ko Chih-en as your vice president to meet the legal requirements for the election combination. Even before the official start of the campaign, you had your eyes on former legislator and Kaohsiung mayoral candidate Ko Chih-en as your vice president. Why is that?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950038,
+        "fields": {
+            "priority": 0,
+            "description": "As the presidential election enters its final stage, it has been discovered that Lai Ching-te's ancestral home is found to have violated building regulations. Although this issue has been known for quite some time, it has only recently been sensationalized. This could be our only opportunity to undermine Lai Ching-te before the election. Do you want to pursue this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950039,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, we have our own troubles. The Democratic Progressive Party (DPP) is attacking the Triumph Apartments owned by your wife, highlighting the high rent and claiming it exploits young people for your personal gain. They argue that you, appearing as a landlord, are unfit to discuss housing justice and social housing. How do you respond?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950040,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, at the final stretch of the election, we might need some advertisements or policies to boost our polling numbers. What policies or advertisements would you most like us to release?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950041,
+        "fields": {
+            "priority": 0,
+            "description": "As 2023 enters its final days, the presidential debates have commenced. Facing Lai Ching-te and Ko Wen-je in this intense battle, what is the most important message you want to convey to the people of Taiwan?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950042,
+        "fields": {
+            "priority": 0,
+            "description": "\nIt seems there is discord within our camp. Former President Ma Ying-jeou, in an interview with Deutsche Welle, mentioned that in the context of cross-strait relations, it is necessary to trust Xi Jinping. The media has widely circulated this, which may be a significant blow to the Kuomintang's electoral prospects. How do you respond to this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950851,
+        "fields": {
+            "priority": 0,
+            "description": "Today is the last day of the election. In which specific area of Taiwan do you plan to campaign to make a final push in these last stages?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950411,
+        "fields": {
+            "priority": 0,
+            "description": "Today is the last day before the election, and your polls have been consistently declining since your nomination. The deadlock with Ko Wen-je and the lead by Lai Ching-te have not been broken, and the situation persists until the registration of presidential candidates in November. There are hardly any individuals willing to be your vice president, until Hung Hsiu-chu, whose nomination was abolished in 2016, volunteered. It is only then that you have a vice presidential candidate to appear on the ballot. On the final day before the election, where do you plan to conduct your campaign activities?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950424,
+        "fields": {
+            "priority": 0,
+            "description": "Today is the last day before the election, On the final day before the election, \nAccording to the latest polls conducted 10 days before the election, your and Lai Ching-te's polls are within the margin of error. In other words, the presidential position hinges on a difference of just 500,000 votes.where do you plan to conduct your campaign activities?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950687,
+        "fields": {
+            "priority": 0,
+            "description": "On November 15th, waking up in the morning, Taiwan's media and political circles were shocked by a piece of news: KMT-TPP has confirmed the formation of a joint ticket, endorsing a single presidential candidate. This is expected to severely impact Lai Ching-te's support. Chairman Zhu, Mayor Hou, former President Ma, and Chairman Ko have reached an agreement to introduce a set of candidates using the cumulative results of previous polls. The terms include a provision that, if the polls fall within the margin of error, it will be considered a victory for Hou You-yi. This is widely seen as a sign that Hou You-yi is likely to win. The final results will be announced on the 18th.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950890,
+        "fields": {
+            "priority": 0,
+            "description": "With the formation of the Joint Tickets, Ko Wen-je has officially become your vice president, marking a political tornado in Taiwan. It's highly likely that Lai Ching-te will lose the presidential position. On the day of the presidential candidate registration, what capabilities of Ko Wen-je would you like to highlight?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950900,
+        "fields": {
+            "priority": 0,
+            "description": "In order to achieve cooperation between the blue and white camps, the cost you have to pay is to accept some reform demands and positions of the TPP. Among these proposals, which ones do you favor more and consider most likely to reach an agreement?\n",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950911,
+        "fields": {
+            "priority": 0,
+            "description": "\nIn this presidential election, facing a one-on-one debate with Lai Ching-te, although you are widely regarded as not the most eloquent, and even your proficiency in Mandarin is limited, your grassroots image in stark contrast to Lai Ching-te's elite image creates a strong juxtaposition. In the debate, what content do you want to emphasize?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950398,
+        "fields": {
+            "priority": 0,
+            "description": "Since you have withdrawn from the primary and essentially paved the way for Terry Gou to secure the presidential candidate position, how do you plan to support him in the upcoming electoral campaign?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950927,
+        "fields": {
+            "priority": 0,
+            "description": "Now, you are in a one-on-one battle with Lai Ching-te in the later stages of the election. Polls indicate that you currently have a lead by several percentage points, but this could be lost due to inappropriate campaign strategies or visiting mistakes. We must stabilize our current position!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950933,
+        "fields": {
+            "priority": 0,
+            "description": "This year's presidential debate has an unprecedented presence of four presidential candidates: yourself, Lai Ching-te, Ko Wen-je, and the former Chairman of Hon Hai Precision Industry, Terry Gou, who does not support you. In this year's presidential debate, what main points do you want to convey?\n",
+            "likelihood": 1
+        }
+    }
+]
+
+campaignTrail_temp.answers_json = [
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950012,
+        "fields": {
+            "question": 1950011,
+            "description": "I will steadfastly continue my course and move forward. Currently, my mission is to serve the citizens of New Taipei City, as they are my top priority and the ones I am most concerned about at the moment."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950013,
+        "fields": {
+            "question": 1950011,
+            "description": "Regardless of any challenges we may face, we will approach them earnestly. If in the future, the party central has any tasks to assign to me, I am more than willing to accept. However, at the moment, my primary focus is on doing things well in New Taipei City."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950014,
+        "fields": {
+            "question": 1950011,
+            "description": "At present, my sole intention is to diligently fulfill my role as the mayor and strive towards constructing a beautiful hometown. To make New Taipei City a great city, we must undertake significant initiatives. By connecting the development of Northern Taiwan through New Taipei, we can contribute to the betterment of Taiwan. A better Taiwan leads to shared prosperity, ensuring peace and stability for the Republic of China."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950388,
+        "fields": {
+            "question": 1950015,
+            "description": "In fact, I do not wish to participate in the primary election. Firstly, I've observed the outcome for Han Kuo-yu, and I believe it's not appropriate for me to run for president while holding my current position . Secondly, I believe Mr.Gou is a more suitable candidate than me. He is a devoted supporter of the Republic of China and can take good care of the country."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950389,
+        "fields": {
+            "question": 1950015,
+            "description": "Chairman Terry Gou is a steadfast supporter of the Republic of China and a patriot. I am pleased to compete alongside him, and if he emerges as the candidate, I will gracefully accept the outcome."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950390,
+        "fields": {
+            "question": 1950015,
+            "description": "I am deeply grateful to Chairman Eric Chu and the party central for giving me this opportunity. In the primary election, I will enhance myself and showcase a broader perspective on international affairs. I recognize the need to develop a more presidential demeanor as I progress."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950399,
+        "fields": {
+            "question": 1950398,
+            "description": "No. My intention in withdrawing from the primary was to focus on effectively managing the city. I didn't want to run for president before completing my term. Therefore, I plan to assist Chairman Terry Gou in his campaign during the later intense stages of the election."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950400,
+        "fields": {
+            "question": 1950398,
+            "description": "Absolutely! I will support him in the campaign, including rallying support for him in New Taipei City and endorsing him for legislative candidates nationwide after his official nomination. I hope he can bring down the Democratic Progressive Party!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950412,
+        "fields": {
+            "question": 1950411,
+            "description": "We have no choice but to stay in Taipei. We cannot afford to let Taipei, this stronghold of the blue camp, be lost!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950413,
+        "fields": {
+            "question": 1950411,
+            "description": "I don't want to lose my hometown. Please allow me to campaign in New Taipei City, and I hope Mayor Hou You-yi can come forward to assist us!\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950414,
+        "fields": {
+            "question": 1950411,
+            "description": "We must secure Taoyuan, the stronghold and vote bank of the Hakka people and the Kuomintang!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950415,
+        "fields": {
+            "question": 1950411,
+            "description": "On the final day, I must drive around the entire Taiwan! Let more people see us!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950425,
+        "fields": {
+            "question": 1950424,
+            "description": "We aim to secure victory in my hometown, New Taipei! Let's conduct the final day of the campaign activities in New Taipei City!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950426,
+        "fields": {
+            "question": 1950424,
+            "description": "Of course, it's in Taipei City. We will declare to all Taipei citizens that tomorrow, we are marching towards the Presidential Office!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950430,
+        "fields": {
+            "question": 1950424,
+            "description": "We plan to hold our last campaign event in Kaohsiung to counter Lai Ching-te and appeal to his support base!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950432,
+        "fields": {
+            "question": 1950424,
+            "description": "The swing state of Taichung is crucial for us, and we aim to secure victory in Taichung."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950441,
+        "fields": {
+            "question": 1950016,
+            "description": "I will visit various counties and cities across Taiwan and establish good relationships with local mayors. I hope to garner more support from these mayors."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950442,
+        "fields": {
+            "question": 1950016,
+            "description": "Let's make some friends in the Legislative Yuan! I will meet with current legislators and discuss campaign matters with them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950443,
+        "fields": {
+            "question": 1950016,
+            "description": "I should appear in the media to share my insights and future prospects in the mayoral election. This can bring me positive media exposure!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950444,
+        "fields": {
+            "question": 1950016,
+            "description": "Anyway, votes come from the voters, and I plan to participate in more offline events to increase my visibility among the electorate. Voters tend to prefer someone familiar and present in their communities!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950454,
+        "fields": {
+            "question": 1950017,
+            "description": "I appreciate Chairman Eric Chu's favor and the support of all the voters. I also want to thank Chairman Terry Gou for his full support. In 2024, we will return to governance, and I am honored to have the opportunity to run for the Kuomintang!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950460,
+        "fields": {
+            "question": 1950018,
+            "description": "Chairman Ko Wen-je has the authority to run for election on his own, and I just need to follow my own path. It's like two brothers climbing a mountain – each making their own effort. Currently, there is no need to discuss coalition votes to avoid affecting the unity and loyalty within our party."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950461,
+        "fields": {
+            "question": 1950018,
+            "description": "I must criticize Ko Wen-je and the TPP. It's widely known that the division within the opposition alliance will only pave the way for the DPP to secure the next term. Chairman Ko Wen-je should seriously consider whether he should indeed continue to run for the presidency!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950462,
+        "fields": {
+            "question": 1950018,
+            "description": "Everyone knows that 60% of the voters want a party alternation. We cannot afford to be divided into two camps. I will extend an olive branch to Chairman Ko . We should work together to bring down the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950463,
+        "fields": {
+            "question": 1950018,
+            "description": "Rather than concerning with Ko, let's focus on targeting Lai Ching-te! Over the past eight years, the DPP government has numerous vulnerabilities we can exploit. Let's concentrate our efforts on the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950477,
+        "fields": {
+            "question": 1950019,
+            "description": "The immediate priority is to investigate and determine what happened. We will promptly send the police to the kindergarten to inspect surveillance footage and search the teachers' personal computers for evidence."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950478,
+        "fields": {
+            "question": 1950019,
+            "description": "\nThe safety and health of the children are our top priorities. We will immediately arrange for them to undergo medical examinations to check if their health has been compromised in any way."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950479,
+        "fields": {
+            "question": 1950019,
+            "description": "The key priority is to calm the parents' emotions. I must hold private meetings with the parents, exchange views and information, and discuss the latest developments and concerns regarding their children."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950487,
+        "fields": {
+            "question": 1950020,
+            "description": "I hope I can handle things well. Let me explain to you why doing things properly is important; it's a matter of attitude because..."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950488,
+        "fields": {
+            "question": 1950020,
+            "description": "When I was a child, I used to hide under the desk and read comic books. My mom would ask, 'What are you doing?' and I would say, 'Studying knowledge by reading comic books.'....."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950489,
+        "fields": {
+            "question": 1950020,
+            "description": "When I was a criminal investigator in the past, combating crime involved collaborating with Interpol, but I always hoped for the exchange of intelligence....."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950490,
+        "fields": {
+            "question": 1950020,
+            "description": "The cross-strait relationship, regardless of the consensus, is entirely based on the Cross-Strait Act. and Only the Constitution of the ROC can bring stability to both sides. I am against Taiwan independence and the One Country, Two Systems!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950502,
+        "fields": {
+            "question": 1950021,
+            "description": "I must seek the recognition of party bosses.and arrange a meeting with the Lien Chan family to request their support. This would be a symbolic move."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950503,
+        "fields": {
+            "question": 1950021,
+            "description": "Allow me to seek the assistance of former party chairman Wu Poh-hsiung of Hakka descent, I need to strengthen my support in Hakka-dominant areas. I hope to gain his recognition!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950504,
+        "fields": {
+            "question": 1950021,
+            "description": "\nI will invite former President Ma Ying-jeou to serve as the Honorary Chairman of my campaign headquarters and request his endorsement and favorable statements for my candidacy."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950513,
+        "fields": {
+            "question": 1950021,
+            "description": "\nI am heading south to Kaohsiung to visit former Legislative Yuan Speaker Wang Jin-ping. I will seek his advice on campaign strategies and solutions to the current situation. I must secure his assistance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950521,
+        "fields": {
+            "question": 1950022,
+            "description": "I am delighted to have King Pu-tsung as a valuable aide in my campaign. He has a strong track record in dealing with the Democratic Progressive Party and will assist me in handling negotiations!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950523,
+        "fields": {
+            "question": 1950023,
+            "description": "I will formally apologize to Han during the gathering and appeal to his supporters to rally behind me. I will acknowledge my mistake in not accepting the position of campaign chairman for New Taipei City in 2020, as I was too focused on municipal affairs and neglected to assist him. I sincerely apologize."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950524,
+        "fields": {
+            "question": 1950023,
+            "description": "I do not need to apologize. Han Kuo-yu's popularity is not at a level where I must pull him back. Furthermore, getting too close to him might harm my image among moderate voters. There is no need to lower my own standing at this point."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950525,
+        "fields": {
+            "question": 1950023,
+            "description": "\nI don't need a formal apology, but let me build a rapport with Han Kuo-yu, present a very familiar and friendly appearance. We don't harbor any dislike for each other; we are good brothers. Let's move past this matter!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950535,
+        "fields": {
+            "question": 1950024,
+            "description": "I support the 1992 Consensus that aligns with the Constitution of the Republic of China. I have made my stance clear! I am against the \"One Country, Two Systems\" and Taiwan independence. I also oppose the Democratic Progressive Party's attempt to stigmatize the 1992 Consensus. It's that simple!\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950536,
+        "fields": {
+            "question": 1950024,
+            "description": "I am not against nuclear power, but rather, I support having nuclear power with proper nuclear safety measures. I assure you that I will ensure the end of the DPP's anti-nuclear policy, and I will restart nuclear power plants to guarantee stable electricity supply and lower electricity prices in Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950537,
+        "fields": {
+            "question": 1950024,
+            "description": "I hope Chairman Terry Gou, being the son of a police officer and a devout follower of Guan Gong, values loyalty and keeps his promises. I believe he will definitely assist me!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950550,
+        "fields": {
+            "question": 1950025,
+            "description": "I sincerely appreciate Mayor Han Kuo-yu's affirmation. I apologize for any previous actions towards him. Now, let's collaborate and work together to win the 2024 election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950558,
+        "fields": {
+            "question": 1950026,
+            "description": "Certainly, I will focus on strengthening my stronghold, Taipei, New Taipei, and Keelung. The northern region is the KMT's most solid base and a crucial vote bank for us!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950559,
+        "fields": {
+            "question": 1950026,
+            "description": "I hope to make efforts in the central region, particularly in Changhua, Taichung, and Nantou. These three areas are crucial in every election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950560,
+        "fields": {
+            "question": 1950026,
+            "description": "I must pay special attention to my hometown, Chiayi County and City. As a southerner, I aim to achieve victory in this deep-green states!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950561,
+        "fields": {
+            "question": 1950026,
+            "description": "\nBeing a southerner myself and proficient in Taiwanese, even though I am from the Kuomintang, I hope to achieve significant results in Tainan, Kaohsiung, and Pingtung. Perhaps, I can turn the tide in these areas!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950579,
+        "fields": {
+            "question": 1950027,
+            "description": "The DPP government has proven incapable of addressing the issue of fraud. Taiwan, once known for its hospitality, is now dubbed the \"Fraud Island.\" I am committed to taking strong measures to tackle the problem of fraud head-on."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950580,
+        "fields": {
+            "question": 1950027,
+            "description": "Under the rule of the Tsai government, we have witnessed increased pressure from the CCP on Taiwan. The median line in the Taiwan Strait has disappeared, and despite the DPP government claiming to resist China and protect Taiwan.we say no to war and yes to dialogue, no to warplanes and yes to business opportunities, no to crises and yes to diplomatic solutions!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950581,
+        "fields": {
+            "question": 1950027,
+            "description": "DPP government is corrupt and plagued by graft. Their digital development sector has squandered 20 billion NT dollars, achieving nothing substantial. In the end, all they managed to do was order takeout!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950582,
+        "fields": {
+            "question": 1950027,
+            "description": "Under the DPP's rule, dissenting voices are suppressed, and even after a court ruled in favor of CTiTV, the NCC continues to deny them the right to resume broadcasting on television. This is the authoritarian oppression of the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950593,
+        "fields": {
+            "question": 1950028,
+            "description": "We must restore law and order. there has been a rampant increase in firearms, drugs, and violent incidents on the streets. Only two death row inmates were executed in the past eight years. The DPP leans towards abolishing the death penalty, but due to public opinion, they refrain from doing so. This is not beneficial for Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950597,
+        "fields": {
+            "question": 1950028,
+            "description": "I will revive the Special Investigation Division. The DPP abolished this institution, responsible for investigating political corruption and official misconduct, as soon as they took office. Was it for their own convenience? I will revive the SPD, and regardless of political affiliation, if any official dares to engage in corruption, we will apprehend them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950599,
+        "fields": {
+            "question": 1950028,
+            "description": "I support housing justice and propose the implementation of a property hoarding tax targeting those with a significant number of properties. This is to ensure that more young people can afford homes. I also commit to continuing the construction of more public housing!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950600,
+        "fields": {
+            "question": 1950028,
+            "description": "My energy policy is clear: Green Sustainability, Reduce Coal with Nuclear, Move towards Coal-free, Transition with Gas. I never been against nuclear power and will include nuclear energy in carbon reduction efforts. If elected, I will complete the inspection and maintenance work for nuclear plants, ensuring safety and extending their operation."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950609,
+        "fields": {
+            "question": 1950029,
+            "description": "This damn Terry Gou! In 2019, he harmed Han Kuo-yu, and now he's doing the same to me this year! We must aggressively attack this untrustworthy guy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950610,
+        "fields": {
+            "question": 1950029,
+            "description": "I hope Chairman Gou can return to the blue camp. We can't afford more division. Persisting in this way will only pave the way for Lai Ching-te to become president!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950611,
+        "fields": {
+            "question": 1950029,
+            "description": "Let's not speak. Just release a campaign video featuring Hou Youyi and Guan Gong, emphasizing the loyalty, benevolence, and integrity of Guan Yu. This will naturally contrast with the untrustworthy behavior of Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950615,
+        "fields": {
+            "question": 1950030,
+            "description": "Polls are only based on phone inquiries and may not accurately reflect actual voting preferences. Let's propose a method for a democratic primary, allowing people across Taiwan to cast their votes to determine the opposition candidate with the highest support!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950616,
+        "fields": {
+            "question": 1950030,
+            "description": "The TPP should not make excessive demands. The KMT is a party with 14+1 county/city mayors and is the second-largest party in the legislature. Our party strength should be taken into account rather than solely relying on individual candidate polls. More people are consider giving their party vote to the KMT!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950617,
+        "fields": {
+            "question": 1950030,
+            "description": "Our current performance in various polls is not very good, but we cannot outright reject the proposal. Refusing it would shift the responsibility for the opposition's inability to integrate onto us. Let's not deny it for now, But we will delay the actual implementation!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950647,
+        "fields": {
+            "question": 1950031,
+            "description": "Everyone knows that the Three Principles of the People, particularly the democratic ideals of government by the people, for the people, and of the people, are closely related. Let's work together to advance these great principles and ensure that the system of liberal democracy continues to thrive in Taiwan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950648,
+        "fields": {
+            "question": 1950031,
+            "description": "Are you... Little Chuck? I didn't expect you to have grown so much. I'm happy to see you again! When I rescued you from the kidnappers all those years ago, you were just a baby. Now, I can hardly recognize you!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950649,
+        "fields": {
+            "question": 1950031,
+            "description": "I would say is my encounters with Mayor Adams of New York City. I even met with legislators from both the Democratic and Republican parties in Washington. AIT Chairman Rosenberger also had a meeting with me. This highlights the strength of the KMT and me in international relations!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950658,
+        "fields": {
+            "question": 1950032,
+            "description": "People have misunderstood Mayor Hou deeply. He genuinely cares about me! Please stop spreading rumors about our supposed discord. After my removal, he was the first to call and offer his comfort, asking if I needed any assistance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950659,
+        "fields": {
+            "question": 1950032,
+            "description": "Mayor Hou is a real man, someone who helped maintain public order in the midst of gunfire and chaos. Such individuals are what Taiwan needs the most—no flashy rhetoric, just someone dedicated to doing good things. I recommend him wholeheartedly!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950660,
+        "fields": {
+            "question": 1950032,
+            "description": "I want everyone to recognize that the DPP is corrupt, not only engaging in financial malfeasance but also steering Taiwan towards the deadly path of war. Only the Kuomintang and Mayor Hou can help Taiwan emerge from the shadows of conflict and restore normal relations with the mainland!\""
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950670,
+        "fields": {
+            "question": 1950033,
+            "description": "We have no choice but to accept the challenge, as time is running out. Even if our poll numbers are not high, we must face the battle. Otherwise, it may be perceived as a display of timidity."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950671,
+        "fields": {
+            "question": 1950033,
+            "description": "We must accept the challenge, and we believe we can surpass Ko Wen-je. We have to outperform him to ensure the Kuomintang's dominant position in the joint ticket alliance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950688,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950691,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950692,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950693,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950721,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950722,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950723,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950724,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950737,
+        "fields": {
+            "question": 1950035,
+            "description": "After receiving a text from Chairman Ko, he mentioned that he believes Terry Gou should find a reason to withdraw from the election, to avoid further disrupting the pan-blue camp. Can I read into this, Chairman Ko?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950738,
+        "fields": {
+            "question": 1950035,
+            "description": "I also brought Chairman Eric Chu and former President Ma Ying-jeou to witness this moment. There is no demand for the TPP to concede a 6% margin in the polls; instead, we will determine the outcome based on the respective margins of error in each poll, alright?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950739,
+        "fields": {
+            "question": 1950035,
+            "description": "Today is a crucial day that determines the future destiny of Taiwan and its people. I hope Chairman Terry Gou and President Ko can prioritize the overall situation. We must unite forces to bring down the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950740,
+        "fields": {
+            "question": 1950035,
+            "description": "Today is a crucial day that determines the future destiny of Taiwan and its people. I hope Chairman Terry Gou and President Ko can prioritize the overall situation. We must unite forces to bring down the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950751,
+        "fields": {
+            "question": 1950036,
+            "description": "Do you know what we need now? A fresh new face. I am choosing Ko Chih-en as my Vice President!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950755,
+        "fields": {
+            "question": 1950036,
+            "description": "Ko Chih-en is my best choice – progressive values, appeal to the youth, and a highly respectable image as a woman. She will undoubtedly complement me perfectly!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950764,
+        "fields": {
+            "question": 1950037,
+            "description": "(Zhao speaking to the media) The DPP likened Mayor Hou to Adou, but I disagree! I just like Zhao Zilong, loyal to Liu Bei. How could he be compared to a Adou? Just Like Zhao yun'ssteadfast and patriotic, with courage running through my veins."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950765,
+        "fields": {
+            "question": 1950037,
+            "description": "I feel that the DPP lacks professionalism, resorting to divisive tactics to win elections. This kind of maneuver seems quite low-level. If I am elected, Mayor Hou You-yi is the leader, the president, and I am the vice president - merely in a preparatory role!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950766,
+        "fields": {
+            "question": 1950037,
+            "description": "I won't give any attention to such tags. DPP has been in power for a considerable time, yet their election strategies seem to rely on questionable tactics. Can the people of Taiwan still believe in a party that governs without progress but resorts to such tactics during elections?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950781,
+        "fields": {
+            "question": 1950038,
+            "description": "Let's aggressively pursue this issue! Lai Ching-te is truly a candidate who disregards the law, even ignoring illegal construction on his own property. Can someone who disregards the law in such a manner be fit for the presidency?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950782,
+        "fields": {
+            "question": 1950038,
+            "description": "Launching a series of ads attacking Lai Ching-te would be an effective strategy to convey that he is an untrustworthy and arrogant candidate. Emphasize how he has tolerated illegal activities even within his own home, highlighting his lack of integrity. Portray him as someone not deserving of trust and as the people's greatest concern."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950783,
+        "fields": {
+            "question": 1950038,
+            "description": "Hold on, let's not get too carried away! Lai Ching-te's unauthorized construction has been years ago, and according to legal provisions, there is no requirement for demolition. It only needs to be documented and registered through photographs. Let's issue a statement acknowledging that Lai Ching-te's illegal actions technically violate the law, but we have chosen to show leniency and not pursue further action against him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950784,
+        "fields": {
+            "question": 1950038,
+            "description": "An excavator? Yes, right in the Zhongfu neighborhood of Wanli District. Go ahead and demolish his ancestral home for me!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950796,
+        "fields": {
+            "question": 1950039,
+            "description": "Firstly, this property is a legitimate part of my family's assets, and you have no right to interfere. Secondly, I have the right to set the rent at whatever amount I deem appropriate; it's determined by the free market!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950797,
+        "fields": {
+            "question": 1950039,
+            "description": "You're right. I'll discuss it with my wife immediately. I will reduce the rent by half, and after the contract expires, I will convert it into social housing. Is that satisfactory for you?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950798,
+        "fields": {
+            "question": 1950039,
+            "description": "you guys like to attack? Well, then I'll respond with an attack. Lai Ching-te, when will you tear down the unauthorized construction? You dare criticize me; have I committed any crimes? And attacking my wife? That property belongs to her, not me. Please refrain from involving my family in this matter."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950799,
+        "fields": {
+            "question": 1950039,
+            "description": "I won't give this fire any more oxygen. Don't respond to these issues, as it's all legal business operations. Voters will see through it naturally."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950814,
+        "fields": {
+            "question": 1950040,
+            "description": "We want to revisit President Ma Ying-jeou's classic campaign ad from 2008. Our formidable team of county and city mayors is making a comeback to support my campaign, symbolizing unity among ROC's local leaders from across the country. This ad aims to bring hope to the people!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950815,
+        "fields": {
+            "question": 1950040,
+            "description": "We must attack, attack, and attack again. Lai Ching-te and his DPP are highly corrupt, even morally corrupt. It's unknown how many are involved in extramarital affairs, adultery, or even cases of sexual harassment and crimes. This party, often associated with romantic and virtuous imagery, is full of hypocrisy and scandals!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950816,
+        "fields": {
+            "question": 1950040,
+            "description": " I will introduce our education reform policy to young people and, at the same time, abolish those De-Sinicized textbooks, allowing Ko Chih-en to play a role in this regard. That's why I chose her, isn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950817,
+        "fields": {
+            "question": 1950040,
+            "description": "I will emphasize our various policies. If you dislike the NCC restricting free speech, despise opaque governance, and are against the DPP's one-party dominance, then join us because we aim to dismantle all of them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950818,
+        "fields": {
+            "question": 1950031,
+            "description": "I will deliver a speech in Washington, emphasizing the importance of the 3D strategy. Which 3Ds? Deterrence, Dialogue, and De-escalation. This can construct peace and stability across the Taiwan Strait while upholding our sovereignty."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950838,
+        "fields": {
+            "question": 1950041,
+            "description": "I understand that scams cause you concern, and the threat of war makes you worry. However, let's not be afraid. You deserve a better future! In the future, I will definitely stand with you!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950839,
+        "fields": {
+            "question": 1950041,
+            "description": "I declare to the people of Taiwan that I am committed to initiating a new era of democratic political reform. Advocating for a cabinet system is not something that can be achieved by one person or one party alone, but it is a task we must accomplish. Our shared goal is peace, integrity, fairness, and justice in governance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950840,
+        "fields": {
+            "question": 1950041,
+            "description": "Candidates, do you truly oppose or support the abolition of the death penalty? All I hear are ambiguous answers, but let me be clear—I am against the abolition of the death penalty. It is a significant harm to the families of the victims. Candidates, please make your stance clear!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950841,
+        "fields": {
+            "question": 1950041,
+            "description": "January 13th marks the day of Mr. Chiang Ching-kuo's passing. Fellow patriots, on this day, it is crucial to come out and vote, exercising your democratic rights. Mr. Chiang Ching-kuo once said, \"What you don't do today, you'll regret tomorrow!\" I am committed to safeguarding Taiwan's democratic system with my life!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950852,
+        "fields": {
+            "question": 1950042,
+            "description": "\nWe must distance ourselves from him. I have a different perspective, and our views do not align with those of President Ma Ying-jeou. To penalize him and minimize the impact, we must reject his attendance at our pre-election night event!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950853,
+        "fields": {
+            "question": 1950042,
+            "description": "I will strongly criticize President Ma Ying-jeou's remarks, as they diverge from the mainstream thoughts of the Taiwanese people! Under the leadership of Mayor Hou You-yi, the Kuomintang will establish new relations with the mainland, and we don't need to blindly trust anyone."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950858,
+        "fields": {
+            "question": 1950042,
+            "description": "Don't pay attention to him. In the critical situation of this election, addressing this issue will only bring about greater division among us!We cannot afford to take risks at this time!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950863,
+        "fields": {
+            "question": 1950851,
+            "description": "I will conduct campaign activities in my home turf, New Taipei and Taipei. At the New Taipei Sports Stadium, we will gather a crowd and defeat the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950864,
+        "fields": {
+            "question": 1950851,
+            "description": "\nI want to conduct activities in the deeply green cities of Tainan and Kaohsiung, engage in a battle in Lai Ching-te's stronghold, and show him that people in the southern region won't blindly support the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950865,
+        "fields": {
+            "question": 1950851,
+            "description": "We will drive through the Hakka region and finally organize our pre-election night event in Taoyuan City!\nThe Hakka and youth votes have been taken away by Ko Wen-je, and we must retain them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950866,
+        "fields": {
+            "question": 1950851,
+            "description": "We must focus on areas with fewer voters and less competition. Hualien, Taitung, Yilan, and Pingtung are our key areas of concern. We must secure the entire east coast!\n\n\n\n\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950891,
+        "fields": {
+            "question": 1950890,
+            "description": "Ko Wen-je is very popular among the youth, and we must emphasize this. Our alliance lacks support from the younger generation the most. Let Ko Wen-je campaign for our alliance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950892,
+        "fields": {
+            "question": 1950890,
+            "description": "The alliance between the KMT and TPP is a shared aspiration of the Taiwanese people, as evidenced by the polls. We are confident in defeating Lai Ching-te. Let's strengthen the unity and cooperation between the two parties and jointly overcome the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950893,
+        "fields": {
+            "question": 1950890,
+            "description": "\nCertainly, Chairman Ko's eloquence and formidable abilities will provide excellent support for me. In the vice presidential debate, I hope he can defeat Hsiao Bi-khim, while I will confront Lai Ching-te. Together, let's advance progress in Taiwan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950901,
+        "fields": {
+            "question": 1950900,
+            "description": "\nWe will create goals for the third wave of democratic reforms in Taiwan. We will promote a Parliamentary system instead of a presidential system where power is concentrated in one party's hands. This change will benefit the future of Taiwan, as democracy requires a system of checks and balances!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950902,
+        "fields": {
+            "question": 1950900,
+            "description": "In the future coalition government, KMT will take the lead in economic and developmental responsibilities, while the TPP will be responsible for oversight and checks and balances. This is much better than the authoritarian rule of the DPP. Our future government will be free from corruption, and anyone who dares to engage in corruption will be held accountable!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950903,
+        "fields": {
+            "question": 1950900,
+            "description": "\nNow, we represent the greatest consensus of the Taiwanese people. Let's unite and launch a full-scale attack on the DPP! The opposition alliance will surge and break through the DPP's base!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950912,
+        "fields": {
+            "question": 1950911,
+            "description": "Lai Ching-te has claimed to be a pragmatic advocate for Taiwan independence. Now he says Taiwan is already an independent country. This is just the opportunistic behavior of a politician without integrity.I has been loyal to the Republic of China  throughout his life, and I will sacrifice my life to protect it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950913,
+        "fields": {
+            "question": 1950911,
+            "description": "Taiwan cannot afford to be ruled by the DPP anymore. The past 8 years of their governance have exposed the rapid pace of corruption and moral decay within your political regime, making it impossible for the people to trust you any longer. Please believe in the Taiwan United Government under the KMT-TPP alliance; we will do better!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950914,
+        "fields": {
+            "question": 1950911,
+            "description": "\nWhat I insist on is the democratic freedom of the 23 million people in Taiwan. We must strengthen national defense, deter war, and hold the key to peace, security, and stability in the Taiwan Strait. The DPP's approach cannot help Taiwan achieve true peace!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950915,
+        "fields": {
+            "question": 1950911,
+            "description": "\nMy father is a veteran, and I am the son of a pork vendor from the rural areas of Chiayi. I understand the hardships of life and have climbed up from being the lowest-ranking police officer to my current position. I am grateful for the support and assistance from each and every one of you!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950928,
+        "fields": {
+            "question": 1950927,
+            "description": "Now it's a one-on-one battle between me and Lai Ching-te! We must rally our base to come back!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950934,
+        "fields": {
+            "question": 1950933,
+            "description": "Lai Ching-te has claimed to be a pragmatic advocate for Taiwan independence. Now he says Taiwan is already an independent country. This is just the opportunistic behavior of a politician without integrity.I has been loyal to the Republic of China throughout his life, and I will sacrifice my life to protect it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950935,
+        "fields": {
+            "question": 1950933,
+            "description": "Chairman Ko had once promised to pursue a blue-white coalition, but now he has backtracked. This proves that Chairman Ko is someone who prioritizes political interests over integrity. He changed his decision to personally sign the agreement due to opposition from his staff and family, which is truly embarrassing."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950936,
+        "fields": {
+            "question": 1950933,
+            "description": "Chairman Guo had once promised to support me, but the subsequent results are well known. Now the opposition is divided into three parts. Where is the benefit in that? I am the strongest candidate. On election day, we should abandon Guo and support Hou!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950946,
+        "fields": {
+            "question": 1950933,
+            "description": "\nI and Mr. Guo both advocate for the ROC, and we both love this country. However, he is not a viable winner. Please concentrate your votes on me; I am the only one with the potential to defeat the Democratic Progressive Party."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 12763,
+        "fields": {
+            "question": 12762,
+            "description": "I value her progressive agendas; she supports LGBT rights and advocates for educational reform. She is deeply concerned about matters in the education sector and has a good understanding of the youth. Interacting with young people on a daily basis in the university setting, I believe her image can bring significant benefits to my campaign!\n\n\n\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 12764,
+        "fields": {
+            "question": 12762,
+            "description": "She is a well-educated woman with a very positive image. She can bring me the scarce female votes that I lack right now, especially among young women. I hope she can outperform Hsiao Bi-khim!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 12765,
+        "fields": {
+            "question": 12762,
+            "description": "We are both locals from Taiwan, but we share a deep love for the Republic of China. Throughout our lives, we have dedicated ourselves to the struggle and hard work for this country. She comes from Pingtung, and I come from Chiayi; we are both Southerners. Let's aim to secure more votes in the southern regions!"
+        }
+    }
+
+]
+
+
+campaignTrail_temp.states_json = [
+    {
+        "model": "campaign_trail.state",
+        "pk": 251,
+        "fields": {
+            "name": "Tainan City",
+            "abbr": "Tainancity",
+            "electoral_votes": 1,
+            "popular_votes": 1120238,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 252,
+        "fields": {
+            "name": "Kaohsiung City",
+            "abbr": "Kaohsiungcity",
+            "electoral_votes": 1,
+            "popular_votes": 1636962,
+            "poll_closing_time": 180,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 253,
+        "fields": {
+            "name": "Pingtung County",
+            "abbr": "Pingtung",
+            "electoral_votes": 1,
+            "popular_votes": 475927,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 254,
+        "fields": {
+            "name": "Taidong County",
+            "abbr": "Taidong",
+            "electoral_votes": 1,
+            "popular_votes": 109941,
+            "poll_closing_time": 75,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 255,
+        "fields": {
+            "name": "Hualien County",
+            "abbr": "Hualien",
+            "electoral_votes": 1,
+            "popular_votes": 174157,
+            "poll_closing_time": 90,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 256,
+        "fields": {
+            "name": "Chiayi County",
+            "abbr": "ChiayiCounty",
+            "electoral_votes": 1,
+            "popular_votes": 292534,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 257,
+        "fields": {
+            "name": "Chiayi City",
+            "abbr": "ChiayiCity",
+            "electoral_votes": 1,
+            "popular_votes": 157656,
+            "poll_closing_time": 80,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 258,
+        "fields": {
+            "name": "Nantou County",
+            "abbr": "Nantou",
+            "electoral_votes": 1,
+            "popular_votes": 287296,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 259,
+        "fields": {
+            "name": "Yunlin County",
+            "abbr": "Yunlin",
+            "electoral_votes": 1,
+            "popular_votes": 380619,
+            "poll_closing_time": 130,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 260,
+        "fields": {
+            "name": "Changhua County",
+            "abbr": "Changhua",
+            "electoral_votes": 1,
+            "popular_votes": 741368,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 261,
+        "fields": {
+            "name": "Penghu County",
+            "abbr": "Penghu",
+            "electoral_votes": 1,
+            "popular_votes": 49277,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 262,
+        "fields": {
+            "name": "Taichung City",
+            "abbr": "Taichung",
+            "electoral_votes": 1,
+            "popular_votes": 1707203,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 263,
+        "fields": {
+            "name": "Yilan County",
+            "abbr": "Yilan",
+            "electoral_votes": 1,
+            "popular_votes": 267129,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 264,
+        "fields": {
+            "name": "Hsinchu County",
+            "abbr": "HsinchuCounty",
+            "electoral_votes": 1,
+            "popular_votes": 340310,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 265,
+        "fields": {
+            "name": "Hsinchu City",
+            "abbr": "HsinchuCity",
+            "electoral_votes": 1,
+            "popular_votes": 266389,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 266,
+        "fields": {
+            "name": "Miaoli County",
+            "abbr": "Miaoli",
+            "electoral_votes": 1,
+            "popular_votes": 318665,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 267,
+        "fields": {
+            "name": "New Taipei City",
+            "abbr": "Newtaipei",
+            "electoral_votes": 1,
+            "popular_votes": 2458480,
+            "poll_closing_time": 225,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 268,
+        "fields": {
+            "name": "Taipei City",
+            "abbr": "Taipei",
+            "electoral_votes": 1,
+            "popular_votes": 1542009,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 269,
+        "fields": {
+            "name": "Taoyuan City",
+            "abbr": "Taoyuan",
+            "electoral_votes": 1,
+            "popular_votes": 1350792,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 270,
+        "fields": {
+            "name": "Keelung City",
+            "abbr": "Keelung",
+            "electoral_votes": 1,
+            "popular_votes": 218781,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 271,
+        "fields": {
+            "name": "Kinmen County",
+            "abbr": "Kinmen",
+            "electoral_votes": 1,
+            "popular_votes": 45612,
+            "poll_closing_time": 70,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 272,
+        "fields": {
+            "name": "Lienchiang County",
+            "abbr": "Matsu",
+            "electoral_votes": 1,
+            "popular_votes": 6159,
+            "poll_closing_time": 50,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.issues_json = [
+    {
+        "model": "campaign_trail.issue",
+        "pk": 32,
+        "fields": {
+            "name": "Party coalition",
+            "description": 0,
+            "stance_1": "Deep Green",
+            "stance_desc_1": 0,
+            "stance_2": "Green",
+            "stance_desc_2": 0,
+            "stance_3": "Light Green",
+            "stance_desc_3": 0,
+            "stance_4": "Neutral",
+            "stance_desc_4": 0,
+            "stance_5": "Light Blue",
+            "stance_desc_5": 0,
+            "stance_6": "Blue",
+            "stance_desc_6": 0,
+            "stance_7": "Deep Blue",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 33,
+        "fields": {
+            "name": "Provincial differences",
+            "description": 0,
+            "stance_1": "Mostly Taiwanese",
+            "stance_desc_1": 0,
+            "stance_2": "Taiwanese and Hakka mixed",
+            "stance_desc_2": 0,
+            "stance_3": "Taiwanese,Hakka,Mainlanders mixed",
+            "stance_desc_3": 0,
+            "stance_4": "mixing of ethnic groups",
+            "stance_desc_4": 0,
+            "stance_5": "Aboriginal",
+            "stance_desc_5": 0,
+            "stance_6": "Taiwanese Hakka(Northern)",
+            "stance_desc_6": 0,
+            "stance_7": "Mostly Mainlanders",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 34,
+        "fields": {
+            "name": "Urban/rural differences",
+            "description": 0,
+            "stance_1": "Townships Rural",
+            "stance_desc_1": 0,
+            "stance_2": "Small towns and large towns",
+            "stance_desc_2": 0,
+            "stance_3": "Small cities and towns",
+            "stance_desc_3": 0,
+            "stance_4": "Medium-sized city",
+            "stance_desc_4": 0,
+            "stance_5": "Groups of Small Cities",
+            "stance_desc_5": 0,
+            "stance_6": "Large Cities",
+            "stance_desc_6": 0,
+            "stance_7": "Capitals",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 35,
+        "fields": {
+            "name": "Young population",
+            "description": 0,
+            "stance_1": "Very little",
+            "stance_desc_1": 0,
+            "stance_2": "Little",
+            "stance_desc_2": 0,
+            "stance_3": "Less",
+            "stance_desc_3": 0,
+            "stance_4": "Normal level",
+            "stance_desc_4": 0,
+            "stance_5": "Relatively much more",
+            "stance_desc_5": 0,
+            "stance_6": "Large young population",
+            "stance_desc_6": 0,
+            "stance_7": "Younger society",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 36,
+        "fields": {
+            "name": "Feelings about DPP Government",
+            "description": 0,
+            "stance_1": "DPP is the best!",
+            "stance_desc_1": 0,
+            "stance_2": "That's what we like!",
+            "stance_desc_2": 0,
+            "stance_3": "Pro-DPP",
+            "stance_desc_3": 0,
+            "stance_4": "no feelings for the DPP",
+            "stance_desc_4": 0,
+            "stance_5": "Hate green governance",
+            "stance_desc_5": 0,
+            "stance_6": "Mosquitoes, cockroaches, and the DPP",
+            "stance_desc_6": 0,
+            "stance_7": "Never support the Taiwan Independence Party!!",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.state_issue_score_json = [
+    //台北市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191111,
+        "fields": {
+            "state": 268,
+            "issue": 32,
+            "state_issue_score": 0.22,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191112,
+        "fields": {
+            "state": 268,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191113,
+        "fields": {
+            "state": 268,
+            "issue": 34,
+            "state_issue_score": 1,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191114,
+        "fields": {
+            "state": 268,
+            "issue": 35,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191115,
+        "fields": {
+            "state": 268,
+            "issue": 36,
+            "state_issue_score": 0.1,
+            "weight": 0.5
+        }
+    },
+    //新北市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191116,
+        "fields": {
+            "state": 267,
+            "issue": 32,
+            "state_issue_score": 0.15,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191117,
+        "fields": {
+            "state": 267,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191118,
+        "fields": {
+            "state": 267,
+            "issue": 34,
+            "state_issue_score": 0.65,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191119,
+        "fields": {
+            "state": 267,
+            "issue": 35,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191120,
+        "fields": {
+            "state": 267,
+            "issue": 36,
+            "state_issue_score": 0.0,
+            "weight": 0.5
+        }
+    },
+    //桃园市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191121,
+        "fields": {
+            "state": 269,
+            "issue": 32,
+            "state_issue_score": 0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191122,
+        "fields": {
+            "state": 269,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191122,
+        "fields": {
+            "state": 269,
+            "issue": 34,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191123,
+        "fields": {
+            "state": 269,
+            "issue": 35,
+            "state_issue_score": 0.75,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191124,
+        "fields": {
+            "state": 269,
+            "issue": 36,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    //新竹市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191125,
+        "fields": {
+            "state": 265,
+            "issue": 32,
+            "state_issue_score": 0.4,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191126,
+        "fields": {
+            "state": 265,
+            "issue": 33,
+            "state_issue_score": -0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191127,
+        "fields": {
+            "state": 265,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191128,
+        "fields": {
+            "state": 265,
+            "issue": 35,
+            "state_issue_score": 0.65,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191129,
+        "fields": {
+            "state": 265,
+            "issue": 36,
+            "state_issue_score": 0.35,
+            "weight": 0.5
+        }
+    },
+    //基隆市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191130,
+        "fields": {
+            "state": 270,
+            "issue": 32,
+            "state_issue_score": 0.5,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191131,
+        "fields": {
+            "state": 270,
+            "issue": 33,
+            "state_issue_score": 0.1,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191132,
+        "fields": {
+            "state": 270,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191133,
+        "fields": {
+            "state": 270,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191134,
+        "fields": {
+            "state": 270,
+            "issue": 36,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    //新竹县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191135,
+        "fields": {
+            "state": 264,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191136,
+        "fields": {
+            "state": 264,
+            "issue": 33,
+            "state_issue_score": 0.45,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191137,
+        "fields": {
+            "state": 264,
+            "issue": 34,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191138,
+        "fields": {
+            "state": 264,
+            "issue": 35,
+            "state_issue_score": 0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191139,
+        "fields": {
+            "state": 264,
+            "issue": 36,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    //苗栗縣
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191140,
+        "fields": {
+            "state": 266,
+            "issue": 32,
+            "state_issue_score": 0.85,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191141,
+        "fields": {
+            "state": 266,
+            "issue": 33,
+            "state_issue_score": 0.55,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191142,
+        "fields": {
+            "state": 266,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191143,
+        "fields": {
+            "state": 266,
+            "issue": 35,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191144,
+        "fields": {
+            "state": 266,
+            "issue": 36,
+            "state_issue_score": 0.85,
+            "weight": 0.5
+        }
+    },
+    //宜兰县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191145,
+        "fields": {
+            "state": 263,
+            "issue": 32,
+            "state_issue_score": -0.45,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191146,
+        "fields": {
+            "state": 263,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191147,
+        "fields": {
+            "state": 263,
+            "issue": 34,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191148,
+        "fields": {
+            "state": 263,
+            "issue": 35,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191149,
+        "fields": {
+            "state": 263,
+            "issue": 36,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    //台中市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191150,
+        "fields": {
+            "state": 262,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191151,
+        "fields": {
+            "state": 262,
+            "issue": 33,
+            "state_issue_score": 0,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191152,
+        "fields": {
+            "state": 262,
+            "issue": 34,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191154,
+        "fields": {
+            "state": 262,
+            "issue": 35,
+            "state_issue_score": 0.35,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191155,
+        "fields": {
+            "state": 262,
+            "issue": 36,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    //南投县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191156,
+        "fields": {
+            "state": 258,
+            "issue": 32,
+            "state_issue_score": 0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191157,
+        "fields": {
+            "state": 258,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191158,
+        "fields": {
+            "state": 258,
+            "issue": 34,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191159,
+        "fields": {
+            "state": 258,
+            "issue": 35,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191160,
+        "fields": {
+            "state": 258,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //花莲县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191161,
+        "fields": {
+            "state": 255,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191162,
+        "fields": {
+            "state": 255,
+            "issue": 33,
+            "state_issue_score": 0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191163,
+        "fields": {
+            "state": 255,
+            "issue": 34,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191164,
+        "fields": {
+            "state": 255,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191165,
+        "fields": {
+            "state": 255,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //台东县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191166,
+        "fields": {
+            "state": 254,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191167,
+        "fields": {
+            "state": 254,
+            "issue": 33,
+            "state_issue_score": 0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191168,
+        "fields": {
+            "state": 254,
+            "issue": 34,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191169,
+        "fields": {
+            "state": 254,
+            "issue": 35,
+            "state_issue_score": -0.33,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191170,
+        "fields": {
+            "state": 254,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //彰化县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191171,
+        "fields": {
+            "state": 260,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191172,
+        "fields": {
+            "state": 260,
+            "issue": 33,
+            "state_issue_score": -0.85,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191173,
+        "fields": {
+            "state": 260,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191174,
+        "fields": {
+            "state": 260,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191175,
+        "fields": {
+            "state": 260,
+            "issue": 36,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    //云林县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191176,
+        "fields": {
+            "state": 259,
+            "issue": 32,
+            "state_issue_score": -0.4,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191177,
+        "fields": {
+            "state": 259,
+            "issue": 33,
+            "state_issue_score": -0.85,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191178,
+        "fields": {
+            "state": 259,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191179,
+        "fields": {
+            "state": 259,
+            "issue": 35,
+            "state_issue_score": -0.85,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191180,
+        "fields": {
+            "state": 259,
+            "issue": 36,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    //澎湖
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191181,
+        "fields": {
+            "state": 261,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191182,
+        "fields": {
+            "state": 261,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191183,
+        "fields": {
+            "state": 261,
+            "issue": 34,
+            "state_issue_score": -0.9,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191184,
+        "fields": {
+            "state": 261,
+            "issue": 35,
+            "state_issue_score": -0.75,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191185,
+        "fields": {
+            "state": 261,
+            "issue": 36,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    //嘉义县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191186,
+        "fields": {
+            "state": 256,
+            "issue": 32,
+            "state_issue_score": -0.75,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191187,
+        "fields": {
+            "state": 256,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191188,
+        "fields": {
+            "state": 256,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191189,
+        "fields": {
+            "state": 256,
+            "issue": 35,
+            "state_issue_score": -0.9,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191190,
+        "fields": {
+            "state": 256,
+            "issue": 36,
+            "state_issue_score": -0.75,
+            "weight": 0.5
+        }
+    },
+    //嘉义市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191191,
+        "fields": {
+            "state": 257,
+            "issue": 32,
+            "state_issue_score": -0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191192,
+        "fields": {
+            "state": 257,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191193,
+        "fields": {
+            "state": 257,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191194,
+        "fields": {
+            "state": 257,
+            "issue": 35,
+            "state_issue_score": -0.6,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191195,
+        "fields": {
+            "state": 257,
+            "issue": 36,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+     //台南市
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191196,
+            "fields": {
+                "state": 251,
+                "issue": 32,
+                "state_issue_score": -0.85,
+                "weight": 1
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191197,
+            "fields": {
+                "state": 251,
+                "issue": 33,
+                "state_issue_score": -0.15,
+                "weight": 2
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191198,
+            "fields": {
+                "state": 251,
+                "issue": 34,
+                "state_issue_score": 0.55,
+                "weight": 0.5
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191199,
+            "fields": {
+                "state": 251,
+                "issue": 35,
+                "state_issue_score": 0.15,
+                "weight": 0.5
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191200,
+            "fields": {
+                "state": 251,
+                "issue": 36,
+                "state_issue_score": -0.75,
+                "weight": 0.5
+            }
+        },
+         //高雄市
+             {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191201,
+                "fields": {
+                    "state": 252,
+                    "issue": 32,
+                    "state_issue_score": -0.55,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191202,
+                "fields": {
+                    "state": 252,
+                    "issue": 33,
+                    "state_issue_score": -0.15,
+                    "weight": 2
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191203,
+                "fields": {
+                    "state": 252,
+                    "issue": 34,
+                    "state_issue_score": 0.65,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191204,
+                "fields": {
+                    "state": 252,
+                    "issue": 35,
+                    "state_issue_score": 0.15,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191205,
+                "fields": {
+                    "state": 252,
+                    "issue": 36,
+                    "state_issue_score": -0.75,
+                    "weight": 0.5
+                }
+            },
+            //屏东县
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191206,
+                "fields": {
+                    "state": 253,
+                    "issue": 32,
+                    "state_issue_score": -0.5,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191207,
+                "fields": {
+                    "state": 253,
+                    "issue": 33,
+                    "state_issue_score": -0.25,
+                    "weight": 2
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191208,
+                "fields": {
+                    "state": 253,
+                    "issue": 34,
+                    "state_issue_score": 0.25,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191209,
+                "fields": {
+                    "state": 253,
+                    "issue": 35,
+                    "state_issue_score": 0,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191210,
+                "fields": {
+                    "state": 253,
+                    "issue": 36,
+                    "state_issue_score": -0.55,
+                    "weight": 0.5
+                }
+            },
+              //金门县
+              {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191211,
+                "fields": {
+                    "state": 271,
+                    "issue": 32,
+                    "state_issue_score": 1,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191212,
+                "fields": {
+                    "state": 271,
+                    "issue": 33,
+                    "state_issue_score": 1,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191213,
+                "fields": {
+                    "state": 271,
+                    "issue": 34,
+                    "state_issue_score": -0.75,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191214,
+                "fields": {
+                    "state": 271,
+                    "issue": 35,
+                    "state_issue_score": -0.25,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191215,
+                "fields": {
+                    "state": 271,
+                    "issue": 36,
+                    "state_issue_score": 1,
+                    "weight": 0.5
+                }
+            },
+                //连江县
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191216,
+                    "fields": {
+                        "state": 272,
+                        "issue": 32,
+                        "state_issue_score": 1,
+                        "weight": 1
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191217,
+                    "fields": {
+                        "state": 272,
+                        "issue": 33,
+                        "state_issue_score": 1,
+                        "weight": 1
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191218,
+                    "fields": {
+                        "state": 272,
+                        "issue": 34,
+                        "state_issue_score": -1,
+                        "weight": 0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191219,
+                    "fields": {
+                        "state": 272,
+                        "issue": 35,
+                        "state_issue_score": 0.25,
+                        "weight": 0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191220,
+                    "fields": {
+                        "state": 272,
+                        "issue": 36,
+                        "state_issue_score": 1,
+                        "weight": 0.5
+                    }
+                },
+]
+campaignTrail_temp.candidate_issue_score_json = [
+    //赖清德
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 328,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 32,
+            "issue_score": -0.85 //深绿
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 329,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 33,
+            "issue_score": -0.75 //台湾本省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 330,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 34,
+            "issue_score": -0.35 //矿工之子
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 331,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 35,
+            "issue_score": 0.25 //年轻人支持度还行
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 332,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 36,
+            "issue_score": -1 //我就是现任副总统啊
+        }
+    },
+    //侯友谊
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 333,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 32,
+            "issue_score": 0.15 //浅蓝，甚至蓝皮绿谷
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 334,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 33,
+            "issue_score": -0.9 //比赖清德更本省
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 335,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 34,
+            "issue_score": -0.5 //嘉义乡下卖猪肉的
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 336,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 35,
+            "issue_score": -0.25 //年轻人不喜欢的老蓝男
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 337,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 36,
+            "issue_score": 0.25 //攻击性不强
+        }
+    },
+    //柯文哲
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 338,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 32,
+            "issue_score": -0.5 //我内心本质还是深绿的
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 339,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 33,
+            "issue_score": -0.75 //本省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 340,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 34,
+            "issue_score": 0.15 //家庭条件还可以
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 341,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 35,
+            "issue_score": 0.8 //阿北阿北我爱你
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 342,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 36,
+            "issue_score": 0.5 //攻击性很强，但并不把下架民进党当第一目标
+        }
+    },
+     //郭台铭
+     {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 343,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 32,
+            "issue_score": 0.7 //深蓝
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 344,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 33,
+            "issue_score": 0.75 //外省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 345,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 34,
+            "issue_score": 0.75 //城里人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 346,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 35,
+            "issue_score": -0.25 //老蓝男
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 347,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 36,
+            "issue_score": 0.4 //攻击性一般，下架民进党是说说听得口号
+        }
+    },
+]
+campaignTrail_temp.running_mate_issue_score_json = [
+  //萧美琴
+  {
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9343,
+    "fields": {
+        "candidate": 1002,
+        "issue": 32,
+        "issue_score": -0.7
+    }
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9344,
+    "fields": {
+        "candidate": 1002,
+        "issue": 33,
+        "issue_score": -0
+    }
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9345,
+    "fields": {
+        "candidate": 1002,
+        "issue": 34,
+        "issue_score": -0.25
+},
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9346,
+    "fields": {
+        "candidate": 1002,
+        "issue": 35,
+        "issue_score": 0.25 
+    }
+},
+    {
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9347,
+    "fields": {
+        "candidate": 1002,
+        "issue": 36,
+        "issue_score": -0.5
+    }
+    },
+    //蓝白联票
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9348,
+        "fields": {
+            "candidate": 50001,
+            "issue": 32,
+            "issue_score": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9349,
+        "fields": {
+            "candidate": 50001,
+            "issue": 33,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9350,
+        "fields": {
+            "candidate": 50001,
+            "issue": 34,
+            "issue_score": 0
+    },
+},
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9351,
+        "fields": {
+            "candidate": 50001,
+            "issue": 35,
+            "issue_score": 0.15 
+        }
+    },
+        {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9352,
+        "fields": {
+            "candidate": 50001,
+            "issue": 36,
+            "issue_score": 0.4
+        }
+        },
+        //赵少康
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93481,
+            "fields": {
+                "candidate": 50000,
+                "issue": 32,
+                "issue_score": 0.95
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93491,
+            "fields": {
+                "candidate": 50000,
+                "issue": 33,
+                "issue_score": 0.95
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93501,
+            "fields": {
+                "candidate": 50000,
+                "issue": 34,
+                "issue_score": 0.55
+        },
+    },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93511,
+            "fields": {
+                "candidate": 50000,
+                "issue": 35,
+                "issue_score": 0.1
+            }
+        },
+            {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93521,
+            "fields": {
+                "candidate": 50000,
+                "issue": 36,
+                "issue_score": 0.5
+            }
+            },
+            //韩国瑜
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 934812,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 32,
+                    "issue_score": 0.95
+                }
+            },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 934912,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 33,
+                    "issue_score": 0.95
+                }
+            },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935013,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 34,
+                    "issue_score": -0.25
+            },
+        },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935114,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 35,
+                    "issue_score": 0
+                }
+            },
+                {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935215,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 36,
+                    "issue_score": 0.65
+                }
+                },
+                //柯志恩
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9348121,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 32,
+                        "issue_score": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9349121,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 33,
+                        "issue_score": -0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9350131,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 34,
+                        "issue_score": -0.15
+                },
+            },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9351141,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 35,
+                        "issue_score": 0.55
+                    }
+                },
+                    {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9352151,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 36,
+                        "issue_score": 0.42
+                    }
+                    },
+                    //赖佩霞
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93481211,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 32,
+                            "issue_score": 0.1
+                        }
+                    },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93491211,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 33,
+                            "issue_score": 0
+                        }
+                    },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93501311,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 34,
+                            "issue_score": 0.25
+                    },
+                },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93511411,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 35,
+                            "issue_score": 0.15
+                        }
+                    },
+                        {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93521511,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 36,
+                            "issue_score": 0.15
+                        }
+                        },
+                        //白蓝联票
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410110,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 32,
+                                "issue_score": -0.1
+                            }
+                        },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410111,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 33,
+                                "issue_score": 0
+                            }
+                        },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410112,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 34,
+                                "issue_score": 0
+                        },
+                    },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410113,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 35,
+                                "issue_score": 0.75
+                            }
+                        },
+                            {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410114,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 36,
+                                "issue_score": 0.25
+                            }
+                            },
+                            //吴欣盈
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241000,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 32,
+                                    "issue_score": 0
+                                }
+                            },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241001,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 33,
+                                    "issue_score": 0
+                                }
+                            },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241002,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 34,
+                                    "issue_score": 0
+                            },
+                           },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241003,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 35,
+                                    "issue_score": 0.75
+                                }
+                            },
+                                {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241004,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 36,
+                                    "issue_score": 0.25
+                                }
+                        }
+    ]
+
+campaignTrail_temp.candidate_state_multiplier_json = [
+       //台南市
+       {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25191,
+        "fields": {
+            "candidate": 2001557,
+            "state": 251,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25192,
+        "fields": {
+            "candidate": 2001591,
+            "state": 251,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25693,
+        "fields": {
+            "candidate": 2001622,
+            "state": 251,
+            "state_multiplier": 0.17
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25694,
+        "fields": {
+            "candidate": 2001653,
+            "state": 251,
+            "state_multiplier": 0.07
+        }
+    },
+    //嘉义县
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25691,
+        "fields": {
+            "candidate": 2001557,
+            "state": 256,
+            "state_multiplier": 0.28
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25692,
+        "fields": {
+            "candidate": 2001591,
+            "state": 256,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25693,
+        "fields": {
+            "candidate": 2001622,
+            "state": 256,
+            "state_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25694,
+        "fields": {
+            "candidate": 2001653,
+            "state": 256,
+            "state_multiplier": 0.07
+        }
+    },
+      //花莲县
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25591,
+        "fields": {
+            "candidate": 2001557,
+            "state": 255,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25592,
+        "fields": {
+            "candidate": 2001591,
+            "state": 255,
+            "state_multiplier": 0.366
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25593,
+        "fields": {
+            "candidate": 2001622,
+            "state": 255,
+            "state_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25594,
+        "fields": {
+            "candidate": 2001653,
+            "state": 255,
+            "state_multiplier": 0.1
+        }
+    },
+      //屏东
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25391,
+        "fields": {
+            "candidate": 2001557,
+            "state": 253,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25392,
+        "fields": {
+            "candidate": 2001591,
+            "state": 253,
+            "state_multiplier": 0.27
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25393,
+        "fields": {
+            "candidate": 2001622,
+            "state": 253,
+            "state_multiplier": 0.14
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25294,
+        "fields": {
+            "candidate": 2001653,
+            "state": 253,
+            "state_multiplier": 0.07
+        }
+    },
+    //高雄
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25291,
+        "fields": {
+            "candidate": 2001557,
+            "state": 252,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25292,
+        "fields": {
+            "candidate": 2001591,
+            "state": 252,
+            "state_multiplier": 0.25
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25293,
+        "fields": {
+            "candidate": 2001622,
+            "state": 252,
+            "state_multiplier": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25294,
+        "fields": {
+            "candidate": 2001653,
+            "state": 252,
+            "state_multiplier": 0.07
+        }
+    },
+    //台东
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252912,
+        "fields": {
+            "candidate": 2001557,
+            "state": 254,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252922,
+        "fields": {
+            "candidate": 2001591,
+            "state": 254,
+            "state_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252932,
+        "fields": {
+            "candidate": 2001622,
+            "state": 254,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252942,
+        "fields": {
+            "candidate": 2001653,
+            "state": 254,
+            "state_multiplier": 0.1
+        }
+    },
+        //嘉义市
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114514,
+            "fields": {
+                "candidate": 2001557,
+                "state": 257,
+                "state_multiplier": 0.28
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114515,
+            "fields": {
+                "candidate": 2001591,
+                "state": 257,
+                "state_multiplier": 0.23
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114516,
+            "fields": {
+                "candidate": 2001622,
+                "state": 257,
+                "state_multiplier": 0.15
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114517,
+            "fields": {
+                "candidate": 2001653,
+                "state": 257,
+                "state_multiplier": 0.05
+            }
+        },
+        //南投
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 566666,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 258,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 666666,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 258,
+                        "state_multiplier": 0.31
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 6666666,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 258,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 66666666,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 258,
+                        "state_multiplier": 0.08
+                    }
+                },
+                //彰化
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 114514123,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 260,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1145141234,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 260,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 11451414,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 260,
+                        "state_multiplier": 0.19
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 21412412,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 260,
+                        "state_multiplier": 0.06
+                    }
+                },
+                //云林
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1111,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 259,
+                        "state_multiplier": 0.32
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2222,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 259,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 3333,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 259,
+                        "state_multiplier": 0.19
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 4444,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 259,
+                        "state_multiplier": 0.04
+                    }
+                },
+                //澎湖
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 5555,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 261,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 6666,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 261,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 7777,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 261,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 8888,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 261,
+                        "state_multiplier": 0.05
+                    }
+                },
+                //台中
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412241,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 262,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412411,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 262,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412412,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 262,
+                        "state_multiplier": 0.22
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412511,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 262,
+                        "state_multiplier": 0.05
+                    }
+                },
+                //新竹县
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101001,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 264,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101002,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 264,
+                        "state_multiplier": 0.29
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101003,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 264,
+                        "state_multiplier": 0.26
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101004,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 264,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //新竹市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010012,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 265,
+                        "state_multiplier": 0.285
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010022,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 265,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010032,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 265,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010042,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 265,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //苗栗
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2194,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 266,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2195,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 266,
+                        "state_multiplier": 0.35
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2196,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 266,
+                        "state_multiplier": 0.22
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2197,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 266,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //新北市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12194,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 267,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12195,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 267,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12196,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 267,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12197,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 267,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //台北市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 268,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 268,
+                        "state_multiplier": 0.34
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 268,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 268,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //桃园
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 269,
+                        "state_multiplier": 0.26
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 269,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 269,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 269,
+                        "state_multiplier": 0.13
+                    }
+                },
+                //基隆
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 270,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 270,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 270,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 270,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //金门
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19581,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 271,
+                        "state_multiplier": 0.05
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19582,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 271,
+                        "state_multiplier": 0.55
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19583,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 271,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19584,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 271,
+                        "state_multiplier": 0.15
+                    }
+                },         
+                 //宜兰
+                 {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195813,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 263,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195823,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 263,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195833,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 263,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195843,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 263,
+                        "state_multiplier": 0.08
+                    }
+                },       
+                  //连江
+                  {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195812,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 272,
+                        "state_multiplier": 0.05
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195822,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 272,
+                        "state_multiplier": 0.55
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195832,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 272,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195842,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 272,
+                        "state_multiplier": 0.15
+                    }
+                },      
+]
+
+
+campaignTrail_temp.answer_score_global_json = [
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 12767,
+        "fields": {
+            "answer": 12763,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 12770,
+        "fields": {
+            "answer": 12764,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 12773,
+        "fields": {
+            "answer": 12765,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13413,
+        "fields": {
+            "answer": 13408,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13415,
+        "fields": {
+            "answer": 13409,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950382,
+        "fields": {
+            "answer": 1950012,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950384,
+        "fields": {
+            "answer": 1950013,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950387,
+        "fields": {
+            "answer": 1950014,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950393,
+        "fields": {
+            "answer": 1950388,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950395,
+        "fields": {
+            "answer": 1950389,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950397,
+        "fields": {
+            "answer": 1950390,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950403,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950404,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950405,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950406,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950407,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.45
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950408,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950409,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.23
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950410,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950423,
+        "fields": {
+            "answer": 1950415,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950437,
+        "fields": {
+            "answer": 1950425,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950438,
+        "fields": {
+            "answer": 1950426,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950439,
+        "fields": {
+            "answer": 1950430,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950440,
+        "fields": {
+            "answer": 1950432,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950451,
+        "fields": {
+            "answer": 1950443,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.021
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950459,
+        "fields": {
+            "answer": 1950454,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950465,
+        "fields": {
+            "answer": 1950463,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950466,
+        "fields": {
+            "answer": 1950463,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950469,
+        "fields": {
+            "answer": 1950462,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950470,
+        "fields": {
+            "answer": 1950462,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950472,
+        "fields": {
+            "answer": 1950461,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950473,
+        "fields": {
+            "answer": 1950461,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950475,
+        "fields": {
+            "answer": 1950460,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950480,
+        "fields": {
+            "answer": 1950454,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950482,
+        "fields": {
+            "answer": 1950477,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.37
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950484,
+        "fields": {
+            "answer": 1950478,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.37
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950486,
+        "fields": {
+            "answer": 1950479,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.37
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950492,
+        "fields": {
+            "answer": 1950487,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950495,
+        "fields": {
+            "answer": 1950488,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950498,
+        "fields": {
+            "answer": 1950489,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950500,
+        "fields": {
+            "answer": 1950490,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950506,
+        "fields": {
+            "answer": 1950502,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.0354
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950508,
+        "fields": {
+            "answer": 1950503,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.005
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950516,
+        "fields": {
+            "answer": 1950504,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.0354
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950528,
+        "fields": {
+            "answer": 1950525,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950531,
+        "fields": {
+            "answer": 1950524,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950533,
+        "fields": {
+            "answer": 1950523,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950539,
+        "fields": {
+            "answer": 1950535,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950541,
+        "fields": {
+            "answer": 1950521,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950542,
+        "fields": {
+            "answer": 1950521,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": 5.3
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950545,
+        "fields": {
+            "answer": 1950536,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950547,
+        "fields": {
+            "answer": 1950537,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950548,
+        "fields": {
+            "answer": 1950537,
+            "candidate": 2001591,
+            "affected_candidate": 1950365,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950552,
+        "fields": {
+            "answer": 1950550,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950595,
+        "fields": {
+            "answer": 1950593,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950601,
+        "fields": {
+            "answer": 1950597,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950606,
+        "fields": {
+            "answer": 1950600,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950622,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950623,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950624,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950626,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950627,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950629,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950635,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950636,
+        "fields": {
+            "answer": 1950615,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950637,
+        "fields": {
+            "answer": 1950615,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950638,
+        "fields": {
+            "answer": 1950579,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950639,
+        "fields": {
+            "answer": 1950580,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950640,
+        "fields": {
+            "answer": 1950581,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950641,
+        "fields": {
+            "answer": 1950582,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950642,
+        "fields": {
+            "answer": 1950616,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950644,
+        "fields": {
+            "answer": 1950617,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950654,
+        "fields": {
+            "answer": 1950647,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950655,
+        "fields": {
+            "answer": 1950648,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950656,
+        "fields": {
+            "answer": 1950649,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950663,
+        "fields": {
+            "answer": 1950658,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950665,
+        "fields": {
+            "answer": 1950659,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950668,
+        "fields": {
+            "answer": 1950660,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950674,
+        "fields": {
+            "answer": 1950658,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950675,
+        "fields": {
+            "answer": 1950659,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950676,
+        "fields": {
+            "answer": 1950660,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950677,
+        "fields": {
+            "answer": 1950670,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950678,
+        "fields": {
+            "answer": 1950671,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950681,
+        "fields": {
+            "answer": 1950600,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950682,
+        "fields": {
+            "answer": 1950599,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950684,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950685,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950686,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950698,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950699,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950700,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950701,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950702,
+        "fields": {
+            "answer": 1950692,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950703,
+        "fields": {
+            "answer": 1950692,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950704,
+        "fields": {
+            "answer": 1950693,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950705,
+        "fields": {
+            "answer": 1950693,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950729,
+        "fields": {
+            "answer": 1950721,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950730,
+        "fields": {
+            "answer": 1950721,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950731,
+        "fields": {
+            "answer": 1950722,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950732,
+        "fields": {
+            "answer": 1950722,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950733,
+        "fields": {
+            "answer": 1950723,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950734,
+        "fields": {
+            "answer": 1950723,
+            "candidate": 2001591,
+            "affected_candidate": 0,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950735,
+        "fields": {
+            "answer": 1950724,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950736,
+        "fields": {
+            "answer": 1950724,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950742,
+        "fields": {
+            "answer": 1950737,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950744,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950745,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950748,
+        "fields": {
+            "answer": 1950739,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950749,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950750,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950758,
+        "fields": {
+            "answer": 1950751,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950759,
+        "fields": {
+            "answer": 1950755,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950760,
+        "fields": {
+            "answer": 1950751,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950761,
+        "fields": {
+            "answer": 1950755,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.14
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950768,
+        "fields": {
+            "answer": 1950766,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950769,
+        "fields": {
+            "answer": 1950766,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950772,
+        "fields": {
+            "answer": 1950765,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950773,
+        "fields": {
+            "answer": 1950765,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950775,
+        "fields": {
+            "answer": 1950764,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950776,
+        "fields": {
+            "answer": 1950764,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950777,
+        "fields": {
+            "answer": 1950737,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950778,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950779,
+        "fields": {
+            "answer": 1950739,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950780,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950786,
+        "fields": {
+            "answer": 1950784,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950787,
+        "fields": {
+            "answer": 1950784,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950791,
+        "fields": {
+            "answer": 1950782,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950792,
+        "fields": {
+            "answer": 1950782,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950793,
+        "fields": {
+            "answer": 1950783,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950794,
+        "fields": {
+            "answer": 1950781,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950795,
+        "fields": {
+            "answer": 1950781,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950801,
+        "fields": {
+            "answer": 1950796,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950802,
+        "fields": {
+            "answer": 1950796,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950806,
+        "fields": {
+            "answer": 1950797,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950810,
+        "fields": {
+            "answer": 1950799,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950811,
+        "fields": {
+            "answer": 1950798,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950812,
+        "fields": {
+            "answer": 1950798,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950820,
+        "fields": {
+            "answer": 1950818,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950823,
+        "fields": {
+            "answer": 1950814,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950826,
+        "fields": {
+            "answer": 1950815,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950827,
+        "fields": {
+            "answer": 1950815,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.034
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950830,
+        "fields": {
+            "answer": 1950816,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950831,
+        "fields": {
+            "answer": 1950816,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950835,
+        "fields": {
+            "answer": 1950817,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950836,
+        "fields": {
+            "answer": 1950814,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950844,
+        "fields": {
+            "answer": 1950838,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950848,
+        "fields": {
+            "answer": 1950840,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.021
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950855,
+        "fields": {
+            "answer": 1950852,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950860,
+        "fields": {
+            "answer": 1950858,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950861,
+        "fields": {
+            "answer": 1950853,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950883,
+        "fields": {
+            "answer": 1950863,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950884,
+        "fields": {
+            "answer": 1950864,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950885,
+        "fields": {
+            "answer": 1950865,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950886,
+        "fields": {
+            "answer": 1950866,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950887,
+        "fields": {
+            "answer": 1950863,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950888,
+        "fields": {
+            "answer": 1950864,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950906,
+        "fields": {
+            "answer": 1950903,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950909,
+        "fields": {
+            "answer": 1950901,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950925,
+        "fields": {
+            "answer": 1950914,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950930,
+        "fields": {
+            "answer": 1950928,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950931,
+        "fields": {
+            "answer": 1950928,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950938,
+        "fields": {
+            "answer": 1950936,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950939,
+        "fields": {
+            "answer": 1950936,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.059
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950941,
+        "fields": {
+            "answer": 1950935,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950942,
+        "fields": {
+            "answer": 1950935,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950944,
+        "fields": {
+            "answer": 1950934,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950945,
+        "fields": {
+            "answer": 1950934,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950949,
+        "fields": {
+            "answer": 1950946,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950950,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950951,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -5
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_issue_json = [
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 12768,
+        "fields": {
+            "answer": 12763,
+            "issue": 35,
+            "issue_score": 0.15,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 12771,
+        "fields": {
+            "answer": 12764,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 12774,
+        "fields": {
+            "answer": 12765,
+            "issue": 33,
+            "issue_score": -0.12,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950385,
+        "fields": {
+            "answer": 1950013,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950446,
+        "fields": {
+            "answer": 1950441,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.155
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950448,
+        "fields": {
+            "answer": 1950442,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950467,
+        "fields": {
+            "answer": 1950463,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950476,
+        "fields": {
+            "answer": 1950460,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950493,
+        "fields": {
+            "answer": 1950487,
+            "issue": 35,
+            "issue_score": -0.15,
+            "issue_importance": 0.3
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950496,
+        "fields": {
+            "answer": 1950488,
+            "issue": 35,
+            "issue_score": -0.15,
+            "issue_importance": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950499,
+        "fields": {
+            "answer": 1950489,
+            "issue": 35,
+            "issue_score": -0.15,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950501,
+        "fields": {
+            "answer": 1950490,
+            "issue": 35,
+            "issue_score": -0.1,
+            "issue_importance": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950527,
+        "fields": {
+            "answer": 1950525,
+            "issue": 32,
+            "issue_score": -0.04,
+            "issue_importance": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950532,
+        "fields": {
+            "answer": 1950524,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950534,
+        "fields": {
+            "answer": 1950523,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950540,
+        "fields": {
+            "answer": 1950535,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950546,
+        "fields": {
+            "answer": 1950536,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950549,
+        "fields": {
+            "answer": 1950537,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950553,
+        "fields": {
+            "answer": 1950550,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950555,
+        "fields": {
+            "answer": 1950550,
+            "issue": 36,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950584,
+        "fields": {
+            "answer": 1950579,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950587,
+        "fields": {
+            "answer": 1950580,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950588,
+        "fields": {
+            "answer": 1950580,
+            "issue": 36,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950589,
+        "fields": {
+            "answer": 1950581,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950591,
+        "fields": {
+            "answer": 1950582,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950592,
+        "fields": {
+            "answer": 1950582,
+            "issue": 36,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950596,
+        "fields": {
+            "answer": 1950593,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950602,
+        "fields": {
+            "answer": 1950597,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950604,
+        "fields": {
+            "answer": 1950599,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950607,
+        "fields": {
+            "answer": 1950600,
+            "issue": 34,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950608,
+        "fields": {
+            "answer": 1950600,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950625,
+        "fields": {
+            "answer": 1950609,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950628,
+        "fields": {
+            "answer": 1950610,
+            "issue": 32,
+            "issue_score": 0.02,
+            "issue_importance": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950630,
+        "fields": {
+            "answer": 1950611,
+            "issue": 32,
+            "issue_score": 0.03,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950631,
+        "fields": {
+            "answer": 1950559,
+            "issue": 33,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950632,
+        "fields": {
+            "answer": 1950560,
+            "issue": 33,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950633,
+        "fields": {
+            "answer": 1950561,
+            "issue": 33,
+            "issue_score": -0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950634,
+        "fields": {
+            "answer": 1950513,
+            "issue": 33,
+            "issue_score": -0.03,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950643,
+        "fields": {
+            "answer": 1950616,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950645,
+        "fields": {
+            "answer": 1950617,
+            "issue": 32,
+            "issue_score": 0.02,
+            "issue_importance": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950653,
+        "fields": {
+            "answer": 1950647,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950657,
+        "fields": {
+            "answer": 1950649,
+            "issue": 32,
+            "issue_score": 0.15,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950662,
+        "fields": {
+            "answer": 1950658,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950666,
+        "fields": {
+            "answer": 1950659,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950669,
+        "fields": {
+            "answer": 1950660,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950679,
+        "fields": {
+            "answer": 1950671,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950680,
+        "fields": {
+            "answer": 1950670,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950762,
+        "fields": {
+            "answer": 1950751,
+            "issue": 35,
+            "issue_score": 0.12,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950763,
+        "fields": {
+            "answer": 1950755,
+            "issue": 35,
+            "issue_score": 0.12,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950770,
+        "fields": {
+            "answer": 1950766,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950804,
+        "fields": {
+            "answer": 1950796,
+            "issue": 35,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950805,
+        "fields": {
+            "answer": 1950797,
+            "issue": 35,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950809,
+        "fields": {
+            "answer": 1950799,
+            "issue": 35,
+            "issue_score": -0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950813,
+        "fields": {
+            "answer": 1950798,
+            "issue": 35,
+            "issue_score": -0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950821,
+        "fields": {
+            "answer": 1950818,
+            "issue": 32,
+            "issue_score": 0.015,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950824,
+        "fields": {
+            "answer": 1950814,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950829,
+        "fields": {
+            "answer": 1950816,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950833,
+        "fields": {
+            "answer": 1950817,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950834,
+        "fields": {
+            "answer": 1950817,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950846,
+        "fields": {
+            "answer": 1950839,
+            "issue": 32,
+            "issue_score": 0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950850,
+        "fields": {
+            "answer": 1950841,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950857,
+        "fields": {
+            "answer": 1950852,
+            "issue": 32,
+            "issue_score": -0.04,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950862,
+        "fields": {
+            "answer": 1950853,
+            "issue": 32,
+            "issue_score": -0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950897,
+        "fields": {
+            "answer": 1950891,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950898,
+        "fields": {
+            "answer": 1950892,
+            "issue": 32,
+            "issue_score": 0.07,
+            "issue_importance": 0.11
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950899,
+        "fields": {
+            "answer": 1950893,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950910,
+        "fields": {
+            "answer": 1950902,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950917,
+        "fields": {
+            "answer": 1950912,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950919,
+        "fields": {
+            "answer": 1950913,
+            "issue": 35,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950921,
+        "fields": {
+            "answer": 1950913,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950924,
+        "fields": {
+            "answer": 1950915,
+            "issue": 33,
+            "issue_score": -0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950926,
+        "fields": {
+            "answer": 1950914,
+            "issue": 32,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950932,
+        "fields": {
+            "answer": 1950928,
+            "issue": 32,
+            "issue_score": 0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950948,
+        "fields": {
+            "answer": 1950946,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_state_json = [
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950420,
+        "fields": {
+            "answer": 1950412,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950421,
+        "fields": {
+            "answer": 1950413,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950422,
+        "fields": {
+            "answer": 1950414,
+            "state": 269,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950428,
+        "fields": {
+            "answer": 1950425,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.0355
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950434,
+        "fields": {
+            "answer": 1950426,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950435,
+        "fields": {
+            "answer": 1950430,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950436,
+        "fields": {
+            "answer": 1950432,
+            "state": 262,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950452,
+        "fields": {
+            "answer": 1950444,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950453,
+        "fields": {
+            "answer": 1950444,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950509,
+        "fields": {
+            "answer": 1950503,
+            "state": 264,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950510,
+        "fields": {
+            "answer": 1950503,
+            "state": 266,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950511,
+        "fields": {
+            "answer": 1950503,
+            "state": 269,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950512,
+        "fields": {
+            "answer": 1950503,
+            "state": 265,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950517,
+        "fields": {
+            "answer": 1950513,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950518,
+        "fields": {
+            "answer": 1950513,
+            "state": 260,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950519,
+        "fields": {
+            "answer": 1950513,
+            "state": 259,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950520,
+        "fields": {
+            "answer": 1950513,
+            "state": 255,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950563,
+        "fields": {
+            "answer": 1950558,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950564,
+        "fields": {
+            "answer": 1950558,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950565,
+        "fields": {
+            "answer": 1950558,
+            "state": 270,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950568,
+        "fields": {
+            "answer": 1950559,
+            "state": 262,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950569,
+        "fields": {
+            "answer": 1950559,
+            "state": 258,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950570,
+        "fields": {
+            "answer": 1950559,
+            "state": 260,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950572,
+        "fields": {
+            "answer": 1950560,
+            "state": 256,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950573,
+        "fields": {
+            "answer": 1950560,
+            "state": 257,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950575,
+        "fields": {
+            "answer": 1950561,
+            "state": 253,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950576,
+        "fields": {
+            "answer": 1950561,
+            "state": 251,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950577,
+        "fields": {
+            "answer": 1950561,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950871,
+        "fields": {
+            "answer": 1950863,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950872,
+        "fields": {
+            "answer": 1950863,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950873,
+        "fields": {
+            "answer": 1950864,
+            "state": 251,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950874,
+        "fields": {
+            "answer": 1950864,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950875,
+        "fields": {
+            "answer": 1950865,
+            "state": 264,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950876,
+        "fields": {
+            "answer": 1950865,
+            "state": 265,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950877,
+        "fields": {
+            "answer": 1950865,
+            "state": 269,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950878,
+        "fields": {
+            "answer": 1950865,
+            "state": 266,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950879,
+        "fields": {
+            "answer": 1950866,
+            "state": 254,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950880,
+        "fields": {
+            "answer": 1950866,
+            "state": 263,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950881,
+        "fields": {
+            "answer": 1950866,
+            "state": 255,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950882,
+        "fields": {
+            "answer": 1950866,
+            "state": 253,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950889,
+        "fields": {
+            "answer": 1950560,
+            "state": 259,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+
+]
+
+campaignTrail_temp.answer_feedback_json = [
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950381,
+        "fields": {
+            "answer": 1950012,
+            "candidate": 2001591,
+            "answer_feedback": "Over the past few months, you have consistently employed vague municipal rhetoric when addressing the media. Whether it's to manage troublesome press interactions or conceal your true intentions, you should start preparing for the presidential election sooner rather than later."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950383,
+        "fields": {
+            "answer": 1950013,
+            "candidate": 2001591,
+            "answer_feedback": "Even though you claim to be focusing on municipal affairs at the moment, your statement 'Regardless of any challenges' has been interpreted by the media as a precursor hinting at your intention to run for president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950386,
+        "fields": {
+            "answer": 1950014,
+            "candidate": 2001591,
+            "answer_feedback": "While you consistently emphasize your current focus on municipal affairs, a presidential election demands a significant amount of time and energy. Do you believe you can effectively balance your responsibilities in local governance while engaging in a campaign?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950392,
+        "fields": {
+            "answer": 1950388,
+            "candidate": 2001591,
+            "answer_feedback": "On May 17th, Terry Gou was drafted as the KMT's presidential candidate, and your qualification for the primary elections came to an end. In the time ahead, you can now focus exclusively on handling municipal affairs in New Taipei City."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950394,
+        "fields": {
+            "answer": 1950389,
+            "candidate": 2001591,
+            "answer_feedback": "While polite words may suggest otherwise, it's worth noting that you currently enjoy a leading advantage in the polls, and Terry Gou has yet to fully regain his Kuomintang membership."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950396,
+        "fields": {
+            "answer": 1950390,
+            "candidate": 2001591,
+            "answer_feedback": "The media spotlight has now turned towards you, with headlines from China Times and United Daily News: 'Mayor Hou Youyi Officially Announces Presidential Bid?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950401,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "answer_feedback": "Understood. It seems you have chosen to continue focusing on municipal affairs, but I hope you won't acquire a reputation for being indifferent to party matters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950402,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "answer_feedback": "Terry Gou is very grateful for your assistance and promises that he will bring down the Democratic Progressive Party. He assures you a position in the cabinet once elected."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950416,
+        "fields": {
+            "answer": 1950415,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950417,
+        "fields": {
+            "answer": 1950414,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950418,
+        "fields": {
+            "answer": 1950413,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950419,
+        "fields": {
+            "answer": 1950412,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950427,
+        "fields": {
+            "answer": 1950425,
+            "candidate": 2001591,
+            "answer_feedback": "You spent the final day in your hometown. Wishing you good luck and hoping that you will be elected as the president tomorrow!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950429,
+        "fields": {
+            "answer": 1950426,
+            "candidate": 2001591,
+            "answer_feedback": "On Ketagalan Boulevard, amidst the bustling crowd of voters hoping for a political change, best of luck tomorrow!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950431,
+        "fields": {
+            "answer": 1950430,
+            "candidate": 2001591,
+            "answer_feedback": "You held the final event near the military dependents' village next to Kaohsiung Harbor, hoping that this would impact Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950433,
+        "fields": {
+            "answer": 1950432,
+            "candidate": 2001591,
+            "answer_feedback": "Absolutely, Taichung City serves as the dividing line between northern and southern Taiwan, making it a crucial region. Wishing you good luck!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950445,
+        "fields": {
+            "answer": 1950441,
+            "candidate": 2001591,
+            "answer_feedback": "\nYou are rallying support from mayors across the country, and with the impressive lineup of 14+1 KMT-supported mayors this year, it will be a significant boost to your campaign."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950447,
+        "fields": {
+            "answer": 1950442,
+            "candidate": 2001591,
+            "answer_feedback": "Building good relationships with legislators is also a wise choice. If elected, you will rely on their support in the Legislative Yuan. Regional legislators can also positively influence your campaign in different areas."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950449,
+        "fields": {
+            "answer": 1950443,
+            "candidate": 2001591,
+            "answer_feedback": "In your interview on TVBS's Situation Room with Zhao Shao-kang, you spoke confidently and it brought you some media exposure. You also appeared on this program before the 2018 mayoral election.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950450,
+        "fields": {
+            "answer": 1950444,
+            "candidate": 2001591,
+            "answer_feedback": "Your participation in the completion events of various construction projects and local festivals in New Taipei City and Taipei City has increased your exposure and familiarity among the voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950458,
+        "fields": {
+            "answer": 1950454,
+            "candidate": 2001591,
+            "answer_feedback": "Terry Gou stated on Facebook: 'Mayor Hou is the most solid popular support within the Kuomintang. It is only natural and the best choice for him to take on greater responsibilities. He will keep his promises and exert utmost effort to support Mayor Hou's victory'."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950464,
+        "fields": {
+            "answer": 1950463,
+            "candidate": 2001591,
+            "answer_feedback": "\nFocusing your energy primarily on the DPP can shape a blue-green confrontation atmosphere, but be cautious. Balance your critiques, as the public is weary of excessive attacks rather than positive campaigning."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950468,
+        "fields": {
+            "answer": 1950462,
+            "candidate": 2001591,
+            "answer_feedback": "As now, Ko Wen-je has not supported your request. He mentioned that it is difficult to cooperate due to differences in policy and ideology between him and the Kuomintang."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950471,
+        "fields": {
+            "answer": 1950461,
+            "candidate": 2001591,
+            "answer_feedback": "Initiating infighting within the opposition camp this early is not good news. It will only benefit the DPP and create a negative impression of the KMT, portraying it as solely focused on attacks without a clear vision.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950474,
+        "fields": {
+            "answer": 1950460,
+            "candidate": 2001591,
+            "answer_feedback": "Currently, this strategy ensures the independence of your party. However, there will come a day when you need to discuss collaboration against the DPP, so please be prepared."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950481,
+        "fields": {
+            "answer": 1950477,
+            "candidate": 2001591,
+            "answer_feedback": "\nUnfortunately, parents cannot wait until the slow administrative and police investigations conclude. Taking advantage of the situation, DPP legislators, along with some parents, held a press conference attacking the efficiency of Mayor Hou's government in handling the case. Your Polls have plummeted as if falling from a skyscraper."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950483,
+        "fields": {
+            "answer": 1950478,
+            "candidate": 2001591,
+            "answer_feedback": "With children claiming they were fed 'colorful potions,' and some showing signs of barbital, awaiting confirmation through hair tests, the credibility of the city government has been damaged. It is essential to conduct a thorough investigation into other kindergartens to prevent any potential issues. This incident has left parents across Taiwan concerned."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950485,
+        "fields": {
+            "answer": 1950479,
+            "candidate": 2001591,
+            "answer_feedback": "You and your city government are facing severe criticism for this incident. Parents are questioning why they reported the case in mid-May and attempted to contact through the mayor's mailbox, but did not receive a response from the government at that time."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950491,
+        "fields": {
+            "answer": 1950487,
+            "candidate": 2001591,
+            "answer_feedback": "Your response at National Chengchi University was disliked by young people; they feel you didn't directly answer the questions. Your standard-style responses are derogatorily referred to as HOHOGPT."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950494,
+        "fields": {
+            "answer": 1950488,
+            "candidate": 2001591,
+            "answer_feedback": "The video of your evasive answers at National Chengchi University has been widely circulated on various news media platforms, drawing a lot of mockery from young people. Even legislator Ko Chih-en believes that this has caused significant damage to your image.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950497,
+        "fields": {
+            "answer": 1950490,
+            "candidate": 2001591,
+            "answer_feedback": "\nBefore to this, you spoke about housing prices for ten minutes, and even your more normal responses were drowned out by online ridicule and the attacks from opponents on the kindergarten incident."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950505,
+        "fields": {
+            "answer": 1950502,
+            "candidate": 2001591,
+            "answer_feedback": "Lien Chan, despite his 87-year-old frame, has released an open letter in his own name, urging all members of the Kuomintang to support Hou You-yi."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950507,
+        "fields": {
+            "answer": 1950503,
+            "candidate": 2001591,
+            "answer_feedback": "\nWu Poh-hsiung, leaning on his cane, strongly supports Hou You-yi, referring to him as \"brothers in adversity.\" He mentioned that the more people get to know him, the more they like him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950514,
+        "fields": {
+            "answer": 1950504,
+            "candidate": 2001591,
+            "answer_feedback": "Ma Ying-jeou has agreed to assist you, and he will recruit a highly valuable individual to support your campaign. As for the specific person, it cannot be disclosed at this moment."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950515,
+        "fields": {
+            "answer": 1950513,
+            "candidate": 2001591,
+            "answer_feedback": "Speaker Wang Jin-ping has successfully organized a legislative support group for you. At the very least, you have the support of the party organization and legislative members, and they have decided to fully support Hou You-yi in the upcoming campaign."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950522,
+        "fields": {
+            "answer": 1950521,
+            "candidate": 2001591,
+            "answer_feedback": "With this news, the media has begun discussing the impact and assistance that 'Little Knife King' (金小刀) might bring to your campaign. After all, he played a crucial role in helping Ma defeat Tsai in 2012, and at that time, Tsai was already a formidable opponent who would become the president in 2016."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950526,
+        "fields": {
+            "answer": 1950525,
+            "candidate": 2001591,
+            "answer_feedback": "You might think it's a clever move, but in reality, the keen-eyed media has caught onto your subtle actions. They interpret your move of pulling a chair next to Han Kuo-yu as a deliberate attempt to cozy up to him, and this has been met with mockery."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950529,
+        "fields": {
+            "answer": 1950523,
+            "candidate": 2001591,
+            "answer_feedback": "While your apology to Han Kuo-yu is accepted, his supporters remain unconvinced and continue to harbor resentment towards you. To win them over, it may require direct intervention and efforts from Han himself."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950530,
+        "fields": {
+            "answer": 1950524,
+            "candidate": 2001591,
+            "answer_feedback": "you serious? Not offering an apology to Han Kuo-yu in this situation might make it challenging to win back his supporters. The swing voters may not necessarily lean towards you, and as for Han's fans, if presented with other options, you know where they might turn."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950538,
+        "fields": {
+            "answer": 1950535,
+            "candidate": 2001591,
+            "answer_feedback": "\nIt seems like your campaign has finally returned to the right track. Many people find it difficult to accept KMT candidates who do not adhere to the 1992 Consensus, while others simply do not accept the consensus at all."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950543,
+        "fields": {
+            "answer": 1950537,
+            "candidate": 2001591,
+            "answer_feedback": "Businessmen worship Guan Gong just to seek his blessings for them to earn more money."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950544,
+        "fields": {
+            "answer": 1950536,
+            "candidate": 2001591,
+            "answer_feedback": "There are several nuclear power plants in New Taipei, However, due to concerns about safety, you have not allowed them to insert nuclear fuel rods, and there is no particularly specific and feasible plan for nuclear waste."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950551,
+        "fields": {
+            "answer": 1950550,
+            "candidate": 2001591,
+            "answer_feedback": "After this , a portion of Han's supporters has shifted their support towards you, solidifying unity within the party!This marks the beginning of your resurgence in the polls!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950562,
+        "fields": {
+            "answer": 1950558,
+            "candidate": 2001591,
+            "answer_feedback": "Strengthening our base is always essential, but we must be cautious as Ko Wen-je and Terry Gou may divert crucial pan-blue votes!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950566,
+        "fields": {
+            "answer": 1950559,
+            "candidate": 2001591,
+            "answer_feedback": "\nCapturing the crucial central region is indeed a priority, especially focusing on Changhua, where a significant number of Minnan people reside. You might have a good chance to perform well there!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950571,
+        "fields": {
+            "answer": 1950560,
+            "candidate": 2001591,
+            "answer_feedback": "It seems like you must secure victory in your hometown; otherwise, it might not look good. At least ensure that Puzi City stays blue, alright?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950574,
+        "fields": {
+            "answer": 1950561,
+            "candidate": 2001591,
+            "answer_feedback": "Although holding a KMT membership in the south often means not winning, your southern identity and local Taiwanese flavor could work in your favor."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950578,
+        "fields": {
+            "answer": 1950489,
+            "candidate": 2001591,
+            "answer_feedback": "Angry students demand direct answers from you... Shifting topics here is not a good move."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950583,
+        "fields": {
+            "answer": 1950579,
+            "candidate": 2001591,
+            "answer_feedback": "The DPP government indeed lacks effective measures against fraud, and their anti-fraud task force is seen as a waste of time and money. However, it remains questionable how many votes you can sway on this issue."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950585,
+        "fields": {
+            "answer": 1950580,
+            "candidate": 2001591,
+            "answer_feedback": "Since 2022, the military threat from the mainland towards Taiwan has intensified. The DPP government, however, has yet to proactively ease the situation. Nevertheless, this can stir up the green base and anti-China sentiments."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950586,
+        "fields": {
+            "answer": 1950581,
+            "candidate": 2001591,
+            "answer_feedback": "While the digital development department, led by Tang Feng, is widely seen as a failure, the current government is reluctant to replace him. Moreover, this issue is not a top concern for the voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950590,
+        "fields": {
+            "answer": 1950582,
+            "candidate": 2001591,
+            "answer_feedback": "This strategy aims to strengthen your deep blue support base. However, many green supporters in Taiwan see CTiTV as pro-China media that could undermine Taiwan's free and democratic system."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950594,
+        "fields": {
+            "answer": 1950593,
+            "candidate": 2001591,
+            "answer_feedback": "death penalty is a sensitive point for the DPP. They have to moderate their stance on this issue. They might argue that Taiwan has not abolished the death penalty, but the number of executions during the DPP's term is significantly lower than during Ma Ying-jeou's presidency."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950598,
+        "fields": {
+            "answer": 1950597,
+            "candidate": 2001591,
+            "answer_feedback": "DPP criticizes your approach, claiming that it aims to return to the era of one-party rule, and they argue that there would be no oversight for the SPD. However, this is undoubtedly well-received among supporters of the blue camp!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950603,
+        "fields": {
+            "answer": 1950599,
+            "candidate": 2001591,
+            "answer_feedback": "This is your attempt to attract young people, but it doesn't seem to be effective. All candidates support the construction of public housing and a property hoarding tax, so it may not have a unique appeal."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950605,
+        "fields": {
+            "answer": 1950600,
+            "candidate": 2001591,
+            "answer_feedback": "on this issue, the KMT and DPP have completely opposite policies, with significant differences. Nuclear power also offers the advantage of generating electricity at a lower cost."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950612,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "answer_feedback": "Hey, isn't your attack a bit too much? You might be angry with him, but opposition voters don't want to see more attacks and divisions. This will only help Ko Wen-je gain more support."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950613,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "answer_feedback": "These are empty words and useless statements; Terry Gou has already announced his independent candidacy, and he won't stop now.\n\n\n\n\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950614,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "answer_feedback": "This is a very interesting advertisement that has caught the media's attention. Many believe that you released this video to satirize Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950618,
+        "fields": {
+            "answer": 1950615,
+            "candidate": 2001591,
+            "answer_feedback": "This is a favorable proposal for you, but it's evident that TPP won't accept it as their party members and support base are lower than yours. Anyway, you've tossed the ball back to them."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950620,
+        "fields": {
+            "answer": 1950616,
+            "candidate": 2001591,
+            "answer_feedback": "While what you say is true, it might create an image of you overpowering a smaller party, and TPP supporters may perceive you as timid, hiding behind the strength of the KMT."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950621,
+        "fields": {
+            "answer": 1950617,
+            "candidate": 2001591,
+            "answer_feedback": "Certainly, negotiations will continue, but you must reach an agreement before November 24th; otherwise, this election will turn into a three-way competition!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950650,
+        "fields": {
+            "answer": 1950649,
+            "candidate": 2001591,
+            "answer_feedback": "\nCompared to Vice President Lai Ching-te, you have indeed met with more important figures. This will be helpful for you and add more points to your international diplomatic efforts."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950651,
+        "fields": {
+            "answer": 1950647,
+            "candidate": 2001591,
+            "answer_feedback": "\nThree Principles of the People encompass nationalism, democracy, and people's livelihood. However, it also has a complex historical relationship with by the people, for the people.and of the people.Unfortunately, in modern times, few Taiwanese can comprehend your political discourse."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950652,
+        "fields": {
+            "answer": 1950648,
+            "candidate": 2001591,
+            "answer_feedback": "In November 1997, when criminals broke into the home of a South African military attaché and kidnapped his entire family, you helped rescue the baby. The infant, who was in your arms back then, has grown up, touching the hearts of many."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950661,
+        "fields": {
+            "answer": 1950658,
+            "candidate": 2001591,
+            "answer_feedback": "This will significantly alleviate the differences between Hou and Han, bringing back the majority of Han's supporters into the Kuomintang camp!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950664,
+        "fields": {
+            "answer": 1950659,
+            "candidate": 2001591,
+            "answer_feedback": "This can enhance Mayor Hou's image in terms of law and order, helping boost his scores in public safety. It will contribute to an improvement in Mayor Hou You-yi's standings in the polls."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950667,
+        "fields": {
+            "answer": 1950660,
+            "candidate": 2001591,
+            "answer_feedback": "Stirring up hatred against the DPP and instilling fear of war is a common tactic. However, here, you mentioned that Mayor Hou You-yi will unite more people who believe in these ideas around him!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950672,
+        "fields": {
+            "answer": 1950670,
+            "candidate": 2001591,
+            "answer_feedback": "From now on, polls will begin to assess your specific data. This will determine the fate of Taiwan. Good luck, Mayor Hou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950673,
+        "fields": {
+            "answer": 1950671,
+            "candidate": 2001591,
+            "answer_feedback": "From now on, polls will begin to assess your specific data. This will determine the fate of Taiwan. Good luck, Mayor Hou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950694,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "answer_feedback": "Tremble, Lai Ching-te, for the opposition alliance is united! President Hou You-yi, hello! Vice President Ko Wen-je, hello!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950695,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "answer_feedback": "After calculations by polling experts, it is not surprising that you emerge victorious and become the presidential candidate, with Ko Wen-je as your running mate for the vice presidency. On January 13th next year, you have a high likelihood of winning!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950696,
+        "fields": {
+            "answer": 1950692,
+            "candidate": 2001591,
+            "answer_feedback": "Damn... Under the interference of Ko Wen-je, his staff, and family, on the 18th, TPP's polling experts suggested excluding all indoor phone polls, and the margin of error in other polls became a contentious issue... "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950697,
+        "fields": {
+            "answer": 1950693,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je's supporters and TPP immediately started spreading online that the margin of error the KMT needs to concede is not the commonly perceived 3% but rather a range of plus or minus 3%. This implies that the KMT is asking Ko Wen-je to concede a margin of error of 6%."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950725,
+        "fields": {
+            "answer": 1950721,
+            "candidate": 2001591,
+            "answer_feedback": "It seems there's a big problem... Both sides are in constant dispute over the margin of error and which poll each side won. No decision was made on the 18th... Is this reaching a breaking point?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950726,
+        "fields": {
+            "answer": 1950722,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je's supporters and TPP immediately started spreading online that the margin of error the KMT needs to concede is not the commonly perceived 3% but rather a range of plus or minus 3%. This implies that the KMT is asking Ko Wen-je to concede a margin of error of 6%."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950727,
+        "fields": {
+            "answer": 1950723,
+            "candidate": 2001591,
+            "answer_feedback": "It seems there's a big problem... Both sides are in constant dispute over the margin of error and which poll each side won. No decision was made on the 18th... Is this reaching a breaking point?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950728,
+        "fields": {
+            "answer": 1950724,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je's supporters and TPP immediately started spreading online that the margin of error the KMT needs to concede is not the commonly perceived 3% but rather a range of plus or minus 3%. This implies that the KMT is asking Ko Wen-je to concede a margin of error of 6%."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950741,
+        "fields": {
+            "answer": 1950737,
+            "candidate": 2001591,
+            "answer_feedback": "Ko agrees but immediately counterattacks, stating that revealing private conversations is something only internet trolls and unscrupulous media outlets would do. Fortunately, this ensures Terry Gou's withdrawal as they announce that he will not register as a presidential candidate."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950743,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "answer_feedback": "Regardless of how you explain it, it's too late. Joint tickets have already failed since the time when the polls became controversial."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950746,
+        "fields": {
+            "answer": 1950739,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je refuses to withdraw from the election, declaring that as long as his supporters don't give up, he won't either. The only consolation is that Terry Gou has withdrawn from the election and stated that he will not continue to participate."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950747,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "answer_feedback": "both Ko Wen-je and Gou believe they have the right to independently continue their candidacies. Despite Gou's low polling numbers, he still managed to gather 940,000 citizen signatures. With the situation completely collapsing, you might need to prepare for a concession speech."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950756,
+        "fields": {
+            "answer": 1950751,
+            "candidate": 2001591,
+            "answer_feedback": "\nSome malicious media outlets fabricated news claiming that Ko Chih-en cried for a long time the night she found out she would be the vice president. She immediately refuted it, stating that not everyone is as prone to tears as Ko Wen-je."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950757,
+        "fields": {
+            "answer": 1950755,
+            "candidate": 2001591,
+            "answer_feedback": " Some malicious media outlets fabricated news claiming that Ko Chih-en cried for a long time the night she found out she would be the vice president. She immediately refuted it, stating that not everyone is as prone to tears as Ko Wen-je."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950767,
+        "fields": {
+            "answer": 1950766,
+            "candidate": 2001591,
+            "answer_feedback": "This is a direct criticism of the DPP. Considering that the Kuomintang might be perceived as too focused on attacks, you must offer the people a new hope to have a chance at winning.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950771,
+        "fields": {
+            "answer": 1950765,
+            "candidate": 2001591,
+            "answer_feedback": "Unfortunately, during the policy statement event, you mistakenly referred to \"Hou You-yi\" as \"Lai Ching-te,\" turning it into a big joke. Damn it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950774,
+        "fields": {
+            "answer": 1950764,
+            "candidate": 2001591,
+            "answer_feedback": "We understand that the story of the Three Kingdoms is popular and interesting, but the DPP continues to question the relationship between you and Hou. They still portray Hou as your puppet..."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950785,
+        "fields": {
+            "answer": 1950784,
+            "candidate": 2001591,
+            "answer_feedback": "You might think it's cool, but the news of violent demolition of Lai Ching-te's ancestral home has triggered a backlash among swing voters and the green base. The public is showing even more sympathy towards him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950788,
+        "fields": {
+            "answer": 1950783,
+            "candidate": 2001591,
+            "answer_feedback": "\nThat's the correct choice. Lai Ching-te's unauthorized construction was built a long time ago and hasn't posed any safety hazards. Most people aren't very concerned about this issue, so it's best not to overreact."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950789,
+        "fields": {
+            "answer": 1950782,
+            "candidate": 2001591,
+            "answer_feedback": "\nPerhaps Lai Ching-te hasn't handled this issue well, but regardless, many local residents support him. Your ads have inadvertently backfired, generating a negative impact with excessive aggression. It might be more beneficial to reconsider the tone and approach to avoid alienating potential supporters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950790,
+        "fields": {
+            "answer": 1950781,
+            "candidate": 2001591,
+            "answer_feedback": "\nLai may indeed lack transparency in this matter, and his teary performance may not garner much sympathy. However, pursuing an attack specifically targeting personal and family matters may not be the best choice, as such tactics are generally unpopular. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950800,
+        "fields": {
+            "answer": 1950796,
+            "candidate": 2001591,
+            "answer_feedback": "This response is indeed very good. it further enhance the negative image among young people and the DPP. While these are facts, it seems that the Taiwanese public might not be receptive to such a stance.nice try."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950803,
+        "fields": {
+            "answer": 1950797,
+            "candidate": 2001591,
+            "answer_feedback": "\nThis helps to immediately stop the bleeding. However, your image as a landlord has already become disliked by some young people, and they won't easily change their minds because of this."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950807,
+        "fields": {
+            "answer": 1950798,
+            "candidate": 2001591,
+            "answer_feedback": "Mutual attacks will only make things worse and strengthen the support bases on both sides. If that's what you prefer, then let it be."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950808,
+        "fields": {
+            "answer": 1950799,
+            "candidate": 2001591,
+            "answer_feedback": "While your image among young people may have further deteriorated, fortunately, most pan-blue and swing voters seem to understand. They recognize that this issue doesn't involve personal character but rather legal business operations."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950819,
+        "fields": {
+            "answer": 1950818,
+            "candidate": 2001591,
+            "answer_feedback": "This will strengthen the Kuomintang's image in national defense and help alleviate concerns among Americans about KMT's pro-China stance."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950822,
+        "fields": {
+            "answer": 1950814,
+            "candidate": 2001591,
+            "answer_feedback": "The effectiveness of this advertisement may not match the one from 2008, but it still resonates and is quite impactful. Well done!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950825,
+        "fields": {
+            "answer": 1950815,
+            "candidate": 2001591,
+            "answer_feedback": "Choosing to engage in close combat with the DPP has its benefits as you can inflict damage, but the downside is that people have less hope for you, only seeing more of your attacks."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950828,
+        "fields": {
+            "answer": 1950816,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Chih-en has utilized her skills as a university professor, capturing the hearts of many young people. It seems that a lot of young individuals are becoming interested in the KMT's election campaign!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950832,
+        "fields": {
+            "answer": 1950817,
+            "candidate": 2001591,
+            "answer_feedback": "This will solidify your base, as most of the opposition voters are reluctant to vote for the DPP. However, winning will still depend on the preferences of swing voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950843,
+        "fields": {
+            "answer": 1950838,
+            "candidate": 2001591,
+            "answer_feedback": "Mayor Hou, you and your supporters sincerely hope for your victory.They hope you can address Taiwan's public safety and fraud issues!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950845,
+        "fields": {
+            "answer": 1950839,
+            "candidate": 2001591,
+            "answer_feedback": "This is a very ambitious goal, and if it involves amending the constitution, it will require bipartisan cooperation. But at least you have set a clear objective."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950847,
+        "fields": {
+            "answer": 1950840,
+            "candidate": 2001591,
+            "answer_feedback": "Over 80% of Taiwanese people support the death penalty, while the DPP has been ambiguous on this issue, reducing the number of executions. Ko believes that if the death penalty is to be abolished, life imprisonment must be maintained."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950849,
+        "fields": {
+            "answer": 1950841,
+            "candidate": 2001591,
+            "answer_feedback": "This will rally your deep-blue supporters and boost their voter turnout. Hopefully, on the anniversary of Mr. Chiang Ching-kuo's passing, you can achieve victory!\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950854,
+        "fields": {
+            "answer": 1950852,
+            "candidate": 2001591,
+            "answer_feedback": "\nWhether it's good or bad, this highlights internal divisions and ideological issues within the Kuomintang. Hopefully, this won't cause you too much harm."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950856,
+        "fields": {
+            "answer": 1950853,
+            "candidate": 2001591,
+            "answer_feedback": "As a light-blue presidential candidate, attacking our only former president is a very serious matter. You may risk losing some core support base votes. Is it really worth it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950859,
+        "fields": {
+            "answer": 1950858,
+            "candidate": 2001591,
+            "answer_feedback": "\nWhile this avoids the emergence of internal party disputes, it may lead to disapproval from the moderate voters. Hopefully, your base is solid enough."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950867,
+        "fields": {
+            "answer": 1950866,
+            "candidate": 2001591,
+            "answer_feedback": "After the final campaign event with our native friends, you had a good night's sleep and am ready to cast you vote tomorrow."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950868,
+        "fields": {
+            "answer": 1950865,
+            "candidate": 2001591,
+            "answer_feedback": "In Taoyuan, you have connected well with the Hakka community, strengthening your support base. Best of luck to you in tomorrow's election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950869,
+        "fields": {
+            "answer": 1950864,
+            "candidate": 2001591,
+            "answer_feedback": "If Lai Ching-te were to fall from grace over one thing, it would be the loss of his stronghold. You and Ko Chih-en have delivered speeches in Tainan and Kaohsiung using Taiwanese, snatching away votes!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950870,
+        "fields": {
+            "answer": 1950863,
+            "candidate": 2001591,
+            "answer_feedback": "\nStrengthening your own stronghold is always a good move. New Taipei City is an enormously important vote bank, equivalent to four Changhua Counties. Any presidential candidate cannot afford to lose here."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950894,
+        "fields": {
+            "answer": 1950891,
+            "candidate": 2001591,
+            "answer_feedback": "\nHe can attract many young votes for you; however, since he formed an alliance with the KMT, some of the lightly green-leaning young people have distanced themselves from him. He cannot transfer all of his votes to you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950895,
+        "fields": {
+            "answer": 1950892,
+            "candidate": 2001591,
+            "answer_feedback": "At present, you are leading in the polls, but you must be cautious about unforeseen events. It's best not to make significant moves at this time!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950896,
+        "fields": {
+            "answer": 1950893,
+            "candidate": 2001591,
+            "answer_feedback": "To achieve this alliance, you must accept some of the TPP's political positions and reform demands. If this is the collective will of the Taiwanese people, then you will be elected on January 13 next year."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950905,
+        "fields": {
+            "answer": 1950903,
+            "candidate": 2001591,
+            "answer_feedback": "In the last presidential election, the Democratic Progressive Party (DPP) secured 8.17 million votes. Can you, with the consensus of the majority of the Taiwanese people, surpass this historical record?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950907,
+        "fields": {
+            "answer": 1950902,
+            "candidate": 2001591,
+            "answer_feedback": "The checks and balances between political parties could be the optimal way to ensure a democratic system, but the downside is that your governance may face constraints.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950908,
+        "fields": {
+            "answer": 1950901,
+            "candidate": 2001591,
+            "answer_feedback": "The Parliamentary system is indeed a challenging goal. Even if you win, amending the constitution or pushing through extensive reforms will require cooperation from the DPP. Gaining more seats in the parliament becomes crucial in this context.\n\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950916,
+        "fields": {
+            "answer": 1950912,
+            "candidate": 2001591,
+            "answer_feedback": "Lai Ching-te may be a flip-flopper, but you have to understand that his base will tolerate him no matter what. The room for maneuvering among the swing voters in the center has diminished considerably."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950918,
+        "fields": {
+            "answer": 1950913,
+            "candidate": 2001591,
+            "answer_feedback": "This is a direct confrontation between the blue and green camps, and we hope you can emerge victorious here!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950922,
+        "fields": {
+            "answer": 1950914,
+            "candidate": 2001591,
+            "answer_feedback": "This will weaken the DPP's red-baiting tactics against you and help restore the KMT's anti-communist image. Moreover, being a true local, your Taiwan-centric image is even stronger than that of Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950923,
+        "fields": {
+            "answer": 1950915,
+            "candidate": 2001591,
+            "answer_feedback": "Lai Ching-te also comes from a humble background; however, his current image carries more of an elite vibe, while you appear similar to an ordinary uncle on the street.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950929,
+        "fields": {
+            "answer": 1950928,
+            "candidate": 2001591,
+            "answer_feedback": "The current lead you have in the polls may easily disappear due to scandals or failed strategies; public opinion is fluid, so proceed with caution!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950937,
+        "fields": {
+            "answer": 1950936,
+            "candidate": 2001591,
+            "answer_feedback": "Guo is definitely trailing in this election, and your appeal to his voters will not be ignored!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950940,
+        "fields": {
+            "answer": 1950935,
+            "candidate": 2001591,
+            "answer_feedback": "Although some in the TPP doubt whether you are only aiming to defeat Ko Wen-je and secure the second position, rather than focusing on attacking Lai Ching-te, the votes are likely to flow significantly between opposition parties."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950943,
+        "fields": {
+            "answer": 1950934,
+            "candidate": 2001591,
+            "answer_feedback": "Lai Ching-te may be a flip-flopper, but you have to understand that his base will tolerate him no matter what. The room for maneuvering among the swing voters in the center has diminished considerably."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950947,
+        "fields": {
+            "answer": 1950946,
+            "candidate": 2001591,
+            "answer_feedback": "\nHe indeed cannot win this election, so the hope for the Pan-Blue Coalition's victory lies here: whoever can secure the support of Terry Gou's voters will be able to win!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 12766,
+        "fields": {
+            "answer": 12763,
+            "candidate": 2001591,
+            "answer_feedback": "Choosing her signifies a significant shift in your campaign, prioritizing young people and middle-aged female voters as your top priority. This may be crucial for your path to victory!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 12769,
+        "fields": {
+            "answer": 12764,
+            "candidate": 2001591,
+            "answer_feedback": "Since 1996, except for the year 2016, the KMT has never nominated a female vice president. This might be the most unexpected and winning choice you need in this critical moment."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 12772,
+        "fields": {
+            "answer": 12765,
+            "candidate": 2001591,
+            "answer_feedback": "Emphasizing her local identity can help you gain more support in the central and southern regions, especially in her hometown of Pingtung and in Kaohsiung."
+        }
+    }
+]
+
+cyoAdventure = function (a) {
+    ans = campaignTrail_temp.player_answers[campaignTrail_temp.player_answers.length-1];
+    if (ans == 13019 || 13020 || 13021 ){
+        campaignTrail_temp.election_json[0]["fields"].advisor_url = "https://i.imgur.com/BZlgvel.jpeg";
+    }
+    if (ans == 1950388 ){
+        campaignTrail_temp.questions_json[2] = {
+            "model": "campaign_trail.question",
+            "pk": 1950398,
+            "fields": {
+              "priority": 1,
+              "description": "Since you have withdrawn from the primary and essentially paved the way for Terry Gou to secure the presidential candidate position, how do you plan to support him in the upcoming electoral campaign?",
+              "likelihood": 1
+            }
+          }
+        }
+        if (ans == 1950399 ){
+            campaignTrail_temp.candidate_json[2]["fields"].first_name = "";
+            campaignTrail_temp.candidate_json[2]["fields"].last_name = "Terry Gou";
+            campaignTrail_temp.candidate_json[6]["fields"].last_name = "None";
+            campaignTrail_temp.candidate_last_name = 'Terry Gou';
+            campaignTrail_temp.candidate_image_url = 'https://www.foxconn.com/img/about/group-profile/founder-m.png?5f65a';
+            campaignTrail_temp.running_mate_image_url = 'https://img.ltn.com.tw/Upload/news/600/2015/10/07/phpbfQCOW.jpg';
+            campaignTrail_temp.running_mate_last_name = 'Hong Xiuzhu';
+            campaignTrail_temp.question_number = 28;
+            campaignTrail_temp.questions_json[29] = {
+                "model": "campaign_trail.question",
+                "pk": 1950411,
+                "fields": {
+                  "priority": 1,
+                  "description": "Today is the last day before the election, and your polls have been consistently declining since your nomination. The deadlock with Ko Wen-je and the lead by Lai Ching-te have not been broken, and the situation persists until the registration of presidential candidates in November. There are hardly any person willing to be your vice president, until Hong Xiu-Zhu, whose nomination was abolished in 2016, volunteered. It is only then that you have a vice presidential candidate to appear on the ballot. On the final day before the election, where do you plan to conduct your campaign activities?",
+                  "likelihood": 1
+                }
+              }
+        }
+        if (ans == 1950400 ){
+            campaignTrail_temp.candidate_json[2]["fields"].first_name = "";
+            campaignTrail_temp.candidate_json[2]["fields"].last_name = "Terry Gou";
+            campaignTrail_temp.candidate_json[6]["fields"].last_name = "None";
+            campaignTrail_temp.candidate_last_name = 'Terry Gou';
+            campaignTrail_temp.candidate_image_url = 'https://www.foxconn.com/img/about/group-profile/founder-m.png?5f65a';
+            campaignTrail_temp.running_mate_image_url = 'https://i.imgur.com/ZmWU9KE.png';
+            campaignTrail_temp.running_mate_last_name = 'Lai Pei-hsia';
+            campaignTrail_temp.question_number = 28;
+            campaignTrail_temp.questions_json[29] = {
+                "model": "campaign_trail.question",
+                "pk": 1950424,
+                "fields": {
+                  "priority": 1,
+                  "description": "Today is the last day before the election, On the final day before the election,  According to the latest polls conducted 10 days before the election, your and Lai Ching-te's approval ratings are within the margin of error. In other words, the presidential position hinges on a difference of just 500,000 votes.where do you plan to conduct your campaign activities?",
+                  "likelihood": 1
+                }
+              }
+        }      
+        if (ans == 1950740 ){
+            campaignTrail_temp.questions_json[27] = {
+                "model": "campaign_trail.question",
+                "pk": 1950933,
+                "fields": {
+                  "priority": 1,
+                  "description": "This year's presidential debate has an unprecedented presence of four presidential candidates: yourself, Lai Ching-te, Ko Wen-je, and the former Chairman of Hon Hai Precision Industry, Terry Gou, who does not support you. In this year's presidential debate, what main points do you want to convey?                  ",
+                  "likelihood": 1
+                }
+              }
+        }
+        
+        if (ans == 1950751 || ans == 1950755 ){
+            campaignTrail_temp.running_mate_image_url = 'https://img.ltn.com.tw/Upload/news/600/2020/01/15/php8mrM1K.jpg';
+            campaignTrail_temp.running_mate_last_name = 'Ko';
+        }
+           //县长女儿
+            getResults = function (out, totv, aa, quickstats) {
+                let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 253);
+                if( aa[0].candidate === 2001591 && stateResult.result[0].candidate == 2001591 && e.player_answers.includes(1950755) || e.player_answers.includes(1950751)) {
+                    unlockAchievement("County Mayor Daughter");
+                 }
+                }
+            //三民主义
+                getResults = function (out, totv, aa, quickstats) {
+               if( aa[0].candidate === 2001591 && e.player_answers.includes(1950647) && e.player_answers.includes(1950740) ) {
+                   unlockAchievement("Three Principles of People");
+                     }
+                    }
+               //果冻获胜
+                getResults = function (out, totv, aa, quickstats) {
+               if( aa[0].candidate === 2001591 && e.player_answers.includes(1950388) && e.player_answers.includes(1950400)){
+                   unlockAchievement("New Taipei Has A Mayor");
+                     }
+                    }
+                //嘉义之子
+                getResults = function (out, totv, aa, quickstats) {
+                    let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 256);
+                    let stateResulttwo = campaignTrail_temp.final_state_results.find((x) => x.state == 257);
+                    let stateResultthree = campaignTrail_temp.final_state_results.find((x) => x.state == 267);
+                if( aa[0].candidate === 2001591 && stateResult.result[0].candidate == 2001591 && stateResulttwo.result[0].candidate == 2001591 && stateResultthree.result[0].candidate == 2001591) {
+                    unlockAchievement("Chiayi favorite son");
+                }
+            }
+         //主流民意获胜
+         getResults = function (out, totv, aa, quickstats) {
+                        if( aa[0].candidate === 2001591 && quickstats[1] > 59.9) {
+                            unlockAchievement("Main Stream Opinion Wins");
+                        }
+                    }
+         //南部孩子回家了
+         getResults = function (out, totv, aa, quickstats) {
+            let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 256);
+            let stateResulttwo = campaignTrail_temp.final_state_results.find((x) => x.state == 257);
+            let stateResultthree = campaignTrail_temp.final_state_results.find((x) => x.state == 259);
+            let stateResultfour = campaignTrail_temp.final_state_results.find((x) => x.state == 260);
+            let stateResultfive = campaignTrail_temp.final_state_results.find((x) => x.state == 263);
+            let stateResultsix = campaignTrail_temp.final_state_results.find((x) => x.state == 253);
+            
+            if( aa[0].candidate === 2001591 && stateResult.result[0].candidate == 2001591 && stateResulttwo.result[0].candidate == 2001591 && stateResultthree.result[0].candidate == 2001591 && stateResultfour.result[0].candidate == 2001591 && stateResultfive.result[0].candidate == 2001591 && stateResultsix.result[0].candidate == 2001591) {
+                unlockAchievement("Southern Boys Returning Home");
+            }
+        }
+    
+        getResults = function (out, totv, aa, quickstats) {
+            if( aa[1].candidate === 2001591 && quickstats[1] < 31.04) {
+                unlockAchievement("Challenge the Bottom Line");
+            }
+        }
+   //各党标题
+   if ( ans == 1950012 || ans == 1950013 || ans == 1950014 ){    
+    nct_stuff.themes[nct_stuff.selectedTheme].coloring_window = "#f4f4ee" 
+    nct_stuff.themes[nct_stuff.selectedTheme].coloring_title = "#13366e" 
+    $(".container")[0].style.backgroundColor = "#6848ff" 
+    $("#game_window")[0].style.borderColor = "#99A0A8" 
+    $(".container")[0].style.backgroundColor = "#F4F4EE" 
+    $("#game_window")[0].style.borderColor = "#f4f4ee" 
+    $("#game_window")[0].style.backgroundImage = "url(https://imgur.com/3praAwi.jpg)" 
+    document.getElementById("header").src = "https://i.imgur.com/I7YpjTe.jpeg" 
+    document.body.background = "https://i.imgur.com/cknN16g.jpg"
+}
+    }
+
+campaignTrail_temp.jet_data = [{}
+]
+
+campaignTrail_temp.candidate_image_url = "https://i.imgur.com/GCeTdoX.png";
+campaignTrail_temp.running_mate_image_url = "https://i.imgur.com/KLN8hlP.jpeg";
+campaignTrail_temp.candidate_last_name = "Hou";
+campaignTrail_temp.running_mate_last_name = "For KMT 2024";
+campaignTrail_temp.running_mate_state_id = '253';
+campaignTrail_temp.player_answers = [];
+campaignTrail_temp.player_visits = [];
+campaignTrail_temp.answer_feedback_flg = 1;
+campaignTrail_temp.game_start_logging_id = '3660822';
+
+const style_overwrite = document.createElement("style");
+style_overwrite.innerHTML = 
+`#campaign_sign {
+    background-color: #13366e;
+    border-color: #b22525;
+  }
+#menu_container {
+  background-color: #c3c3c3;
+}
+#overall_result_container {
+  background-color: #c3c3c3;
+}
+#state_info h3 {
+  background-color: #ffffff;
+}
+#overall_result h3 {
+  background-color: #ffffff;
+}`
+;
+document.head.appendChild(style_overwrite);
+
+
+let style = document.createElement('style');
+style.type = 'text/css';
+style.id = 'dynamic-style';
+
+style.innerHTML = `
+  .inner_window_question h3 {
+    background-color: #e1e1e1;
+  }
+  .overlay_window h3 {
+    background-color: #b4b4b4;
+  }
+`;
+
+document.head.appendChild(style);
+
+
+function checkIfCanAddMap() {
+    map = document.getElementById("map_container");
+    
+    if(map) {
+        map.style.backgroundImage = "url('https://images.rawpixel.com/image_800/czNmcy1wcml2YXRlL3Jhd3BpeGVsX2ltYWdlcy93ZWJzaXRlX2NvbnRlbnQvbHIvdjk5Ni0wMDlfMS1rcm9pcjRkay5qcGc.jpg')"; 
+    }
+}
+
+setInterval(checkIfCanAddMap, 250);
+
+(function(e, t, n, r, i) {
+    function s(e, t, n, r) {
+        r = r instanceof Array ? r : [];
+        var i = {};
+        for (var s = 0; s < r.length; s++) {
+            i[r[s]] = true
+        }
+        var o = function(e) {
+            this.element = e
+        };
+        o.prototype = n;
+        e.fn[t] = function() {
+            var n = arguments;
+            var r = this;
+            this.each(function() {
+                var s = e(this);
+                var u = s.data("plugin-" + t);
+                if (!u) {
+                    u = new o(s);
+                    s.data("plugin-" + t, u);
+                    if (u._init) {
+                        u._init.apply(u, n)
+                    }
+                } else if (typeof n[0] == "string" && n[0].charAt(0) != "_" && typeof u[n[0]] == "function") {
+                    var a = Array.prototype.slice.call(n, 1);
+                    var f = u[n[0]].apply(u, a);
+                    if (n[0] in i) {
+                        r = f
+                    }
+                }
+            });
+            return r
+        }
+    }
+    var o = 1010,
+        u = 500,
+        a = 50;
+    var f = {
+        stateStyles: {
+            fill: "#333",
+            stroke: "#666",
+            "stroke-width": 1,
+            "stroke-linejoin": "round",
+            scale: [1, 1]
+        },
+        stateHoverStyles: {
+            fill: "#33c",
+            stroke: "#000",
+            scale: [1.1, 1.1]
+        },
+        stateHoverAnimation: 500,
+        stateSpecificStyles: {},
+        stateSpecificHoverStyles: {},
+        click: null,
+        mouseover: null,
+        mouseout: null,
+        clickState: {},
+        mouseoverState: {},
+        mouseoutState: {},
+        showLabels: true,
+        labelWidth: 20,
+        labelHeight: 15,
+        labelGap: 6,
+        labelRadius: 3,
+        labelBackingStyles: {
+            fill: "#333",
+            stroke: "#666",
+            "stroke-width": 1,
+            "stroke-linejoin": "round",
+            scale: [1, 1]
+        },
+        labelBackingHoverStyles: {
+            fill: "#33c",
+            stroke: "#000"
+        },
+        stateSpecificLabelBackingStyles: {},
+        stateSpecificLabelBackingHoverStyles: {},
+        labelTextStyles: {
+            fill: "#fff",
+            stroke: "none",
+            "font-weight": 300,
+            "stroke-width": 0,
+            "font-size": "10px"
+        },
+        labelTextHoverStyles: {},
+        stateSpecificLabelTextStyles: {},
+        stateSpecificLabelTextHoverStyles: {}
+    };
+    var l = {
+        _init: function(t) {
+            this.options = {};
+            e.extend(this.options, f, t);
+            var n = this.element.width();
+            var i = this.element.height();
+            var s = this.element.width() / o;
+            var l = this.element.height() / u;
+            this.scale = Math.min(s, l);
+            this.labelAreaWidth = Math.ceil(a / this.scale);
+            var c = o + Math.max(0, this.labelAreaWidth - a);
+            this.paper = r(this.element.get(0), c, u);
+            this.paper.setSize(n, i);
+            this.paper.setViewBox(-500, 0, c, u, false);
+            this.stateHitAreas = {};
+            this.stateShapes = {};
+            this.topShape = null;
+            this._initCreateStates();
+            this.labelShapes = {};
+            this.labelTexts = {};
+            this.labelHitAreas = {};
+            if (this.options.showLabels) {
+                this._initCreateLabels()
+            }
+        },
+        _initCreateStates: function() {
+            var t = this.options.stateStyles;
+            var n = this.paper;
+            var r = {
+                Tainancity:"m178.94 309.54c1.821 0.85976 1.9013 1.8004 3.9722 1.3601 0.52002 1.6719-1.5712 1.0502-1.4009 2.6113 0.8704 0.21983 2.3913 0.20091 2.5009 1.2003 2.4514 1.3001-0.0196 1.501 0.46065 3.6413 2.191-0.12068 3.2917 1.4299 5.2733 1.8898 0.13963 1.4005-0.8306 1.1807-1.6207 1.8011-1.0903 0.85976-1.1105 1.2309-1.181 2.6706-0.0698 1.411-0.89063 5.8318 0.97023 6.032 0.0496 0.85128 0.0496 1.7515 0 2.6008-0.82081 0.37966-1.1705 1.4814-1.1105 2.3405 0.5807 0.0202 1.2006 0.03 1.7806 0.06 0.17029 0.33986 0.2897 0.71103 0.39083 1.0607 1.7114-0.20939 1.8902 1.5512 3.2813 1.8904 0.16051-0.81019 1.3415-1.1305 1.7219-0.3503 0.0692 0 0.55983-0.0104 0.61072 0 0.84039-1.4103 2.5114-1.3803 2.8611-3.2414 0.73077 1.1709 1.2312 1.6308 2.6314 1.7411 1.4909 0.10959 2.4716-0.39988 3.8418-0.0998 0.76079 1.1598 1.6618 0.69994 1.8817-0.36074 0.39931 0.31051 0.63942 0.76061 0.63029 1.3007-0.15986 0.0398-0.30014 0-0.45021 0.06-0.12984 1.3803-0.89063 1.4599-1.6501 2.4606-0.97023 1.2694-0.14094 1.9498-0.3804 3.1696-0.3308 1.6608-3.2924 3.1214-4.3331 4.6817-1.5007 2.2616-2.7815 3.6608-3.7217 6.3217-0.85083 2.4208-1.6612 4.5519-3.9122 5.5415-2.3711 1.0496-3.1919 3.0013-4.8727 4.8018-0.71055 0.74886-1.9209 1.7593-2.8317 2.1696-1.4204 0.63993-2.4814 0.69081-3.1815 2.3412-0.21009 0.50098-0.16051 1.4899-0.4502 1.8611-0.53047 0.68038-0.94022 0.39009-1.581 0.75996-1.0707 0.62036-1.4707 1.6112-2.281 2.6217-1.0505 1.291-1.0603 2.12-1.6906 3.5917-0.52068 1.2303-1.5509 2.2799-2.2915 3.3706-0.74056 1.0711-1.4707 2.1814-2.0312 3.1312-0.46065 0.77953 0.15007 1.1905-0.97088 1.3197-0.79015 0.0998-1.1705-0.12916-1.0603-0.96936-0.64008-0.0307-1.3108-0.0307-1.9509 0-1.2006 1.4703-2.7515 1.5004-4.0323 2.7711-1.0707 1.0705-0.46065 1.2303-2.0011 1.5695-0.89062 0.21005-2.3809 0.51991-2.1812-0.84019-1.8008-0.15982-3.432-0.77039-5.4827-0.69081-1.3604 0.0502-3.862-0.33008-4.8531 0.43053-1.3708-0.99153-4.3024-0.48011-4.8524-2.9113-1.641 0.95044-6.023-1.3503-7.784 0.42923-0.26034-1.9707-0.0803-4.4417-0.65052-5.7913-0.99045-2.3803-1.2103-4.501-3.1619-6.2114-2.0612-1.8102-4.8929-2.9609-6.513-5.122-1.4009-1.8806-2.9916-3.0216-5.3731-3.8415-5.5428-1.9009-6.4536-7.8024-2.5009-11.954 1.1608-1.2198 1.4811-1.2603 1.5007-3.2107 0.01-1.4606-0.20031-3.1207 0.15985-4.501 0.63029-2.3901 3.1521-3.9714 4.0225-6.3817 0.98067-2.7208-0.42019-5.6817 0.86062-8.4522 0.65051-1.4005 0.52002-2.7606 0.97022-4.1612 0.35038-1.1305 0.68053-0.7306 1.331-1.6308 0.52002-0.72016 0.39018-0.96087 0.49001-1.8813 0.21009-1.9198 0.97022-2.3601 1.7806-3.7815 1.4609 0.61123 2.4911 1.8709 4.0323 2.3008 0.1703 0.8702 0.81037 1.561 1.0603 2.4508 0.51024-0.0404 1.0903 0.09 1.611 0.0502 0.15007 1.9707 3.6819 4.7417 3.5618 1.1598 0.2499 0.3503 0.49001 0.45989 0.6603 0.96935 0.77057 0.0802 1.6012 1.1814 2.3111 1.0202 0.50045-0.11025 0.80059-1.1814 1.1608-1.6713 0.86062-1.1807 2.1108-1.7711 2.3613-3.4704 1.4211-1.5701 4.8028 0.42988 4.2822-2.8311-1.121-0.58122-0.30014-1.8513 0.65052-1.9113 0.98066-0.06 1.271 1.1403 2.6914 0.55121-0.30993-1.3614-1.2808-2.4221 0.31058-3.5512 1.4811-1.0405 2.8513 0.25897 2.7417-2.261 0.84038 0.0404 1.731 0.27006 2.6412 0.14025 1.5405-0.21984 0.94022-0.34965 1.9907-1.3001 1.3806-1.261 3.1521-1.0907 5.013-1.3705 1.611-0.24005 2.9316-1.0007 4.6626-1.0007 1.4707 0 3.9618 1.1102 5.0025-0.34965 0.97936 0.81476 2.5198 1.3144 3.6708 1.8546z",
+                Kaohsiungcity:"m156.17 440.89c0.0502 0.35029 0.20031 0.66993 0.12984 1.0502-0.0803-0.0111-0.15985 0-0.23032-0.0111-0.27991-0.50033-0.60027-0.33986-1.0309-0.58905-0.39996-0.24006-0.4502-0.63014-0.67009-0.96152-0.44042-0.67973-1.1105-1.3301-1.6312-1.9498-1.0707-1.291-2.0612-2.6908-3.0516-4.002-0.20031-0.27006-0.29035-0.8004-0.56047-0.93021-0.0202-0.06 0.01-0.12003-0.0202-0.17026-0.2499-0.34964-0.93043-0.3803-1.2404-0.63993 0.48022-0.15916 1.1608-0.0691 1.6808-0.0489-0.0202 0.17874 0.0803 0.30007 0.0803 0.47881 0.73077-0.0998 0.16051 0.93086 0.85083 0.96152 0.0202 0.0489-0.0104 0.12916 0.0202 0.17026 0.16964 0.14938 0.42998 0.17873 0.57026 0.30007 0.13963 0.12981 0.2897 0.47032 0.42998 0.63014 0.4502 0.49055 0.67009 0.78018 0.93043 1.3307 0.10961 0.2394 0.18986 0.5199 0.39017 0.72995 0.23033 0.24984 0.45021 0.2805 0.66031 0.47033 0.39018 0.36986 0.55068 0.78996 1.0603 1.06 0.12984 0.51012 0.52002 1.1103 0.78035 1.5408 0.0503 0.01 0.0998 0.01 0.15986 0.0196 0.0515 0.37052 0.29166 0.62036 0.69162 0.56035zm102.79-136.88c-0.15007 0-0.25968 0.0104-0.27012 0.0496-0.24011 0.69082-0.0502 1.1409 0.77057 1.3307 0.30992 1.6406 0.55982 2.8402 0.33994 4.6113-1.5203 0.24984-4.1014-0.3503-4.3226 1.5395-0.03 0.28116 0.51023 0.45011 0.51023 0.82063 0 0.77952-0.28969 0.71038-0.47043 1.2101-0.35038 0.93934-0.79014 1.5401-0.67009 2.6002 1.8015-0.20092 1.0309 0.68037 2.0109 1.3307 0.79015 0.53947 1.8413 0.33986 2.7717 0.39009-0.0692 0.3503 0.20096 0.81019 0.19052 1.0705 1.4609-0.61057 3.342 2.9113 3.1417 4.0412-1.0205 0.36987-1.1705 1.0705-0.95065 1.7704-0.8704 0.52056-2.052 0.29029-2.9818 0.6308-1.2006 0.42988-2.0409 1.3803-3.2115 1.9302-1.331 0.61122-2.4716 0.88129-3.832 1.2009-1.731 0.41031-2.2615 1.1507-3.3315 2.3412-0.7497 0.8291-1.4511 2.291-2.3411 2.9609-0.82929 0.61906-2.7012 0.25897-3.3113 1.2303-0.57026 0.92043 0.14028 3.2114-0.0202 4.3106-0.0698 0.54012-0.45021 0.92043-0.5011 1.4906-0.06 0.75996 0.29035 1.4514 0.17095 2.1703-0.28056 1.6204-1.6716 1.2616-2.3515 2.6608-0.30014 0.63014 0.21009 1.1807-0.35038 1.8011-0.39018 0.42075-1.4211 0.53034-1.9411 0.57013-0.27012 1.03 0.81037 1.291 1.611 1.5004 0.14028 2.6504 0.4104 5.9629-0.0998 8.5135-0.1703 0.91912-0.77057 2.0294-1.3604 2.8311-0.47043 0.63928-0.88997 0.75996-1.0498 1.5904-0.2101 1.0907 0.21988 0.88128 0.54025 1.5316 0.33015 0.66929 1.7604 2.621 0.96044 3.4808-0.89063 0.96087-2.9414-0.47098-3.462 1.1898-0.44108 1.4103 1.3108 2.0711 0.30013 3.6308-0.6205 0.95044-2.2419 1.6406-3.0118 2.4208-1.9809 2.0105-3.1514 6.702-1.6005 9.2728 0.24011-0.0189 0.55982 0.0802 0.79014 0.0502 0.53046 1.3999-0.06 3.1312 0.18009 4.6322 0.27012 1.6608 2.1212 2.0796 2.0305 3.651 1.9711-0.24005 1.7408 0.76061 1.8315 2.3308 2.0305 0.0189 1.3911 1.0705 0.28056 1.6497-0.0502-0.12916-0.11027-0.2394-0.18008-0.3503-0.74056-1.0796-3.5012-2.3901-4.7924-2.2799-1.4609 0.12916-2.3215 1.1298-3.5116 1.6797-1.2103 0.56035-2.1714 0.19048-2.0214 2.1409-2.251 0.10959-4.1125-0.60079-4.5021-3.1214-1.641-1.0705-2.9218-2.3105-4.8126-3.0209-1.1307-0.4201-1.7206-0.54012-2.9916-0.33007-1.2404 0.20091-1.5007 0.60013-2.4716 1.0202-0.30014 0.8702-1.4909 1.7293-2.071 2.5408-2.0011-2.0907-2.8122-4.2303-5.9936-3.561-1.38 0.28963-2.4409 1.2205-3.8013 1.7-1.1307 0.39074-2.9224 0.27006-3.8431 1.0802-0.90042 0.79062-1.0309 1.9707-1.8308 2.7104-0.71055 0.64972-1.791 1.9204-2.6314 2.3803-2.0312 1.1005-5.9232 0.28898-7.724-0.50098-1.0505-0.46054-2.3913-0.88064-3.6519-0.55056-1.5712 0.4214-1.4309 1.1703-1.3408 2.8409 0.0502 0.91064 0.73012 3.1996 0.33994 4.0014-0.45999 0.93021-1.1705 0.17874-1.6808 0.77887-0.35038 0.41097-0.15986 1.4814-0.15986 2.0516 0.01 2.7815 0 5.5617 0 8.3321 0 1.2101 0.2499 2.9309-0.36995 3.972-0.84038 1.4097-1.4707 1.079-1.4609 3.1996v4.3327c0 1.5604-0.39996 2.3706-0.68053 3.6602-0.58005 2.7815 0.28057 5.4221 0.64008 8.0118 0.18008 1.2407 0.39018 2.7411 0.2101 4.0014-0.32037 2.1514-1.2606 1.0007-2.3411 2.1709-1.3604 1.4814-0.50045 6.3817-0.50045 8.3321v0.21005c-0.92064-0.63993-1.301-0.42141-2.6614-0.54013-2.4213-0.23092-3.0118-2.5806-5.043-3.6308-1.4211-0.72995-2.1316-0.82911-3.2519-1.9107-0.96044-0.93086-2.4416-2.2009-3.2617-3.1918-0.2499-0.52055-0.8704-1.291-1.4309-1.5206 0.11027-0.53034 0.39018-0.50034 0.93043-0.47033 0.01 0.06 0 0.11024 0.0202 0.15982 0.03 0.0104 0.0698 0.0196 0.0998 0.03 0.0502 0.18982 0.15986 0.2805 0.2101 0.47032 0.2499 0.11024 0.69032 0.21005 0.86061 0.3914 0.24011 0.2394 0.2101 0.69994 0.50045 0.85911 0.28056 0.15982 0.91085-0.0189 1.1908-0.0496 0.46065-0.0404 0.72034 0.0404 1.181 0.14025 0.0104 0.69929 0.90041 0.25049 1.2508 0.7306 0.15007-0.97066-1.2208-1.2407-1.8713-1.7006-0.33994-0.24005-0.82016-0.45988-1.1105-0.74038-0.39997-0.39075-0.36995-0.78997-0.57026-1.2401-0.40976-0.8702-1.7108-0.54012-2.3809-1.3105-0.38039-0.42988-0.24011-0.88064-0.5807-1.3001-0.25968-0.33008-0.71054-0.60014-0.99045-0.93935-0.30993-0.36986-0.75035-0.66993-1.1307-1.0111-0.42019-0.39074-0.7001-0.91064-1.0303-1.3797-0.61071-0.83041-1.2006-1.6504-2.0116-2.231 0.42019-0.0307 1.331-0.17091 1.6912 0.03 0.40975 0.23027 0.36995 0.93086 0.55982 1.3803 0.38039 0.17026 1.4106 0.63015 1.3708 1.06 0.81037 0-0.35038-1.1011-0.56048-1.1898-0.19052-0.42075-0.23032-0.82975-0.49-1.1703-0.25969-0.33072-0.61007-0.48011-0.82995-0.86041-0.2499-0.44945-0.23032-0.57992-0.80058-0.84998-0.46-0.22048-0.86062-0.16047-1.3408-0.29028-0.81037-0.24006-1.5307-1.15-2.1714-1.6993-0.94021-0.81018-0.88084-1.3999-0.88084-2.6217v-2.1807c0-0.33073-0.0698-0.71038 0.1305-0.94 0.15985-0.19048 0.6603-0.23092 0.89062-0.42075 0.36017-0.31964 0.81037-1.06 0.91086-1.5206 0.15985-0.80105-0.29036-1-0.63029-1.6106-0.06-0.0307-0.12985-0.0496-0.18009-0.0698 0.39997-0.24984 0.70011 0.12981 0.96044 0.36073 0.40976 0.34965 0.47044 0.40966 1.1007 0.37965 0.0502-0.88976-0.0502-1.8891-0.38039-2.6706-0.97023-0.0907-0.88084 0.31051-1.1203 1.0405-0.50045 0.06-0.59049-1.3196-0.69032-1.73-0.16051-0.68103-0.74056-1.261-0.8704-1.9413-0.0698-0.39987 0.0698-0.77039-0.12984-1.1207-0.1703-0.30007-0.61072-0.45989-0.79015-0.75996-0.35037-0.61123 0.11027-1.2701-0.48022-1.8206 0.23033-1.4103-1.5307-2.2505-2.1616-3.1612-0.57026-0.82128-0.7001-1.6915-0.82995-2.6608-0.29035-2.0405-0.54024-1.5904-1.8713-2.9713-0.88084-0.91064-0.64008-1.3301-0.8306-2.6713-0.32036-2.2505-1.4811-4.1716-1.5105-6.4919-0.0202-2-0.53046-3.8911-1.3604-5.6517-1.1405-0.27006-1.581-1.4508-1.7806-2.9002 1.761-1.7802 6.1437 0.52055 7.784-0.42988 0.55003 2.4312 3.4816 1.9198 4.8524 2.9113 0.99046-0.76061 3.492-0.38031 4.8531-0.43054 2.0514-0.0796 3.6819 0.53034 5.4827 0.69147-0.20031 1.3601 1.2906 1.0496 2.1812 0.84019 1.5405-0.33986 0.93043-0.50098 2.0011-1.5701 1.2808-1.2707 2.8317-1.3007 4.0323-2.7711 0.64008-0.03 1.3108-0.03 1.9509 0-0.10962 0.84019 0.27012 1.0705 1.0603 0.97 1.121-0.12981 0.51023-0.54012 0.97088-1.3203 0.55982-0.94978 1.2906-2.06 2.0312-3.1312 0.74055-1.09 1.7708-2.1403 2.2915-3.3706 0.63029-1.471 0.64008-2.3008 1.6906-3.591 0.81037-1.0111 1.2103-2.0007 2.281-2.6223 0.64008-0.36922 1.0505-0.0796 1.5809-0.75996 0.29035-0.36922 0.24011-1.3601 0.45021-1.8611 0.7001-1.6504 1.761-1.7 3.1815-2.3405 0.91085-0.41031 2.1212-1.4214 2.8317-2.1703 1.6808-1.8011 2.5009-3.7515 4.8727-4.8018 2.251-0.99023 3.0614-3.1207 3.9122-5.5415 0.94021-2.6608 2.221-4.0614 3.7217-6.321 1.0407-1.561 4.0023-3.0216 4.3324-4.6824 0.24011-1.2198-0.58984-1.9002 0.38104-3.1696 0.76013-1.0007 1.5203-1.0802 1.6501-2.4606 0.15007-0.06 0.29035-0.0202 0.4502-0.06 0.0104-0.54012-0.23097-0.99088-0.63028-1.3007 0.01-0.0496 0.0189-0.10959 0.03-0.17026 0.12919-1.0496-0.43063-2.4306-0.71054-3.3308-0.65052-2.0509-1.3911-4.9316-0.64008-7.1521 0.8704-0.14025 2.8115-0.12916 3.6519 0.14025 1.5209 0.51012 0.67009 1.8513 1.9809 2.5114 2.8715 1.4508 2.482-2.7013 4.0121-3.8409 1.1405-0.85128 1.9809-0.11089 3.171-0.66145 0.35038-0.15982 1.9509-1.8402 2.1714-2.1305 0.65052-0.85063 0.5011-2.1207 1.4909-2.7515 0.98066-0.61971 2.6516-0.25963 3.8124-0.31964 0.28056-1.4306 0.39996-2.5506 1.821-3.1918 0.96109-0.42075 3.3315 0.25049 4.0519-0.39922 0.36995-0.33986 0.77122-2.8918 1.1105-3.6015 0.53046-1.1103 0.86061-2 1.2103-3.1514 0.38039-1.3105 0.82081-2.2805 2.1714-2.7593 1.2006-0.43053 3.0908 0.23941 4.0114-0.70059 0.21009-0.21983 0.36995-1.3601 0.6205-1.7202 0.27991-0.41031 0.93043-1.0802 1.3206-1.3418 1.0302-0.66928 2.4011-0.8004 3.5514-0.94978 1.1816-0.14025 1.9914-0.2094 2.6914-1.1298 0.79015 0.0802 1.821-0.27984 2.4018-0.88977 0.24989-0.0691 0.50044-0.12981 0.74055-0.18004 1.2208-0.24984 1.0903-0.11024 2.1714 0.36987 1.5509 0.69081 2.9316 0.59035 4.8022 0.69994 0.0104 0.33008 0.25055 0.55056 0.2101 0.93087 0.35037-0.0104 0.74055 0.27985 1.1307 0.23027 0.14942 0.98109-0.26033 1.7104-0.29035 2.6217 0.14028-0.0104 0.32037 0.0104 0.46065 0.0404 0.0176 0.12981-0.0124 0.30986-0.0124 0.45924z",
+                Pingtung:"m166.08 473.61c0.38039 0.47033 0.52002 0.84019 0.50045 1.4403-0.0398 0-2.1408 2.4514-2.3515 2.681-0.8704 0.88912-2.5212 1.7104-2.9016-0.16047 1.2808-0.74952 0.64008-2.0405 1.3206-3.1116 0.71054-1.1279 2.2615-0.91913 3.432-0.84933zm69.867-77.268c0.47044 1.2205-0.3693 2.9909 0.65052 4.0907 0.52002 0.57013 2.9218 1.4305 3.7119 1.7906 1.121 0.51012 1.121-0.18982 1.5007 1.1598 0.19052 0.6608 0.10961 1.9198 0.12984 2.5414 0.0692 1.8611-0.53046 2.5806-2.1016 3.4912 0.61137 1.8317 1.1307 5.6928-0.85017 7.1521-1.0107 0.75017-2.7613-0.18983-4.0121 0.32029-0.88997 0.36074-1.6605 1.4814-2.5414 2.1207-1.4106 1.0411-1.9607 1.03-3.802 1.2205-1.0603 0.10959-2.822-0.19047-3.5318 0.78997-0.73077 0.99153 0.25968 2.6413-0.1305 3.8722-0.39018 1.2205-1.6312 2.06-2.0005 3.3412-0.35038 1.2094-0.2499 1.8806-1.0002 2.9498-0.73077 1.0405-1.2906 1.76-1.701 2.8807-0.77057 2.0907-1.0303 4.201-1.1601 6.4828-3.0314 0.03 0.39932 5.3817 0.74056 6.1919 0.7001 1.6797 1.1608 5.4508 0.63029 7.0425-0.32037 0.96935-1.2006 2.1507-0.51024 3.4612 0.76079 1.4299 1.8015 0.21004 2.9616 1.0404 1.2704 0.90021 1.9013 5.1312 1.6808 6.6022-1.6612 0.0698-4.0114 0.74039-4.472 2.3601-0.25055 0.87085-0.0411 2.1011-0.18008 3.0013-0.10962 0.77105-0.46 1.6915-0.30014 2.471 0.48022-0.0802 0.8704 0.21983 1.2808 0.21983 0.45021 2.0516 2.0011 1.5401 3.5318 2.6419 1.671 1.1807 1.581 2.4808 1.4707 4.6406-2.2412 0.03-2.3711 1.6902-2.2817 3.5004 0.86061-0.0685 2.9414 0.40053 3.6421 0.82063 1.9711 1.1703-0.77058 1.8017-0.47044 3.1807 0.90042-0.12003 1.1908 0.50163 1.0002 1.3418 1.8511 0.0992 2.1212 0.57013 3.4712 1.1807 1.1908 0.53947 3.2421-0.0307 3.5318 1.6412 1.8008-0.23092 1.5907 1.9498 3.4418 0.99936 0.73077-0.38031 1.9711-1.7208 2.681-2.4508 0.33081 1.1598 0.67009 2.3608 0.39997 3.3608-0.2101 0.82062-0.6205 1.0907-0.71055 2.1207-0.09 0.91977-0.12984 1.7208-0.30013 2.5506-0.56048 2.7398 0.29035 6.411 0.0998 9.5931-0.98066 0.4201-1.2612 1.8206-0.97022 2.8611 0.38039 1.3601 0.94021 1.4292 2.4716 1.3601 0.09 0.48011 0.09 1.1403 0 1.6106-0.73077 0.6608-1.4511 0.59035-1.8113 1.531-0.33015 0.8702 0.0111 2.5617 0.0111 3.501 0 0.98044-0.27012 2.4103-0.0111 3.3406 0.32036 1.1011 1.2508 1.2101 0.98067 2.6308-0.61985 0.12981-1.2006 0.24006-1.7806 0.39988-0.0411 0.55056-0.21989 1.0404-0.21989 1.6002-1.5509 0.40966-0.93042 0.77104-1.4707 1.8702-0.70076 1.3908-0.68053 0.85976-2.3013 1.2003-2.5212 0.53034-2.0409 2.4814-2.0409 4.8011 0 1.8506-0.60028 4.9218 0.72033 6.2923 0.67988 0.69994 1.151 0.45989 1.6207 1.3712 0.29035 0.58971 0.38039 2.4808 0.30014 3.1507-1.7708 0.45989-1.8106-1.2309-2.7606-2.1905-0.51024-0.51991-0.95066-0.4899-1.3911-1.1207-0.34972-0.5199-0.4104-1.2198-0.82994-1.8004-1.0603-1.4703-1.8811-0.78018-3.5018-1.3608-0.71054-0.25962-1.2906-0.91977-1.9907-1.1814-0.59048-0.21983-1.3506-0.18982-1.9711-0.36008-0.79014-1.5003-4.5021-2.561-5.3327-0.44032-0.49001 1.2401 0.79014 1.6008 0.63029 2.8011-0.16965 1.3203-1.6606 1.3705-2.6712 1.8206-0.53046-0.78018-1.6605-1.4606-2.0011-2.1507-0.47956-0.97001-0.1592-2.7208-0.1592-3.8311 0-1.3007 0.1703-2.7208 0-4.0014-0.23097-1.7606-0.99111-1.5401-1.962-2.711-0.83973-1-0.69945-1.8891-1.0798-3.0809-0.20096-0.63079-0.65052-0.79061-0.63029-1.5506 0.03-0.82976 0.50958-0.75996 0.66944-1.501 0.12071-0.55056-0.25903-1.5095 0-2 0.51023-0.96087 0.56047-0.12068 1.331-0.66081 0.81038-0.55056 1.8511-2.1311 0.53046-2.8611-0.24011-0.39987-0.43063-0.99088-0.50109-1.4508 0.44041 0.0802 1.0107-0.12982 1.4518-0.0496 0.20944-1.2505 0.42933-2.4814 0.36016-3.8115-0.0998-1.8806-0.36995-1.8206-1.4707-3.0411-1.6906-1.8904-0.35038-4.8911-1.0309-7.2923-0.35038-1.2309-1.4909-1.8402-1.8008-3.1709-0.30013-1.291-0.13962-2.4599-0.54024-3.6608-0.8704-2.5695-3.1521-3.0007-4.3722-5.3014-0.60027-1.1292-0.46064-2.471-0.46064-3.8715 0-1.6112-0.46065-2.3608-1.0009-3.6713-0.84038-2.0405-2.0409-3.6817-3.7217-5.291-0.85082-0.82063-1.7304-1.2805-2.1108-2.381-0.54025-1.5395-0.65051-1.79-1.7108-3.1612-1.6508-2.1403-3.1019-2.7208-5.4632-4.0105-1.0714-0.5897-2.7117-0.83954-3.5018-1.8311-1.3904-0.17939-3.3518-0.50034-4.3722-1.2903-0.89063-0.7006-1.3108-1.8409-2.131-2.6719-1.7708-1.7906-4.8531-2.3797-6.0034-4.3706-0.72033-1.2401-0.95065-1.8617-2.1212-2.8709-0.2101-0.17026-0.39018-0.31051-0.55004-0.42075v-0.2094c0-1.9504-0.86061-6.852 0.50045-8.3321 1.0805-1.1703 2.0214-0.0202 2.3411-2.1709 0.18008-1.2603-0.03-2.7593-0.2101-4.0014-0.36017-2.591-1.2208-5.2316-0.64008-8.0118 0.28057-1.291 0.68053-2.1011 0.68053-3.6602v-4.3327c-0.0104-2.1207 0.62051-1.79 1.4609-3.1996 0.6205-1.0411 0.36995-2.7606 0.36995-3.972 0-2.7711 0.01-5.5519 0-8.3321 0-0.57013-0.19052-1.6412 0.15986-2.0516 0.51023-0.60014 1.2208 0.15003 1.6808-0.77888 0.39018-0.8017-0.2897-3.0907-0.33994-4.002-0.09-1.6712-0.23032-2.4208 1.3408-2.8402 1.2606-0.33007 2.6014 0.09 3.6519 0.55056 1.8008 0.78997 5.6935 1.6002 7.724 0.50099 0.84039-0.45989 1.9209-1.7306 2.6314-2.3803 0.80123-0.74039 0.93042-1.9198 1.8308-2.7111 0.92064-0.80953 2.7117-0.69016 3.8431-1.0796 1.3604-0.47946 2.4213-1.4103 3.802-1.7 3.1815-0.66994 3.9912 1.4703 5.993 3.561 0.58071-0.81019 1.7708-1.6706 2.071-2.5408 0.97022-0.4214 1.2306-0.82127 2.4716-1.0202 1.271-0.21005 1.8615-0.09 2.9916 0.33008 1.8909 0.71038 3.1717 1.9504 4.8126 3.0209 0.39083 2.5206 2.251 3.231 4.5021 3.1214-0.15007-1.9504 0.81037-1.5806 2.0214-2.1409 1.1908-0.54991 2.052-1.5506 3.5116-1.6797 1.2912-0.1109 4.0519 1.2003 4.7931 2.2799 0.0672 0.10763 0.12789 0.21787 0.17747 0.34703z",
+                Taidong:"m327.47 304.02c-0.32036 0.81019-0.64007 1.6302-0.96044 2.5004-0.7001 1.9204-0.23097 3.9309-0.55068 5.9518-0.27013 1.7417-1.1601 3.3412-1.4407 5.0627-0.25055 1.5904-0.0196 4.8415-1.181 6.0614-1.0903 1.1598-3.1417 1.2309-4.3122 2.6908-1.3108 1.6412-1.6508 2.9713-1.761 5.2519-0.0803 1.5708 0.36995 4.6217-0.50045 5.8116-0.76079 1.0607-2.852 0.77105-3.5723 2.3712-0.63095 1.4208-0.0698 3.651 0.0692 5.0712 0.29035 2.8611-0.1703 8.1527 3.7322 7.8129-1.0798 0.39009-1.35 1.6002-2.2308 2.1403-0.63029 0.39922-1.3004-0.0496-2.0116 0.50033-0.47956 0.36073-0.58983 1.1403-0.93042 1.3608-1.8211 1.1598-5.4827 0.12981-4.8126 3.9413 0.0502 1.7104-0.68053 3.561-1.331 4.8311-0.61072 1.1703-0.32037 2.4599-0.71055 3.621-0.42998 1.2805-1.4909 2.441-1.9607 3.732-0.44042 1.1807-0.36995 2.2199-1.0407 3.3216-1.301 2.1305-4.1621 2.5108-4.9229 4.8716-0.4502 1.3803-0.0907 2.3405-0.88084 3.591-0.59048 0.93021-1.0498 1.9504-1.7003 2.8611-0.42085 0.60013-0.98067 0.85063-1.2912 1.4814-0.25968 0.51991-0.10048 1.319-0.3693 1.8304-0.70075 1.2707-2.1114 0.97001-1.992 2.8409-2.2204 0.12003-6.4138-0.59035-7.4441 2.0607-1.0798 2.7698 0.82082 4.9603 1.6312 7.1319 0.71054 1.8898-0.31971 2.0411-1.5007 2.7111-1.5607 0.88063-1.1301 1.1403-1.331 2.9609-0.24989 2.2799-3.1619 3.1696-4.5223 5.1605-0.03 0.0502 0.01 0.39139-0.0104 0.48011-0.97023 0.75995-2.3913 1.1298-3.312 1.8904-0.93042 0.75996-1.2006 2.321-2.3313 2.9707-1.0107 0.59035-2.5212 0.14938-3.7021 0.6308-1.2208 0.50098-1.6312 1.5199-2.5009 2.5004-1.6012 1.8102-4.4022 2.1109-5.9232 3.9218-0.64008 0.74104-0.90041 2.3803-1.2103 3.2916-0.39931 1.2003-0.57026 2.4006-0.63029 3.7013-0.12005 2.5004-0.17029 4.3712-2.2014 5.8116-1.1203 0.78996-1.9202 0.91064-2.6308 1.9909-0.66095 0.99023-1.1908 2.1605-1.6716 3.3301-0.52003 1.2609-0.4202 2.5206-0.8704 3.8011-0.44042 1.2401-1.181 2.2805-1.5105 3.5408-0.63942 2.4821-0.44042 5.0327-1.181 7.4724-1.8308 0.47098-1.5607 4.6824-2.2713 6.203-0.88997 1.9002-1.2997 3.651-1.9111 5.5904-0.57026 1.8108-1.2208 4.4123-2.8017 5.5722-0.85017 0.6308-0.43977 2.3405-0.8293 3.6608-0.28121 0.91978 0.33016 7.2023 0.33016 8.1723 0 0.69016 0.24011 1.5004 0.47956 2.351-0.71054 0.72995-1.9502 2.0705-2.681 2.4508-1.8511 0.95043-1.6416-1.2303-3.4418-0.99936-0.28969-1.6719-2.3411-1.1011-3.5318-1.6412-1.35-0.61058-1.6201-1.0802-3.4712-1.1807 0.19052-0.84019-0.0998-1.4606-1.0002-1.3418-0.30013-1.379 2.4409-2.0105 0.47044-3.1807-0.70076-0.42009-2.7815-0.88911-3.6421-0.82062-0.09-1.8096 0.0411-3.4704 2.2817-3.5004 0.10962-2.1612 0.20031-3.4612-1.4707-4.6406-1.5307-1.1011-3.0816-0.59035-3.5318-2.6419-0.41041 0-0.80059-0.30007-1.2808-0.21983-0.15985-0.77953 0.19052-1.7 0.30014-2.471 0.14028-0.90021-0.0698-2.1305 0.18008-3.0014 0.46-1.6197 2.8115-2.2903 4.472-2.3601 0.21989-1.471-0.4104-5.702-1.6808-6.6022-1.1601-0.8291-2.2014 0.39074-2.9616-1.0405-0.69032-1.3105 0.18987-2.4906 0.51023-3.4612 0.53046-1.5904 0.0698-5.3628-0.63029-7.0425-0.33994-0.81019-3.772-6.1618-0.74056-6.1919 0.12919-2.2805 0.39018-4.3908 1.1601-6.4828 0.41041-1.1207 0.97023-1.8396 1.701-2.8807 0.75034-1.0705 0.65052-1.7404 1.0002-2.9498 0.3693-1.2805 1.611-2.1207 2.0005-3.3412 0.39083-1.2309-0.60028-2.8807 0.13049-3.8722 0.70989-0.98044 2.4716-0.68037 3.5318-0.78996 1.8406-0.19048 2.3913-0.17939 3.802-1.2205 0.88084-0.63927 1.6508-1.76 2.5414-2.1207 1.2508-0.50947 3.0027 0.42988 4.012-0.31964 1.9809-1.4599 1.4609-5.321 0.85018-7.1527 1.5712-0.91064 2.1714-1.6302 2.101-3.4912-0.0196-0.62036 0.0607-1.8806-0.12919-2.5414-0.38039-1.3497-0.38039-0.64971-1.5007-1.1598-0.79079-0.36008-3.1926-1.2205-3.7119-1.7906-1.0205-1.1011-0.18008-2.8702-0.65051-4.0907 1.1105-0.58057 1.7512-1.6308-0.28057-1.6497-0.0907-1.5701 0.14028-2.5708-1.8315-2.3308 0.0907-1.5701-1.7604-1.9902-2.0305-3.6511-0.24011-1.501 0.35038-3.231-0.18008-4.6322-0.23032 0.03-0.55069-0.0691-0.79015-0.0502-1.5509-2.5695-0.38039-7.2623 1.6005-9.2728 0.77057-0.77952 2.3913-1.4703 3.0118-2.4208 1.0107-1.561-0.74121-2.2205-0.30014-3.6302 0.52002-1.6615 2.5708-0.23092 3.462-1.1905 0.80059-0.85976-0.63028-2.8115-0.96044-3.4808-0.32036-0.65037-0.75034-0.44097-0.54024-1.5317 0.15985-0.8291 0.58004-0.94978 1.0498-1.5904 0.59048-0.80171 1.1908-1.9113 1.3604-2.8311 0.51024-2.5506 0.24011-5.8618 0.0998-8.5135-0.80058-0.2094-1.8811-0.47033-1.611-1.5004 0.52003-0.0404 1.5509-0.14938 1.9411-0.57013 0.55982-0.62036 0.0502-1.1709 0.35038-1.8011 0.67988-1.3999 2.071-1.0405 2.3515-2.6608 0.12005-0.72017-0.23098-1.4103-0.17095-2.1703 0.0502-0.57013 0.43063-0.95044 0.5011-1.4899 0.16051-1.1011-0.55004-3.3908 0.0202-4.3112 0.61072-0.97 2.4814-0.61122 3.3113-1.2303 0.89062-0.66993 1.5907-2.1318 2.3411-2.9609 1.0714-1.1905 1.6012-1.9309 3.3315-2.3405 1.3604-0.32029 2.5009-0.59036 3.832-1.2016 1.1705-0.54991 2.0109-1.5004 3.2115-1.9302 0.93043-0.33986 2.1114-0.11024 2.9818-0.6308 0.17943 0.65037 0.66031 1.3105 1.0309 1.7208 0.99046 1.1103 2.1401 2.0516 2.4905 3.7111 0.36082 1.7404 0.0111 2.8311 1.2508 4.2114 0.97023 1.0705 3.2617 0.81018 3.4118 2.09 1.4002 0.0907 4.1217-0.14938 5.133 0.69081 1.5209 1.2609 0.36016 3.1918 3.0014 3.3412 1.5509 0.09 3.3022-1.4508 4.8531-0.33986 1.3108 0.94979 1.4302 3.1996 1.5098 4.8115 0.81038 0.0489 1.6508 0.01 2.4514 0.06 0.06 1.03-0.03 2.1305 0.19052 3.1312 0.30014 1.3503 2.1414 2.1807 3.4816 2.03-0.33994 1.5095 0.63029 1.561 1.8315 1.501 0.21988 0.94 1.2208 1.4703 1.7408 2.2603 0.52002 0.79061 0.58918 1.9707 1.611 2.3908 2.131 0.89043 4.7226-0.91064 6.6533-1.03 0.11027-1.2694-0.28057-2.3712-0.14094-3.6413 0.0998-0.93934 0.9611-2.0105 0.9611-2.8696 0.0104-1.3203-1.2704-1.7606-1.2912-2.972-0.0196-1.2101 1.0603-2.2407 2.3013-2.0209 0.88084-2.3405 1.671-4.7117 2.8317-7.0118 0.63029-1.2505 0.03-2.6008 0.53046-3.8115 0.47044-1.1605 1.9914-1.3908 2.6308-2.4906 0.70011-1.2094 0.42998-2.6308 0.54025-4.0014 0.12071-1.4703 0.70989-2.2205 1.1705-3.501 0.15007-0.4201 0.0411-1.3503 0.48022-1.6406 0.50045-0.33007 1.5607 0.57013 2.2014-0.06 0.69031-0.69994 0.28969-2.6217 1.1503-3.471 1.0009-0.99153 2.5316-0.66993 1.5007-2.1709-0.30014-0.42988-2.1708-1.8304-2.6412-2.0202-0.10961-1.8709 0.12985-3.3914 0.84039-4.9414 1.2306-0.71038 0.7001-3.6308 2.2713-3.4012 0.68053-0.97001 2.4605-0.45011 2.2308-2.2707 1.0909-0.64972 2.9113-0.31964 3.9722 0.14025 0.41041 0.18004 1.1405 0.85128 1.5307 0.96087 0.62572 0.18004 1.1164-0.10894 1.7564-0.1396zm-3.9279 119.23-0.0202-0.18004c0.23097-0.12003 4.063-0.30985 4.3722-0.0189 1.5209-0.91064 2.4018-0.82975 2.6614 0.99088 0.15986 0.0404 0.29035 0.0196 0.45021 0.06-0.48022 0.80105-0.81037 1.7704-1.0002 2.7815-0.79015 0.12916-0.75035 0.21984-0.95066 0.82911 0.27013-0.0496 0.66031 0.0802 0.94022 0.0502-0.0607 0.78018 0.09 1.6302 0.33994 2.2694-1.5412 0.83041-3.4522-1.6706-5.1128-1.9902-0.21988-0.40053-0.29035-0.98044-0.17029-1.441 1.7003-0.91978-1.5509-2.3301-2.052-3.0307 0.1318-0.3105 0.29231-0.30007 0.5422-0.32029zm19.79 101.38c0.68053 1.6706 0.32037 2.231 0.33994 3.9518-1.301 0.17939-2.3222-0.39922-3.6121-0.33986-1.3611-2.1709-2.5616-3.0307-5.0025-3.171-0.60028-1.2609-2.6112-2.2407-3.573-3.4312-0.70989-0.88064-0.47043-2.1905-0.79014-3.201-0.27013-0.84019-1.7408-2.1005-1.3108-2.8109 0.8704-0.0802 1.5712 0.20026 2.4513 0.15982 0.0405 0.15916 0 0.30006 0.0502 0.44945 1.8106 0.0907 5.5428 0.55969 6.9834-0.41031 0.23098 0.81018 0.11027 0.33007 0.64008 0.8004 0.0104 0.58122 0.03 1.1905 0.0405 1.7802 0.15986 0.0404 0.30014 0.0104 0.46065 0.0502 0.2101 1.09-0.47043 1.1807-0.65052 1.6706-0.21988 0.61122-0.36995 1.1102-0.30014 1.9504 1.0903-0.18005 1.1105 0.85063 1.1608 1.6608 0.82994 0.03 0.68052 0.0496 1.0009 0.66994 0.70076-0.0398 1.4615 0.0307 2.1114 0.22048z",
+                Hualien:"m262.01 324.77c-0.21989-0.69994-0.0698-1.3999 0.95065-1.7704 0.20031-1.1298-1.6808-4.6517-3.1417-4.0411 0.0104-0.25897-0.25903-0.72017-0.19052-1.0705-0.93043-0.0496-1.9809 0.14938-2.7717-0.39009-0.98001-0.65037-0.20944-1.5317-2.0109-1.3307-0.12006-1.06 0.32036-1.6602 0.67009-2.6002 0.18008-0.50098 0.47043-0.43053 0.47043-1.2101 0-0.36921-0.54025-0.53947-0.50958-0.82062 0.21988-1.8898 2.8017-1.291 4.3226-1.5395 0.21988-1.7717-0.0307-2.972-0.33994-4.6113-0.82081-0.18983-1.0107-0.63993-0.77057-1.3307 0.0104-0.0404 0.12005-0.0496 0.27012-0.0496 0.2897-0.0196 0.72033-0.0104 0.84039-0.12981 0.20031-0.2094 0.15985-0.61057 0.47956-0.88977 0.8704-0.74104 0.48022-0.69081 1.7108-0.94978 0.72033-0.15004 1.4707-0.15004 2.1414-0.36987 0.14941-2.4906-2.191-1.9504-1.3108-4.3112 0.61985-1.6497 1.3304-3.3301 2.3802-4.8004 1.8713-2.6413 7.6137-2.561 10.085-0.72016 0.49001-0.7704 1.331-0.90021 2.0116-1.3405 0.10961-1.8311-0.2101-3.5715-0.0998-5.4417 1.6312-0.48011 1.4106-0.72017 1.7806-2.1709-0.27012 0.06-0.68053-0.0998-0.95065-0.0496-0.13963-0.78018-0.24011-1.6308 0.61136-1.8409 0.03-0.12003-0.0307-0.34899 0.06-0.43966 1.1601-0.5597 2.0514 0.60013 2.972 0.31963 0.48022-0.14025 1.4309-1.9002 1.5209-2.321 1.0198-0.71104 1.1908 0.20939 1.9411 0.20026 0.57026-0.0104 1.1014-0.32029 1.6716-0.42988 0.50045-0.71038 0.10961-1.3503 0.3693-2.1311 0.33994-1.0502 0.72033-0.5897 1.1712-1.3803 0.55982-1.0007-0.16051-2.3608 0.2499-3.441 0.39017-1 1.7003-1.7404 1.9111-3.0209 0.16051-0.9002-0.59049-1.5003-0.51023-2.3308 0.0907-0.8291 0.73011-1.2505 0.84038-2.3308 0.09-0.88064 0.0998-1.9707 0.01-2.8402-0.23946-2.1207-1.81-2.2805-2.0109-4.1612-0.2897-2.8213-0.2897-2.651-2.972-3.201-0.27991-1.4808 1.331-3.6113 2.7822-3.8311-0.17095-1.4103-0.24011-2.9211 0.21988-4.2812 0.53046 0 0.77971-0.2805 1.2808-0.39074 0.69031-1.3405 0.51023-3.06 1.1503-4.471 0.23097-0.5199 0.69031-0.65037 0.88083-1.1703 0.14094-0.3803 0.0411-0.93087 0.16051-1.3307 0.27013-0.84019 0.70011-1.2609 1.0303-1.9804 0.21988 0.0404 0.55003-0.0202 0.78036-0.0502 0.0698-1.3803-0.80059-5.8018 1.331-5.6615 0.1703-3.3816 0.51024-6.7822 0.33994-10.124-0.69945-0.0404-1.4204-0.01-2.1205-0.0502-0.12005-2.4808 0.64008-3.4312 1.3206-5.4717 0.42998-1.2903 0.75034-2.0607 1.3708-3.291 0.73011-1.4508 0.47108-2.4006 0.6205-3.8813 0.21988-2.2505 0.96109-1.0196 2.4611-1.8709 0.85996-0.47945 1.5405-1.6706 2.2112-2.4306 1.2912-1.4703 2.1812-4.9414 0.45999-6.1716-0.82994-0.59035-2.3313-0.90021-3.2513-1.5708-1.181-0.8702-1.0707-1.2903-2.8513-1.3105-0.23098-0.72017-0.3308-1.6902-0.0698-2.351 0.30013-0.72995 0.97022-0.77039 1.2208-1.2505 0.3804-0.70973 0.03-1.5304 0.32037-2.2199 0.42019-0.97979 0.4104-0.5199 1.3708-0.95043 1.6012-0.71038 2.4213-1.1814 3.6023-2.2205 1.2201-1.06 1.9411-0.93022 3.6721-1.0196 0.17943-0.80105 0.14028-1.6712-0.78036-1.8408-0.0998-1.1605 0.1305-1.5904 0.55069-2.1612 0.16964-0.21983 0.36995-0.47033 0.60028-0.8004 0.47108-0.67972 0.82994-2.3706 1.5209-2.9707 0.94087-0.82063 2.7326-0.0802 3.312-1.0307 0.59048-0.97979-0.35038-3.0607-0.01-4.1723 0.44042-1.4103 1.7304-1.4201 2.5205-2.4899 0.53046-0.74104-0.01-0.95043 0.82082-1.5108 0.49-0.33986 1.151-0.20026 1.7108-0.66994 0.78036-0.63014 1.7519-1.5095 2.1218-2.3301 0.50045-1.1403-0.30079-2.8317 0.20031-3.972 0.24011-0.54991 1.4504-1.7098 2.2412-2.1807 0.0411 0.0907 0.0907 0.18004 0.15007 0.27006 0.4104 0.60014 0.93956 0.39074 1.5712 0.59035 0.74056 0.23027 1.1705 0.87999 1.8811 1.2003 0.46064 0.21005 1.0009 0.27006 1.4302 0.54012 0.44107 0.27006 0.72033 0.59035 1.0805 0.93022 0.15986 0.15003 0.32037 0.25962 0.5011 0.39074 0.2897 0.18982 0.19052 0.21983 0.41041 0.0992 0.3693-0.19048 0.48022-0.66015 1.0407-0.50033 0.24011 0.0691 0.27013 0.21983 0.58005 0.24984 0.25055 0.0202 0.38039-0.0502 0.59049-0.0802 0.45021-0.0698 0.93043-0.06 1.3715 0.0411 0.61006 0.12916 1.1503 0.30985 1.7904 0.36921 0.41106 0.0404 0.84038 0 1.2508 0.0502 0.98067 0.0998 1.151 1.1905 1.761 1.8206 0.62051 0.63928 0.8306 1.3301 1.8106 1.4606 0.81037 0.10959 1.5809 0.01 2.3613 0.2094 0.39018 0.0998 0.82016 0.26027 1.2397 0.22048 0.26034-0.0307 0.47108-0.12981 0.74121-0.0907 0.23946 0.03 0.42019 0.15003 0.66944 0.12068-0.0998-0.25049-0.0398-0.53034-0.0803-0.82062-0.0502-0.47946-0.23032-0.45924-0.60027-0.80954-0.17943-0.17091-0.33015-0.28963-0.27013-0.55969 0.06-0.29029 0.03-0.14938 0.21989-0.14025 0.12984 0.0202 0.15006 0.18004 0.32036 0.17026 0.18987-0.0104 0.30014-0.19048 0.42998-0.31051 0.20031-0.20092 0.41041-0.65037 0.70076-0.72995 0.28904-0.0802 0.39018 0.21983 0.6205 0.10959 0.23946-0.10959 0.21988-0.63015 0.28904-0.84998 0.0901-0.27006 0.30014-0.53034 0.54025-0.66993 0.0502 0.24005 0.23098 0.48011 0.46065 0.53033 0.42019 0.11025 0.40975-0.1409 0.71054 0.23027 0.15986 0.20027 0.2897 0.78018 0.59049 0.58057 0.16964-0.11024 0.16964-0.61057 0.18987-0.80953 0.03-0.27006 0.0803-0.69994 0.0104-0.96087-0.11027-0.42989-0.44955-0.33986-0.74056-0.66016-0.19052-0.21004-0.19052-0.45988-0.33994-0.67972-0.2003-0.27984-0.55982-0.39009-0.6603-0.77039-0.20031-0.75017 0.49001-1.6308 1.2404-1.1305 0.32037 0.21984 0.68053 0.68038 0.95066 0.96022 0.33015 0.3503 0.63942 0.69995 0.98066 1.0411 1.1503 1.1507 0.0803-1.1011 1.2006-0.76061 0.24011 0.0802 0.36016 0.44032 0.55003 0.63015 0.38039 0.3803 0.90041 0.51011 1.2612 0.92043 0.36017 0.41031 0.66031 0.84997 1.1099 1.1598 0.35038 0.25049 0.66095 0.19048 1.0805 0.25049 0.46064 0.0691 0.53046 0.3105 0.90041 0.50033 0.39996 0.21005 0.96109-0.0404 1.3904 0.12003 0.29035 0.11024 0.59049 0.36073 0.8704 0.5199 0.53046 0.29028 0.99111 0.61123 1.5816 0.79062 0.46 0.14938 0.93043 0.12002 1.4204 0.12002 0.53046-0.01 0.92064 0.12982 1.4106 0.29029 0.61985 0.19048 1.4713 0.0196 2.0514 0.33986 0.33994 0.18983 0.60093 0.54012 0.93108 0.72995 0.2897 0.17026 0.58136 0.23027 0.90042 0.31051 0.49066 0.12981 1.5405 0.7606 2.022 0.3803 0.0196-0.01 0.0405-0.03 0.0405-0.0496 0.0796 0.42988 0.18987 0.96022 0.0411 1.3405-0.15007 0.43053-0.76078 0.27006-0.87105 0.88064-2.0905 1.3112-2.9414 2.9218-3.2219 5.4019-0.18987 1.7104-0.15985 2.2805-1.8811 2.8807-1.3708 0.48011-2.1904 0.8702-3.3518 1.6406 0.06 1.1305-1.0107 2.3908-1.9313 2.8311-0.57027 0.2805-1.2802 0.44032-1.8406 0.68037-0.95065 0.39009-1.0707 0.74952-1.7512 1.4508-0.99111 1.0196-1.4217 1.7606-1.5105 3.4006-0.0404 0.92043-0.33993 3.8011 0.61007 4.1416 0.57091 1.9615 0.39083 4.5115-1.2606 5.702-0.63943 0.4501-1.4707 0.72016-2.0612 1.1514-0.61071 0.44945-1.4511 1.3705-1.9411 1.9707-1.8504 2.2812-1.9307 8.5428-0.0698 10.763 0.39997 0.47032 1.0414 0.91064 1.5809 1.0502 0.97023 1.4508 1.7715 3.5506 0.62051 5.2016-0.36017-0.03-0.62051 0.16047-0.95066 0.17026-0.0496 0.1709-0.12919 0.29028-0.17029 0.46054-0.39997 0.0998-0.81037 0.19047-1.2097 0.29028-0.0998 0.23027-0.18987 0.21983-0.2897 0.45989-3.002 0.20026-1.7512 9.1221-1.8615 11.283-0.0907 1.8304-0.86062 3.8611-1.3611 5.5219-0.60028 1.9602-0.44042 3.8813-0.76079 5.972-0.17943 1.2303-1.0603 2.3706-1.8811 3.351-1.1601 1.4005-1.2397 2.1409-1.2397 4.0314 0 1.7508 0.68053 3.9818 0.12006 5.6322-0.53046 1.5806-1.9711 2.5004-2.4912 4.2512-1.0407 3.5708 0.0698 8.1723-1.5607 11.684-0.91085 1.9707-2.0807 2.2107-2.4513 4.5617-0.32037 2.0405 0.23032 4.2114 0.01 6.2623-0.21009 1.8611-1.4002 3.2805-1.761 4.9909-0.41041 1.9609-0.0796 3.9211-0.74056 5.762-0.59049 1.6706-2.1316 4.0907-0.12006 5.4913-0.57026 2.7411-1.4818 5.0418-2.4416 7.4926-0.64008 0.03-1.1307 0.31898-1.7519 0.13959-0.39018-0.10959-1.1203-0.77952-1.5307-0.96087-1.0603-0.45924-2.8813-0.78996-3.9723-0.14025 0.23097 1.8206-1.5503 1.3007-2.2308 2.2707-1.5712-0.23092-1.0407 2.6908-2.2713 3.4012-0.71054 1.5499-0.95065 3.0705-0.83973 4.9414 0.47043 0.18982 2.3411 1.5904 2.6412 2.0202 1.0309 1.501-0.5011 1.1814-1.5007 2.1709-0.86061 0.85063-0.45999 2.7711-1.151 3.471-0.63943 0.63015-1.7004-0.27006-2.2014 0.06-0.44042 0.28964-0.33015 1.2205-0.47957 1.6406-0.46064 1.2805-1.0505 2.0307-1.1705 3.501-0.11092 1.3712 0.1592 2.7906-0.54025 4.0014-0.64008 1.1011-2.1616 1.3301-2.6314 2.4906-0.5011 1.2094 0.0998 2.561-0.53046 3.8115-1.1601 2.3001-1.9502 4.6713-2.8317 7.0118-1.2397-0.21983-2.3215 0.81019-2.3006 2.0216 0.0196 1.2101 1.3004 1.6497 1.2906 2.9713 0 0.85977-0.86061 1.9302-0.96044 2.8702-0.13963 1.2694 0.25055 2.3712 0.14028 3.6406-1.9307 0.12068-4.5223 1.9204-6.6533 1.03-1.0198-0.4201-1.0903-1.6002-1.611-2.3908-0.52067-0.78996-1.5209-1.319-1.7408-2.2603-1.2006 0.06-2.1714 0.0104-1.8308-1.501-1.3415 0.14938-3.1821-0.67972-3.4822-2.03-0.21988-1.0007-0.12919-2.1011-0.19052-3.1312-0.80059-0.0502-1.641-0.0104-2.4513-0.06-0.0803-1.6112-0.20031-3.8618-1.5098-4.8115-1.5509-1.1102-3.3028 0.42988-4.8531 0.33986-2.6412-0.14938-1.4811-2.0803-3.0014-3.3412-1.0107-0.83954-3.7322-0.60014-5.133-0.69081-0.15007-1.2799-2.4416-1.0196-3.4118-2.09-1.2404-1.3803-0.89063-2.471-1.2508-4.2114-0.35037-1.6608-1.5013-2.6008-2.4911-3.7104-0.37778-0.41814-0.858-1.0783-1.0381-1.7287z",
+                ChiayiCity:"m184.85 297.29c0.06 1.2094-0.28056 1.4703-1.301 1.9994-0.12984 0.89042-0.33994 2.5317-1.6005 1.8017-0.42019-0.24005-0.55069-0.76061-1.0805-0.89042-0.39017-0.10959-1.2808-0.14938-1.671-0.09-0.75034 0.12003-1.4707 1.1005-1.9907 1.6706-0.51023 0.57013-1.4113 1.5506-2.3313 1.4005-0.48022-0.50164-0.2499-1.1709-0.67988-1.711-0.52002-0.64972-0.99046-0.55056-0.93043-1.5904-0.71054-0.0404-1.4309 0.0104-2.1414-0.03-0.0698-1.1011-1.1803-0.61057-1.8308-0.55056-0.98001 0.0992-1.4106-0.69994-0.27012-1.0404 0.0998-0.63993 0.76078-1.5904-0.39997-1.501-0.42019-0.53034-0.53046-1.4899-0.6205-2.1403-0.12984-0.97001-0.01-0.91978 0.94022-1.261 0.4502-0.17025 0.91085-0.42988 1.181-0.82062 0.0998-0.0104 0.21989 0.0104 0.30993 0 0.0502 0.33986 0.12005 0.66081 0.19052 0.98044 0.77057-0.0404 0.99045-0.63014 1.6605-0.82062 0.62051-0.17939 1.3911-0.0698 2.0612-0.0998-0.18009-1.3601 1.2606-0.94979 2.1714-1 0.0196-0.34899 0.17029-0.63014 0.42998-0.8291 0.33994 0.21983 0.26034 0.50033 0.48022 0.78018 0.20031 0.27985 0.63029 0.4488 0.79014 0.70973 0.49001 0.77952 0.03 1.2701 1.3004 1.1709 0.0998-0.29029 0.1703-0.57013 0.19053-0.89042 0.38039 0.03 1.5105 0.24005 1.7512 0.49054 0.32036 0.33008 0.24989 1.2101 0.33993 1.6497 0.93108 0.17026 1.3004 0.84019 2.3013 0.85976 0.03 0.4899 0.0398 0.93087 0.10961 1.3914 0.22967 0.17026 0.33994 0.2805 0.64008 0.36073z",
+                ChiayiCounty:"m205.81 336.38c-0.21988 1.0607-1.1216 1.5206-1.8817 0.36073-1.3708-0.30007-2.3515 0.2094-3.8418 0.0998-1.4002-0.11024-1.9013-0.57013-2.6314-1.741-0.35038 1.8611-2.0207 1.8311-2.8611 3.2414-0.0502-0.0104-0.54025 0-0.61071 0-0.38039-0.78018-1.5614-0.45988-1.7219 0.3503-1.3904-0.33986-1.5705-2.1011-3.2813-1.8904-0.0998-0.34965-0.22053-0.72017-0.39083-1.0607-0.5807-0.03-1.2006-0.0398-1.7806-0.06-0.0607-0.85912 0.2897-1.9609 1.1105-2.3405 0.0496-0.85063 0.0496-1.7508 0-2.6008-1.8615-0.20026-1.0414-4.6211-0.97023-6.032 0.0692-1.4397 0.09-1.8096 1.181-2.6706 0.79014-0.62036 1.761-0.39922 1.6207-1.8011-1.9816-0.45989-3.0816-2.0105-5.2733-1.8898-0.48022-2.1403 1.9914-2.3412-0.46064-3.6413-0.10962-0.99936-1.6312-0.98045-2.5009-1.2003-0.1703-1.561 1.9209-0.93935 1.4009-2.6112-2.071 0.44032-2.1512-0.50033-3.9723-1.3601-1.1503-0.54012-2.6915-1.0404-3.6721-1.8506-1.0407 1.4599-3.5318 0.34965-5.0025 0.34965-1.731 0-3.0516 0.76061-4.6626 1.0007-1.8609 0.27985-3.6317 0.10959-5.013 1.3705-1.0505 0.95044-0.45021 1.0802-1.9907 1.3001-0.91085 0.12982-1.8008-0.0998-2.6412-0.14025 0.10961 2.5206-1.2606 1.2205-2.7417 2.261-1.5907 1.1298-0.6205 2.1905-0.31057 3.5512-1.4204 0.58905-1.7108-0.61123-2.6915-0.55056-0.95065 0.06-1.7708 1.3294-0.65051 1.9106 0.52002 3.261-2.8618 1.2609-4.2822 2.8311-0.24989 1.7-1.5007 2.291-2.3613 3.471-0.36016 0.4899-0.6603 1.5604-1.1608 1.6706-0.71054 0.15982-1.5405-0.93934-2.3111-1.0196-0.17029-0.51012-0.40975-0.61971-0.6603-0.97 0.12005 3.5812-3.4118 0.81018-3.5618-1.1598-0.52003 0.0405-1.1007-0.0907-1.611-0.0502-0.2499-0.88912-0.89063-1.5806-1.0603-2.4508-1.5405-0.42989-2.5714-1.6908-4.0323-2.3001 0.03-0.0607 0.0698-0.12068 0.0998-0.17939 0.74056-1.3607-0.0404-3.7313 1.4811-4.471 0.21988-0.1109 0.48022-0.15982 0.7001-0.24006 0.30014-0.12133 0.42019-0.25962 0.67074-0.39074 0.10962-0.0607 0.76014-0.16047 0.82016-0.23092 0.67988-0.80106-2.3815-1.4201-2.6712-1.5199 1.8909-0.17025 6.6232-0.12068 4.6521-3.1814-0.36995-0.0411-0.55003 0.31051-0.80058 0.55969-0.53046-0.42074-1.2103-1.5506-0.93043-2.1011 0.20031-0.39987 0.58005-0.45989 0.56047-0.96935-0.0202-0.45011-0.33993-0.42988-0.0698-0.93087-0.48022-0.0104-0.86061-0.54012-0.81037-1.0104 0.06-0.62036 0.78036-0.88064 1.0505-1.3196 0.49001-0.79127 0.06-2.4019-1.0505-1.9309-0.44042 0.18983-0.44042 0.85977-1.1203 0.69081-0.53046-0.12981-0.70076-0.76061-0.44042-1.2309 0.35038-0.63993 0.78036-0.34965 1.3108-0.5199 0.7001-0.22114 0.38039-0.82128 0.38039-1.441 0-1.2401 0.88084-1.441 1.5607-2.2499 0.72033-0.86042 0.38039-2.0516-0.99046-1.5506-0.18987 0.0796-0.36995 0.31898-0.57026 0.37965-0.25968 0.0907-0.55003-0.0196-0.82016 0.0496-0.27012 0.0607-0.39996 0.33073-0.60027 0.39075-0.36995 0.11024-0.42019-0.0907-0.70076-0.15982-0.21988-0.06-0.63029 0.0104-0.82016-0.0998-0.42998-0.25049-0.17029-0.39922-0.30992-0.75996-0.20031-0.50098-0.73077-0.54012-0.94087-0.99087-0.27991-0.58971 0.21988-1.1905 0.36995-1.7104 0.0803-0.25962 0.0803-0.55969 0.20031-0.79061 0.13963-0.31051 0.36996-0.40966 0.50045-0.69081 0.47043-0.11025 0.58005 0.20091 0.96044 0.33072 0.33994 0.11025 0.80059 0.0405 1.1608 0.0405 0.58005 0 1.8909 0.25962 1.611-0.62036-0.12006-0.36008-0.66031-0.4201-0.55004-0.87999 0.06-0.27006 0.33994-0.35029 0.48022-0.59035 0.70011 0.45989 1.2006 0.95044 1.0505 2.0607 0.32036-0.0502 0.79014 0.12981 1.1105 0.06 0.42019 0.75996 2.9714 0.95044 3.862 1.1403 1.6508 0.35029 3.2317 0.85063 4.8224 1.1605 2.0312 0.39922 3.8724 0.40966 3.522-2.1709-0.0998-0.66994-0.89063-1.3601-0.98067-1.8617-0.14028-0.78997 0.38039-1.5304 0.50045-2.2805 0.33015-0.01 1.5607-0.21983 1.8113-0.03 0.63029 0.47098 0 1.0913 0.36996 1.6412 0.92064 1.3712 2.221 0.69081 1.9907-0.93021 1.9209-0.63993 1.1705-1.1403 2.101-2.7404 0.85082-1.441 1.6207-0.68038 3.342-0.82063-0.10049-0.63993-0.59049-1.1102-0.61072-1.7802 1.0407-0.09 2.161 0.18983 3.1214 0.4501 0.0405-2.2707 0.15007-2.651 2.3515-2.8122 1.4106-0.0998 3.0314-1.0405 2.7019-2.8004 0.88019-0.36008 1.9809-0.17939 2.9414-0.23027-0.2101-1.6615 1.9013-3.0516 3.3615-2.972 1.5007 0.0698 2.3515 2.9511 4.5125 1.6804 0.77057-0.4501 0.54025-1.3203 1.5307-1.6804 0.76013-0.27006 2.1512 0 2.9616 0 0.90041 0 1.9411 0.14025 2.8017-0.0398 0.96044-0.19048 1.38-0.86041 2.5114-0.60013 0.2499 1.3105 1.6207 1.8806 1.7206 3.1109 0.23098-0.0189 0.55004 0.0802 0.78036 0.06 0.80059 4.1514 4.6123 2.6112 7.694 3.3014 1.7114 0.39074 2.8115 1.291 4.8531 1.1703 1.7519-0.10959 3.1514-0.85976 4.9627-0.81019 0.35038 2.1514 0.06 3.1012 2.6614 2.4514 0.24011-0.49055 0.46064-0.47946 0.82994-0.79062 0.20096 2.0516 2.452 0.69994 3.5423 0.65037 1.4811-0.0692 3.6121 1.4103 5.0025 1 1.1007-0.33008 0.80059-0.71038 0.79015-1.8311 0-0.53034 0.09-2.0209-0.12071-2.5114-0.25903-0.62036-1.2306-0.4899-1.3604-1.3405-0.06-0.42988 0.64007-1.2003 1.1405-1.4305 0.2101 0.12068 0.5011 0.21983 0.89062 0.27006 1.2006 0.17026 2.5714-0.20026 3.9723-0.14025 0.0104 0.32029 0.19053 0.4899 0.2101 0.78018 0.75034 0.0502 1.5307 0.0202 2.2817 0.06 0.92064 0.68038 0.52002 1.4005 1.6906 1.8213 0.79014 0.27006 2.3111 0 3.1521-0.0404 0.0502-0.15004 0.01-0.29029 0.0502-0.45011 0 0 0.47957-0.0202 0.44955 0.0104 0.36995 0.66081 1.0903 1.3908 1.2012 2.1403 0.0692 0.55056-0.31123 1.9204-0.33994 2.6608-0.0502 0.98045-0.12985 1.6908-0.70011 2.4606-0.53046 0.7293-1.5007 0.77953-1.4511 1.8506 0.15986 0.0489 0.30014 0.0104 0.46065 0.0489 0.06 1.5904 0.70989 2.9811 1.01 4.4815 0.25055 1.2309 0.16051 3.7711 1.6508 4.1918 0.06 2.2499 0.52003 2.2805 2.6915 2.3001 1.6201 0.0196 3.0516 0.45011 4.6417 0.31116 0.39997-2.242 7.5844-0.54012 9.1849-0.44097 0 0-0.06 0.30007-0.0802 0.30007 0.0698 0.22049 0.28056 0.36074 0.29035 0.63993 0.45999-0.0698 0.94021-0.21005 1.4002-0.33008-0.58071 0.61058-1.6116 0.97001-2.4018 0.88977-0.7001 0.91978-1.5098 0.99088-2.6914 1.1298-1.151 0.14938-2.5212 0.27985-3.5514 0.94978-0.39084 0.26028-1.0414 0.93087-1.3206 1.3412-0.2499 0.36073-0.41041 1.501-0.6205 1.7208-0.92064 0.93934-2.8115 0.27006-4.0114 0.69994-1.3506 0.47946-1.791 1.4508-2.1714 2.76-0.35038 1.1507-0.67988 2.0411-1.2103 3.1514-0.33994 0.71038-0.74056 3.261-1.1105 3.6015-0.72033 0.64971-3.0908-0.0196-4.0519 0.39987-1.4204 0.63993-1.5398 1.76-1.821 3.1918-1.1601 0.06-2.8317-0.30007-3.8124 0.31899-0.99046 0.63145-0.84039 1.9009-1.4909 2.7522-0.21988 0.28898-1.821 1.9707-2.1714 2.1305-1.1901 0.55056-2.0305-0.18982-3.171 0.66081-1.5307 1.1403-1.1412 5.291-4.0121 3.8415-1.3108-0.6608-0.45999-2-1.9809-2.5114-0.84038-0.27006-2.7815-0.2805-3.6519-0.14025-0.75035 2.2205-0.01 5.1012 0.64008 7.1521 0.27991 0.90086 0.83973 2.2812 0.71054 3.3308-9e-3 0.0626-0.0189 0.12264-0.0287 0.17222zm-22.262-37.091c1.0198-0.53033 1.3604-0.78996 1.301-1.9994-0.30014-0.0802-0.41106-0.19048-0.64008-0.36008-0.0698-0.46054-0.0803-0.90151-0.10961-1.3914-1.0009-0.0196-1.3708-0.69081-2.3013-0.85976-0.09-0.43967-0.0202-1.3196-0.33993-1.6497-0.24012-0.25049-1.3708-0.46054-1.7512-0.49054-0.0202 0.32029-0.09 0.60013-0.19053 0.89042-1.2704 0.0992-0.81037-0.3914-1.3004-1.1709-0.1605-0.25963-0.59048-0.42988-0.79014-0.70973-0.21988-0.28115-0.14028-0.56035-0.48022-0.78018-0.25969 0.20026-0.41041 0.47946-0.42998 0.8291-0.91085 0.0502-2.3515-0.36008-2.1714 1-0.67009 0.03-1.4407-0.0796-2.0612 0.0998-0.67009 0.19048-0.89062 0.77953-1.6605 0.82062-0.0698-0.31963-0.14028-0.63992-0.19052-0.98044-0.09 0.0104-0.2101-0.0104-0.30993 0-0.27012 0.39074-0.73077 0.65037-1.181 0.82063-0.95066 0.33986-1.0707 0.28963-0.94022 1.2603 0.09 0.65037 0.20031 1.6112 0.6205 2.1409 1.1608-0.0907 0.50045 0.85976 0.39997 1.5004-1.1405 0.33986-0.70989 1.1403 0.27012 1.0411 0.65052-0.0607 1.761-0.55121 1.8308 0.55057 0.71055 0.0398 1.4309-0.0104 2.1414 0.03-0.06 1.0405 0.41041 0.94 0.93043 1.5904 0.42998 0.53947 0.20031 1.2094 0.67988 1.7104 0.92064 0.14938 1.821-0.82976 2.3313-1.3999 0.52002-0.57013 1.2404-1.5506 1.9907-1.6706 0.39018-0.0607 1.2808-0.0196 1.671 0.09 0.53047 0.12982 0.66031 0.65037 1.0805 0.89042 1.2606 0.7293 1.4707-0.91194 1.6005-1.8024z",
+                Nantou:"m217.09 275.91c-0.88997-0.5199-0.50958-1.5506-1.671-2.351-1.581-1.0907-0.96044 0.88977-1.7806 1.79-0.74056 0.81019-2.9805-0.4899-3.0314 0.98109-1.4818 0.0692-2.7515-0.20091-4.1125-0.33986-0.39084-0.82975-0.2101-1.8206-0.57027-2.6106-1.121 0.36009-1.7806 2.1905-2.9316 1.9504-0.39997-2.0307-0.12071-3.3308 0.25968-5.1918 0.36082-1.7515 1.4909-2.7906 1.9118-4.4214 0.36017-1.3307-0.35038-1.3001-0.7001-2.2009-0.36017-0.91065-0.27991-1.6504-0.32037-2.6706-0.0404-0.66993-0.58005-2.351-0.18008-3.0013 0.47109-0.77952 1.5209-0.47032 2.4716-0.52055 0.10962-2.0607-0.15986-3.7913-0.63942-5.6406-0.26034-1.0202-0.54025-1.2505-1.0903-1.9805 0.18987 0 0.39997-0.03 0.57027-0.0502-0.0698-0.8004 0.51023-1.2003 0.88997-1.7802 1.7519-0.41031 2.972-0.95043 4.9425-1.0496-0.01-0.0698-0.01-0.39074 0-0.4501-0.49 0-0.82994-0.31051-1.2808-0.39009-0.03-0.4899-0.27991-0.90021-0.21988-1.4403-0.33994-0.33008-0.86062-0.59035-1.2808-0.66994 0.03 1.7515-3.8118 0.54013-4.0519-0.50033-1.6605-0.42988-1.4609-2.9107-2.7815-3.0509 0.50958-1.2707-0.21989-6.3021 1.2697-6.8422 0.0698-1.1403-0.09-2.3308 0.32036-3.351 0.21989-0.55056 0.71055-0.6608 0.8815-1.291 0.12005-0.47032 0-1.1605-0.0307-1.6406-0.23032 0.03-0.55004-0.0802-0.77971-0.0502-0.0907-1.561-0.55003-3.2708-0.33015-4.7815 3.1208 0.12003 3.2806-4.201 1.9411-6.002-0.47043 0.09-0.85017-0.19048-1.2704-0.21983-0.3693-4.1012 4.553-0.39009 5.8931-2.6706 0.28057 0.15982 0.58071 0.29029 0.91086 0.36922 1.2006 0.3105 2.9218-0.0104 4.1726-0.0104 1.8106 0 2.3913 0.31116 3.8424 0.80105 3.342 1.1396 4.6221-0.93086 6.4543-3.1814 0.66944-0.81997 1.5007-1.7704 1.8902-2.7704 0.42085-1.1011 0.62051-2.8813 1.6912-3.6413 0.82081-0.58057 1.9711-0.3503 2.942-0.39987 0.12005-2.4808-0.21989-5.0516 0.65051-7.3119 0.47957-1.2101 1.2906-1.9602 2.7019-1.3203 0.58005 0.25962 0.75034 0.97 1.3004 1.2003 0.73077 0.29029 0.82015-0.03 1.6808-0.17938 0.44955 1.1102-0.33081 2.9211 0.23032 3.9302 0.88084 1.5904 2.4011 0.48011 2.6314-0.96023 0.19052-1.1605-1.1105-3.321 0.84038-3.0007 1.3408 0.20939 1.121 1.8898 2.9616 1.4703 0.54025-1.1814 1.7708-1.1814 2.8409-1.6602 2.3613-1.09 4.4825-0.32029 7.234 0.0196 0.33994-1.0196 0.79015-1.8402 2.052-1.73 0.09-2.291 1.151-4.0111 3.631-4.1012 2.6014-0.09 3.6023-0.40053 5.6635-1.6712 1.8308-1.1298 2.3711-2.8702 3.9618-4.1612 1.5614-1.2799 4.4434-0.58905 6.4738-0.69929 0.12919-1.4814 0.0496-2.7411 1.3604-3.1409 1.0198-0.3105 2.9414-0.63014 4.0023-0.50033 0.55982 0.0802 1.0498 0.60992 1.6312 0.47033 0.42998-0.0998 0.81037-0.95044 1.5398-1.1305 0.70076-0.17939 1.4217-0.12916 2.1714-0.33986 0.66096-0.19048 0.84039-1.2205 1.3604-0.19048 0.72033 0.0404 1.5509 0.10046 2.2713 0.06 1.1405-0.0691 0.48022 0.48011 1.2006-0.69994 0.82016-1.3497 0.99111-2.6406 3.1417-2.3105-0.33994 2.1507 1.6201 1.0411 2.2204 2.1103 0.7001 0.12002 1.4818 0.0502 2.1108-0.15982 0.24011-2.0105 6.0934-0.0202 6.7936 1.0202-0.0802 0.19048-0.0502 0.28963-0.0698 0.47946 0.0196 0 0.03 0.0104 0.0502 0-0.42019 0.57013-0.65052 1-0.55069 2.1612 0.92064 0.17025 0.96044 1.0404 0.78036 1.8402-1.731 0.0907-2.452-0.0404-3.6728 1.0202-1.181 1.0404-2.0005 1.5101-3.6023 2.2205-0.96044 0.42988-0.95065-0.03-1.3708 0.95043-0.29035 0.69016 0.06 1.5101-0.32036 2.2199-0.2499 0.48011-0.92064 0.5199-1.2208 1.2505-0.26033 0.66081-0.16051 1.6308 0.0692 2.351 1.7806 0.0202 1.6716 0.44032 2.852 1.3105 0.92064 0.66993 2.4213 0.98044 3.2513 1.5708 1.7212 1.2303 0.82995 4.7013-0.45999 6.1716-0.67009 0.76061-1.3506 1.9504-2.2112 2.4306-1.5007 0.85128-2.2419-0.38031-2.4611 1.8709-0.14942 1.4814 0.10961 2.4312-0.62051 3.8813-0.61985 1.2303-0.94021 2.0007-1.3708 3.291-0.67988 2.0405-1.4407 2.9909-1.3206 5.4717 0.7001 0.0411 1.4211 0.0104 2.1205 0.0502 0.17095 3.3412-0.16964 6.7418-0.33994 10.124-2.1323-0.14025-1.2612 4.2812-1.331 5.6615-0.23097 0.03-0.56047 0.09-0.78035 0.0502-0.33016 0.72016-0.76079 1.1403-1.0303 1.9804-0.12005 0.39988-0.0202 0.95044-0.16051 1.3307-0.19052 0.5199-0.65051 0.65037-0.88084 1.1703-0.64007 1.4103-0.45999 3.1305-1.1503 4.471-0.5011 0.10959-0.75034 0.39074-1.2815 0.39074-0.45999 1.3608-0.39017 2.8702-0.21988 4.2812-1.4511 0.21983-3.0608 2.351-2.7815 3.8311 2.6817 0.54991 2.6817 0.3803 2.972 3.201 0.20097 1.8806 1.7715 2.0405 2.0109 4.1612 0.0907 0.8702 0.0802 1.9602-0.01 2.8402-0.11027 1.0802-0.75034 1.501-0.84039 2.3308-0.0802 0.83041 0.67009 1.4306 0.51024 2.3308-0.2101 1.2805-1.5209 2.0209-1.9111 3.0209-0.4104 1.0802 0.31058 2.441-0.25055 3.441-0.44955 0.78997-0.82994 0.33008-1.1705 1.3803-0.25904 0.77953 0.13049 1.4208-0.3693 2.1311-0.57092 0.10959-1.1014 0.42075-1.6716 0.42988-0.74969 0.0104-0.92064-0.91064-1.9411-0.20026-0.09 0.42075-1.0407 2.1807-1.5209 2.321-0.92064 0.2805-1.8113-0.88064-2.972-0.31964-0.0907 0.0907-0.03 0.31964-0.0607 0.43966-0.85017 0.21005-0.74969 1.0607-0.61072 1.8409 0.27013-0.0502 0.68053 0.10959 0.95066 0.0496-0.36995 1.4508-0.15007 1.6908-1.7806 2.1709-0.11027 1.8702 0.21009 3.6106 0.0998 5.4417-0.68053 0.44032-1.5209 0.57014-2.0116 1.3405-2.4716-1.8396-8.214-1.9198-10.085 0.72017-1.0498 1.4703-1.761 3.1507-2.3802 4.8004-0.8815 2.3608 1.4602 1.8206 1.3108 4.3112-0.67009 0.21984-1.4217 0.21984-2.1414 0.36987-1.2306 0.25897-0.84039 0.20874-1.7108 0.94978-0.32036 0.2805-0.28056 0.68038-0.48022 0.88977-0.12005 0.12068-0.55003 0.11025-0.84038 0.12981 0-0.14938 0.0307-0.33007 0.0111-0.45988-0.14028-0.03-0.32037-0.0502-0.46065-0.0405 0.03-0.91064 0.44042-1.6412 0.29035-2.6217-0.39083 0.0496-0.78036-0.24005-1.1307-0.23027 0.0411-0.3803-0.20031-0.60079-0.2101-0.93086-1.8713-0.10959-3.2513-0.0104-4.8022-0.69995-1.0805-0.48011-0.95065-0.6197-2.1714-0.36986-0.24011 0.0502-0.49 0.11024-0.74055 0.18004-0.46 0.12003-0.94022 0.25897-1.4002 0.33007-0.0104-0.2805-0.21989-0.42074-0.29035-0.63993 0.0202 0 0.0802-0.30006 0.0802-0.30006-1.6012-0.0992-8.7849-1.8011-9.1849 0.44097-1.5907 0.14025-3.0216-0.29029-4.6417-0.31116-2.1714-0.0196-2.6314-0.0502-2.6915-2.3001-1.4909-0.42074-1.4002-2.9609-1.6508-4.1918-0.30014-1.5003-0.95066-2.8911-1.01-4.4815-0.16051-0.0398-0.30014 0-0.46065-0.0489-0.0502-1.0711 0.92064-1.1213 1.4511-1.8506 0.57026-0.77104 0.65052-1.4814 0.70011-2.4606 0.03-0.74039 0.4104-2.1103 0.33994-2.6608-0.11027-0.74952-0.82995-1.4808-1.2006-2.1403 0.03-0.03-0.44955-0.0104-0.44955-0.0104-0.0411 0.16047 0 0.30007-0.0502 0.4501-0.84039 0.0405-2.3613 0.31051-3.1521 0.0405-1.1705-0.42075-0.77057-1.1409-1.6906-1.8213-0.75034-0.0398-1.5314-0.01-2.2817-0.06-0.0196-0.29028-0.20031-0.46054-0.21009-0.78017-1.4002-0.06-2.7717 0.31115-3.9723 0.14024-0.39083-0.0489-0.68053-0.14873-0.89063-0.26875z",
+                Yunlin:"m204.7 249.7c0.55004 0.72995 0.82929 0.96022 1.0903 1.9805 0.47957 1.8506 0.7497 3.5806 0.63943 5.6406-0.95066 0.0502-2.0005-0.25897-2.4716 0.52055-0.39932 0.65037 0.14028 2.3308 0.18008 3.0014 0.0411 1.0196-0.0405 1.7606 0.32037 2.6706 0.35037 0.90021 1.0603 0.8702 0.7001 2.2009-0.42085 1.6308-1.5503 2.6706-1.9118 4.4214-0.38039 1.8611-0.6603 3.1612-0.25968 5.1918 1.151 0.24006 1.8106-1.5904 2.9316-1.9504 0.36017 0.78997 0.17943 1.7802 0.57026 2.6106 1.3604 0.14025 2.6308 0.41032 4.1125 0.33986 0.0502-1.471 2.2908-0.17025 3.0314-0.98109 0.82147-0.90021 0.20097-2.88 1.7806-1.79 1.1608 0.8004 0.78036 1.8304 1.671 2.351-0.50045 0.23092-1.2006 1.0007-1.1405 1.4305 0.12984 0.84998 1.1014 0.72017 1.3604 1.3405 0.2101 0.49055 0.12071 1.9804 0.12071 2.5114 0.01 1.1207 0.30992 1.501-0.79015 1.8311-1.3904 0.41031-3.522-1.0705-5.0025-1-1.0903 0.0496-3.342 1.3999-3.5416-0.65037-0.36996 0.31116-0.59049 0.30007-0.8306 0.79062-2.6014 0.64971-2.3111-0.30007-2.6614-2.4514-1.8113-0.0496-3.2115 0.7006-4.9627 0.81019-2.0409 0.12068-3.141-0.77953-4.8531-1.1703-3.0816-0.69016-6.8934 0.85063-7.694-3.3008-0.23032 0.0196-0.55003-0.0802-0.78036-0.0607-0.0992-1.2303-1.4707-1.8004-1.7206-3.1109-1.1307-0.25962-1.5509 0.41032-2.5114 0.60014-0.86061 0.17939-1.902 0.0398-2.8017 0.0398-0.81037 0-2.2014-0.27006-2.9616 0-0.9911 0.36009-0.76078 1.2303-1.5307 1.6804-2.1616 1.2707-3.0118-1.6106-4.5125-1.6804-1.4609-0.0802-3.5723 1.3105-3.3615 2.972-0.96044 0.0502-2.0612-0.13046-2.9414 0.23027 0.33015 1.7606-1.2912 2.7013-2.7019 2.8004-2.2014 0.15982-2.3111 0.54012-2.3515 2.8122-0.96044-0.26027-2.0807-0.54012-3.1214-0.4501 0.0202 0.66994 0.51024 1.1403 0.61072 1.7802-1.7212 0.14025-2.4912-0.62036-3.342 0.82063-0.93043 1.6002-0.18009 2.1005-2.101 2.7404 0.23033 1.6197-1.0707 2.3001-1.9907 0.93021-0.36996-0.54991 0.25968-1.1703-0.36996-1.6412-0.25055-0.18982-1.4811 0.0202-1.8113 0.0307-0.12006 0.74952-0.64008 1.4899-0.50045 2.2799 0.09 0.50164 0.88084 1.1905 0.98067 1.8617 0.35038 2.5806-1.4909 2.5708-3.522 2.1709-1.5907-0.31116-3.1717-0.81019-4.8224-1.1605-0.89063-0.18983-3.4418-0.38031-3.862-1.1403-0.32037 0.0698-0.79015-0.11024-1.1105-0.06 0.15006-1.1102-0.35038-1.6008-1.0505-2.0607 0.0405-0.0496 0.06-0.11024 0.0803-0.18004 0.26033-1.0705-0.55004-0.88912-0.95066-1.5304-0.0502-0.0104-0.11026 0-0.1605-0.0196-0.0503-0.87085-0.06-1.8011-0.01-2.6804 0.0405-0.71038 0.27991-0.36987 0.50045-0.81019 0.21988-0.45988-0.21989-0.63993-0.4202-0.88977-0.57026-0.71038-0.38039-1.6908-0.33015-2.621 0.0202-0.52056 0.30014-0.66994 0.36995-1.0607 0.0803-0.40966-0.24011-0.75017-0.31057-1.1403-0.0803-0.48011 0.0202-1.0405-0.01-1.5304-0.36995-0.13047-1.151-0.74104-1.0505-1.2107 0.0998-0.5199 0.85082-0.27006 1.1105-0.80105 0.18008-0.36922 0.0104-1.2505 0.0104-1.6797 0-0.72017 0.32036-0.94 0.50044-1.5708 0.18009-0.62036 0.4202-1.0098 0.88084-1.5101 0.49001-0.53034 0.6205-0.84019 0.85996-1.5095 0.24011-0.66993 0.39018-1.09 0.45021-1.7906 0.0398-0.56035 0.27012-0.89043 0.64008-1.3007 0.57026-0.62036 2.2112-1.6008 1.7206-2.6308-0.21989-0.45989-0.45021-0.48989-0.48022-1.1403-0.03-0.4201 0.0998-0.97979-0.0803-1.3601-0.21009-0.44945-0.48022-0.3803-0.85082-0.30985-0.32037 0.06-0.20031 0.36008-0.57026 0.10959-0.18009-0.12068-0.27992-0.33986-0.26034-0.56034 0.12005-0.97979 1.8413-0.62036 2.5016-0.70973 0.0398-0.8702-0.15007-1.7404-0.18008-2.6008-0.0398-0.99022 0.20031-1.2505 0.70076-2 0.81037-0.0404 2.681 0.30007 3.1214-0.44032-0.0998-0.52055-0.20031-0.99088-0.20031-1.561 0-0.27985-0.0803-0.69016 0.0802-0.93021 0.18009-0.27007 0.55069-0.27007 0.73077-0.50034-0.6603-0.30007-0.88084 0.2505-1.181 0.66994-0.27991 0.39987-0.81037 0.75996-1.0205 1.1905-0.45021 0.12003-0.72033 0.63993-1.121 0.87999-0.32037 0.19047-0.67988 0.12068-0.99046 0.25049-0.24011 0.0998-0.42019 0.30007-0.67987 0.30007-0.09-0.68038-0.59049-1.2101-1.0205-1.7215-0.51024-0.6197-0.47043-1.0796-0.49001-1.8806 0.21988 0.51011 0.70011 1.0307 1.3004 0.93999 0.52002-0.0907 0.59049-0.54991 0.78036-1.0007 0.38039-0.89042 0.47043-1.8904 0.42019-2.8807-0.68053 0.0698-1.0309 0.24984-1.5105 0.74038-0.46065 0.45989-0.78036 0.58057-1.3506 0.8702-0.09-0.50033 0.74055-1.0307 1.1105-1.2903 0.47043-0.33986 0.68053-0.7306 1.1307-1.0711 0.39018-0.28898 0.89063-0.74952 1.3708-0.9002 0.88084-0.28964 1.3206-0.57013 1.9711-1.2094 0.6205-0.62036 1.2906-1.1703 2.1616-1.4005 0.75034-0.21005 3.3015 0.46054 2.9414-1-0.15007-0.60014-0.88084-0.63928-0.24011-1.3001 0.27991-0.2805 0.67009-0.36987 1.0603-0.39075 0.30014 0.12068 0.74056 0.18005 1.1307 0.11025 0.67009 2.0516 3.5919 0.81997 4.3918 2.2805 2.3411 0.66015 4.3226 0.86042 6.9736 0.86042 1.1908 0 2.681 0.24984 3.8418 0.01 1.4009-0.30007 1.9013-1.2903 3.1319-0.20026 0.97023-2.0516 1.7708-1.8102 4.0323-1.8102 0.92064 0 1.8308-0.06 2.6216 0.21005 1.0407 0.35029 1.241 0.9002 2.5212 0.82062-0.0398 0.27006 0.11027 0.66994 0.06 0.94 0.20031 0.20026 0.20031 0.01 0.33015 0.33986 1.581 0.0907 2.4611 0.06 3.6317 0.69081 0.99045 0.53034 1.7212 1.3307 2.6614 1.6608 2.651 0.90999 5.593 0.20939 8.3543 0.33986 0.4104 0.0202 1.4818-0.0189 1.8413 0.16047 0.47043 0.23092 0.73012 1.06 1.1908 1.3105 0.91085 0.47097 2.7417 0.48011 3.802 0.53034 1.6801 0.0802 3.3818 0.17025 5.0626 0.14938 1.9111-0.0189 2.0214-0.0802 3.141 1.4814 0.0215 0.0157 0.0313 0.0359 0.0418 0.0555z",
+                Penghu:"m30.865 336.76c0.46065 0.0698 0.20031 0.18004-0.06003 0.3503-0.51023 0.33986-0.21988 1.15-0.59049 1.6504-0.15007 0.20026-0.32036 0.4788-0.49001 0.64906-0.23032 0.21005-0.47043 0.0907-0.7001 0.25114-0.28056 0.20027-0.14028 0.50947-0.2499 0.8004-0.09004 0.24006-0.27012 0.39988-0.32036 0.66994-0.04045 0.24006 0.0098 0.50033-0.33015 0.50033-0.1703-0.21983-0.40975-0.47032-0.60028-0.69016-0.15986-0.19047-0.56048-0.33072-0.6603-0.53034-0.10962-0.23027 0.1305-0.58904 0.16051-0.80953 0.02023-0.18982 0.02023-0.52055-0.06981-0.69081-0.21988-0.41031-0.76078-0.48989-1.0009-0.90021-0.03001-0.0698-0.05024-0.19047-0.09983-0.24005-0.09983-0.0998-0.18987-0.0405-0.30014-0.11024-0.1703-0.09-0.25968-0.4488-0.47043-0.45989 0.45021 0 0.90041-0.03 1.3506-0.0405 0.32036 0 0.39018-0.0411 0.61072-0.21983 0.23032-0.19048 0.2897-0.18004 0.64008-0.18004 0.48022 0 0.95065 0.0404 1.3708-0.12003 0.20031-0.0698 0.36016-0.0502 0.56047-0.0998 0.27012-0.0607 0.15986-0.22049 0.33994-0.31116 0.10896 0.4214 0.56961 0.48076 0.90955 0.53099zm9.855-23.999c0.12006 0.36008 0.21988 0.66015 0.06981 1.06-0.15986 0.4214-0.55004 0.48011-0.59049 0.96087-0.02023 0.42075 0.24011 0.69994 0.4104 1.0496-0.73077 0.11024-4.3827 0.0907-4.3925-0.78996 0.33015-0.0202 0.60028-0.19048 0.6603-0.50034 0.80058-0.41031 1.3904-1.1905 1.3108-2.0803-0.09983-0.0104-0.2101-0.0307-0.31058-0.0307-0.55982-0.66015-0.09004-0.97-0.09983-1.6497 0-0.54013-0.64008-1.3412 0.26034-1.6713 0.13963-0.03 0.33994 0.17026 0.48022 0.17939 0.11027 0.78997 0.51023 0.0998 0.85082 0.15982 0.81037 0.12981 0.2499 0.25049 0.58005 0.75017 0.1703 0.25898 0.73077 0.42989 0.82016 0.60014 0.24011 0.4201-0.2101 0.85063-0.24011 1.06-0.06916 0.55186 0.03067 0.38226 0.19052 0.90216zm4.2326 0.90021c0.01957 0.25962 0.06981 0.21005-0.1703 0.34964-0.12006 0.0607-0.29035 0.12134-0.43063 0.18004-0.53046 0.25898-0.40975-0.20091-0.85017-0.24983-0.31058-0.0411-0.20031 0.18982-0.33015 0.33986-0.08025 0.11024-0.11027 0.0998-0.2101 0.17025-0.09983 0.0613-0.24011 0.16047-0.36995 0.24006-0.0098 0.22048 0.08025 0.55056-0.1703 0.65036-0.36995 0.12982-0.40975-0.33007-0.45999-0.55056-0.50045 0.03-0.43063-0.69994-0.43063-1.0404 0.33015 0 0.6603 0.0104 0.99046-0.0111 0.09004-0.25898 0.08025-0.57013 0.06003-0.85911-0.11027-0.0111-0.23032-0.0998-0.24011-0.22049-0.04045-0.3105 0.24011-0.14025 0.38039-0.25962 0.11027-0.0998 0.03001-0.27007 0.11027-0.34965 0.10962-0.0907 0.39997 0 0.49001 0.12981 0.20031 0.31051-0.1703 0.55056 0.33994 0.60014 0.19052 0.0196 0.42019-0.12981 0.5807-0.09 0.14028 0.03 0.15007 0.14938 0.2499 0.20874 0.09983 0.0613 0.2101 0.0111 0.30014 0.10046 0.1703 0.15134 0.15072 0.46185 0.16051 0.66146zm0.24011-20.209c-0.21988 0.4201-0.13963 0.91978-0.16964 1.3901-0.90041 0.0502-1.6012 0.2805-2.4213 0.20027-0.42019-0.0489-0.7399-0.16961-1.1503 0-0.32036 0.13046-0.09983 0.63993-0.73077 0.55121-0.0398-0.18004-0.15986-0.21983-0.20031-0.39074-0.21988 0.0411-0.50045-0.0607-0.72033-0.03-0.06003-0.6308 0.71054-0.60079 0.6603-1.1507 0.73012 0.17874 1.7108-0.22048 2.3913-0.42988 0.77057-0.25049 1.4909-0.2107 2.3411-0.14025zm0.26034-23.275c0.19052 0.0998 0.19052 0.8402 0.09004 1.09-0.6603 1.6112-2.3913 0.72016-3.7419 1.2609-0.02023 0.74952-0.0098 0.82975 0.30014 1.4299 0.30014 0.55056 0.36995 0.75017 0.33015 1.4606-0.04045 0.95044 0.15986 2.7019-1.2103 2.6106-0.14028 0.53034 0.98002 1.8011-0.25055 1.8409-0.01957 0.33986-0.12006 0.90021-0.01957 1.2401 0.09983 0.3105 0.43977 0.45989 0.57026 0.75995 0.44042 1.0705-0.38039 1.1807-1.2208 1.1403 0.02023-0.12068-0.0398-0.2805-0.01957-0.39075-0.76078-0.0404-1.7512-0.53034-2.4018-0.09 0.30014 1.3405-1.6207 0.0496-1.611 1.06-0.69032-0.0802-1.0805 0.32029-1.8008 0.25049-0.39997-0.98044 0.06981-1.1102 0.75034-1.5095 0.58005-0.33986 0.27012-0.3803 0.57026-0.81018 0.2101-0.31116 0.1703-0.52056 0.72033-0.58122 0.30992 0.51012 0.51023 0.61971 1.0505 0.60079 0.26034-0.0111 1.1412-0.27006 1.331-0.42075 0.60028-0.50099 0.67009-2.1507 0.38039-2.9211-1.3911 0-1.4009-1.3412-0.08026-0.86041 0.03001-0.61123-0.03001-0.92043 0.32036-1.3803 0.33015-0.44032 0.76078-0.42075 0.85082-1.09-0.14028 0.03-0.33994-0.0502-0.48022-0.03 0.02023-0.11024-0.0398-0.28115-0.02023-0.39074-0.24011-0.0404-0.47043-0.16047-0.73012-0.11024 0.27012-0.8004-0.2499-1.9198 0.09004-2.6406 0.85017-0.0104 0.70989-0.25049 0.98002-0.85063 0.2101-0.44032 0.61072-0.66015 0.75034-1 0.36995-0.8004-0.18008-0.69016 0.75034-1.0802 0.45021-0.19048 0.86061-0.46054 1.3108-0.65037l0.03001 0.0698c0.1305-0.01 0.27012-0.01 0.40062 0.0104-0.2101 0.36074-0.39018 0.6608-0.63029 1.0111-0.29035 0.39922-0.69032 0.39922-0.51024 1.0496 0.77057-0.0502 1.3708 0.57013 2.2412 0.3503 0.21923-0.0587 0.71902-0.52838 0.90955-0.42858zm8.5742-4.4032c-0.23032 1.3803 1.641 2.2205 1.5007 3.8109-0.36995 0.0202-0.76078 0.0104-1.1405 0.0307-0.26034 0.38031-0.32036 1.2401-0.2499 1.7208 0.84039-0.19048 0.82995 0.8004 0.39018 1.1703-0.63029-0.0404-0.50045 0.63014-0.47043 1.0802 1.5307 0.03 1.2912 1.1005 1.2208 2.4208-0.4104 0.03-0.89063-0.2805-1.2306-0.48989-0.7001-0.45011-0.29035-0.48011-0.59049-1.2505-0.39018-1.0411-1.761-0.57013-1.3206-1.9915 0.54025-0.09 0.33015-1.1096 0.31058-1.5806-0.86061 0.0411-0.49001-0.77953-0.75034-1.2603-0.16051-0.29029-0.53046-0.33986-0.65052-0.66994-0.09983-0.24984 0-0.72016-0.01957-0.99023-0.8704-0.26027-2.191-0.63014-2.0814 0.63928-0.53046-0.0196-0.44042 0.52056-0.74056 0.78018-0.50045-0.3803-0.69032-0.93935-1.331-0.65037 0.09004-0.06 0.01044-0.16047 0.08025-0.27984h0.09004c0.31058-0.76061-0.38039-1.1905-0.32036-1.9009 0.56048 0.10959 0.84039-0.36987 1.4009-0.43054 0.54025-0.0691 1.2306 0.0998 1.8211 0.0698-0.04045-0.15982 0.06003-0.39987 0.03001-0.56035 0.41041-0.03 1.0309 0.17026 1.0805-0.33007 0.7001-0.21005 0.84039 0.41031 1.3408 0.63014 0.52981 0.22179 1.0505-0.058 1.6305 0.032zm1.592-17.163c0.09004 0.40966 0.1703 0.78997 0.16051 1.2205-0.18008-0.0411-0.45021 0.0691-0.64008 0.03-0.04045 0.78996-0.31058 0.85976-0.67009 1.3999-0.23032 0.33986-0.15007 1.4606-0.91085 1.2401 0.02023-0.1396-0.08025-0.18004-0.09983-0.24005-0.0098-0.66016-0.10962-1.3503 0.27012-1.9009 0.30014-0.44031 1.1307-0.55056 1.1405-1.1703-0.32036-0.06-0.52002-0.33987-0.59049-0.66994-0.39018 0.0411-0.65052-0.20026-0.64008-0.57992 0.78036-0.21005 1.1803 0.78018 1.9803 0.67059zm0.75687 4.9772c0.27012 0.19048 1.1405 1.0007 1.0009 1.4208-0.14028 0.42988-1.4811 0.24984-1.8511 0.39988-0.5807 0.24005-1.0603 0.92043-1.2306 1.5708-0.39018-0.31116-0.47043-0.78996-0.42998-1.291-0.24011 0.0411-0.43063-0.10959-0.64008-0.10959-0.19052-0.63014 0.40975-0.54012 0.67009-0.9002 0.25968-0.36009 0.23032-0.60014 0.24011-1.0705 0.45999-0.0907 0.78036-0.80105 0.99046-1.1814 0.25968 0.75147 0.64986 0.75147 1.2501 1.1611zm9.1868 29.42c1.0309 0.25049 1.4211 0.16047 1.3904 1.4097-1.1608 0.0913-2.5812 1.0411-2.5009-0.88912-1.3506-0.0698-2.8415-0.14025-4.1523-0.0907-0.82016 0.0307-1.2704 0.22049-1.5007 0.91064-0.2499 0.72017 0.02023 1.1207-0.82995 1.4208-0.30014 0.11024-0.64008-0.0405-0.92064 0.0998-0.35038 0.17939-0.45021 0.52055-0.73012 0.74952-0.46065 0.39074-1.0009 0.33986-1.3408 0.84019-0.75034 1.1103 0.81037 2.8918-0.08026 3.9818-0.30992 0.37965-0.89063 0.25897-1.4204 0.23027-0.43063-1.561-2.0011 0.12068-3.1019 0.17939-0.61072 0.0404-1.4009-0.14939-1.5907-0.82976-0.14028-0.50033 0.42998-1.2394-0.06003-1.7704-0.49001-0.55056-1.2404 0.0998-1.8308-0.50033-0.47043-0.47032-0.21988-1.1605-0.77057-1.5617-0.44042-0.31899-1.5509 0.0698-1.7708-0.64972-0.18987-0.58056 0.55069-0.82062 0.6205-1.3412 0.43063-0.20027 0.30014-0.66015 0.5807-1 1.2103-0.33007-0.02023 2.3412 1.3108 2.1703 0.27991 0.72016 0.75034 1.0104 0.69032 1.8904 0.52002 0.14938 0.8704-0.0998 0.8306-0.63993 1.6207-0.0796 0.81037 0.53034 1.2508 1.6412 1.0407 0.20026 1.2906-0.66994 1.2508-1.561 0.67988 0.0496 2.9616 1.6204 2.5512 0.0111-0.0398-0.19048-0.45999-0.27007-0.48022-0.52121-0.04045-0.47946 0.30014-0.45924 0.50045-0.66929 0.27012-0.30006 0.49001 0.0496 0.51023-0.59035 0-0.12981-0.28056-0.63014-0.36016-0.74039-1.1007-1.3901-2.101 0.20092-3.1417 0.33073-0.97023 0.12003-2.6216-0.76061-2.4911-1.9009 0.68053-0.0691 1.7108 1.2101 2.2412 0.24006 0.65052-1.2101-1.0407-1.4703-1.7408-1.2401-0.09004 0.48011-0.59049 0.31116-1.0107 0.31964 0.15007-0.88977 0.31058-1.1801 1.151-1.6002 0.12006-0.68038-0.98067-1.6106-0.6603-2.0607 0.2499-0.33986 2.0311-0.01 2.4716 0-0.33994-0.90021 0.33994-0.85911 1.0205-0.82911 0.03001 0.66929-0.18008 1.9994 0.36995 2.471 0.09983 0.09 1.0303 0.30007 1.1405 0.26941 0.67009-0.17939 0.39997-0.36987 0.44042-0.94 0.10962-1.6902 0.96044-0.33986 1.5705-1.15 0.64008-0.84084-0.65052-1.4703-0.85017-1.9009-0.12006-0.03-0.1703-0.06-0.2499-0.0998 0.45021-0.12002 0.82016-0.67972 1.4302-0.50033 0.53046 0.16047 0.35038 0.88977 1.2306 0.4899-0.12006-0.74104 0.91085-1.1403 1.2808-0.4899 0.16051 0.28963-0.36016 0.99023-0.42998 1.3405-0.09004 0.4501-0.09983 1.3001 0 1.7508 0.10962 0.48011 0.58005 1.1514 1.0903 0.50099-0.26034-0.36987-0.18008-1.5506-0.06981-1.9413 0.27991-1.0196 0.88084-0.30007 1.8008-0.41031 0.06982-1.3999-0.16051-2.1709 1.5007-1.8898 0.09983 0.67972 0.33015 1.1292 0.36016 1.8898 0.2499-0.03 0.55069 0.0502 0.81037 0.03 0.06981 0.0802 0.09004 0.0907 0.1703 0.17091-0.04045 0.19048 0.02023 0.45989 0.02023 0.72016 0.76078-0.0802 0.23032-1.1605 0.39997-1.6608 0.24011-0.66016 0.76078-0.51991 1.4909-0.48011 0.02023 0.4501-0.15007 1.2205 0.01044 1.6504 0.23032 0.59035 0.52002 0.57991 0.59049 1.3307 0.09722 1.1285-0.05285 2.2884 0.0072 3.409z",
+                Changhua:"m211.1 246.37c-0.01 0.0607-0.01 0.3803 0 0.4501-1.9711 0.0998-3.1919 0.63928-4.9425 1.0496-0.38039 0.58057-0.96044 0.98044-0.88997 1.7802-0.17095 0.0202-0.38039 0.0502-0.57026 0.0502-0.0111-0.0202-0.0202-0.0411-0.0411-0.06-1.1203-1.561-1.2306-1.501-3.141-1.4814-1.6808 0.0202-3.3824-0.0692-5.0632-0.14938-1.0603-0.0502-2.8918-0.0607-3.8013-0.53034-0.46064-0.24984-0.72033-1.0802-1.1908-1.3105-0.36017-0.18004-1.4309-0.14025-1.8413-0.16047-2.7606-0.12981-5.7033 0.57013-8.3543-0.33986-0.94022-0.33008-1.671-1.1298-2.6614-1.6608-1.1705-0.63014-2.0514-0.60014-3.6317-0.69016-0.12984-0.33007-0.12984-0.13959-0.33015-0.33986 0.0502-0.26941-0.0998-0.66928-0.06-0.93934-1.2802 0.0802-1.4805-0.47033-2.5212-0.82063-0.79015-0.27006-1.7004-0.21004-2.6216-0.21004-2.2608 0-3.0614-0.24006-4.0323 1.8102-1.2306-1.0907-1.731-0.0998-3.1319 0.20027-1.1608 0.24005-2.651-0.01-3.8418-0.01-2.6517 0-4.6326-0.20091-6.9736-0.86041-0.80059-1.4606-3.7217-0.23093-4.3918-2.2805-0.39018 0.0698-0.8306 0.01-1.1307-0.11024 0.18009-0.01 0.36996-0.01 0.54025 0 0.60028 0.03 1.4309 0.27006 1.8909-0.21983 0.48022-0.53034-0.18008-0.72017-0.32036-1.3503-0.20031-0.90021 0.59048-1.6008 1.4309-1.561 0.11027-0.69081 0.0803-0.91065 0.8306-0.93022 0.6205-0.0202 1.5105 0.17026 2.0514-0.12981 0.4502-0.25049 0.84038-1.0502 1.0903-1.4814 0.30014-0.53033 0.20031-1.1102 0.42998-1.6406 0.53046-1.2205 1.4309-2.1103 2.2112-3.1312 0.33015-0.43967 0.60028-1.1011 0.77057-1.6204 0.06-0.21004 0.0202-0.57013 0.12984-0.75017 0.19053-0.30985 0.36996-0.23027 0.50045-0.60992 0.10962-0.31051 0.06-0.94 0.06-1.2603-1.1007-0.29028-2.071-0.40053-1.3506-1.6608 0.54025-0.95043 1.3806-1.7 1.731-2.8506 0.27012-0.89042 0.43063-1.8506 1.0009-2.6713 0.15985-0.23027 0.36016-0.36921 0.52002-0.63927 0.12984-0.23093 0.12005-0.48011 0.35037-0.63015 0.50045-0.32029 1.3911 0.30007 1.8811-0.0698 0.33993-0.25049 0.39017-1.0907 0.48022-1.4703 0.15985-0.66994 0.35037-1.3503 0.78035-1.8898 0.58071-0.72016 1.181-1.1807 1.3206-2.1103 0.14028-0.88064 0.7001-1.3712 1.3604-1.9407 0.48022-0.42074 1.9711-0.97 2.131-1.5101 0.88083-0.15004 2.6014-0.66994 2.4213-1.8709-1.0002-0.0802-2.131 0.11024-3.1717 0.0502-0.80058-0.0404-0.78036-0.21983-0.71054-0.95044 0.0502-0.44031-0.0405-1.09 0.0803-1.5506 0.28057-1.1305 1.761-1.1605 2.7613-1.2505 0.57026-0.0502 1.0707-0.26028 1.611-0.31116 0.56047-0.0496 1.1412 0 1.6912 0 0.61071 0 1.5809 0.21005 1.9209-0.42923 0.27991-0.53034 0.0196-1.3412-0.06-1.8709-0.0998-0.65037 0.12984-1.09 0.26034-1.7006 0.13963-0.5897 0.09-1.3196 0.06-1.9302-0.53046-0.0202-1.0309-0.06-1.5607-0.0691-0.77057-0.0104-0.71054 0.0802-0.75034 0.8004-0.06 0.0202-0.11027 0-0.1703 0.0202-0.0202 0.33986 0 0.70059-0.0202 1.0496-0.64007-0.09-0.28056 1.1011-0.44042 1.4906-0.84038 0.0502-1.9914-0.21984-2.8011 0.0111-0.57026 0.1696-0.40061 0.69929-0.95065 0.99022-0.15007 0.0802-0.45021 0.0404-0.61071 0.09-0.2897 0.0907-0.3804 0.33987-0.73012 0.29029 0.21988-1.1703 1.1608-1.4208 1.8511-2.2407 0.76078-0.91065 1.4407-1.8506 2.251-2.7104 0.7001-0.74039 1.5007-1.5108 2.2713-2.2812 0.33015-0.33008 0.67988-0.72017 0.92064-1.1403 0.29035-0.53034 0.36016-1.0502 0.81037-1.4906 1.0205-1.0007 3.0216-0.43053 4.4322-0.51011 0-0.53947 0.06-0.5199-0.12005-0.99023-0.45021-1.2603 0.92064-1.4403 1.4002-2.3608 0.27012-0.53034 0.2003-1.2701 0.71054-1.7202 0.96109-0.85063 2.7913-0.50033 4.0121-0.31116-0.0405-0.12002-0.0803-0.23027-0.12071-0.31963 0.0803 0.03 0.15986 0.0691 0.24011 0.11024 0.0803 1.3497 0.11027 2.2903 0.54025 3.4612 0.42084 1.15 1.0714 1.8402 1.5007 2.8409 0.49001 1.1703 0.0907 2.9002 0.7001 3.9713 0.72033 1.2505 2.0312 0.78997 3.1019 1.2303 0.09 0.68037 0.67009 0.81018 1.331 0.66015-0.0692 0.32029 0.12984 0.80105 0.06 1.1102 1.1405 0.58122 2.0011 1.0502 3.3028 1.2003 1.4106 0.15982 2.6712-0.0802 3.9723 0.36073-0.09 1.8004 0.58005 1.8102 1.2404 3.1012 0.58984 1.15 0.3804 3.0007 2.2706 2.5604-0.11027 0.46054 0.0202 0.21983-0.28056 0.51012-0.0803 0.96022-0.93043 1.5604-1.0303 2.471-0.11027 0.98044 0.33994 2.1005 0.36017 3.1403 0.64007 0.03 1.3108 0.03 1.9509 0-0.0802-0.38031 0.1305-0.91 0.0502-1.2903 2.1512 0.25962 3.2017 2.6106 5.0626 3.621-1.3408 2.2805-6.2631-1.4306-5.8931 2.6706 0.42084 0.03 0.80123 0.30986 1.2704 0.21983 1.3408 1.8004 1.181 6.1221-1.9418 6.002-0.21988 1.5101 0.24011 3.2212 0.3308 4.7815 0.23033-0.03 0.55004 0.0802 0.77971 0.0502 0.03 0.47945 0.15007 1.1703 0.03 1.6406-0.17029 0.63015-0.6603 0.74039-0.88084 1.291-0.4104 1.0196-0.24989 2.2107-0.32036 3.351-1.4909 0.54012-0.76078 5.5715-1.2697 6.8422 1.32 0.14025 1.1203 2.621 2.7815 3.0509 0.24011 1.0404 4.0825 2.2512 4.0519 0.50033 0.42019 0.0802 0.93956 0.33986 1.2808 0.66994-0.06 0.54012 0.19052 0.95043 0.21988 1.4403 0.45151 0.0776 0.79145 0.38813 1.2821 0.38813z",
+                Taichung:"m182.09 177.11c-0.03-0.84997-0.10962-2.0907 0.38039-2.8004 0.42998-0.63015 1.5209-1.4606 2.3515-1.5206-0.0411-0.8004 0.47957-1.09 0.0496-1.8604-0.27012-0.4899-0.80058-0.80106-1.2097-1.1814 1.2397 0.63993 2.5707 0.71038 2.6712 2.4814 0.33015 0.0398 0.57026-0.20092 0.80124-0.36987 0.11027-0.91065 0.26947-1.0202 1.121-1.0705 0.21988-0.97979-0.93108-0.39988-1.0603-1.291-0.74121-0.12982-1.5209-0.21005-2.2817-0.20027 0.82995 0 1.3108-0.48989 1.8713-1 0.3693-0.33986 0.39932-0.29028 0.47957-0.81018 0.06-0.36009 0.0907-0.74039 0.0502-1.1103-0.0692-0.03-0.11027-0.0502-0.18008-0.0802 0.43063 0.0104 1.1307-0.0802 1.701-0.06 0.96044 0.0411 0.76078 0.11024 1.0009 0.8702 0.40975-0.01 0.81037-0.09 1.1705-0.25897 0.0405-0.33073 0.31058-1.1703 0.12005-1.4103-0.0803-0.0998-0.52002-0.15003-0.6603-0.21004-0.24011-0.10959-0.32036-0.32029-0.75034-0.30986 0.41105-0.44097 1.6207 0.0992 1.9809-0.30007 0.56047-0.63079-0.17943-1.9504 0.0411-2.6719 0.2897-0.96936 1.4909-1.5206 2.0801-2.2701 0.97022-1.2205 0.17094-2.591 0.80123-3.8813 0.39018-0.78018 1.1105-1.15 1.761-1.7306 0.60028-0.54012 1.1803-1.2394 1.5698-1.9504 0.32037-0.57991 0.97088-1.1598 1.1816-1.7704 0.24011-0.65036 0.16051-1.1102 0.63942-1.6908 0.8306-1.0104 2.0716-1.4906 2.7019-2.6106 0.0196-0.03 0.0404-0.0691 0.06-0.0998 1.4106 1.1305 1.5105 2.7815 2.5512 4.2114 1.0707 1.4514 2.8709 1.9707 4.0917 3.6217 1.121 1.5003 2.0612 2.351 3.4627 3.591 0.74969 0.66015 1.0407 1.5506 1.9907 1.9602 1.0909 0.47946 1.7212 0.06 2.8017 0.8702 1.7806 1.3405 3.2017 3.2714 5.163 4.4912 2.1212 1.3203 4.9829 0.7006 6.834 2.1807 0.88084 0.70973 1.4609 1.8702 2.4318 2.5806 1.0798 0.78018 2.0605 0.41031 3.4522 0.20092 2.4514-0.36987 5.4821 0.50946 7.6737-0.33073 3.2017-1.2198 0.0998-4.6211 1.6201-6.882 1.4413-2.1096 4.6423 0.0998 6.3831 0.3803 2.2119 0.36008 5.7333-0.30007 7.174 1.8702 0.35038 0.53034 0.15985 1.2505 0.53046 1.7704 0.2499 0.3503 0.93956 0.48011 1.2508 0.74039 1.2306 1.0307 1.4407 1.5708 3.1919 1.4305 0.14028-0.69994 0.63029-1.1507 0.88084-1.7802 1.5907-0.0307 1.5405-1.3803 2.482-1.7006 1.2306-0.41031 1.5712 0.8402 2.6712 0.68038 0.33994-0.0502 2.0514-1.0104 2.3313-1.1703 1.32-0.78997 0.55917-1.0502 1.3708-2.1409 0.36995-0.50033 1.1014-0.33007 1.4609-0.69016 0.38039-0.3803 0.33015-0.8702 0.63029-1.2101 0.89062-1.03 1.151-0.84019 2.542-1.1292 2.3006-0.47098 3.1514-1.2505 4.2013-3.3021 2.221-0.39922 2.052-1.0705 2.1616-3.1703 0.69032-0.12067 1.4602-0.0202 2.1212 0.15917 0.31058 1.501 0.70011 2.8618 2.5205 1.6804 1.1014-0.72995 1.1412-2.03 2.6419-2.561 0.47044-1.1703-0.0802-2.6106 0.39018-3.7809 0.81038 0.0404 1.4106-0.39988 1.9411-0.87999v0.1396c1.6208 0.0802 3.4627 0.0802 5.043-0.15982 1.32-0.20092 2.4905-0.84019 3.4118-1.7802 0.0411 0.03 0.0803 0.0502 0.12071 0.0698 0.2499 0.15982 0.51023 0.28963 0.7001 0.5199 0.20031 0.25962 0.26948 0.60014 0.42998 0.87998 0.33081 0.60014 0.2101 1.1703 0.2101 1.8506-0.01 0.35029-0.0502 0.65036-0.2101 0.92043-0.14941 0.25962-0.35037 0.48011-0.42998 0.78017-0.0607 0.24984-0.18008 0.74039-0.0698 1.0007 0.11027 0.30007 0.49001 0.45989 0.74056 0.63928 0.28056 0.21004 0.44042 0.52055 0.68053 0.78018 0.29035 0.32029 0.42998 0.29028 0.8704 0.29028 0.83059 0 2.0109-0.20092 2.7019 0.17026 0.31971 0.18004 0.91085 0.29028 1.121 0.57991 0.17029 0.23092 0.0998 0.76061 0.0998 1.0411 0 0.82062-0.0202 1.6908 0.82929 2.0111 0.38039 0.14025 0.90041 0.17939 1.3206 0.12003 0.49-0.0691 0.55003-0.3105 0.85017-0.66015 0.2499-0.29028 0.56047-0.3803 0.89062-0.58122 0.41041-0.2394 0.68053-0.21983 1.1412-0.30985 0.50045-0.0998 1.0107-0.12003 1.5607-0.12003 0.35038 0 0.39996 0 0.65051-0.15982 0.16051-0.11024 0.26034-0.28115 0.46065-0.33986 0.48022-0.12981 1.0505-0.12981 1.5307-0.0992 0.73012 0.03 0.85083 0.2094 1.2808 0.76061 0.24011 0.30986 0.25968 0.17939 0.61071 0.30007 0.5807 0.20027 0.70076 0.61971 0.79015 1.1703 0.03 0.20027 0.0802 0.38031 0.14941 0.5597-0.79014 0.47097-2.0005 1.6308-2.2412 2.1814-0.50045 1.1396 0.30014 2.8311-0.20031 3.9713-0.36995 0.81997-1.3415 1.7-2.1212 2.3301-0.56048 0.47098-1.2208 0.33073-1.7114 0.66994-0.82995 0.56035-0.2897 0.77039-0.82081 1.5108-0.79015 1.0705-2.0801 1.0796-2.5205 2.4899-0.33993 1.1103 0.60028 3.1918 0.01 4.1723-0.58005 0.95044-2.3711 0.2094-3.312 1.0307-0.69032 0.60014-1.0498 2.291-1.5209 2.9707-0.23032 0.33007-0.43063 0.58056-0.60028 0.8004-0.0202 0.0104-0.03 0-0.0502 0 0.0196-0.19048-0.0104-0.28963 0.0698-0.47946-0.70011-1.0411-6.5534-3.0307-6.7936-1.0202-0.63029 0.21005-1.4106 0.27985-2.1108 0.15982-0.60027-1.0705-2.5616 0.0411-2.2204-2.1103-2.1512-0.33008-2.3222 0.96087-3.1417 2.3105-0.72033 1.1807-0.06 0.63079-1.2006 0.69994-0.72033 0.0411-1.5509-0.0202-2.2706-0.06-0.52067-1.03-0.70011 0-1.3611 0.19048-0.74969 0.21004-1.4707 0.16047-2.1708 0.33986-0.73012 0.18004-1.1105 1.0307-1.5405 1.1305-0.5807 0.1396-1.0707-0.39009-1.6312-0.47032-1.0603-0.13047-2.9818 0.18982-4.0023 0.50033-1.3115 0.39987-1.2312 1.6602-1.3604 3.1409-2.0312 0.11024-4.9125-0.58057-6.4732 0.69929-1.5907 1.291-2.1323 3.0307-3.9625 4.1618-2.0612 1.2694-3.0614 1.5806-5.6628 1.6706-2.482 0.09-3.5423 1.8102-3.6317 4.1012-1.2606-0.11024-1.7108 0.70973-2.052 1.7306-2.7515-0.33986-4.8727-1.1103-7.234-0.0202-1.0707 0.47945-2.3006 0.47945-2.8409 1.6602-1.8406 0.4201-1.6207-1.2603-2.9616-1.4703-1.9509-0.32029-0.65052 1.8402-0.84039 3.0007-0.23032 1.4403-1.7512 2.5506-2.6314 0.96087-0.55983-1.0111 0.21988-2.8206-0.23033-3.9309-0.86061 0.14938-0.95065 0.47033-1.6808 0.18004-0.55003-0.23092-0.72033-0.93999-1.3004-1.2009-1.4113-0.63928-2.221 0.10959-2.7019 1.3203-0.8704 2.261-0.53046 4.8318-0.65052 7.3119-0.97023 0.0502-2.1212-0.18004-2.9414 0.39988-1.0714 0.76061-1.271 2.5408-1.6919 3.6413-0.39018 0.99936-1.2201 1.9498-1.8902 2.7711-1.8315 2.2499-3.1123 4.3216-6.4543 3.1807-1.4511-0.48989-2.0305-0.80105-3.8424-0.80105-1.2508 0-2.9714 0.32029-4.1726 0.0111-0.3308-0.0802-0.63094-0.21005-0.91085-0.36987-1.8608-1.0104-2.9113-3.3608-5.0625-3.621 0.0803 0.38031-0.12984 0.91064-0.0502 1.2903-0.63943 0.03-1.3108 0.03-1.9509 0-0.0196-1.0405-0.47043-2.1605-0.36016-3.1403 0.0998-0.91064 0.95065-1.5101 1.0302-2.471 0.30014-0.29029 0.1703-0.0502 0.28057-0.51012-1.8902 0.44032-1.6801-1.4103-2.2706-2.5604-0.66096-1.291-1.331-1.3007-1.2404-3.1012-1.301-0.44097-2.5616-0.20091-3.9723-0.36073-1.301-0.14938-2.1616-0.61971-3.3022-1.2003 0.0692-0.3105-0.12984-0.78996-0.0607-1.1102-0.6603 0.15003-1.2404 0.0202-1.331-0.66015-1.0707-0.43967-2.3809 0.0202-3.1019-1.2303-0.61007-1.0711-0.20945-2.8011-0.69946-3.9714-0.43063-1.0007-1.0805-1.6908-1.5013-2.8409-0.42932-1.1703-0.45999-2.1103-0.54024-3.4612-0.0796-0.0411-0.15921-0.0802-0.23946-0.11024-0.60028-1.2303-2.0612-0.78018-3.0614-1.5206-0.55069-0.40053-0.86061-0.63993-1.5007-0.84019-0.60027-0.18004-0.96044-0.33008-1.4811-0.67059 0.33015-0.12003 0.64008-0.25897 0.92064-0.45989 0.50045-0.3803 0.48022-0.58057 0.6205-1.1005 0.11027-0.4501 0.26034-0.72995 0.46065-1.1305 0.15007-0.30985 0.17029-0.8004 0.48022-0.99022-0.06 0.57013-0.0196 1.3999 0.06 1.9811 0.12005 0.7704 0.67987 0.90021 0.88018 0.12003 0.15007-0.57991-0.20031-1.4606 0.44042-1.6902 0.51024-0.18004 1.4217 0.21983 1.9209 0.30985 0.14029-0.57013 0.0502-1.0404 0.0803-1.6197 0.0202-0.56034 0.16051-1.1213 0.17029-1.6804-0.33994-0.0698-0.53046 0.27006-0.72033 0.51012-0.44042 0.55056-0.32036 0.50033-0.90041 0.44031-0.87562-0.10437-0.94609 0.2655-1.2958 1.0359z",
+                Yilan:"m393.17 81.6c0.64987 0.54012 1.0505 1.2003 1.0002 2.0405-0.0404 0.04044-0.0692 0.0698-0.12005 0.12068-1.1014 0.06915-3.342 0.46054-3.2519-1.1011-0.20031-0.06001-0.4104-0.12981-0.60027-0.21005-0.0104-0.03979-0.0104-0.06915-0.0104-0.10959h0.0196c0.36995 0.06067 0.81037 0.12981 1.2103 0.10959 0.18987-0.39922 0.11027-0.87998 0.53046-1.12 0.4613-0.25962 0.89193 0 1.2221 0.27006zm-72.209 76.407c-0.0692-0.17938-0.12006-0.36008-0.14942-0.55969-0.0907-0.55056-0.21009-0.97-0.79014-1.1709-0.35038-0.12003-0.36995 0.0104-0.61072-0.30007-0.43063-0.55056-0.55068-0.72995-1.2808-0.76061-0.48022-0.03-1.0505-0.03-1.5307 0.0998-0.20096 0.06-0.30013 0.23092-0.46064 0.33986-0.2499 0.15982-0.30014 0.15982-0.65052 0.15982-0.55003 0-1.0603 0.0196-1.5614 0.12002-0.45999 0.09-0.73011 0.0692-1.1412 0.30986-0.33015 0.20091-0.63943 0.29028-0.88998 0.58122-0.30013 0.3503-0.36016 0.5897-0.85082 0.66015-0.42019 0.06-0.93956 0.0202-1.32-0.12003-0.85017-0.32029-0.82994-1.1905-0.82994-2.0111 0-0.2805 0.0698-0.81019-0.0992-1.0411-0.21009-0.28898-0.80123-0.39922-1.1216-0.57992-0.69032-0.36986-1.87-0.17025-2.7012-0.17025-0.44042 0-0.58005 0.03-0.8704-0.29029-0.24011-0.25962-0.39996-0.57013-0.68053-0.78018-0.2499-0.17938-0.63029-0.33986-0.74056-0.63927-0.10961-0.26028 0.0104-0.75018 0.0692-1.0007 0.0803-0.30007 0.28056-0.5199 0.43063-0.78018 0.15986-0.27006 0.20096-0.57078 0.2101-0.92043 0-0.67972 0.12005-1.2505-0.2101-1.8506-0.16051-0.27984-0.23032-0.62036-0.43063-0.87998-0.19053-0.23092-0.44956-0.36008-0.69945-0.5199 0.39017-0.73061 0.31971-1.8311 0.79014-2.5708 0.27012-0.41031 0.77057-0.36922 1.0107-0.66015 0.2101-0.24984 0.24011-0.80106 0.39018-1.1305 0.24011-0.57013 0.73012-1.7404 1.2103-2.06 0.47043-0.32029 0.90041-0.0698 1.3904-0.25114 0.63942-0.23027 0.29035-0.5199 0.74056-0.84998 0.0998-0.71038 0.53046-0.62036 1.0107-0.81997 0.75034-0.31116 0.5807-0.17026 0.75034-1.0007 0.30014-1.4103 1.0107-0.84997 2.1616-1.2603 0.31057-1.1011-0.23033-1.7515 0.93108-2.2505 0.91998-0.40966 1.2508-0.33986 1.0798-1.4906-0.15986-1.1103-1.1301-3.7313-0.34973-4.6915 0.39018-0.47946 1.1705-0.44032 1.6312-0.95044 0.74969-0.85911 0.0692-0.95043-0.35038-1.6902-0.16051-0.28963-0.24011-0.66928-0.24011-1.0705-0.0104-1.06 0.50045-2.3105 1.3708-2.6217 0.71054-0.24984 1.1608-0.01 1.7114-0.72017 0.46-0.60013 0.44042-1.3001 0.65052-2.0105 0.41041-1.4208 1.4609-1.8709 2.5714-2.681 0.21988-0.66928 0.57026-1.9009 0.27991-2.5004-0.30993-0.66015-0.72033-0.46054-0.45999-1.2394 0.12005-0.33008 0.47043-0.77105 0.71054-1.0307 0.67009-0.74039 2.3411-0.88129 3.5618-0.95044 0.2101 0 0.39997-0.0111 0.57026-0.0202 0.88149-0.0404 1.2704-0.06 2.0011-0.43053 0.58005-0.28898 1.0805-0.77953 1.7708-0.92043 0.70989-0.14025 1.5307 0.0607 2.1812-0.20026 0.35038-0.14025 0.63029-0.4201 0.98067-0.54991 0.2897-0.0998 0.67988-0.0802 0.92064-0.23093 0.86061-0.50033 0.54025-1.7802 1.0714-2.5108 0.53959-0.76061 2.4905-0.91064 3.432-0.90021 1.2208 0 1.5907-0.40966 1.5098-1.6602 2.7026 0.12003 2.7326-2.0705 1.9711-4.0712-0.33016-0.87998-0.44042-1.7508 0-2.6908 0.33015-0.69016 1.2097-1.8304-0.0503-2.2603 0-0.12068 0.0405-0.26028 0.0503-0.33986 0.0692-1.4299 2.3613-1.6197 3.3518-1.6497 1.1105-0.04045 0.85017-0.20092 1.0002-1.1709 0.0998-0.60014 0.36017-1.1096 0.85083-1.4808 1.0302-0.76061 2.7913-0.69016 4.0721-0.77039 1.3806-0.08024 2.7515-0.02022 4.1524-0.09067 0.0398-0.69016-0.12071-1.5506 0.33015-2.1005 0.36995-0.44945 1.151-0.63014 1.6012-0.97 0.49-0.36922 0.81037-1 1.1705-1.4299 0.65052-0.78018 2.3006-1.7306 3.312-1.9302 1.3408-0.26028 2.7404 0.21983 3.9416-0.48011 1.1601-0.66015 1.6116-1.6106 2.9009-2.0105 0.29035-0.56035 0.86061-0.66994 0.75034-1.3007-0.0998-0.57992-0.7001-0.62036-0.38039-1.4208 1.4009-0.0098 0.94021-1.7202 1.4106-2.5004 1.2097-0.24984 2.3913-0.3503 3.6525-0.3503 0.53047 0 1.2808 0.0698 1.7004-0.23027 0.3693-0.26028 0.68053-0.72016 1.1405-1.0202 0.58071-0.36987 2.0801-1.2003 2.2315-1.9107 0.21989-1.06-1.0805-1.9805-2.1414-1.9413-0.42998-1.4403 0.26033-2.0796 1.1712-3.0711 1.1014-1.1703 2.2608-0.84019 3.8215-0.91064 0.6603-0.04044 1.4296-0.02022 2.0801-0.15004 0.82081-0.14938 1.0805-0.60014 1.5705-1.12 0.84039-0.91064 2.0912-1.5206 3.2722-1.6504 0.46-0.04958 1.4309-0.01957 1.8517-0.23027 0.56961-0.2805 0.60028-0.88064 1.2312-1.1305 1.2006-0.47033 2.2008 0.42988 3.3916 0.36987-0.11027 0.30007-0.15007 0.66015-0.0998 1.1103-1.4106-0.05023-2.882 0.66015-4.1432 1.2094-0.39931 0.17091-1.181 0.32029-1.3708 0.69081-0.19053 0.39009 0.15985 1.0796-0.44042 1.2394-0.0202 0.03001 0 0.0698-0.0104 0.10959-0.4215 0.28115-0.64008 0.6608-1.0303 0.97066-0.36995 0.31051-0.71054 0.91064-1.2103 0.96022-0.42084 0.4899-0.93108 1.0202-1.6312 1.1605-0.39018 0.08024-0.50045 0.08024-0.82929 0.33008-0.25969 0.20092-0.68053 0.42988-0.8306 0.75017-0.2897 0.63014 0.16051 1.4808 0.16051 2.1311-0.0104 0.6608-0.65052 1.3203-1.1705 1.6602-0.24011 0.17091-0.52067 0.30007-0.72033 0.50098-0.18987 0.19048-0.49001 0.41031-0.68053 0.63014-0.4489 0.53034-0.84039 1.1298-1.3604 1.5701-0.47957 0.41031-1.0107 0.98044-1.4413 1.4403-0.47892 0.53034-0.88932 0.8291-1.0407 1.5604-0.12984 0.63014-0.49 1.1103-0.76013 1.6902-0.31058 0.6608-0.53046 1.4103-0.82081 2.0907-0.60028 1.3901-0.47043 2.9811-0.58984 4.5219-0.0502 0.61058-0.09 1.2805-0.25903 1.8402-0.12984 0.45989-0.2512 0.85063-0.3308 1.3301-0.0796 0.50098-0.18987 0.97066-0.28057 1.4305-0.27012 1.3307-0.0502 2.7906-0.0502 4.1514 0 1.2303 0.2101 2.5702 0.51024 3.7509 0.27012 1.0705 1.1014 2.1703 1.6312 3.0901 0.27991 0.46054 0.40976 0.69081 0.44042 1.2101 0.03 0.44945 0.0796 0.85976 0.1703 1.291 0.12984 0.69081 0.36995 1.3999 0.3308 2.1207-0.03 0.60014-0.0411 1.2205-0.0411 1.8402 0 0.60013 0.0496 1.1814 0.0802 1.7802 0.0196 0.48989 0.26947 0.93021 0.31971 1.4208 0.0405 0.36008-0.0998 0.67972-0.0411 1.0496 0.12136 0.74104 0.72033 1.2909 0.93173 1.9915 0.28904 0.93021 0.17878 1.7 0.79014 2.4899 0.47044 0.61057 0.68053 1.501 1.3708 1.9009 0.65052 0.38031 1.1014 0.5199 1.8413 0.66081 0.20879 0.0404 0.39997 0.14024 0.61985 0.17025-0.0111 0.31051 0.23946 1.2205-0.36995 1.1207-0.2101-0.0404-0.33015-0.35029-0.50045-0.47032-0.2101-0.15004-0.30014-0.15004-0.58135-0.16047-0.49001-0.01-1.0407-0.0998-1.4106 0.24984-0.34973 0.33007-0.28057 0.8702-0.2499 1.3307 0.25969 0.12981 0.45999 0.36986 0.74056 0.47032 0.20944 0.0698 0.44107 0.0698 0.66095 0.17091 0.0992 0.15982 0.21989 0.33986 0.30014 0.50033 0.12006-0.0998 0.21989-0.21004 0.30014-0.33986 0.18987-0.0196 0.39083 0.0196 0.57026 0.0907 0.0104 0.28049-0.17943 1.1403 0.12071 1.2094 0.18987 0.32029-0.14028 0.36987-0.3693 0.43054-0.48022 0.12068-0.51024 0.03-0.56048 0.61057-0.0998 1.09-0.03 2.1898 0.03 3.2805 0.68053-0.17026 0.4502 1.4005 0.4502 1.8011 0 0.68038 0.28057 1.7097-0.50109 1.9602-0.72034 0.21983-1.4511 0.06-2.1212 0.57078-0.28904 0.2094-0.52067 0.40966-0.88084 0.47032-0.54024 0.09-1.0407 0.0196-1.3715 0.57992-0.25055 0.42075-0.22054 1.0307-0.1703 1.5101 0.0411 0.33986 0.0998 0.66994 0.30014 0.93935 0.25968 0.35029 0.68053 0.29028 0.95065 0.55121 0.25969 0.24005 0.1703 0.63014 0.25969 0.96022 0.14028 0.53034 0.39018 0.78018 0.82081 1.1207 0.17943 0.14025 0.82016 0.72995 0.84038 0.92043 0.0398 0.31116-0.73077 0.32029-0.99176 0.33008-1.4707 0.0698-2.3606 1.2407-3.4411 2.1318-0.31971 0.25897-0.88084 0.57992-1.0714 0.95044-0.20031 0.3803-0.1703 1.0104-0.30014 1.4208-0.63942 0.06-1.181 1.1807-1.6305 1.6308-0.35038 0.33986-0.63094 0.66993-0.90107 1.0802-0.20031 0.30986-0.53046 0.60014-0.70989 0.91-0.17029 0.32029-0.25968 0.74038-0.39083 1.0907-0.14028 0.36987-0.2101 0.81997-0.24011 1.2101-0.0796 0.96022-0.06 1.9504-0.25968 2.8702-0.18987 0.8702-0.27013 1.7306-0.31058 2.6308-0.0411 0.75017-0.31971 1.3105-0.73012 1.9204-0.49001 0.71038-0.82081 1.3503-0.8704 2.2505-0.0405 0.8702-0.25055 1.6706-0.25055 2.5512 0 0.63015-0.0411 1.2505-0.0496 1.8696-0.0104 0.36074 0.15986 1.0502-0.0998 1.3307 0 0.0202-0.0196 0.0411-0.0405 0.0502-0.48022 0.38031-1.5314-0.24984-2.0214-0.3803-0.31971-0.0802-0.61137-0.14025-0.90107-0.31051-0.33015-0.18983-0.58983-0.54012-0.93108-0.72995-0.58005-0.32029-1.4302-0.15003-2.0514-0.33986-0.49001-0.16047-0.88084-0.30007-1.4106-0.28963-0.49001 0-0.96109 0.03-1.4204-0.12068-0.59048-0.17939-1.0505-0.50033-1.5816-0.78997-0.27991-0.15982-0.58005-0.40966-0.8704-0.5199-0.42933-0.15982-0.99045 0.09-1.3904-0.12003-0.3693-0.18982-0.44042-0.42988-0.90041-0.50098-0.4202-0.06-0.73012 0-1.0805-0.24984-0.44955-0.31051-0.74969-0.75017-1.1099-1.1605-0.36082-0.41032-0.88084-0.54013-1.2612-0.92043-0.18987-0.19048-0.30992-0.55056-0.55003-0.63015-1.1203-0.33986-0.0502 1.9113-1.2006 0.76061-0.33994-0.33986-0.65052-0.69016-0.98067-1.0404-0.27013-0.27985-0.63029-0.74039-0.95066-0.96022-0.75034-0.50099-1.4407 0.3803-1.2404 1.1298 0.0998 0.3803 0.46065 0.48989 0.6603 0.77105 0.15007 0.21983 0.15007 0.47032 0.33994 0.67972 0.2897 0.31964 0.63029 0.23027 0.74056 0.66015 0.0698 0.25962 0.0196 0.69016-0.0104 0.96022-0.0202 0.20092-0.0202 0.69994-0.18987 0.81019-0.30014 0.20026-0.43063-0.38031-0.59049-0.58057-0.30013-0.36987-0.29035-0.12068-0.71054-0.23093-0.23098-0.0502-0.41041-0.28963-0.46065-0.53033-0.24011 0.13959-0.4502 0.39922-0.54024 0.66928-0.0692 0.21983-0.0503 0.74104-0.2897 0.85063-0.23033 0.11024-0.33015-0.19048-0.61985-0.10959-0.29035 0.0802-0.5011 0.53034-0.70076 0.7293-0.12984 0.12068-0.24011 0.30007-0.42998 0.31116-0.17029 0.01-0.19052-0.15004-0.32036-0.17026-0.19053-0.0104-0.16051-0.15004-0.21989 0.14025-0.06 0.27006 0.0907 0.39009 0.27013 0.55904 0.36995 0.3503 0.55003 0.33008 0.60027 0.81019 0.0411 0.29028-0.0202 0.57013 0.0803 0.81997-0.2499 0.03-0.42998-0.09-0.66944-0.12003-0.27013-0.0404-0.48022 0.06-0.74121 0.09-0.42019 0.0411-0.85017-0.12003-1.2397-0.21983-0.78036-0.20027-1.5509-0.0998-2.3613-0.21005-0.98002-0.12981-1.1908-0.81997-1.8106-1.4599-0.61071-0.6308-0.7797-1.7215-1.761-1.8206-0.41041-0.0502-0.83973-0.0111-1.2508-0.0502-0.63943-0.06-1.181-0.24005-1.7904-0.36986-0.44107-0.0992-0.92064-0.11025-1.3715-0.0405-0.2101 0.03-0.33994 0.0992-0.59049 0.0802-0.30992-0.03-0.33994-0.18004-0.58005-0.25049-0.56047-0.15917-0.67009 0.31115-1.0407 0.50098-0.21988 0.12003-0.12071 0.09-0.41041-0.0998-0.18008-0.13047-0.33994-0.24006-0.5011-0.39009-0.36016-0.33986-0.63942-0.66016-1.0798-0.93022-0.42998-0.27006-0.97023-0.33007-1.4309-0.54012-0.71055-0.32029-1.1405-0.97001-1.8811-1.2003-0.63094-0.20091-1.1608 0.01-1.5712-0.59035-0.0574-0.0855-0.10701-0.17548-0.14746-0.2655z",
+                HsinchuCounty:"m293.48 147.63c0.0196-0.71104-0.09-1.4514-0.0502-2.1514 0.03-0.55969 0.18987-1.1807 0.0698-1.73-0.12005-0.56034-0.58005-0.84019-0.91085-1.2707-0.2897-0.38031-0.67009-0.63015-1.0002-0.96023-0.67988-0.71103-1.2312-1.5812-1.9118-2.2805-0.60027-0.61123-1.2704-1.1102-1.7604-1.8011-0.55982-0.80041 0.47043-1.3705 0.19052-2.1403-0.25968-0.66993-1.0002-1.1703-1.5705-0.70973-0.69097 0.57013-1.5509 0.16961-2.2315 0.69016-0.30014 0.23027-0.52002 0.57079-0.88084 0.66015-0.36017 0.0907-0.88997 0.0111-1.2508 0-0.35038-0.01-0.66944-0.03-1.0002 0-0.39997 0.0411-0.58071 0.24006-0.93108 0.32029-0.47044 0.12003-0.61072-0.12981-0.95066-0.30985-0.34972-0.19048-0.72946-0.12068-1.1203-0.14025-0.69032-0.0307-1.0498-0.93086-1.7108-0.48011-0.25968 0.16961-0.38039 0.62036-0.61072 0.73974-0.18008 0.10045-0.82015 0.0502-1.0205 0-0.39018-0.10959-0.43064-0.51012-0.76079-0.69995-0.30014-0.19048-0.6205-0.06-0.90041 0.11025-0.21988 0.12981-0.3693 0.28963-0.55004 0.48011-0.24011 0.26027-0.47043 0.35029-0.79014 0.53033-0.30014 0.16961-0.44042 0.24984-0.67988 0.4899-0.24011 0.23027-0.33015 0.33986-0.6603 0.3803-0.69097 0.0692-1.3604-0.0607-1.8615-0.39074-0.52067-0.3503-1.1705-0.0691-1.791-0.24984-0.15985-0.2805-0.44955-0.47032-0.58005-0.78996-0.14028-0.3503-0.0802-0.75017-0.13049-1.1207-0.0998-0.66994-0.74056-1.3901-0.2499-2.0516 0.23032-0.32029 0.54025-0.36008 0.91085-0.43967 0.53047-0.0998 0.36996-0.18004 0.60093-0.57013 0.20945-0.3503 0.58984-0.55056 0.66031-1.0104 0.0692-0.42009-0.24011-0.4501-0.5011-0.62036-0.2897-0.20026-0.61072-0.48989-0.84039-0.77039-0.23946-0.2805-0.50958-0.5199-0.80058-0.75996-0.3804-0.32029-0.89063-0.74039-1.3604-0.95043-0.0803-0.47033 0.76078-0.33987 1.0407-0.44032 0.32037-0.12068 0.53046-0.36074 0.58136-0.72017 0.10961-0.78018 0.3693-1.5003 0.85996-2.1305 0.35038-0.46054 0.39083-0.9002 0.70989-1.3307 0.27012-0.36008 0.65051-0.66015 0.55134-1.1703-0.15007-0.78018-1.0414-1.0502-1.2808-1.711-0.17095-0.47033 0.12919-0.69994-0.33994-1.0405-0.39018-0.27006-0.73011-0.25049-0.99045-0.66993-0.23098-0.36009-0.29035-0.74039-0.81037-0.59036-0.30014 0.09-0.99111 0.48011-1.0407 0.76061-0.22053-0.0802-0.39996-0.41031-0.55069-0.58057-0.24011-0.27006-0.52002-0.48989-0.7797-0.74038-0.65052-0.6308-1.3115-1.0104-2.2119-1.3301-0.58983-0.21005-0.81037-0.78996-1.4106-1.0111-0.14942-0.0496-0.3693-0.03-0.50045-0.0802-0.2101-0.0991-0.12984-0.0691-0.25968-0.30007-0.19053-0.31964-0.20031-0.39009-0.57027-0.50033-0.19052-0.41031 0-0.89042-0.09-1.3307-0.10961-0.50033-0.60027-0.3503-1.0805-0.36987-0.80059-0.0496-1.1099-0.69016-1.5607-1.2394-0.23098-0.27985-0.54025-0.47033-0.76078-0.76061-0.30993-0.39009-0.43977-0.88129-0.78036-1.2505-0.21989-0.23092-0.54025-0.3105-0.77971-0.51011-0.25968-0.21984-0.35038-0.54013-0.64007-0.69016-0.54025-0.2805-0.91086-0.0411-0.66031-0.81019 0.12984-0.39987 0.50045-0.62036 0.76013-0.96022 0.33016-0.44097 1.2508-1.4814 0.82995-2.1612-0.27012-0.44945-1.4811-0.43053-1.9111-0.29028-0.64008 0.21005-0.33994 1-1.1705 0.8702-0.78036-0.12003-0.76079-1.0104-1.5907-0.5897-0.2897 0.14025-0.39018 0.3105-0.70011 0.0991-0.18008-0.10959-0.39083-0.47946-0.42084-0.66015-0.0196-0.0202-0.0502-0.0404-0.0803-0.06 1.2612-1.0104 0.11027-3.2212 0.85148-4.5213 0.8293-0.29028 1.8008-0.15003 2.7215-0.20092 0.0496-0.97001-0.15007-2.1207 0.65051-2.8206 0.76079-0.66015 2.1408 0.02022 2.6112-0.91064 0.2499-0.4899 0.13963-0.93021 0.47957-1.4403 0.30014-0.4501 0.41041-0.63014 0.94022-0.7306 0.74055-0.15004 1.9711 0.66015 2.1812 1.3203 0.2897 0.01044 0.60028 0.01957 0.89063 0.03001 0.0398 0.20026 0.18987 0.31964 0.18987 0.54991 0.5807 0.46054 0.28056 1.0307 0.49001 1.6804 0.33015 1.0307 0.63029 0.27985 1.2397 0.08024 0.90106-0.28963 1.1712 0.09915 0.91085-1.1403-0.10962-0.53034-0.15986-1.3601-0.33994-1.9204-0.19052-0.60014-0.64986-0.91064-0.98067-1.4305-0.38039-0.60014-0.33015-1.1096-0.33015-1.8396 0-1.5101-0.65051-1.9909-1.84-2.7508-0.64008-0.41031-1.0603-1.0104-1.7519-1.2401-0.89063-0.30007-1.3708-0.0698-1.8406-0.99023-0.88084-0.06067-1.4602-0.21005-2.2204-0.45989-0.73077-0.23092-1.6207 0.0098-2.2921-0.36987-1.35-0.76061-1.4211-2.651-3.0216-2.8311 0.0404-0.06001 0.0698-0.11024 0.0404-0.19048 0.0992-2.471 1.9202-1.6008 2.9218-3.1709 0.4502-0.71038-0.03-1.9107 0.14028-2.7508 0.26034-1.2401 1.0205-2.3105 1.6312-3.3908 0.5011-0.85976 0.66096-1.9805 1.3115-2.6908 0.4202-0.44945 0.93043-0.78996 1.4407-1.12 0.47956 0.12981 1.1705 0.12981 1.5607 0.03979 0.61006-0.1396 0.82995-0.7293 1.4407-0.90021 0.63029-0.17939 1.1908 0.2805 1.8106 0.3803 0.8704 0.13046 1.35-0.24006 2.0807-0.39922 0.61072-0.12981 1.4707-0.01044 1.9907 0.27006 0.41041 0.21983 1.3806 0.8702 1.6606 1.1703 0.81037 0.88977 0.0202 2.9713 0.27012 4.1416 0.26034 1.2205 2.4716 1.09 3.5925 1.5708 0.66944 0.28898 1.0107 0.54991 1.8308 0.5199 0.69032-0.03001 1.3506-0.11024 2.071-0.0698-0.11027 0.54012-0.06 1.2003-0.23032 1.7404 0.0992-0.33008 1.4511 0.63993 1.4602 0.65037 0.70011 0.24006 1.9509 0.01044 2.7019 0.01044 0.71055 0 2.2204 0.33986 2.4213 1 0.0405 0.14025-0.24011 0.36074-0.17029 0.58057 0.0992 0.36008 0.3693 0.19048 0.47957 0.44032 0.15006 0.33986 0.15985 1.12 0.16964 1.5003 0.0111 0.66994-0.0496 0.84998-0.47957 1.3307-0.36995 0.40966-0.82016 0.42075-0.6603 1.1403 0.30014-0.03001 0.47957 0.0698 0.72033 0.19048 0.20031 0.09981 0.52002 0.67972 0.78036 0.85976 0.28969 0.20026 0.74969 0.39987 1.0798 0.5199 0.55069 0.19048 1.7108 0.14938 1.5907 1.0104 0.86061-0.1396 1.181 0.56035 1.331 1.2505 1.0407 0.33008 1.6808 1.5708 2.8918 1.3307 0-0.18004 0.14028-0.33986 0.11027-0.54991 0.53046-0.08024 1.0413 0.09915 1.5614 0.08024 0.03 0.66928-0.26034 1.6706 0.51023 1.8206 0.63942 0.12003 1.2606-0.72016 1.8308-0.75017 0.91085-0.03979 0.57091 0.92043 1.1705 1.3405 0.39018 0.27006 1.4002 0.43053 1.9013 0.51012-0.03 0.59035 0.01 1.3412 0.3693 1.8206 0.45021 0.60014 0.99111 0.29028 1.6312 0.67972 0.0998 0.06001 0.31058 0.3803 0.5011 0.50098 0.30014 0.20026 0.6205 0.33008 0.85082 0.4899 0.65052 0.44945 0.78036 0.55969 1.581 0.74039 1.3004 0.30007 2.2014 1.6706 1.9209 3.0914-0.12984 0.66015-0.67988 0.93021-0.82995 1.5003-0.15985 0.55969 0.0104 1.3803 0.18008 1.9009 0.21989 0.0502 0.12071 0.0802 0.2499 0.17026 0.11027-0.0202 0.27013 0.0202 0.39083 0.0202 0.41041 1.8004-1.3911 2.9707-0.72033 4.8115 0.12984 0 0.2499 0.03 0.38039 0 0.44042-0.48011 1.5509-0.51012 2.2713-0.39988 0.93957 0.1396 0.80059 0.50034 1.3108 1.1905 0.33994 0.45989 0.88084 0.76061 1.0198 1.3901 0.16051 0.71038 0 1.4703 0.18008 2.1507 0.39018 0.0202 1.6312-0.17939 1.9209 0.0802 0.31906 0.2805 0.17943 1.411 0.14942 1.8506-0.03 0.61123-0.14942 1.0502 0.2499 1.5708 0.45999 0.61057 0.80124 0.66994 0.76013 1.5904 1.4609-0.28898 0.30014 3.2812 0.33994 4.002 0.86061 0.50033 0.74056 1.7508 1.5809 2.2512 0.76079 0.01 1.2508 0.77039 1.8413 0.99023 0.73012 0.27984 1.8902 0.0502 2.6712-0.0502 0 0.39987 0.0802 0.78018 0.24011 1.0711 0.42019 0.74039 1.1007 0.82976 0.35038 1.6902-0.46065 0.50947-1.2404 0.47033-1.6312 0.95044-0.78036 0.96022 0.19052 3.5806 0.35038 4.6909 0.1703 1.1507-0.15986 1.0802-1.0805 1.4906-1.1608 0.50098-0.6205 1.1507-0.93042 2.2505-1.1516 0.41031-1.8622-0.15004-2.1616 1.2603-0.17029 0.8304 0 0.69081-0.74969 1.0007-0.48022 0.20026-0.91085 0.10959-1.0113 0.81997-0.44956 0.33008-0.0992 0.62036-0.74056 0.85063-0.49001 0.17939-0.92064-0.0698-1.3904 0.25049-0.48022 0.32029-0.97088 1.4906-1.2103 2.0607-0.14942 0.33008-0.17943 0.88064-0.39018 1.1298-0.24011 0.29028-0.74056 0.24984-1.0107 0.66015-0.47043 0.74104-0.39997 1.8402-0.79015 2.5708-0.0411-0.0202-0.0802-0.0404-0.1207-0.0698-0.91999 0.94-2.0905 1.5812-3.4118 1.7802-1.5809 0.24005-3.4222 0.24005-5.043 0.15982 6.5e-4 -0.0437 6.5e-4 -0.0939 6.5e-4 -0.14351z",
+                HsinchuCity:"m239.48 98.926c0.2101-0.57078 0.27012-0.55121 0.82995-0.91064 0.30013-0.19048 0.85996-0.51012 1.1209-0.81019 0.25904-0.30007 0.20031-0.63014 0.30993-0.98044 0.0803-0.27006 0.24011-0.77953 0.11027-1.0802-0.14942-0.36008-0.63029-0.4201-0.91086-0.60014-0.24989-0.14025-0.58135-0.4899-0.42084-0.8291 0.0998-0.20092 0.28056-0.12068 0.39083-0.29028 0.09-0.14938 0.03-0.46054 0.03-0.63014 0-0.71038-0.0502-1.4501 0-2.1611 0.0196-0.34965 0.10962-0.5897 0.24011-0.8702 0.12006-0.26941 0.39018-0.4201 0.55069-0.66015 0.18987-0.31051 0.21989-0.7006 0.40976-1.0196 0.21988-0.3803 0.47956-0.4501 0.51023-0.91064 0.0196-0.33986-0.03-0.68037 0.0803-1.0007 0.11027-0.30985 0.3693-0.5199 0.5396-0.78996 0.20096-0.30985 0.41106-0.4899 0.64008-0.74039 0.23032-0.24006 0.42019-0.53034 0.6205-0.84019 0.38039-0.55969 0.42019-1.4103-0.25969-1.7306-0.30013-0.14025-0.63029-0.21983-0.95065-0.24984 0.06-0.4899 2.5616-0.16047 3.0314-0.27985 0.03-0.06001 0.0692-0.0998 0.09-0.14025 1.6005 0.17939 1.6716 2.0705 3.0216 2.8311 0.67009 0.3803 1.5614 0.1396 2.2921 0.36987 0.75948 0.24984 1.3408 0.39922 2.2204 0.45989 0.47109 0.91978 0.95066 0.69016 1.8406 0.99023 0.69032 0.23027 1.1105 0.83041 1.7512 1.2401 1.1908 0.76061 1.8406 1.2401 1.8406 2.7508 0 0.72995-0.0502 1.2394 0.33015 1.8396 0.33015 0.52055 0.79014 0.83041 0.98067 1.4305 0.18008 0.56035 0.23097 1.3908 0.33993 1.9204 0.25969 1.2394-0.0104 0.85063-0.91085 1.1403-0.61006 0.20026-0.9102 0.95044-1.2397-0.08024-0.21009-0.65037 0.09-1.2205-0.49001-1.6804 0-0.23092-0.15006-0.3503-0.18986-0.54991-0.29036-0.01109-0.60028-0.02022-0.89063-0.03001-0.2101-0.6608-1.4407-1.4703-2.1812-1.3203-0.53046 0.0998-0.64008 0.27985-0.94021 0.7306-0.33994 0.51012-0.23033 0.95044-0.48022 1.4403-0.47044 0.93021-1.8511 0.24984-2.6112 0.91064-0.80059 0.69994-0.60028 1.8506-0.65052 2.8206-0.91999 0.05023-1.8902-0.09002-2.7215 0.20092-0.74055 1.3001 0.40976 3.5108-0.85082 4.5212-0.42019-0.29028-1.1608-0.33007-1.7206-0.33007-0.8306 0-1.2912-0.14025-1.2808-1.0411 0-0.63928-0.03-1.1298-0.4104-1.6197-0.14094-0.18004-0.41106-0.36986-0.51024-0.54991-0.12984-0.21983-0.0907-0.50098-0.16964-0.74104-0.69097-0.19048-1.1105 1.4103-1.791 1.5401-0.31123 0.06-1.0903 0.03-1.3715-0.09-0.40062-0.15004-0.44955-0.44032-0.91085-0.46054-0.0111-0.06002-0.0202-0.11024 0-0.15004 0.0189-0.20026 0.20944-0.2805 0.3693-0.4201 0.24272-0.2094 0.27273-0.28963 0.37256-0.54926z",
+                Miaoli:"m246.9 103.34c0.03 0.0202 0.06 0.0404 0.0803 0.06 0.03 0.18004 0.24011 0.54991 0.42019 0.66015 0.31123 0.21005 0.41106 0.0411 0.70076-0.0992 0.82994-0.42075 0.81037 0.47032 1.5907 0.5897 0.82994 0.12981 0.53046-0.66015 1.1705-0.8702 0.42998-0.14025 1.641-0.16047 1.9111 0.29028 0.42084 0.67973-0.50045 1.7202-0.82995 2.1612-0.25968 0.33986-0.63094 0.5597-0.76013 0.96022-0.2512 0.7704 0.12005 0.53034 0.6603 0.81019 0.29035 0.14938 0.38039 0.47032 0.63943 0.69016 0.24011 0.20026 0.56047 0.27984 0.78036 0.51011 0.33993 0.36922 0.47043 0.86042 0.78035 1.2505 0.21989 0.29028 0.53046 0.48011 0.76079 0.76061 0.44955 0.54991 0.76078 1.1905 1.5607 1.2394 0.48022 0.0202 0.97088-0.12916 1.0805 0.36987 0.09 0.44032-0.0998 0.92043 0.09 1.3307 0.36995 0.10959 0.38039 0.18004 0.57026 0.50033 0.12985 0.23093 0.0502 0.20092 0.25969 0.30072 0.13049 0.0496 0.35038 0.03 0.50044 0.0796 0.60028 0.22048 0.82016 0.80105 1.4106 1.0111 0.90042 0.31964 1.5607 0.69929 2.2112 1.3301 0.26034 0.25049 0.54025 0.47032 0.78036 0.74039 0.15007 0.17025 0.33015 0.50033 0.55004 0.58056 0.0502-0.27984 0.74121-0.66928 1.0414-0.76061 0.52002-0.14938 0.5807 0.23093 0.80971 0.59036 0.26034 0.42009 0.60093 0.39987 0.99111 0.66993 0.47044 0.33986 0.1703 0.57013 0.33994 1.0405 0.24011 0.66015 1.1307 0.93021 1.2815 1.711 0.0992 0.51012-0.28122 0.81019-0.55134 1.1703-0.31906 0.42988-0.36017 0.8702-0.70989 1.3307-0.49001 0.63015-0.74969 1.3497-0.86062 2.1305-0.0496 0.36009-0.25968 0.60014-0.5807 0.72017-0.27991 0.0991-1.1203-0.03-1.0407 0.44032 0.47043 0.21004 0.98067 0.63014 1.3604 0.95043 0.29035 0.24006 0.55982 0.48011 0.80058 0.75996 0.23098 0.2805 0.55004 0.57013 0.84039 0.77039 0.25968 0.17026 0.57026 0.20092 0.5011 0.62036-0.0698 0.45989-0.45021 0.66015-0.66096 1.0104-0.23032 0.39074-0.0692 0.47033-0.60028 0.57013-0.3693 0.0802-0.68053 0.12068-0.91085 0.43967-0.49001 0.6608 0.14942 1.3803 0.2499 2.0516 0.0502 0.36921-0.01 0.77039 0.13049 1.1207 0.12919 0.32029 0.4202 0.51012 0.58005 0.78996 0.6205 0.18004 1.2704-0.0998 1.791 0.24984 0.50045 0.33008 1.1705 0.46054 1.8609 0.39075 0.3308-0.0411 0.42084-0.15004 0.66095-0.38031 0.24011-0.24005 0.38039-0.32029 0.67988-0.48989 0.31971-0.18005 0.55003-0.27007 0.79014-0.53034 0.17943-0.19048 0.33016-0.3503 0.55004-0.48011 0.28056-0.17026 0.60027-0.30007 0.90041-0.11025 0.33015 0.19048 0.36996 0.59036 0.76079 0.69995 0.20031 0.0502 0.84038 0.10045 1.0205 0 0.23032-0.12003 0.34972-0.57013 0.61071-0.73974 0.6603-0.4501 1.0205 0.44945 1.7108 0.48011 0.39017 0.0196 0.77057-0.0502 1.1203 0.14025 0.33994 0.17939 0.48022 0.42923 0.95066 0.30986 0.35037-0.0802 0.53046-0.27985 0.93042-0.3203 0.33081-0.03 0.65052-0.01 1.0009 0 0.36016 0.0111 0.89062 0.0907 1.2508 0 0.36016-0.09 0.5807-0.42988 0.88084-0.66015 0.68053-0.5199 1.5405-0.12002 2.2315-0.69016 0.57026-0.46054 1.3108 0.0398 1.5698 0.70973 0.28121 0.7704-0.74969 1.3405-0.19052 2.1409 0.49 0.69016 1.1608 1.1898 1.761 1.8004 0.67988 0.69929 1.2306 1.5702 1.9118 2.2805 0.33015 0.33007 0.71054 0.58056 1.0002 0.96022 0.33015 0.43053 0.79015 0.71038 0.91085 1.2707 0.12006 0.54991-0.0404 1.1703-0.0698 1.73-0.0405 0.69995 0.0698 1.4403 0.0502 2.1514-0.53046 0.47946-1.1307 0.91977-1.9411 0.87998-0.47108 1.1703 0.0803 2.6106-0.39083 3.7809-1.5007 0.53034-1.5398 1.8311-2.6412 2.561-1.8211 1.1814-2.2112-0.17939-2.5212-1.6804-0.6603-0.17939-1.4302-0.27985-2.1212-0.15917-0.10962 2.1005 0.0607 2.7704-2.161 3.1703-1.0505 2.0516-1.9013 2.8311-4.2019 3.3021-1.3904 0.28898-1.6501 0.0991-2.5414 1.1292-0.30013 0.33986-0.24989 0.83041-0.63029 1.2101-0.36081 0.36008-1.0903 0.19048-1.4609 0.69016-0.81038 1.0907-0.0502 1.3503-1.3715 2.1409-0.28057 0.16048-1.9914 1.12-2.3306 1.1703-1.1014 0.15982-1.4407-1.0907-2.6719-0.68037-0.93956 0.32029-0.88997 1.6706-2.4814 1.7-0.2499 0.6308-0.74056 1.0802-0.88084 1.7802-1.7519 0.14025-1.9607-0.39988-3.1926-1.4306-0.31058-0.25962-1.0002-0.39009-1.2508-0.74039-0.3693-0.5199-0.17943-1.2401-0.53046-1.7704-1.4407-2.1709-4.9627-1.5101-7.1739-1.8702-1.7408-0.2805-4.9425-2.4899-6.3832-0.3803-1.5209 2.261 1.5809 5.6615-1.6201 6.882-2.191 0.8402-5.2224-0.0404-7.6744 0.33073-1.3911 0.2094-2.3711 0.58057-3.4522-0.20091-0.96958-0.71038-1.5509-1.8709-2.4311-2.5806-1.8511-1.4808-4.7128-0.85976-6.834-2.1807-1.9613-1.2205-3.3824-3.1507-5.163-4.4912-1.0805-0.81019-1.7108-0.39074-2.8017-0.8702-0.95065-0.40966-1.2404-1.3001-1.9913-1.9602-1.4002-1.2401-2.3411-2.0907-3.462-3.5917-1.2208-1.6497-3.0216-2.1696-4.0917-3.621-1.0414-1.4299-1.1405-3.0809-2.5512-4.2114 0.58984-0.96935 1.6312-1.7202 2.5414-2.4599 0.47044-0.39074 1.1908-0.75017 1.5614-1.2003 0.38039-0.46054 0.17943-0.91064 0.33994-1.4305 0.2897-0.92043 1.1705-1.4906 1.5607-2.3608 0.4502-1.0007 0.91085-1.6908 1.5614-2.6008 0.30013-0.42923 0.49-1.15 0.55982-1.6602 0.11027-0.84019 0.11027-1.1403 0.69097-1.8096 0.54025-0.63993 0.63942-0.99088 0.67988-1.8004 0.06-1.2309 0.5807-2.5617 0.88083-3.762 0.36996-1.4703 1.6312-2.1005 2.4109-3.381 0.50045-0.83041 0.61072-1.7906 1.1705-2.651 0.36995-0.55904 0.92064-1.5206 1.5607-1.6602 1.0413-0.24006 4.1928 1 3.7824-1.2394-0.54025-0.22048-0.92064 0.12916-1.4106 0.0992-0.0411-0.23027 0.5807-1.1298 0.74056-1.4103 0.30013-0.53034 0.68053-0.92043 0.86061-1.5304 0.33994-1.1305 0.65051-1.9407 1.6201-2.6706 0.70076-0.53034 1.562-1.3007 2.5218-1.4403 1.1803-0.18004 2.3802-0.39988 3.5618-0.50099 0.59049-0.06 1.2103 0.0202 1.8008-0.01 0.2499-1.3503 1.2208-2.621 2.5009-3.1312 0.0907-0.98045 1.0505-1.1103 1.5809-1.7802 0.49001-0.6197 0.44107-1.2805 0.49001-2.0803 0.0607-0.81997 0.53046-1.4703 1.0805-2.0307 0.44042-0.44032 0.97088-1.3307 1.562-1.5401-0.0202 0.04044-0.0111 0.09067 0 0.15004 0.45999 0.0202 0.50958 0.30985 0.91085 0.46054 0.27991 0.12003 1.0603 0.14938 1.3715 0.09 0.68053-0.12981 1.1007-1.7306 1.7904-1.5401 0.0803 0.24006 0.0404 0.52056 0.17029 0.74104 0.0992 0.17939 0.3693 0.36922 0.50958 0.54991 0.3804 0.4899 0.41106 0.98044 0.41106 1.6204-0.0111 0.90021 0.44956 1.0405 1.2808 1.0405 0.56112-5e-3 1.301 0.0346 1.7212 0.32486z",
+                Taipei:"m351.36 53.383c0.0104 0.32029 0.0104 0.65037 0 0.97066-0.52002-0.02022-1.0407 0.06915-1.5705 0.09915-0.25968 0.01044-0.5807-0.06001-0.82994 0.02022-0.20031 0.0698-0.4202 0.36008-0.56048 0.39987-0.50045 0.14938-0.96044-0.11024-1.5307-0.09067-0.63029 0.03066-0.92064 0.32029-1.4909 0.44097-0.90042 0.19048-2.3313-0.39987-3.141 0.17026-0.20096 0.1396-0.10962 0.44032-0.28056 0.63014-0.15986 0.17026-0.42933-0.05023-0.58984 0.26028-0.35038 0.66928 0.3693 0.87998 0.82016 1.0196 0.0692 1.2805-1.0303 5.092 1.0909 4.8318 0.06 0.3503 1.3004 0.54991 1.6605 0.66994 0.25968 0.96935-0.47043 0.77953-1.151 0.81997-0.82995 0.05023-0.77123 0.41031-1.4106 0.66928-0.59049 0.22048-1.2208-0.2394-1.761-0.31964-0.61071-0.09981-1.3708 0.23027-1.5098-0.59035-0.67009 0.13046-1.0414 0.65037-1.7414 0.57013-0.55004-0.06001-0.85996-0.47032-1.1601-0.92043-0.47108-0.67972-1.3506-1.6804-1.2704-2.5708-0.3804 0.02022-0.8704-0.03001-1.1705-0.2394-0.39997-0.2805-0.25969-0.74104-0.47044-0.94-0.72033-0.66994-1.4609 0.47032-1.9117 0.83041-0.01-1.2009 1.791-2.1905 0.74121-3.3412-0.44107-0.48011-0.97023-0.68037-1.4009-1.1703-0.44042-0.50098-0.60028-0.96087-1.3604-0.90021-0.82016 0.06001-1.0505 0.72016-1.4909 1.2505-0.61072 0.74039-0.79015 0.88977-1.3604 0.09981-0.46065-0.63928-0.42019-0.95044-0.55982-1.681-0.0907-0.43967-0.61137-1.1801-0.59049-1.5904 0.06-1.06 2.2308-1.06 2.8115-2.0209 0.59049-0.94 0.61137-2.8011 0.61137-3.9818 0-1.2205-0.73077-2.1507-1.5816-2.9811-0.41041-0.39922-0.69032-0.8004-1.2501-1.0196-0.57091-0.21983-1.2404-0.10959-1.8315-0.24984-0.52002-0.12981-1.0603-0.20092-1.5607-0.39987-0.84038-0.32029-0.75034-0.42075-0.79014-1.1905-0.0202-0.54991-0.19053-1.2903 0.03-1.8095 0.0992-0.23092 1.2306-1.0202 1.2208-0.69081 0.0405-0.8004-0.2101-1.7606 0.42998-2.2407 0.7001-0.53034 1.331-0.10959 1.2612-1.3999 1.0309-0.06001 1.2097 0.12981 1.4909-0.85063 0.16051-0.57992 0.28056-0.97 0.65052-1.5003 0.28904-0.42075 0.67987-1.1011 1.1803-1.2609 0.54025-0.17026 1.4211 0.01957 1.9914 0 0.19052-1.1703-0.0802-1.8102 1.3415-1.8206 0.5807-0.01044 1.0002-0.06915 1.4902-0.25962 0.24011-0.09067 0.89062-0.3803 1.0205-0.57013 0.2101-0.36008-0.1605-1.06 0.0502-1.4403 0.21989-0.39074 0.89063-0.4899 1.1301-0.80105 0.18008-0.23027 0.36082-1.03 0.64007-1.1703 0.58005-0.28963 0.96045 0.42075 1.3904 0.65037-0.33994 1.6308 0.90041 1.8617 2.191 1.9309 0.60028 1.5003-0.03 3.3308 0.76013 4.822 0.14942 0.27006 0.50958 0.50033 0.61072 0.7293 0.15007 0.36987 0.0202 0.86042 0.06 1.2707 0.0698 0.85063 0.53046 1.2401 1.151 1.7704 0.20944 0.77105 0.85996 0.80105 0.85082 1.8206-0.0111 1.1011-0.69097 0.98044-1.0909 1.8311-0.10962 0.21983-0.13963 0.82976-0.0803 1.0907 0.14029 0.51012 0.0104 0.30007 0.66944 0.40966 0.78036 0.12981 1.3917 0.60014 2.1512 0.68037 0.0307 1.0405 1.1908 0.69994 1.4309 1.6504 0.2499 0.93935-0.48022 2.9707-1.0002 3.6706-0.85083 1.1507-0.63029 1.0705-0.33015 2.4208 0.32036 1.4808 2.0011 2.8011 3.2519 3.3301 0.53047 0.23092 1.1007 0.3803 1.7512 0.42075 0.76666 0.04175 1.1966-0.49838 1.8974-0.23875z",
+                Newtaipei:"m400.14 55.204c1.2012 4.4117-4.7722 2.1905-5.6935 4.7613-1.1901 0.06001-2.1904-0.84019-3.3909-0.36987-0.6316 0.25049-0.66161 0.85063-1.2319 1.1305-0.4202 0.21005-1.3911 0.18004-1.8511 0.23092-1.181 0.12916-2.4318 0.74039-3.2722 1.6497-0.49001 0.5199-0.7497 0.97001-1.5705 1.12-0.65051 0.12981-1.4211 0.1109-2.0801 0.15003-1.562 0.0698-2.7221-0.25962-3.8215 0.91064-0.91085 0.99023-1.6012 1.6308-1.1712 3.0711 1.0609-0.04044 2.3613 0.88064 2.1414 1.9407-0.15007 0.71038-1.6508 1.5401-2.2315 1.9107-0.46 0.30007-0.77122 0.76061-1.1405 1.0202-0.42085 0.30007-1.1705 0.23027-1.7004 0.23027-1.2612 0-2.4416 0.09981-3.6526 0.3503-0.47043 0.78018-0.0104 2.4906-1.4106 2.5004-0.31972 0.80105 0.28056 0.84084 0.38039 1.4208 0.11027 0.6308-0.46 0.74104-0.75035 1.3007-1.2906 0.39988-1.7408 1.3503-2.9009 2.0105-1.2012 0.69994-2.6008 0.21983-3.9416 0.48011-1.0113 0.20026-2.6614 1.15-3.312 1.9302-0.36082 0.42988-0.67988 1.06-1.1705 1.4305-0.4502 0.33986-1.2312 0.5199-1.6012 0.96935-0.4502 0.54991-0.29035 1.4103-0.33015 2.1005-1.4009 0.0698-2.7717 0.01044-4.1523 0.09067-1.2808 0.08024-3.0418 0.0098-4.0721 0.77039-0.49 0.36987-0.75034 0.88064-0.85082 1.4814-0.15007 0.96935 0.11027 1.1298-1.0002 1.1703-0.99046 0.03001-3.282 0.21983-3.3518 1.6497-0.0104 0.08024-0.0502 0.21983-0.0502 0.33986 1.2606 0.42988 0.38039 1.5701 0.0502 2.2603-0.44042 0.94-0.33015 1.8108 0 2.6908 0.76078 2.0007 0.73077 4.1912-1.9711 4.0712 0.0803 1.2505-0.28905 1.6602-1.5098 1.6602-0.94021-0.01-2.8924 0.14025-3.4327 0.9002-0.53046 0.72995-0.20944 2.0105-1.0707 2.5108-0.24011 0.15003-0.63029 0.13046-0.92064 0.23092-0.35038 0.12981-0.63029 0.40966-0.98066 0.54991-0.65052 0.26027-1.4707 0.06-2.1812 0.20026-0.69097 0.1409-1.1908 0.6308-1.7708 0.92043-0.73077 0.36987-1.1203 0.39074-2.0011 0.43053-0.1703 0.0104-0.36017 0.0202-0.57026 0.0202 0.01-0.92043 0.0398-1.8409-0.0104-2.7508-0.94022 0.11024-0.91086-0.74039-1.6312-1.1814-0.42084-0.24984-0.54024-0.33986-1.0205-0.4201-0.36016-0.0502-0.85017 0.11024-1.151-0.0998-0.64007-0.42989-0.21988-1.3301-0.54025-1.9602-0.26033-0.51011-0.72033-1.0307-1.0407-1.5206-0.75035-1.15-1.4511-2.1605-1.8615-3.501-0.17029-0.57013-0.21988-1.3197-0.33015-1.9198-0.20031-0.98044-0.14028-1.2009 0.60028-1.6412 1.0603-0.63014 1.3715-1.9302 2.7215-2.1201 0.31123-0.2805 0.29035-0.76061 0.2499-1.2205-2.3411 0.1409-0.99959-2.6504-1.7304-3.6811-0.39997-0.57013-1.3004-0.06001-1.6906-0.99023-1.1105 0.12003-1.6612-1.8709-2.2315-2.4514-0.68053-0.69016-2.7019-1.5806-3.5919-0.7306-0.44956 0.43053-0.30014 1.0711-1.1601 1.2505-0.81037 0.17091-1.331-0.58057-1.9209-0.91978-1.3108-0.74104-2.5009-0.59035-3.9918-0.68037-0.21988-1.0502 2.0612-1.3007 2.7319-1.3307 0.03-0.44097 0.0803-0.82976-0.21988-1.1814-0.2101-0.24984-0.91086-0.21983-1.0805-0.57992-0.43063-0.89042 1.6808-1.1403 1.3408-1.9909-0.24989-0.61058-1.1705 0.08024-1.6207-0.23092-0.36017-0.25962-0.38039-1.2303-0.33994-1.6602-0.12005 0-0.28056-0.04044-0.39018-0.03001-0.35038-0.30007-0.39083-1.0007-0.76078-1.2407-0.31123-0.20026-1.0205 0.01109-1.3415-0.24006-0.69031-0.53034 0.0405-1.4808-0.0104-2.4103-0.30992-0.01044-0.63029-0.01044-0.91085-0.0698 0.0202-0.14025 0.0411-0.90021 0.11092-0.93021 0.23946-0.09981 0.44956-0.23092 0.72033-0.27006 0.15007-0.3803 0.19052-1.1807 0.01-1.4906-0.30993-0.54012-0.72033-0.14025-1.0707-0.4899-0.42998-0.42988 0-1.1005 0.39997-1.2603 0.36016-0.15003 1.1007 0.01044 1.4909-0.01044 0.12005-0.77953-0.33994-1.2805-0.49001-1.9909-0.14093-0.71038-0.19052-1.5095-0.16051-2.2505 0.0104-0.33986-0.0802-1.0705 0.0992-1.3405 0.30014-0.4501 0.44107-0.21005 0.90041-0.33008 0.74121-0.18983 1.3115-0.30007 2.1016-0.1396 1.1301 0.23027 3.0118 0.57013 4.1523 0.14938 1.1301-0.43053 0.74056-2 2.4011-1.9407 0.19052-0.39987 0.77057-0.82976 1.1705-1 0.0398-0.54012 0.03-0.8702-0.30014-1.2603-0.18987-0.21983-0.72033-0.21005-0.84039-0.57013-0.32036-0.96087 1.3604-1.0307 1.9711-1.0007-0.03-0.92043-0.58984-1.0405-0.88019-1.7606-0.31058-0.74039-0.09-1.8004 0.12984-2.4599-0.0411-0.01044-0.09-0.02022-0.14028-0.03001-0.0405-0.2805-0.0998-0.55056-0.19052-0.81019-0.99111-0.24006-0.94022-0.55969-1.0002-1.5003-0.31123-0.0698-0.54025-0.2805-0.5807-0.58057-1.1712-0.12003-2.052-0.54991-3.2422-0.60014-0.76078-0.02022-1.6012-0.44032-2.071-0.93021-0.30992-0.32029-0.33015-0.63993-0.53046-0.98044-0.32036-0.53034-0.5011-0.44032-0.90041-0.75017-0.68053-0.51012-1.3611-0.90021-1.6808-1.6602-1.0303-0.02022-2.0912-0.05023-3.1417-0.11024-0.0692-0.20026-0.18008-0.24984-0.20031-0.47033-0.36995-0.29028-0.5807-0.67972-1.0714-0.8702-0.47957-0.19048-1.0002-0.0411-1.4407-0.36987-0.66031-0.5199-0.42933-1.9107-0.39932-2.8109 0.21989-0.01044 0.39018-0.02022 0.46065-0.05023 0.42933-0.15003 1.7512-0.15982 2.5505-0.33008 1.8817-0.39074 3.5729-0.15003 5.5128-0.24006 0.86061-0.0411 1.5007-0.17026 2.2419-0.76061 1.0198-0.81019 1.32-1.3705 2.7515-2.0007 0.0404-0.21983 0.90041-0.28963 1.0009-0.50033 1.9809-1.1011 6.8738-4.0509 2.7815-5.702 1.5307-0.33986 0.9102-1.3105 1.4609-2.3105 0.47043-0.86042 1.7512-1.6106 2.2112-2.3007 0.94022-1.4299 1.9509-3.2603 1.8413-5.4006 0-0.13046 2.4311-0.0698 2.6712-0.18004 1.2103-0.60014 1.0002-1.3601 1.7806-2.2603 1.3408-1.5604 3.402-2.561 4.5523-4.3112 1.2508 0.01109 4.703 0.96087 3.4816-1.4899 0.67009 0.33986 0.53046-0.05023 1.0205 0.66015 1.38 0.08024 3.8418 0.53034 4.6521-0.62036 0.80058 0.63014 1.0407 0.69016 2.0214 0.4501 0.12071 0.21983-0.0202 0.44032 0.0803 0.66928 1.2006 0.20092 1.7408 1.0202 2.7117 1.5401 1.2606 0.66994 0.59048 0.66015 2.251 0.74952 0.06 0.97 1.3708 1.6804 1.7003 2.5917 0.42085 1.1801 0.12985 2.8604 0.33994 4.1201 0.55917-0.12003 1.3604 0.20092 1.9202 0.08024-0.25903 2.2805 1.5712 2.6308 1.581 4.6713 0.96109 0.04044 1.962 0.04044 2.9224 0 0.69032-1.0007 2.071-0.93021 2.9916-1.9302 0.1703 2.2603-1.9613 3.1709-2.1616 4.9322 0.0502-0.4899 1.5105 0.7704 2.4716 1.6308-1.1399 0.53034-1.9307 1.0796-2.9505 1.7208-0.47043 0.29028-0.43063 1.2094-1.0505 1.4508-0.66944 0.25962-1.9907-0.01044-2.7215 0.03001-0.65052 1.8409-2.3913 1.4103-4.0023 1.501-0.12984 0.40966-0.12984 1.2603 0 1.6706 0.58071-0.14938 1.3708 0.0411 1.9209-0.17026 0.09 1.711-0.26034 6.0209 2.0005 6.002 0.03 0.27985-0.03 0.65037 0.0802 0.92043 0.42998-0.02022 1.0009 0.14938 1.4211 0.07958 0.42085 1.1403 1.4511 1.5708 2.5512 0.81019-0.21009 0.15982-0.43063 0.55056-0.7797 0.78018 0-0.01957 0.0796 0.55056 0.06 0.58057 1.4504-0.30007 2.5708 0.5199 2.5009 2.0007 2.0801 0.12003 3.5619 1.0405 5.5323 1.2205 0.47108 0.05023 1.0107 0.44945 1.6912 0.33008 0.60027-0.09981 0.48022-1.06 1.0414-1.2101 1.2697-0.34965 2.7515 0.58057 3.2121-1.0405 0.36017-1.2603-0.95065-2.1709-1.9711-2.3001 0.0998-1.8311-0.13963-3.1312-1.4504-4.2218 1.0498-0.24006 1.8406-1.1103 2.9009-1.2505 1.2012-0.16047 2.0605 0.78996 3.4712 0.47098-0.09-0.63993 0.33994-1.1103 0.33015-1.6713 0.3308 0.0698 0.84038-0.12003 1.1705-0.08024 0.0613-0.32029 0.39148-1.09 0.42149-1.4208v-0.03001c0.36017 0.01044 0.73012 0.01957 1.0805 0.03001-0.12136 0.55969 0.20031 1.3607 0.0796 1.9204 1.1099 0.07958 1.6612-0.84019 2.2504-0.92043 1.271-0.15982 1.8622 0.33008 2.7117 0.46054 1.4211 0.23027 4.7526-0.42075 5.043 1.2094 1.1405 0.18983 2.6216 0.39009 2.7515-0.92043 0.53046 0.06001 1.4811-0.28898 1.7108-0.28898-0.42084 0.74039-0.33015 1.5695-0.21009 2.4599 0.23097 0.0698 0.44042 0 0.67074 0.08024 0.36017 1.4299-2.5714 5.9316 0.2499 6.002 0.24011 1.1801 0.7908 1.7202 0.98067 2.9009 0.14028 0.85976-0.2101 2.4899-0.15007 3.5206 2.4115 1.5701 4.2535 0.91064 7.1739 1.0802 0.41106 1.1507 2.512 0.84084 3.6225 0.71038zm-48.785-0.84998c0.0104-0.32029 0.0104-0.65037 0-0.97066-0.69946-0.25962-1.1301 0.2805-1.9013 0.24006-0.65052-0.0411-1.2201-0.19048-1.7512-0.42075-1.2508-0.53034-2.9316-1.8506-3.2519-3.3301-0.30014-1.3503-0.52002-1.2701 0.33015-2.4208 0.52068-0.69994 1.2508-2.7313 1.0002-3.6706-0.24011-0.95044-1.4002-0.61123-1.4302-1.6504-0.76013-0.08024-1.3715-0.55056-2.1512-0.68037-0.66096-0.10959-0.53046 0.09981-0.67009-0.40966-0.06-0.26028-0.03-0.8702 0.0802-1.0907 0.40062-0.85063 1.0805-0.72995 1.0909-1.8311 0.01-1.0196-0.64008-1.0496-0.85083-1.8206-0.6205-0.53034-1.0805-0.91978-1.151-1.7704-0.0405-0.41031 0.0907-0.90021-0.06-1.2707-0.0998-0.23027-0.46064-0.45924-0.61071-0.7293-0.79015-1.4906-0.15986-3.3216-0.76013-4.822-1.2912-0.06915-2.5316-0.30007-2.191-1.9309-0.43063-0.23027-0.81037-0.93935-1.3904-0.65037-0.28056 0.14025-0.46065 0.94-0.64008 1.1703-0.23945 0.31116-0.91085 0.41031-1.1301 0.80105-0.2101 0.3803 0.15986 1.0802-0.0502 1.4403-0.12984 0.19048-0.78036 0.47946-1.0198 0.57013-0.49066 0.19048-0.91085 0.24984-1.4909 0.25962-1.4211 0.01044-1.151 0.65037-1.3415 1.8206-0.57027 0.01957-1.4511-0.17026-1.9914 0-0.50045 0.15982-0.89063 0.84019-1.1803 1.2609-0.36995 0.53034-0.49001 0.92043-0.65051 1.5003-0.28057 0.98044-0.46 0.78996-1.4909 0.85063 0.0692 1.2909-0.56047 0.8702-1.2606 1.3999-0.64008 0.47946-0.39084 1.4403-0.43064 2.2407 0.0104-0.33008-1.1203 0.46054-1.2208 0.69081-0.21989 0.5199-0.0502 1.2603-0.03 1.8095 0.0398 0.77039-0.0502 0.8702 0.79015 1.1905 0.50044 0.20026 1.0407 0.27006 1.5607 0.39988 0.59049 0.14025 1.2612 0.03001 1.8315 0.24984 0.55982 0.21983 0.84038 0.62036 1.2508 1.0196 0.85017 0.83041 1.5809 1.7606 1.5809 2.9811 0 1.1807-0.0202 3.0411-0.61137 3.9818-0.5807 0.96022-2.7515 0.96022-2.8115 2.0209-0.0202 0.41031 0.50044 1.1507 0.59048 1.5904 0.14029 0.7306 0.0992 1.0411 0.55983 1.681 0.57026 0.78996 0.75034 0.63993 1.3604-0.0998 0.44042-0.53034 0.67009-1.1905 1.4909-1.2505 0.76078-0.06067 0.92064 0.39922 1.3604 0.90021 0.43063 0.4899 0.9611 0.69016 1.4009 1.1703 1.0498 1.15-0.75034 2.1396-0.74121 3.3412 0.45021-0.36074 1.1908-1.501 1.9118-0.83041 0.2101 0.20026 0.0692 0.66015 0.47043 0.94 0.30014 0.2094 0.79015 0.25962 1.1705 0.2394-0.0803 0.89042 0.80124 1.8904 1.2704 2.5708 0.30013 0.4501 0.61071 0.86042 1.1608 0.92043 0.7001 0.08024 1.0707-0.43967 1.7408-0.57013 0.13963 0.82062 0.90041 0.4899 1.5098 0.59035 0.54025 0.08024 1.1705 0.54012 1.761 0.31964 0.64008-0.25897 0.58071-0.61971 1.4106-0.66928 0.68053-0.04044 1.4106 0.14938 1.151-0.81997-0.36017-0.12068-1.6012-0.32029-1.6606-0.66994-2.1212 0.25962-1.0198-3.5512-1.0909-4.8318-0.45021-0.14025-1.1705-0.3503-0.82016-1.0196 0.1605-0.31116 0.43063-0.09067 0.58983-0.26028 0.17095-0.18983 0.0803-0.4899 0.28057-0.63014 0.81037-0.57013 2.2412 0.02022 3.141-0.17026 0.57026-0.12068 0.85996-0.41031 1.4909-0.44097 0.57027-0.01957 1.0309 0.24006 1.5307 0.09067 0.14093-0.0411 0.36081-0.33008 0.56047-0.39988 0.2499-0.08024 0.57026-0.01044 0.82995-0.02022 0.53372-0.03066 1.0537-0.12068 1.5744-0.10046z",
+                Taoyuan:"m324.59 106.65c0.0502 0.91065 0.0202 1.8304 0.0104 2.7508-1.2208 0.0691-2.8918 0.21005-3.5619 0.95044-0.24011 0.25962-0.59048 0.69994-0.71054 1.0307-0.26034 0.78018 0.15007 0.57991 0.45999 1.2394 0.29035 0.60079-0.06 1.8311-0.27991 2.5004-1.1105 0.81019-2.1616 1.2609-2.5714 2.681-0.2101 0.71038-0.19053 1.4103-0.65052 2.0105-0.55069 0.71038-1.0009 0.47033-1.7114 0.72017-0.8704 0.3105-1.3806 1.561-1.3708 2.621-0.78035 0.0998-1.9418 0.33008-2.6719 0.0502-0.58984-0.21983-1.0798-0.98044-1.8406-0.99088-0.84039-0.50033-0.72033-1.7508-1.5809-2.2505-0.0405-0.72017 1.1209-4.291-0.33994-4.002 0.0411-0.92043-0.30014-0.97979-0.76013-1.5904-0.39997-0.5199-0.28057-0.96087-0.2499-1.5708 0.03-0.43967 0.16964-1.5701-0.15007-1.8506-0.2897-0.25963-1.5307-0.06-1.9202-0.0802-0.18008-0.67972-0.0202-1.4403-0.18008-2.1507-0.13963-0.63014-0.67988-0.93021-1.0198-1.3901-0.51023-0.69081-0.36995-1.0502-1.3115-1.1905-0.72033-0.11025-1.8308-0.0802-2.2706 0.39987-0.12984 0.03-0.2499 0-0.38039 0-0.67009-1.8409 1.1301-3.0111 0.72033-4.8115-0.12005 0-0.27991-0.0411-0.39018-0.0202-0.12984-0.09-0.03-0.12068-0.2499-0.17026-0.17029-0.52055-0.33993-1.3412-0.18008-1.9009 0.15007-0.57013 0.70011-0.84019 0.82995-1.501 0.28056-1.4208-0.6205-2.79-1.9209-3.0907-0.80059-0.18004-0.93043-0.28963-1.581-0.74104-0.23097-0.15917-0.55068-0.28898-0.85082-0.4899-0.19052-0.12003-0.39997-0.44032-0.5011-0.50033-0.63943-0.39009-1.181-0.08024-1.6312-0.67972-0.36016-0.48011-0.39931-1.2303-0.3693-1.8206-0.50109-0.08024-1.5105-0.24006-1.9013-0.51012-0.60028-0.4201-0.26034-1.3803-1.1705-1.3405-0.57026 0.03001-1.1908 0.8702-1.8315 0.75017-0.77057-0.15004-0.47957-1.1514-0.50958-1.8206-0.52068 0.01957-1.0309-0.16047-1.5614-0.08024 0.03 0.2094-0.11027 0.36922-0.11027 0.54991-1.2097 0.24006-1.8511-1.0007-2.8918-1.3307-0.15007-0.69081-0.47109-1.3901-1.331-1.2505 0.12006-0.86042-1.0414-0.81997-1.5907-1.0104-0.33015-0.12068-0.79015-0.32029-1.0805-0.5199-0.25968-0.18004-0.5807-0.75996-0.7797-0.85976-0.24011-0.12003-0.42085-0.21983-0.72033-0.19048-0.15986-0.72016 0.29035-0.7306 0.66095-1.1403 0.42933-0.48011 0.49001-0.66015 0.47957-1.3307-0.01-0.3803-0.0196-1.1605-0.16964-1.5003-0.11027-0.24984-0.38039-0.08024-0.48022-0.44032-0.0692-0.21983 0.21009-0.44097 0.17095-0.58057-0.20097-0.66015-1.7108-1.0007-2.422-1.0007-0.74969 0-2.0005 0.23092-2.7012-0.0098-0.0104-0.01044-1.3611-0.98044-1.4609-0.65037 0.17094-0.54012 0.1207-1.2003 0.23097-1.7404-0.72033-0.04044-1.3806 0.0411-2.071 0.0698-0.82081 0.03001-1.1608-0.23092-1.8315-0.5199-1.121-0.48011-3.3309-0.3503-3.5919-1.5708-0.2499-1.1703 0.54025-3.2505-0.27012-4.1423-0.27991-0.30007-1.2508-0.95044-1.6606-1.1703-0.52002-0.27985-1.3806-0.39922-1.9907-0.27006-0.73077 0.16047-1.2103 0.53034-2.0814 0.39987-0.61985-0.09981-1.1803-0.55904-1.81-0.3803-0.61137 0.17026-0.8306 0.76061-1.4407 0.90021-0.39083 0.09067-1.0805 0.09067-1.5614-0.03979 0.45999-0.30007 0.92064-0.60014 1.2704-0.99088 0.60028-0.66015 1.9307-2.561 2.2308-3.4514 0.47043-1.3901-0.39018-4.4208 1.271-4.7313 0.49-2.7411 2.2608-4.6909 4.6326-6.002 2.1714-1.2003 5.133-1.0104 5.9532-3.6706 0.66096-0.04958 0.82016-0.44945 1.4217-0.58057 0.0692-4.3014 8.9037-0.39009 9.8347-3.9211 2.512-0.54012 4.6221-2.5708 6.9534-3.6113 3.0118-1.3405 4.6025-0.98044 7.5145-1.9302 0.35038-0.10959 1.3806-0.0998 1.9914-0.12003-0.03 0.90021-0.25968 2.291 0.39931 2.8109 0.44108 0.33008 0.9611 0.18004 1.4407 0.36987 0.49 0.19048 0.7001 0.57992 1.0714 0.8702 0.0202 0.21983 0.12984 0.27006 0.20031 0.47032 1.0505 0.06001 2.1114 0.09002 3.1417 0.11024 0.32036 0.75996 1.0009 1.15 1.6808 1.6602 0.39996 0.30985 0.5807 0.21983 0.90041 0.75017 0.20031 0.33986 0.21988 0.66015 0.53046 0.98044 0.47044 0.4899 1.3108 0.91064 2.071 0.93021 1.1908 0.05023 2.0716 0.48011 3.2421 0.60014 0.0405 0.30007 0.27013 0.51012 0.5807 0.57992 0.06 0.94065 0.01 1.2609 1.0002 1.501 0.09 0.25962 0.14941 0.53034 0.19052 0.80953 0.0502 0.01044 0.0992 0.02022 0.14028 0.03001-0.21988 0.6608-0.44042 1.7215-0.12984 2.4606 0.2897 0.72017 0.85017 0.84019 0.88084 1.7606-0.61137-0.03001-2.2921 0.04044-1.9711 1.0007 0.12006 0.36008 0.65052 0.34965 0.84039 0.57013 0.33015 0.39009 0.33994 0.72017 0.30014 1.2603-0.40062 0.17026-0.98067 0.60014-1.1705 1-1.6605-0.06067-1.2704 1.5095-2.4011 1.9407-1.1405 0.42075-3.0223 0.08024-4.1523-0.14938-0.79015-0.16047-1.3604-0.05023-2.101 0.1396-0.46064 0.12003-0.60092-0.12068-0.90106 0.33008-0.17943 0.27006-0.09 1-0.0992 1.3405-0.03 0.74039 0.0196 1.5401 0.16051 2.2505 0.14942 0.71038 0.61072 1.2094 0.49001 1.9909-0.39083 0.02022-1.1307-0.14025-1.4909 0.01044-0.39997 0.15982-0.82995 0.82976-0.39997 1.2603 0.35038 0.3503 0.76078-0.05023 1.0707 0.4899 0.18008 0.31051 0.14093 1.1103-0.01 1.4906-0.27012 0.03979-0.48022 0.1696-0.72033 0.27006-0.0698 0.03001-0.0907 0.78996-0.11027 0.93021 0.28057 0.06001 0.60028 0.06001 0.91086 0.0698 0.0502 0.93021-0.67988 1.8806 0.0104 2.4103 0.32036 0.24984 1.0302 0.04044 1.3415 0.24006 0.3693 0.24006 0.41041 0.94 0.76078 1.2407 0.10962-0.01109 0.27013 0.03001 0.39018 0.03001-0.0404 0.42988-0.0202 1.3999 0.33994 1.6602 0.44956 0.31051 1.3708-0.3803 1.6201 0.23027 0.33994 0.85128-1.7708 1.1011-1.3408 1.9915 0.1703 0.36008 0.8704 0.33008 1.0805 0.57992 0.30013 0.3503 0.25055 0.74039 0.21988 1.1807-0.67009 0.03001-2.9511 0.28115-2.7319 1.3307 1.4909 0.09067 2.681-0.06001 3.9918 0.68037 0.59049 0.33986 1.1105 1.09 1.9209 0.92043 0.85996-0.17939 0.71054-0.81997 1.1601-1.2505 0.89062-0.84998 2.912 0.0411 3.5925 0.7306 0.56961 0.57992 1.1203 2.5708 2.2308 2.4508 0.39018 0.93021 1.2906 0.42075 1.6906 0.99088 0.73077 1.0307-0.61072 3.8207 1.7304 3.6811 0.0411 0.46054 0.0607 0.94-0.2499 1.2205-1.35 0.18983-1.6605 1.4906-2.7215 2.1201-0.74056 0.44032-0.80059 0.66015-0.60028 1.6406 0.10962 0.60014 0.15986 1.3503 0.33015 1.9204 0.41041 1.3405 1.1105 2.351 1.8615 3.501 0.31971 0.4899 0.7797 1.0104 1.0407 1.5206 0.32037 0.63014-0.0998 1.5304 0.54025 1.9602 0.30014 0.21005 0.79015 0.0502 1.151 0.0998 0.48022 0.0802 0.60028 0.17025 1.0205 0.42009 0.71577 0.44684 0.6851 1.2975 1.626 1.1872z",
+                Keelung:"m354.05 44.801c-1.1007 0.76061-2.131 0.33008-2.5505-0.81019-0.42085 0.0698-0.99176-0.09915-1.4217-0.08024-0.10962-0.26941-0.0502-0.63928-0.0803-0.91978-2.2615 0.01892-1.9111-4.2916-2.0005-6.002-0.55069 0.2094-1.3415 0.01957-1.9209 0.17026-0.12984-0.40966-0.12984-1.2603 0-1.6706 1.611-0.09067 3.3518 0.33986 4.0023-1.501 0.73077-0.04044 2.052 0.23092 2.7215-0.03001 0.6205-0.24006 0.58135-1.1598 1.0505-1.4508 1.0205-0.63993 1.8106-1.1905 2.9511-1.7208 0.46064 0.42988 0.80972 0.76061 0.82016 0.77039 1.4811 1.0502 2.6621 1.0705 4.6326 1.1801 0.4502 1.8617-0.28057 2.7906-0.14942 4.4423 0.68053-0.86042 1.7004-1.4005 1.7304-2.6908 2.4611-1.3203 4.0525 1.6706 6.6742 0.7306-0.11027 0.4899 0.17878 1.2003 0.0796 1.6902 0.52068 0.02022 1.0498 0.03001 1.5907 0.05023v0.03001c-0.03 0.33008-0.36016 1.1005-0.42084 1.4208-0.33015-0.04044-0.84039 0.15004-1.1705 0.08024 0.0104 0.56035-0.42084 1.0307-0.33015 1.6706-1.4106 0.32029-2.2706-0.63014-3.4718-0.47032-1.0603 0.14025-1.8511 1.0104-2.9009 1.2505 1.3108 1.0907 1.5503 2.3908 1.4511 4.2212 1.0198 0.13046 2.3306 1.0411 1.9711 2.3007-0.46064 1.6204-1.9418 0.69016-3.2121 1.0405-0.55982 0.15003-0.44042 1.1103-1.0407 1.2101-0.68053 0.12003-1.2208-0.2805-1.6912-0.33008-1.9711-0.18004-3.4516-1.1011-5.5323-1.2205 0.0698-1.4814-1.0505-2.3007-2.5009-2.0007 0.0196-0.03001-0.06-0.60014-0.06-0.58057 0.34907-0.23027 0.56896-0.62036 0.77971-0.78018z",
+                Kinmen:"m41.675 107.89c-0.0762 4e-3 -0.14595 0.0243-0.18718 0.0468-0.0375 0.0225-0.0711 0.0402-0.0936 0.0702l-0.0468 0.0936c-0.05235 0.16473-0.0159 0.38094-0.0234 0.53817-0.77124 0.0375-1.3965-0.23867-2.1526-0.16379-0.17222 0.015-0.27516 0.0412-0.32758 0.0936-0.015 8e-3 -9e-3 9e-3 -0.0234 0.0234-0.09735 0.11235-0.102 0.2967-0.30418 0.49137-0.21714 0.20217-0.453 0.4034-0.46797 0.72537-0.0075 0.41931 0.2527 0.74409 0.1404 1.1933-0.09735 0.34443-0.40246 0.4268-0.51478 0.74877-0.08985 0.2471 0.015 0.66641 0 0.93596-0.0225 0.3669-0.1095 0.46984-0.49137 0.51477-0.15724 0.0225-0.32666 0.0524-0.49138 0-0.09735-0.0225-0.24522-0.1563-0.32757-0.16379-0.75626-0.0973-0.35661 1.154-0.3042 1.521 0.045 0.34443-0.0135 0.56532-0.1404 0.84236-0.1422 0.32946-0.03375 0.42867-0.0936 0.79557-0.045-7e-3 -0.0795 0-0.117 0-0.03 0.10485-0.1011 0.16098-0.0936 0.28078-0.38936 0.0748-0.53722-0.27891-0.88916-0.23398-0.0225 0.11235 0.07485 0.23959 0.1872 0.37438 0.03 0.0375 0.072 0.0795 0.117 0.117 0.15723 0.1497 0.32384 0.27611 0.42117 0.35097 0.0375 0.0225 0.087 0.0552 0.117 0.0702 0.1422 0.0599 0.26301 0.0468 0.39778 0.0468 0.09735 8e-3 0.20778 0.0328 0.32758 0.0702 0.11235 0.0375 0.21434 0.10485 0.30418 0.1872 0.05235 0.0375 0.1029 0.0954 0.1404 0.1404 0.0375 0.0448 0.0795 0.0954 0.117 0.1404l0.0702 0.0468 0.0468 0.0702c0.1797 0.1797 0.39498 0.30699 0.70197 0.18719 0.35192-0.1347 0.1161-0.47265 0.28078-0.77216 0.22462-0.41182 0.906-0.78433 1.3103-0.88917 0.21789-0.0598 0.66546-0.25176 0.91256-0.117 0.23211 0.1497 0.1104 0.43898 0.1404 0.67857 0.0075 0.0748 0.0411 0.1347 0.0936 0.1872 0.015-0.0225 0.0243-0.0318 0.0468-0.0468 0.1497-0.1497 0.41368-0.27705 0.60837-0.37438 0.25458-0.1347 0.5026-0.33975 0.77217-0.44459 0.07485-0.26206-0.10395-0.43615-0.35098-0.42117-0.11235-0.45675-0.0468-0.63364 0.32758-0.86577 0.31448-0.20965 0.58497-0.3697 0.95936-0.44457 0.36688-0.0823 0.69354-0.0795 1.0529 0.0702 0.2995 0.11985 0.55222 0.34349 0.88916 0.35099 0.1497-0.20966 0.0486-0.47079 0.0936-0.72537 0.015-0.12735-0.04215-0.20685 0.0702-0.30419 0.09735-0.0898 0.25272 0.0206 0.32758-0.0468 0.26208-0.20965 0.045-0.94999 0.1872-1.2869 0.0225-0.0448 0.0243-0.072 0.0468-0.117 0.0375-0.0899 0.0795-0.19842 0.117-0.28078 0.0225-0.0448 0.0477-0.0795 0.0702-0.117 0.03-0.0523 0.072-0.0795 0.117-0.117 0.11985-0.11235 0.24615-0.19374 0.35098-0.35099 0.22462-0.37438 0.0543-1.0389 0.0468-1.4507-0.2471-0.0225-0.57 0.0263-0.77217-0.0936-0.05235-0.03-0.1188-0.072-0.16378-0.117-0.03-0.03-0.0636-0.0561-0.0936-0.0936-0.05985-0.0748-0.09645-0.1591-0.1638-0.23398-0.03-0.0375-0.0795-0.0795-0.117-0.117-0.4268-0.3594-0.98836-0.45674-1.3103-0.93596-0.0225-0.0375-0.0243-0.0881-0.0468-0.1404-0.0225-0.0524-0.0636-0.10395-0.0936-0.16378-0.0375-0.0824-0.0645-0.18158-0.117-0.23399-0.0225-0.0225-0.0477-0.0318-0.0702-0.0468-0.18718-0.11235-0.59433-0.0468-0.81896-0.0468-0.15162 0-0.47348-0.0594-0.70197-0.0468zm32.666-14.206c-0.71882-0.05985 0.19842 0.96028 0.28078 1.1699v0.0234c0.03 0.07485 0.0468 0.17596 0.0468 0.28078 0 0.21714-0.0468 0.45114-0.0468 0.60837 0 0.3669 0.0402 0.51946-0.30418 0.63177-0.20217 0.06735-0.3332 0.08805-0.46798 0.1404-0.05235 0.0225-0.10395 0.0327-0.16378 0.0702-0.03 0.015-0.0561 0.0477-0.0936 0.0702-0.10485 0.06735-0.21526 0.13575-0.32758 0.2106-0.11235 0.08235-0.22276 0.15818-0.32758 0.21058-0.1422 0.06735-0.29482 0.0702-0.44458 0.0702-0.05235 0.0075-0.11145 0-0.16378 0-0.06735 0-0.14325 9e-3 -0.21058 0.0234-0.0375 0.0075-0.0795 9e-3 -0.117 0.0234-0.25458 0.07485-0.44085 0.21058-0.72537 0.21058-0.07485 0.12735-0.1338 0.30513-0.1638 0.51478-0.04485 0.45675 0.06645 1.0408 0.35098 1.3103 0.0375 0.0375 0.072 0.0711 0.117 0.0936 0.0075 0.0075 0.0159 0 0.0234 0 0.04485 0.015 0.0954 0.0393 0.1404 0.0468v-0.117c0-0.015-0.0075-0.0318 0-0.0468v-0.0234c-0.0075-0.0075 0.0075-0.0159 0.0234-0.0234-0.0075-0.0075-0.0075-0.0159 0-0.0234-0.0075-0.0225-0.01515-0.0318 0-0.0468-0.0075-0.03 9e-3 -0.0711 0.0234-0.0936 0.0075-0.03-0.0075-0.0402 0-0.0702 0-0.015 0.01605-0.0234 0.0234-0.0234v-0.0468c0.0225-0.07485 0.04035-0.14325 0.0702-0.2106 0.0225-0.06735 0.0477-0.12735 0.0702-0.18718 0.015-0.0225 0.0159-0.0711 0.0234-0.0936 0.08235-0.0075 0.19281-0.0075 0.32758 0 0.05985 0 0.13575-0.0075 0.2106 0 0.0375 0 0.072 0.0234 0.117 0.0234 0.0225 0 0.0318-0.0075 0.0468 0 0.0375 0 0.0795-0.0075 0.117 0 0.08985 0.0075 0.19936 0.0318 0.30418 0.0468l0.0936 0.0234h0.0234c0.05985 0.0075 0.10395 9e-3 0.16378 0.0234 0.05985 0.015 0.1347 0.0318 0.18718 0.0468 0.05235 0.0225 0.08805 0.0552 0.1404 0.0702 0.04485 0.015 0.1029 0.0402 0.1404 0.0702 0.05985 0.0225 0.0954 0.0561 0.1404 0.0936 0.045 0.03 0.0945 0.07215 0.117 0.117 0.045 0.06735 0.0777 0.12825 0.0702 0.21058v0.0234c-0.0075 0-0.0318-0.0159-0.0468-0.0234h-0.0231c-0.18718-0.015-0.42117 0.0216-0.60837-0.0234-0.22462-0.04485-0.33694-0.19467-0.56157-0.18718h-0.0702c-0.0375 0-0.0795 0.0159-0.117 0.0234-0.015 0.0075-0.0318 0.0234-0.0468 0.0234-0.0375 0.015-0.0636 0.0243-0.0936 0.0468-0.06735 0.05985-0.09735 0.1535 0 0.28078 0.0075 0.015 0.0318 9e-3 0.0468 0.0234 0.08235 0.05985 0.19188 0.0543 0.30418 0.0468 0.10485 0 0.21246 0.0135 0.25738 0.1404 0.0225 0 0.0477 0.01575 0.0702 0.0234 0.0225-0.0075 0.0318-0.0075 0.0468 0 0.10485 0.31448 0.12825 0.45861 0.0234 0.79556l-0.0234 0.0936c-0.03 0.0973-0.04965 0.18345-0.117 0.28079-0.05985 0.0823-0.18999 0.12075-0.25738 0.2106l-0.0468 0.0468c-0.0075 0.015 0 0.0243 0 0.0468-0.0075 0.0448-0.0075 0.0881 0 0.1404 0.04485 0.16473 0.19094 0.32571 0.28078 0.46797 0.11235 0.17221 0.19188 0.46705 0.30418 0.63177l0.0468 0.0468c-0.03-7e-3 -0.0402-0.0159-0.0702-0.0234-0.0375-8e-3 -0.087-9e-3 -0.117-0.0234-0.05985-0.0225-0.11145-0.0561-0.16378-0.0936-0.0375-0.015-0.0636-0.0243-0.0936-0.0468-0.35193-0.25458-0.44178-0.67482-0.56158-1.1465-0.22462-0.0974-0.14595-0.27237-0.28078-0.44459l-0.0702-0.0702-0.0234-0.0468c-0.0375-0.03-0.1029-0.0477-0.1404-0.0702-0.08235-0.0375-0.17595-0.0636-0.28078-0.0936-0.1422-0.0375-0.263-0.0486-0.39778-0.0936-0.04485-0.015-0.08805-0.0243-0.1404-0.0468 0 0-0.0234-0.0157-0.0234-0.0234-0.0225-0.015-0.0477-0.0168-0.0702-0.0468-0.015-0.0075-9e-3 -0.0318-0.0234-0.0468-0.0225-0.03-0.0477-0.04785-0.0702-0.0702-0.015-0.015-0.0318-0.0393-0.0468-0.0468-0.07485-0.04485-0.1769-0.04305-0.30418 0.0468-0.21039 0.1422-0.22725 0.48951-0.0468 0.63177 0.1497 0.11235 0.26114 0.0561 0.35098 0.0936l0.0468 0.0234c0.03 0.03 0.0561 0.058 0.0936 0.1404 0.1422 0.26957 0.2705 0.74034 0.2106 1.0998-0.015 0.0749-0.0477 0.12735-0.0702 0.18718-0.15724 0.015-0.30232 0.0402-0.44458 0.0702-0.1497 0.03-0.29482 0.0795-0.44458 0.117-0.08985 0.03-0.17595 0.0478-0.28078 0.0702-0.05235 8e-3 -0.1029 0.0318-0.1404 0.0468s-0.0636 0.0243-0.0936 0.0468c-0.0375 0.0225-0.0711 0.0402-0.0936 0.0702-0.015 0.0225-0.0318 0.0636-0.0468 0.0936-0.015 0.0448-0.0234 0.10395-0.0234 0.1638-0.0075 0.0748-7.5e-4 0.15255-0.0234 0.25739-0.0075 0.0449-0.0243 0.10395-0.0468 0.16378-0.07485 0-0.16004 8e-3 -0.25738 0h-0.1404c-0.0225 0-0.0552-7e-3 -0.0702 0-0.10485 8e-3 -0.18999 0.0252-0.25738 0.0702-0.03 0.015-0.0552 0.0402-0.0702 0.0702-0.1872 0.29951 0.1011 0.6168 0.28078 0.81897 0.0225 0.015 0.0552 0.0318 0.0702 0.0468 0.37438 0.4268 0.41182 0.96872 0.37438 1.5678-0.0075 0.0973-0.0075 0.18251-0.0234 0.25739-0.0075 0.0748-0.0243 0.14325-0.0468 0.21058-0.045 0.11985-0.11415 0.24803-0.23398 0.39779-0.0375 0.045-0.0795 0.087-0.117 0.117-0.03 0.0375-0.0636 0.0478-0.0936 0.0702-0.03 0.0225-0.0402 0.0552-0.0702 0.0702s-0.07965 0.0159-0.117 0.0234c-0.08235 0.0225-0.20124 0.0234-0.35098 0.0234-0.31448 1e-5 -0.66734-5e-3 -0.95936 0.0702-0.2995 0.0748-0.44739 0.22557-0.70197 0.39778-0.27704 0.19467-0.3126 0.25646-0.70197 0.23399-0.21714-0.32946-0.52881-0.25083-0.86576-0.28079-0.40432-0.03-0.4998-0.33132-0.88916-0.42118-0.08985-0.0225-0.18345-0.0393-0.28078-0.0468-0.23961-0.015-0.49324-1e-3 -0.72537-0.0468-0.61398-0.10485-1.0988-0.2499-1.638-0.63177-0.89103-0.62897-1.5668-1.5612-2.4802-2.1526-0.48669-0.32198-0.94156-0.32384-1.2635-0.79556-0.26206-0.41182-0.46518-0.85921-0.77216-1.2635-0.29952-0.40434-0.69356-0.92566-1.053-1.2402-0.55408-0.47172-0.87138-0.13755-1.0062 0.49138-0.614 0.03-1.1194-0.1236-1.5912 0.28079-0.44176 0.37438-0.8199 0.74782-1.4039 0.91255-0.89852 0.23961-1.856 1.7043-1.4741 2.7376 0.19468 0.48669 0.6065 0.32945 0.93596 0.56157 0.1347 0.0898 0.18532 0.19842 0.32758 0.28079 0.0225 8e-3 0.0477 0.0393 0.0702 0.0468 0.045 0.0225 0.0954 0.0318 0.1404 0.0468 0.045 0.0225 0.08805 0.0318 0.1404 0.0468 0.11235 0.03 0.22276 0.0542 0.32758 0.0468 0.0375-0.20217 6e-3 -0.3566-0.0702-0.49139-0.05235-0.10485-0.1422-0.20778-0.18718-0.32758-0.0075-0.0225-0.0159-0.0402-0.0234-0.0702l-0.0468-0.0936c-0.10485-0.19467-0.27237-0.47358-0.25738-0.60837 0.24708-0.0449 0.44644 0.0786 0.67856 0.0936 0.25458 0.03 0.36783-0.1329 0.58498-0.1404 0.38936-0.015 0.88728 0.73095 0.84236-0.0702h0.21058c0.22464 7e-3 0.44178 0.015 0.56158-0.18719 0.10485-0.1797-0.11235-0.57936 0.18718-0.63177 0.32198-0.0524 0.23025 0.44364 0.32758 0.60837 0.07485 0.11985 0.61866 0.4764 0.117 0.49137-0.18718 0.29202-0.25738 0.30606-0.25738 0.72537 0 0.41183 0.08985 0.68138-0.37438 0.74877h-0.0702c-0.12735 0.0225-0.32384 0.03-0.42118 0-0.1422-0.0524-0.27048-0.32853-0.39777-0.35098-0.1422-0.0225-0.21996 0.0272-0.2574 0.117-0.0075 0.015-0.0234 0.0243-0.0234 0.0468-0.0075 0.015-0.0234 0.0477-0.0234 0.0702-0.0225 0.1347-0.0168 0.28546-0.0468 0.39778-0.25458 0.015-0.51758 8e-3 -0.77216 0.0234-0.015 0.20966 0.16566 0.14505 0.21058 0.25739 0.015 0.03 0.0234 0.0636 0.0234 0.0936 0.0075 0.0225 0.0234 0.0477 0.0234 0.0702 0.0075 0.0523 0.0075 0.10395 0 0.16378v0.117c0 8e-3 0.0075 0.0159 0 0.0234 0.0075 0.0375-0.01575 0.0636-0.0234 0.0936-0.0225 0.23961-0.0711 0.45395-0.0936 0.67857-0.0375 0.5466 0.39966 1.0314 0.63177 1.4507 0.21714 0.39684 0.34443 0.58029 0.37438 1.0296 0.03 0.32196 0.117 0.58309 0.117 0.91255 0 0.26955 0.0162 0.54098 0.0234 0.79556 0.0075 0.35941 0.0234 0.69261 0.0234 1.0296 0 0.20966 0.0972 0.76374 0 0.93596-0.11235 0.19468-0.55408 0.26767-0.74877 0.32758-0.08235 0.0225-0.18344 0.0477-0.28078 0.0702-0.06735 0.015-0.11985 9e-3 -0.18718 0.0234-0.09735 0.0225-0.21434 0.0402-0.30418 0.0702-0.12735 0.0448-0.24522 0.11235-0.32758 0.18719-0.11235 0.11235-0.16098 0.27517-0.0936 0.51478 0.05985 0.23211 0.25458 0.47172 0.18718 0.74876 0 0.015 0.0075 0.0159 0 0.0234 0 0.03-0.0075 0.0477-0.0234 0.0702-0.0225 0.0448-0.07215 0.0954-0.117 0.1404-0.03 0.0225-0.0636 0.0552-0.0936 0.0702-0.0375 0.0225-0.072 0.0477-0.117 0.0702-0.06735 0.0448-0.12735 0.0795-0.18718 0.117-0.03 0.0225-0.0711 0.0477-0.0936 0.0702-0.29202 0.23212-0.33507 0.23961-0.70197 0.1872-0.08235-7e-3 -0.26206-9e-3 -0.37438-0.0234-0.0225 0-0.0318 7e-3 -0.0468 0-0.015-2e-5 -0.0318-0.0157-0.0468-0.0234-0.03-0.015-0.0552-0.0168-0.0702-0.0468-0.0075 7e-3 0-0.0157 0-0.0234-0.05985-0.0599-0.06555-0.11985-0.1404-0.1872-0.20216-0.18719-0.36128-0.27891-0.60837-0.23399-0.04485 8e-3 -0.08805 0.0318-0.1404 0.0468-0.0375 0.0973-0.09645 0.18158-0.16378 0.23399-0.0225 0.0225-0.0402 0.0318-0.0702 0.0468-0.12735 0.0898-0.28827 0.0918-0.46798 0.0468-0.08235-0.015-0.17502-0.0243-0.25738-0.0468-0.0225 0-0.0318-0.0162-0.0468-0.0234-0.08235-0.0225-0.17502-0.0552-0.25738-0.0702h-0.0234c-0.1422-0.0225-0.2939-0.0135-0.42118 0.0234-0.0375 0.015-0.0561 0.0318-0.0936 0.0468-0.0375 0.0225-0.0636 0.0168-0.0936 0.0468-0.04485 0.0375-0.1029 0.0879-0.1404 0.1404-0.15723 0.21715-0.14505 0.33882-0.0702 0.42118 0.05235 0.0524 0.14415 0.1029 0.234 0.1404 0.08985 0.03 0.19094 0.0561 0.28078 0.0936 0.24708 0.11235 0.59994 0.50636 0.77216 0.67857 0.0375 0.015 0.0795 0.0168 0.117 0.0468 0.045 0.03 0.0954 0.072 0.1404 0.117 0.26956 0.23961 0.5438 0.68699 0.67857 0.88916 0.05235 0.0748 0.0636 0.10395 0.0936 0.1638 0.015 0.015 0.0318 0.0402 0.0468 0.0702 0.0225 0.0599 9e-3 0.22836 0.0468 0.28078 0.03 0.03 0.0486 0.0627 0.0936 0.0702 0.04485 0.015 0.11145 0.0159 0.1638 0.0234h0.0234c0.04485 8e-3 0.0954 9e-3 0.1404 0.0234 0.03 7e-3 0.0477 0.0159 0.0702 0.0234 0.0225 7e-3 0.0318 0.0318 0.0468 0.0468 0.10485 0.0973 0.17408 0.23211 0.23398 0.37437 0.0375 0.0898 0.0636 0.20685 0.0936 0.3042 0.045 0.1422 0.08895 0.27704 0.16378 0.37437 0.05985 0.0824 0.16848 0.13485 0.28078 0.1872 0.11985 0.0448 0.23212 0.087 0.37438 0.117 0.13485 0.03 0.28641 0.0552 0.42118 0.0702 0.12735 0.015 0.26114 0.0318 0.35098 0.0468 0.03 0.12735 0.09735 0.23772 0.18718 0.32759 0.07485 8e-3 0.12735 0 0.1872 0 0.06735 0 0.1422 9e-3 0.18718 0.0234 0.0375 8e-3 0.0636-6e-3 0.0936 0.0234 0.05235 0.0375 0.0954 0.10485 0.1404 0.18718 0.0225 0.0448 0.0477 0.088 0.0702 0.1404 0.045 0.10485 0.0795 0.22277 0.117 0.32759 0.015 0.0524 0.0477 0.0954 0.0702 0.1404 0.05235 7e-3 0.087 0.0486 0.117 0.0936 0.09735 0.11985 0.16098 0.34723 0.28078 0.44458 0.25458 0.2396 0.2939 0.1694 0.60837 0.117 0.32946-0.0448 0.86109-0.20122 1.1232 0.0234 0.0225 0.015 0.0552 0.0402 0.0702 0.0702 0.0375 0.0524 0.0552 0.11235 0.0702 0.18719 0.15723 0.11985 0.43054 0.19749 0.65517 0.25738 0.03 0.015 0.0402 0.0159 0.0702 0.0234 0.03 7e-3 0.0711 0.0234 0.0936 0.0234 0.1347 0.03 0.2293 0.03 0.30418 0 0.015 0 0.0393-8e-3 0.0468-0.0234 0.0225-8e-3 0.0318-0.0243 0.0468-0.0468 0.05235-0.0674 0.0795-0.17782 0.117-0.32758 0.0375-0.015 0.0954-0.0234 0.1404-0.0234 0.10485-0.0225 0.19935-0.0309 0.30418-0.0234 0.10485 0 0.20684-7.5e-4 0.30418-0.0234 0.0225 0 0.0477 7e-3 0.0702 0 0.03-8e-3 0.0477-0.0161 0.0702-0.0234 0.0375-0.015 0.0795-0.0477 0.117-0.0702s0.0711-0.0402 0.0936-0.0702c0.20217-0.20216 0.26768-0.51758 0.32758-0.77216 0.15723-0.6664 0.14415-1.0436 0.60837-1.5678 0.39684-0.45675 0.52881-1.096 0.86576-1.5678 0.1497-0.20965 0.23118-0.4839 0.35098-0.67857 0.0375-0.0524 0.0795-0.0954 0.117-0.1404 0.08235-0.0824 0.1591-0.15163 0.23398-0.234 0.04485-0.0375 0.087-0.088 0.117-0.1404 0.0225-0.015 9e-3 -0.0477 0.0234-0.0702 0.1872-0.45673-0.0318-0.7029 0.51478-0.91255 0.23211-0.0974 0.30324-0.1161 0.46797-0.28079 0.43428-0.44176 0.58592-0.64113 1.1699-0.86575 0.32198-0.12735 0.5569-0.31167 0.81897-0.49139 0.17222-0.1347 0.35847-0.23772 0.53817-0.32758 0.35192-0.18719 0.73378-0.34161 1.1232-0.49137 0.61398-0.23961 1.082-0.4764 1.7782-0.49137 0.68138 0 1.3534-0.0748 2.0122-0.1872 0.63645-0.11235 1.183-0.23399 1.8718-0.23399 0.16473 0 0.31072 9e-3 0.46797 0.0234 0.1497 8e-3 0.31822 0.0168 0.46798 0.0468 0.07485 0.015 0.1347 0.0477 0.18718 0.0702 0.17222 0.0598 0.26582 0.13665 0.46798 0.23399 0.32944 0.1497 0.50634 0.1086 0.67856 0.46798 0.09735 0.1797 0.12825 0.41369 0.2106 0.60837 0.03 0.0598 0.0486 0.11145 0.0936 0.16379 0.04485 0.0523 0.10395 0.0795 0.16378 0.117 0.19468 0.0974 0.453 0.1179 0.65517 0.1404 0.15724 0.0225 0.34162-4e-3 0.49138 0.0468 0.1497 0.0598 0.2396 0.20497 0.37437 0.2574 0.15724 0.0523 0.32666 7.3e-4 0.49138 0.0234 0.03 0 0.0636 0.0159 0.0936 0.0234 0.0375 0.015 0.0636 0.0243 0.0936 0.0468 0.06735 0.0448 0.11985 0.0956 0.18718 0.1404 0.03 0.0225 0.0561 0.0552 0.0936 0.0702 0.15724 0.0898 0.31917 0.0824 0.49138 0.18718 0.1497 0.0824 0.20122 0.19749 0.35098 0.25739h0.0234l0.0234 0.1404c0.0075 0.0448 0.01605 0.0795 0.0234 0.117 0.015 0.0824 0.04875 0.17502 0.0936 0.25738 0.11985 0.23961 0.24522 0.36878 0.32758 0.60837 0.11235 0.28454 0.18063 0.52602 0.21058 0.79557 0.0075 0.0448 0.0234 0.0954 0.0234 0.1404 0.015 0.0898 0.0075 0.17595 0 0.28079-0.57656 0.20217-1.8064-0.30699-1.7316 0.56157 0.49419 0.0225 0.97246-0.0459 1.4741-0.0234 0.05985 0.41931-1.0333 0.20685-1.3103 0.30418-0.05235 0.20217 0.1245 0.28266 0.30418 0.32759 0.045 0.1347 0.0702 0.30231 0.0702 0.44458 0.30699-0.0375 0.57374-0.24241 0.86576-0.25738 0.26206-0.015 0.58965 0.1077 0.88916 0.0702 0.55334-0.0524 0.37083-0.1422 0.49138-0.56159 0.11985-0.42679 0.41276-0.29763 0.77216-0.32758 0.60651-0.0448 0.81054-0.70383 1.3571-0.93596 0.29202-0.11985 0.68325-0.0411 0.98276-0.0936 0.05985-8e-3 0.13485-0.0477 0.18718-0.0702 0.1497-0.0749 0.24054-0.19935 0.2106-0.49137-0.0225-0.20965-0.06555-0.30138-0.1404-0.42118-0.03-0.0448-0.0402-0.0647-0.0702-0.117l-0.0234-0.0234c-0.0225-0.0375-0.0318-0.0636-0.0468-0.0936-0.10485-0.16473-0.11235-0.18533 0-0.32759 0.015-0.0225 0.0243-0.0636 0.0468-0.0936 0.03-0.0449 0.0879-0.0954 0.1404-0.1404 0.2396-0.24709 0.61586-0.48201 0.79556-0.0702 0.33694 0.0973 0.57 0.15537 0.95936 0.1404 0.20966-0.24709 0.57375-0.61678 0.49138-1.0062-0.1497-0.0898-0.27986-0.20498-0.44458-0.25739-0.05235-0.12735-0.0375-0.27798 0-0.39778-0.16473-0.12735-0.53444-0.31355-0.63177-0.53817-0.08235-0.19467 7.5e-4 -0.64862 0.0234-0.86576 0.08985-0.74128 0.6636-0.80211 1.2401-0.58497-0.0225 0.22463 0.49138 0.27143 0.67857 0.23399 0.40434-0.0974 0.2527-0.40434 0.32758-0.74877 0.05985-0.25458 0.18158-0.48669 0.23398-0.74876 0.0075-0.03 0-0.0636 0-0.0936 0.0075-0.0748 0.0318-0.15912 0.0468-0.234 0.0075-0.03 9e-3 -0.0636 0.0234-0.0936 0.0075-0.015 0.0159-9e-3 0.0234-0.0234 0.05985-0.0898 0.2106-0.21432 0.2106-0.30418 0-0.45674-1.0923-0.1254-1.4741-0.51477-0.03-0.03-0.0786-0.072-0.0936-0.117-0.09735-0.2471 0.1125-0.54192 0-0.81896-0.09735-0.25458-0.41649-0.4165-0.49137-0.67857-0.1497-0.50916-0.05235-1.4732 0-2.0122 0.045-0.43428 0.28452-1.534 0.74876-1.6614 0.10485-0.23211 0.43522-0.34068 0.39778-0.65517-0.0075-0.10485-0.13005-0.24615-0.25738-0.35097-0.05235-0.0375-0.08805-0.0711-0.1404-0.0936-0.0225-8e-3 -0.0711-0.0159-0.0936-0.0234-0.05985-0.015-0.10395-0.0234-0.16378-0.0234-0.05985 0-0.11145 7e-3 -0.1638 0.0234-0.0225 8e-3 -0.0477 8e-3 -0.0702 0.0234-0.0225 0-0.0477 0.0159-0.0702 0.0234-0.05235 0.0225-0.1188 0.0477-0.16378 0.0702-0.1497 0.0748-0.263 0.1404-0.39778 0.1404-0.11985 0-0.25552-0.0459-0.39778-0.2106-0.06735-0.0824-0.12735-0.16659-0.18718-0.23398-0.05985-0.0824-0.1188-0.15911-0.1638-0.23399-0.05985-0.10485-0.1263-0.21528-0.16378-0.32758-0.03-0.10485-0.0318-0.2237-0.0468-0.35099-0.015-0.10485-0.03075-0.20029-0.0234-0.32758 0.03-0.614 0.25364-1.3272-0.39778-1.5444-0.05235-0.015-0.0954-0.0477-0.1404-0.0702-0.08235-0.0375-0.1422-0.0645-0.18718-0.117-0.20966-0.1872-0.19376-0.46611-0.1638-0.79557l0.0234-0.16379v-0.1872c0.0075-0.20216-0.0075-0.453 0.0234-0.65517 0.0075-0.06735 7.5e-4 -0.10395 0.0234-0.16378 0.11235-0.2995 0.3566-0.3828 0.30418-0.77217-0.05235-0.0075-0.1188-0.0159-0.16378-0.0234-0.0225 0-0.0318-0.0234-0.0468-0.0234-0.26956-0.015-0.51759 0.01785-0.77217 0.0702-0.16473 0.0375-0.31822 0.08055-0.46798 0.1404-0.03 0.015-0.0636 0.0393-0.0936 0.0468-0.05985 0.0225-0.12735 0.0402-0.18718 0.0702l-0.0702 0.0468c-0.11985 0.07485-9e-3 0.23306-0.23398 0.2106-0.1797-0.0075-0.36034-0.39591-0.39778-0.53817-0.03-0.0375-0.0327-0.0411-0.0702-0.0936-0.12735-0.0075-0.26206-0.0159-0.37438-0.0234-0.23211 0-0.43521-0.0135-0.58497-0.1404-0.08235-0.06735-0.1347-0.15351-0.18718-0.2808-0.04485-0.11985-0.0627-0.24708-0.0702-0.37437 0-0.06735 0.0075-0.12735 0-0.1872-0.015-0.06735-0.0318-0.12735-0.0468-0.18718-0.08985-0.28454-0.20498-0.497-0.2574-0.81897-0.0375-0.1797-0.1188-0.3828-0.16378-0.58497-0.015-0.05235-0.0159-0.11145-0.0234-0.16378-0.0075-0.07485-0.0075-0.15912 0-0.234v-0.1404c0.0075-0.11985 0.02265-0.26206 0-0.37437-0.0075-0.04485-0.01605-0.07215-0.0234-0.117-0.0375-0.1347-0.11415-0.26674-0.23398-0.30418-0.03-0.0075-0.072-0.015-0.117 0-0.015-0.0075-0.0318 0.0159-0.0468 0.0234l-0.0702 0.0234c-0.13485 0.08235-0.16473 0.30512-0.37438 0.32758-0.06735-0.16473-0.0243-0.35098-0.0468-0.53818-0.38187-0.1797-1.257 0.09825-1.6614 0.2106h-0.0234c-0.05985 0.0225-0.1029 0.0393-0.1404 0.0468h-0.0234c-0.16473 0.0375-0.24802 0.01785-0.39778-0.117-0.0375-0.03-0.072-0.0645-0.117-0.117h-0.0234c-0.16473-0.1497-0.36876-0.42962-0.60837-0.44458z",
+                Matsu:"m47.89 49.587c-0.5391 0.81864-0.3307 2.5646-0.0312 3.463-0.75874 0.08984-1.3228 0.52164-1.8719 1.0607 0.87854 1.6672-0.22714 1.5961-0.68638 2.9638-0.56906 1.6672 0.4917 2.5258 1.5599 3.2446 0.40934 0.27954 0.76624 0.68512 1.1856 0.90476 1.0383 0.46922 0.98962 0.07608 1.7783-0.09354 0.7288-0.18968 0.60276-0.31948 1.5911-0.24958 0.62896 0.02994 1.2292 0.46298 2.028 0.34318 0.39934-0.75874 1.4738-2.1078 2.4022-2.028 0.51914 1.6772 2.6594-0.27828 3.3382-0.71756 1.4876-0.98836 2.26-1.5712 2.0904-3.5878-1.797 0.08986-3.4904-0.45424-5.3974-0.37438-1.1381 0.04992-1.7571-0.1273-2.2464 0.81116-0.1198 0.22962-0.1572 0.47672-0.1872 0.68636l-0.0312 0.28078c0 0.03994-0.0212 0.08486-0.0312 0.1248-0.01 0.08986-0.012 0.1797-0.0312 0.24958-0.01 0.03994-0.012 0.09484-0.0312 0.1248-0.03 0.0599-0.065 0.10608-0.1248 0.156-0.1798 0.12978-0.52538 0.19468-1.1543 0.1248-0.1398-1.6972-0.2683-4.0908-2.7142-3.6814 0.32944-0.609 0.76498-1.0795 1.4039-1.2791 0.1598-0.16972 0.40708-0.72506 0.46798-0.90476 0.1598-0.32946-2.9376-1.4726-3.307-1.6223zm23.56-17.784c-0.38328 0.04264-0.8218 0.14792-1.2479 0.24958-0.21306 0.05082-0.42916 0.11702-0.62396 0.156-0.1948 0.03894-0.37314 0.05302-0.53038 0.0624-0.34942 0.02-0.85984-0.07238-1.2791-0.0624h-0.0312c-0.1698 0-0.31698 2e-3 -0.43678 0.0624-0.70882 0.26956-0.46922 0.52664-0.99836 0.93596-0.34442 0.24958-0.7213 0.5831-1.1231 0.87356s-0.82864 0.53786-1.2479 0.59278c-1.228 0.13978-1.807-0.80616-2.7454 0.31198-1.0882 1.2679 0.1548 1.9006 0.37438 3.0886 0.1198 0.6689-0.0212 0.95716-0.2808 1.2167-0.0698 0.0599-0.1386 0.12728-0.21838 0.18718-0.31948 0.24958-0.74252 0.54536-1.092 1.1543-0.1398 0.25958-0.2421 0.56532-0.31198 0.90476-0.02 0.1198-0.0524 0.25458-0.0624 0.37438-0.0598 0.58902 8e-3 1.2068 0.1872 1.7159 0.1598 0.04992 0.1872-0.04492 0.1872 0.1248 0.20966-0.02996 0.52914 0.09234 0.74876 0.0624-0.1572 0.84736 0.41046 1.3996 1.1232 1.2167 0.1018-0.02616 0.2059-0.06738 0.31198-0.1248-0.0486-0.1872-0.091-0.41458-0.1248-0.65516-0.23696-1.6842-0.0236-4.4052 1.8719-4.4926-0.0224-0.5441 0.0872-0.94332 0.28078-1.2479 0.0968-0.1523 0.20398-0.30146 0.34318-0.40558 0.69598-0.5206 1.8782-0.47422 3.0574-0.37438-0.0798 0.49918 0.1884 0.94468 0.21838 1.4039 1.797-0.7887 2.9938-1.7147 5.2102-0.93596 0.1872 0.38936-0.093 2.9332 0.49918 3.5254 0.0494 0.04932 0.125 0.07348 0.1872 0.09354s0.1106 0.0138 0.1872 0c0.153-0.02786 0.34192-0.1198 0.56156-0.31198 0.0674-0.0587 0.1122-0.13966 0.156-0.2184 0.0438-0.07876 0.1006-0.1542 0.1248-0.2496 0.1936-0.76316-0.191-2.0002-0.1248-2.839 8e-3 -0.10486 8e-3 -0.22142 0.0312-0.31198 0.024-0.09056 0.0812-0.14556 0.1248-0.2184 0.0436-0.07288 0.089-0.13552 0.156-0.1872 0.20096-0.15502 0.5154-0.22214 0.99836-0.1248 0.0798-0.45924 0.0798-1.1107 0-1.5599-0.76874-0.04992-3.01 0.68512-2.8702-0.34318 0.1598-0.99836 1.6186-0.7238 1.2791-2.371-1.1381 0.24958-1.1656-0.99836-2.184-1.2479-0.1798-0.04742-0.43086-0.0596-0.68636-0.03114z"
+                };
+            var i = {};
+            for (var s in r) {
+                i = {};
+                if (this.options.stateSpecificStyles[s]) {
+                    e.extend(i, t, this.options.stateSpecificStyles[s])
+                } else {
+                    i = t
+                }
+                this.stateShapes[s] = n.path(r[s]).attr(i);
+                this.topShape = this.stateShapes[s];
+                this.stateHitAreas[s] = n.path(r[s]).attr({
+                    fill: "#000",
+                    "stroke-width": 0,
+                    opacity: 0,
+                    cursor: "pointer"
+                });
+                this.stateHitAreas[s].node.dataState = s
+            }
+            this._onClickProxy = e.proxy(this, "_onClick");
+            this._onMouseOverProxy = e.proxy(this, "_onMouseOver"),
+            this._onMouseOutProxy = e.proxy(this, "_onMouseOut");
+            for (var s in this.stateHitAreas) {
+                this.stateHitAreas[s].toFront();
+                e(this.stateHitAreas[s].node).bind("mouseout", this._onMouseOutProxy);
+                e(this.stateHitAreas[s].node).bind("click", this._onClickProxy);
+                e(this.stateHitAreas[s].node).bind("mouseover", this._onMouseOverProxy)
+            }
+        },
+        _initCreateLabels: function() {
+            var t = this.paper;
+            var n = [];
+            var r = 860;
+            var i = 220;
+            var s = this.options.labelWidth;
+            var o = this.options.labelHeight;
+            var u = this.options.labelGap;
+            var a = this.options.labelRadius;
+            var f = s / this.scale;
+            var l = o / this.scale;
+            var c = (s + u) / this.scale;
+            var h = (o + u) / this.scale * .5;
+            var p = a / this.scale;
+            var d = this.options.labelBackingStyles;
+            var v = this.options.labelTextStyles;
+            var m = {};
+            for (var g = 0, y, b, w; g < n.length; ++g) {
+                w = n[g];
+                y = (g + 1) % 2 * c + r;
+                b = g * h + i;
+                m = {};
+                if (this.options.stateSpecificLabelBackingStyles[w]) {
+                    e.extend(m, d, this.options.stateSpecificLabelBackingStyles[w])
+                } else {
+                    m = d
+                }
+                this.labelShapes[w] = t.rect(y, b, f, l, p).attr(m);
+                m = {};
+                if (this.options.stateSpecificLabelTextStyles[w]) {
+                    e.extend(m, v, this.options.stateSpecificLabelTextStyles[w])
+                } else {
+                    e.extend(m, v)
+                }
+                if (m["font-size"]) {
+                    m["font-size"] = parseInt(m["font-size"]) / this.scale + "px"
+                }
+                this.labelTexts[w] = t.text(y + f / 2, b + l / 2, w).attr(m);
+                this.labelHitAreas[w] = t.rect(y, b, f, l, p).attr({
+                    fill: "#000",
+                    "stroke-width": 0,
+                    opacity: 0,
+                    cursor: "pointer"
+                });
+                this.labelHitAreas[w].node.dataState = w
+            }
+            for (var w in this.labelHitAreas) {
+                this.labelHitAreas[w].toFront();
+                e(this.labelHitAreas[w].node).bind("mouseout", this._onMouseOutProxy);
+                e(this.labelHitAreas[w].node).bind("click", this._onClickProxy);
+                e(this.labelHitAreas[w].node).bind("mouseover", this._onMouseOverProxy)
+            }
+        },
+        _getStateFromEvent: function(e) {
+            var t = e.target && e.target.dataState || e.dataState;
+            return this._getState(t)
+        },
+        _getState: function(e) {
+            var t = this.stateShapes[e];
+            var n = this.stateHitAreas[e];
+            var r = this.labelShapes[e];
+            var i = this.labelTexts[e];
+            var s = this.labelHitAreas[e];
+            return {
+                shape: t,
+                hitArea: n,
+                name: e,
+                labelBacking: r,
+                labelText: i,
+                labelHitArea: s
+            }
+        },
+        _onMouseOut: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("mouseout", e, t)
+        },
+        _defaultMouseOutAction: function(t) {
+            var n = {};
+            if (this.options.stateSpecificStyles[t.name]) {
+                e.extend(n, this.options.stateStyles, this.options.stateSpecificStyles[t.name])
+            } else {
+                n = this.options.stateStyles
+            }
+            t.shape.animate(n, this.options.stateHoverAnimation);
+            if (t.labelBacking) {
+                var n = {};
+                if (this.options.stateSpecificLabelBackingStyles[t.name]) {
+                    e.extend(n, this.options.labelBackingStyles, this.options.stateSpecificLabelBackingStyles[t.name])
+                } else {
+                    n = this.options.labelBackingStyles
+                }
+                t.labelBacking.animate(n, this.options.stateHoverAnimation)
+            }
+        },
+        _onClick: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("click", e, t)
+        },
+        _onMouseOver: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("mouseover", e, t)
+        },
+        _defaultMouseOverAction: function(t) {
+            this.bringShapeToFront(t.shape);
+            this.paper.safari();
+            var n = {};
+            if (this.options.stateSpecificHoverStyles[t.name]) {
+                e.extend(n, this.options.stateHoverStyles, this.options.stateSpecificHoverStyles[t.name])
+            } else {
+                n = this.options.stateHoverStyles
+            }
+            t.shape.animate(n, this.options.stateHoverAnimation);
+            if (t.labelBacking) {
+                var n = {};
+                if (this.options.stateSpecificLabelBackingHoverStyles[t.name]) {
+                    e.extend(n, this.options.labelBackingHoverStyles, this.options.stateSpecificLabelBackingHoverStyles[t.name])
+                } else {
+                    n = this.options.labelBackingHoverStyles
+                }
+                t.labelBacking.animate(n, this.options.stateHoverAnimation)
+            }
+        },
+        _triggerEvent: function(t, n, r) {
+            var i = r.name;
+            var s = false;
+            var o = e.Event("usmap" + t + i);
+            o.originalEvent = n;
+            if (this.options[t + "State"][i]) {
+                s = this.options[t + "State"][i](o, r) === false
+            }
+            if (o.isPropagationStopped()) {
+                this.element.trigger(o, [r]);
+                s = s || o.isDefaultPrevented()
+            }
+            if (!o.isPropagationStopped()) {
+                var u = e.Event("usmap" + t);
+                u.originalEvent = n;
+                if (this.options[t]) {
+                    s = this.options[t](u, r) === false || s
+                }
+                if (!u.isPropagationStopped()) {
+                    this.element.trigger(u, [r]);
+                    s = s || u.isDefaultPrevented()
+                }
+            }
+            if (!s) {
+                switch (t) {
+                case "mouseover":
+                    this._defaultMouseOverAction(r);
+                    break;
+                case "mouseout":
+                    this._defaultMouseOutAction(r);
+                    break
+                }
+            }
+            return !s
+        },
+        trigger: function(e, t, n) {
+            t = t.replace("usmap", "");
+            e = e.toUpperCase();
+            var r = this._getState(e);
+            this._triggerEvent(t, n, r)
+        },
+        bringShapeToFront: function(e) {
+            if (this.topShape) {
+                e.insertAfter(this.topShape)
+            }
+            this.topShape = e
+        }
+    };
+    var c = [];
+    s(e, "usmap", l, c)
+})(jQuery, document, window, Raphael)
+
+
+
+endingPicker = (out, totv, aa, quickstats) => {
+    
+    //out = "win", "loss", or "tie" for your candidate
+    //totv = total votes in entire election
+    //aa = all final overall results data
+    //quickstat = relevant data on candidate performance (format: your candidate's electoral vote count, your candidate's popular vote share, your candidate's raw vote total)
+  
+    /*
+    e.header = "<h2></h2>"
+    e.pages = ["<p></p>",
+               "<p></p>"]
+    */
+  
+    // NORMAL ENDINGS
+  e.final_overall_results.sort((a, b) => b.popular_votes - a.popular_votes);
+  map = document.getElementById("map_container");
+
+  //不帮助果冻，果冻失败
+  
+  if (aa[0].candidate === 2001557 && e.player_answers.includes(1950399)) {
+  used=false
+  if (used != true) {
+              setInterval(function () {
+                  used = true;
+                  imgg = document.getElementsByClassName("person_image")[0];
+                  if (imgg != null) {
+                      imgg.src =  "https://cc.tvbs.com.tw/img/upload/2023/05/11/20230511101843-4fbdaa77.jpg";
+                  }
+              }, 100);
+          }
+  return "<div style='overflow-y:scroll;height:250px;'><h3>KMT's Landslide Failure, DPP Re-elected</h3><p>Since the nomination of Terry Gou on May 17, 2023, the Kuomintang (KMT) has made a significant mistake. Gou's campaign encountered numerous issues over the months, ultimately leading to the current outcome. Firstly, Gou's involvement in past scandals resurfaced, severely impacting his and the KMT's image. Many within the KMT were also dissatisfied with the influence he had on the party in 2019, including a considerable number of Han Kuo-yu's supporters, as he competed against Han in 2019 and played a role in his significant defeat.</p><p>Mayor Hou You-yi focused on municipal governance and did not actively support Gou's campaign, lacking the backing of the initially popular presidential candidate Hou You-yi. Gou's campaign suffered from a lack of enthusiasm and support.</p><p>Things took a turn for the worse when Ko Wen-je refused to form a KMT-TPP ticket with Gou. Ko was wary of Gou's extensive business background and unclear ties with Beijing, as Gou had substantial business interests in mainland China. Gou insisted on running for president instead of vice president, refused to let the outcome be decided by polls, and even made statements like 'Let the Older brother go first for four years.' By November 23, Ko Wen-je still refused to communicate with Gou. At this point, Gou's approval ratings had fallen to the level of Eric Chu in 2016, and he still had not found a vice president. Ultimately, on November 24, Hung Hsiu-chu, who had been nominated in 2016 before being abolished, became Gou's vice president in an attempt to salvage his candidacy and keep the KMT in the election. Unfortunately, these efforts were in vain, and Gou's defeat was a reality.</p><p>With Gou's defeat, you have one less opponent to deal with in the next four years. Despite achieving high satisfaction ratings in polls for excellent municipal governance, earning the title of 'Five-Star Mayor,' it came at the cost of the KMT's survival and development. After this election, the KMT's electoral capabilities have once again been undermined. How many years will it take for this party to emerge from the shadow of 2016? Perhaps it will never happen.</p></div>"  
+  
+    } 
+    //帮助果冻，果冻失败
+
+    if (aa[0].candidate === 2001557 && e.player_answers.includes(1950400)) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://image.cache.storm.mg/styles/smg-800x533-fp-wm/s3/media/image/2019/11/23/20191123-114039_U4040_M570673_9ed1.jpg?itok=or7yughm";
+                        }
+                    }, 100);
+                }
+        return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Sets Historic Record, KMT Faces Third Defeat</h3><p>Since the Drafted of Terry Gou, his approval ratings have been consistently unstable, ultimately resulting in the current consequences. Lai Ching-te and the Democratic Progressive Party (DPP) have once again emerged victorious, setting a historical record in Taiwan by securing a third term. Meanwhile, you have also set a historical record of failure, a responsibility that Terry Gou must bear. If it weren't for his mishandling of the KMT-TPP Ticket in the later stages of the election, the KMT might have won by tens of thousands or even hundreds of thousands of votes against the DPP. However, his disdainful remarks towards Ko Wen-je and his supporters led Ko's supporters to refuse to transfer their votes to him, even when he was leading in the polls. He publicly stated that Ko Wen-je would absolutely not win and requested Ko's supporters to vote for him to defeat the DPP. His insistence on Ko Wen-je being the vice president further angered the TPP and its supporters. On registration day, Terry Gou, an outsider in politics, appointed actress Lai Pei-hsia as vice president, who had starred in the Taiwanese TV series Wave Makers, a show that exposed sexual harassment issues within the DPP. Despite her good and excellent image as well as eloquence, she lacked political experience and was questioned for the KMT's governing capabilities. Although Hou You-yi consistently supported Terry Gou, he ultimately faced defeat.</p> <p>With Terry Gou's defeat, you have one less opponent to deal with in the next four years. Despite achieving high satisfaction ratings in polls for excellent municipal governance, earning the title of 'Five-Star Mayor,' and establishing numerous connections and enhancing your strength and network in the local community, this success comes at the cost of the KMT's survival and development. After this election, the KMT's electoral capabilities have once again been undermined, and people are losing confidence in the party. However, due to the relatively small gap in this election, they are now looking towards you as the wise rising star. Can you secure victory in 2028? How many years will it take for the KMT to emerge from the shadow of 2016? Perhaps it will never happen. Perhaps it will be in the next four years.</p></div>"  
+        
+          } 
+
+    //不帮助果冻，果冻获胜
+
+    if (aa[0].candidate === 2001591 && e.player_answers.includes(1950399) ) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/800/20240113/2000x1333_wmky_495863372336_0.jpg";
+                        }
+                    }, 100);
+                }
+        return "You fool! I told you not to support him, to make sure he loses, and then let him give up in four years! Now he's the president, and in 2028, Terry Gou will definitely choose to run for re-election. What are you going to do then? After 2026, you can just go home and sleep. Goodbye, Mayor Hou!"  
+        
+          } 
+
+    //帮助果冻，果冻获胜
+    if (aa[0].candidate === 2001591 && e.player_answers.includes(1950400) ) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://news-data.pts.org.tw/media/149657/cover.jpg";
+                        }
+                    }, 100);
+                }
+        return "<div style='overflow-y:scroll;height:250px;'><h3>Terry Gou and Kuomintang Secure Victory! Political Alternation Achieved</h3><p>Since Terry Gou was drafted on May 17, avoiding the internal primary conflicts, his approval ratings have been neck-and-neck with Lai Ching-te until he was officially confirmed as the candidate in July. Gou gradually gained a stable lead over Lai. However, the rise of Ko Wen-je and the TPP caused a decline in Gou's approval ratings. Gou had to consider the KMT-TPP Tickets, and after sporadic negotiations over several months, a decision was made on November 15 to determine the outcome through polls. However, Ko Wen-je regretted the agreement after signing, leading to a loss of confidence in him. Voters looking to oust the Democratic Progressive Party (DPP) ultimately rallied towards Terry Gou. Gou nominated political outsider Lai Pei-hsia as vice president, bringing a positive media image. In the vice presidential debate, her unique eloquence, speaking skills, and sincere words resonated with many voters. According to polls, a staggering 62% considered Lai Pei-hsia the best in the debate. Ultimately, on January 13, Terry Gou emerged victorious and assumed the presidency.</p> <p>With Terry Gou's victory, your support for him will not go unnoticed. He has promised you a position in the cabinet, and the position of Premier is highly likely to be yours! Additionally, your high satisfaction ratings in municipal governance, earning the title of 'Five-Star Mayor,' and building numerous connections and enhancing strength and relationships in the local community have contributed to the survival and development of the Kuomintang. After this election, the electoral capabilities of the Kuomintang seem to have returned, and people's confidence in the party has been proven at the ballot box. Media and the public are speculating on who the DPP will field in the 2028 or even 2032 elections, while in the Kuomintang camp, attention is now turning to you, the rising star. If Terry Gou is willing to serve only one term, can you secure victory in 2028? Or do you plan to compete in the primaries against the incumbent president at that time? Regardless, you have considerable strength to contend with, and I wish you the best of luck, Mayor Hou!</p></div>"  
+        
+          } 
+          ///侯侯本体结局
+          if (aa[0].candidate === 2001591 && quickstats[1] > 40 && quickstats[1] < 46.0) {
+            used=false
+            if (used != true) {
+                        setInterval(function () {
+                            used = true;
+                            imgg = document.getElementsByClassName("person_image")[0];
+                            if (imgg != null) {
+                                imgg.src =  "https://v3-statics.mirrormedia.mg/images/dc330714-e51a-4952-8eb8-bfa1f3db329d-w1600.webP";
+                            }
+                        }, 100);
+                    }
+            return "<div style='overflow-y:scroll;height:250px;'><h3>Fourth Party Alternation! KMT Victory, DPP Rule Ends</h3><p>I believe Ko Wen-je must be regretting now, why he didn't accept the offer to be the Vice President on November 18. Because if he did, he would have gained many administrative resources for free, the second-highest position in the country, and the expansion of TPP's strength. But he chose to give up. In November, when the opposition alliances parted ways, many predicted that DPP would unprecedentedly enter its third term. However, when Ko Chih-en appeared as the Vice President,Many young people are attracted to the Kuomintang with the unconventional election combination, especially female voters.. Faced with the untrustworthy Ko Wen-je and the political prodigy who rose to fame 30 years ago, they immediately flocked to the latter. This led to a sharp increase in KMT's poll numbers after November,Ko Chih-en has brought in some demographics that may not have previously supported the Kuomintang and has emphasized her progressive agenda along with the Kuomintang's pragmatic cross-strait policy for you., helping you secure victory. Ko Chih-en has pledged to assist you in education reform and to focus on minority groups and women's rights once in office.</p><p>In terms of this legislative yuan, you witnessed a complete victory. With 57+2 seats in the National Assembly, you will ensure your majority without having to consider DPP and TPP. You can pass any bills you want, ensuring the smooth operation of the Hou You-yi government in the parliament. However, to push for the cabinet system and other reforms you have promised, cooperation between the three parties must be promoted.</p><p>On May 20 this year, you will become the President of the Republic of China, a son of a pork vendor from rural Chiayi, who has been serving the country since entering the police academy, facing countless gunshots, confrontations, and battles against criminals. But if it weren't for Eric Chu promoting you to Deputy Mayor of New Taipei in 2010, you probably wouldn't have entered politics. In just over a decade, you have become the president. Perhaps your Mandarin is not good, perhaps your appearance is not as impressive as others, perhaps you don't even have much personal charm, but you are steadfast and down-to-earth, which has won the favor of the majority of Taiwanese voters. The first thing you will face after taking office is the mayoral by-election in New Taipei, as well as the major elections for mayors across the country in 2026. You must firmly grasp the local base of the blue camp, and in 2028, your prospects for re-election will be very promising! Good luck, President Hou You-yi!</p></div>"  
+            
+          } 
+          else if (aa[0].candidate === 2001591 && quickstats[1] < 40 && quickstats[1] > 35.0 ) {
+            used=false
+            if (used != true) {
+                        setInterval(function () {
+                            used = true;
+                            imgg = document.getElementsByClassName("person_image")[0];
+                            if (imgg != null) {
+                                imgg.src =  "https://www.upmedia.mg/upload/article/20230525101057669889.jpg";
+                            }
+                        }, 100);
+                    }
+            return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Loses Third Term, 8-Year Curse Continues, Underdog Emerges Victorious</h3> <p>In an intense duel, the one who fights to the end is the true winner. With the possibility of Joint Tickets completely lost, Hou You-yi could only find Ko Chih-en as the vice presidential candidate. On the positive side, she is more likely to attract female and young voters compared to other male vice-presidential candidates.To put it negatively, there is simply no other KMT member willing to be your vice president because polls show you lagging behind Lai Ching-te. No one is willing to waste time and sacrifice their political future to help you. Due to the new voter base and consolidation of southern voters that Ko Chih-en has pioneered,We manage to defeat Lai Ching-te in the final stage of the election. It's truly a thrilling and exciting battle! Ko Wen-je must be regretting now; he could have become vice president, but now he can only be elected as Taipei City citizen. Haha.</p> <p>In terms of this legislative session, you have just obtained a majority, but it's very fragile. The 55+2 seats in the National Assembly will ensure your absolute majority without having to consider the faces of DPP and TPP. You can pass any bills you want, ensuring the smooth operation of the Hou You-yi government in the parliament. However, to push for the cabinet system and other promised reforms, cooperation between the three parties must be promoted. Additionally, if someone in the National Assembly does not vote for you, even one or two people whose party lines are inconsistent, it may lead to you losing the majority. So, you must uphold party discipline. After all, you are now the president, and you might also serve as the party chairman.</p><p>On May 20 next year, you will become the President of the Republic of China, a son of a pork vendor from rural Chiayi, who has been serving the country since entering the police academy, facing countless gunshots, confrontations, and battles against criminals. But if it weren't for Eric Chu promoting you to Deputy Mayor of New Taipei in 2010, you probably wouldn't have entered politics. In just over a decade, you have become the president. Perhaps your Mandarin is not good, perhaps your appearance is not as impressive as others, perhaps you don't even have much personal charm, but you are steadfast and down-to-earth, which has won the favor of the majority of Taiwanese voters. The first thing you will face after taking office is the mayoral by-election in New Taipei, as well as the major elections for mayors across the country in 2026. You must firmly grasp the local base of the blue camp, and in 2028, your prospects for re-election will be very promising! Good luck, President Hou You-yi!</p></div>    "
+          }
+            else if (aa[0].candidate === 2001557 && quickstats[1] <40 && quickstats[1] > 35.0 ) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/1024/20231231/1200x814_wmky_053032638365_202312030108000000.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Unprecedentedly Enters Third Term: KMT Fails to Achieve Party Alternation</h3><p>As predicted, the miracle did not happen. Lai Ching-te maintained his high approval ratings until the last day of the election. Everyone knew that the lack of cooperation between the blue and white camps would benefit Lai Ching-te. As expected, both you and Ko Wen-je lost in the election. However, Lai Ching-te's vote share is not as high as expected, staying below 40%, which means he didn't even secure full support from the DPP base. Ko Chih-en's entry brought a strong boost to the blue camp, but the Triumph Apartments incident and the influence of Ma Ying-jeou may have affected your base and votes. You may have also performed poorly in the early stages of the campaign, leading to a drag, but since this was a result that everyone could foresee, it might not be as bad as it seems.</p> <p>Fortunately, we have maintained a relative majority in the Legislative Yuan. The 53+2 seats will ensure that we are the largest party in the legislature. While we didn't achieve an absolute majority, meaning we have to cooperate with the TPP to pass bills, they will become a crucial minority in the parliament.</p> <p>After the election, you must return to the position of Mayor of New Taipei City. Your deputy mayor has been acting on your behalf for the past few months. Your term will continue until 2026. Although some extremists talk about replicating the outcome of Han Kuo-yu in 2020 and attempting to recall you as mayor, their chances of success are unlikely, and you are not particularly disliked. They are not likely to succeed. In 2026, you must step down, and at that time, you will be a free person, able to enjoy retirement and the remaining years of your life. However, if you still have ambitions for 2028, this election is just a stepping stone. Failure is the mother of success. Since the DPP can be re-elected, what reason do you have not to strive for the nomination in 2028?</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Ko Chih-en for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>"
+            }
+            else if (aa[0].candidate === 2001557 && quickstats[1] > 40.0 && quickstats[1] < 46.0) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://d1j71ui15yt4f9.cloudfront.net/wp-content/uploads/2023/12/03223725/20231203000125.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>Narrow Defeat with High Votes: KMT Loses to DPP with Over 40%</h3><p>Once, people believed that getting 40% of the votes in a three-way race would guarantee victory. Unfortunately, luck wasn't on your side, and the DPP secured a victory with just a slightly higher vote count. You garnered nearly the same number of votes, yet you have to return to your position as the mayor of New Taipei City. Is there a flaw in our electoral system? Despite securing a substantial 40% of the votes, achieving a party alternation proved elusive. Your supporters blame Ko Wen-je for siphoning off many of your votes, but despite our best efforts, party alternation couldn't be realized.</p><p>For you, the consolation is that Ko Wen-je secured third place. Before the election, he had significant momentum with substantial support from young people, and TPP supporters made their voices heard online. However, these were ultimately futile dreams. Even if Ko Wen-je had said he would let you run alone, you wouldn't have won. You proved that the KMT, with a solid base, wouldn't easily lose to the TPP, which has only been around for a few years. Among the opposition voters, there's a saying: whoever is in third place is the culprit for the opposition's failure. Judging by the voting pattern, he is indeed the third, and he lost by a significant margin. After the election, his Facebook was turned upside down by angry opposition voters.</p><p>Although Lai Ching-te becomes president, his governance won't be smooth. The high satisfaction with the Tsai administration won't be fully inherited by him. He is destined to face a minority government and a parliament where the opposition party is in power. Currently, the KMT has 56+2 seats, making it the largest party in the Legislative Yuan and securing an absolute majority. This means that, barring any surprises, Han Kuo-yu, who supports you, will become the president of the Legislative Yuan. This is a significant payback for him.  However, being selected as the vice president by you, Ko Chih-en missed the opportunity to become a legislator. In the next four years, she will have no public office, and this is the cost of failure. and you can go back to being the mayor of New Taipei City. You can try running again in 2028, as your performance has at least matched that of Han Kuo-yu in 2020, and this was in a three-way race. If you enter the race in 2028, the presidency could very well be yours. Good luck, Mayor Hou!</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Ko Chih-en for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p>/div>"
+            }
+          else if (aa[0].candidate === 2001557 && quickstats[1] < 35.0 && quickstats[1] > 30.0) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://images.ctee.com.tw/newsphoto/2024-01-13/1024/20240113700644_20240113212416.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Triumphs Again, KMT Faces Another Defeat: When Will the Chapter of 2016 End?</h3> <p>On the night of your defeat, you had a nightmare: perhaps the KMT will never govern again? It's a frightening thought, but since 2016, the KMT has lost the presidential election three times in a row. The last time they won was 12 years ago, a cycle ago, but it feels as distant as a century ago. The DPP has achieved an unprecedented third term, even though their government is a minority one without the support of the majority of the people. The KMT's failure was anticipated, as the DPP had a few percentage points of a lead, and every step forward for you was challenging, ultimately leading to the KMT's defeat.</p><p>For you, the consolation is that Ko Wen-je came in third. Before the election, he had significant momentum, with substantial support from young people and a large voice among internet users, especially TPP supporters. However, these were ultimately futile dreams. Even if Ko Wen-je said he would let you run alone, you wouldn't have won. You proved that the KMT, with a solid base, wouldn't easily lose to the TPP, which has only been around for a few years. Among the opposition voters, there's a saying: whoever is in third place is the culprit for the opposition's failure. Judging by the voting pattern, he is indeed the third, so he might be the culprit?</p> <p>Although Lai Ching-te becomes president, his governance won't be smooth. The high satisfaction with the Tsai administration won't be fully inherited by him. He is destined to face a minority government and a parliament where the opposition party is in power. Currently, the KMT has 52+2 seats, making it the largest party in the Legislative Yuan. This means that, barring any surprises, Han Kuo-yu, who supports you, will become the president of the Legislative Yuan. This is a significant payback for him. However, being selected as the vice president by you, Ko Chih-en missed the opportunity to become a legislator. In the next four years, she will have no public office, and this is the cost of failure., and you can go back to being the mayor of New Taipei City. The world seems unchanged, just like before! You can try running again in 2028... if the ROC can survive until then.</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Ko Chih-en for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>"
+              map.style.backgroundImage = "url(https://i.imgur.com/VjbWx3Q.jpeg)"; 
+            }
+          else if (aa[0].candidate === 2001591 && quickstats[1] > 46.0 ) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://pgw.udn.com.tw/gw/photo.php?u=https://uc.udn.com.tw/photo/2023/11/22/realtime/27460842.jpg&s=Y&x=144&y=0&sw=3445&sh=2297&sl=W&fw=800&exp=3600&w=930";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>Hou's Crushing Comeback: KMT Triumphs Over DPP in 2024, Regaining Power!</h3><p>As the lights lit up at the KMT campaign headquarters, the audience below had anticipation and anxiety in their eyes. For most of the past year, Lai Ching-te had been leading in the polls, only recently trading victories with Hou You-yi in the last couple of months. In the audience, there were infants in cradles, elderly individuals in their seventies and eighties, and middle-aged people in their forties and fifties, all hoping for a KMT victory to bring them a better future. When the vote counting began, Hou You-yi and Lai Ching-te were neck and neck. However, people noticed that Hou You-yi had a significantly high vote share in deep-blue regions. In battleground areas like Changhua and Taichung, he also performed admirably, gradually widening the gap. In the end, Hou You-yi secured victory in the presidential election with over 46% of the votes, becoming the 16th president.</p><p>The young people and students gathered around Ko Chih-en immediately screamed and cheered. You and your campaign team quickly conducted a simulated inauguration ceremony, preparing for the formal inauguration on May 20.    Ko Chih-en has brought in some demographics that may not have previously supported the Kuomintang and has emphasized her progressive agenda along with the Kuomintang's pragmatic cross-strait policy for you.The DPP suffered a major defeat in this election, prompting them to reflect on whether their governance over the past eight years had left the people extremely dissatisfied, leading them to choose the strongest candidate even in the face of opposition division, ultimately ousting the DPP. Lai Ching-te's days as vice president were also coming to an end.</p><p>As the president who led the KMT back to power and won a challenging battle, the rewards for you are substantial. The KMT holds 59+2 seats in the Legislative Yuan, becoming the largest party and securing an absolute majority in the legislature. Han Kuo-yu, who supports you, is destined to become the president of the Legislative Yuan, and party chairman Eric Chu can become the premier. According to tradition, the party chairman should be the president, a significant reward for You. Ko Chih-en, as vice president, can handle diplomatic affairs and even represent you on foreign visits. Due to the enormous victory you achieved this year, it's almost certain that you will be nominated for re-election by the KMT in 2028. However, the upcoming New Taipei City mayoral by-election and the 2026 county and city mayoral elections will test your governing abilities. If you can navigate them successfully, then you have a great chance of winning re-election in 2028. Good luck, President Hou You-yi!</p></div>"
+            }
+            else if (aa[0].candidate === 2001622 ) {
+            used=false
+            if (used != true) {
+                        setInterval(function () {
+                            used = true;
+                            imgg = document.getElementsByClassName("person_image")[0];
+                            if (imgg != null) {
+                                imgg.src =  "https://d1b8dyiuti31bx.cloudfront.net/NewsPhotos/20231231/109_025527539611.jpg";
+                            }
+                        }, 100);
+                    }
+            return "<div style='overflow-y:scroll;height:250px;'><h3>Taiwan's Political Earthquake: Blue and Green Parties Overturned, Ko Wen-je Emerges Victorious</h3> <p>A year ago, nobody would have believed that Ko Wen-je and his TPP could secure the presidency of the ROC. However, it happened. Ko Wen-je and his People Party (TPP) claimed the presidency, leaving both the blue and green camps and their supporters in shock. Ko Wen-je's young fanbase erupted in joy, filling the internet with their celebrations, contrasting with the disappointment among blue and green supporters.</p><p>The world's attention turned to Ko Wen-je and the TPP. Media outlets from major countries, including China, the United States, South Korea, Japan, Russia, the United Kingdom, and France, featured front-page coverage on the process and outcome of Ko Wen-je and the TPP securing the presidency in Taiwan. However, Ko Wen-je is destined to be a crippled president as the TPP is the smallest party in the parliament. The solid foundations of the KMT and DPP in the legislature cannot be easily shaken. Can you imagine a president from the third-largest party dealing with a parliament full of opponents? It's almost unimaginable, but it happened. Ko Wen-je can choose to collaborate with either the blue or green camp, but he will never have dominance.</p> <p>With Ko Wen-je's election, your campaign turned into a joke. The KMT lost to a small party that had only been established for five years, and the defeat was embarrassing. The only consolation is that the DPP also suffered a severe setback, so you're not alone in this. As for the future, who knows? Ko Wen-je is an unpredictable figure, and the stance of his government remains uncertain. We know nothing at this point.</p></div> "
+               }
+               else if (aa[0].candidate === 2001557 && quickstats[1] > 46.0 ) {
+                  used=false
+                  if (used != true) {
+                              setInterval(function () {
+                                  used = true;
+                                  imgg = document.getElementsByClassName("person_image")[0];
+                                  if (imgg != null) {
+                                      imgg.src =  "https://cdn.hk01.com/di/media/images/dw/20240112/822423439976435712294650.jpeg/DZO8aeGaT0u6zDkTim6YltXgdsj2Ey8DbXl0JW15dCU?v=w1280r16_9";
+                                  }
+                              }, 100);
+                          }
+                  return "<div style='overflow-y:scroll;height:250px;'><h3>Head-to-Head Showdown Upended: DPP Defeats KMT-TPP Alliance</h3><p>In the November polls, most surveys indicated that the KMT-TPP joint ticket, whether led by Ko Wen-je or Hou You-yi, could defeat Lai Ching-te by at least several hundred thousand votes. However, on January 13th, how did things take such a turn? Lai Ching-te has emerged victorious over you, reminiscent of 2004 when the KMT's poll numbers remained high but were caught up and surpassed in the final stages. It was a painful night, with the supporters of the KMT and TPP left speechless, while not far away, the cheers of DPP supporters echoed through the skies.</p><p>In the Legislative Yuan, the KMT only leads the DPP by one seat, and the 51+2 seats will mean that you only need one person to abstain from voting to lose the relative majority. This is not good news for the KMT, and the TPP might consider choosing to cooperate with the DPP because your failure has brought about bitter political consequences. However, at least in the Legislative Yuan, there is some room for cooperation and contention among the three parties, and the election for the Legislative Yuan President on February 1st will be intense.</p><p>Given your lackluster performance in what was considered a sure-win game, you are being blamed as the main culprit for the failure. Your lack of proficiency in Mandarin, running for office while holding another position, and the image of a charmless rural figure have all weighed you down – issues of your own making. More importantly, your failure to handle some crucial issues properly undoubtedly impacted your votes and the likelihood of ultimate victory. You may not even be able to retain the position of New Taipei City Mayor, as some angry and extreme TPP and KMT supporters are planning to recall you as a failed leader. The saying goes,'a drowning man will clutch at a straw', and now you must find a way to return to city governance and regain the favor of the citizens. Good luck, Mayor Hou.</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Ko Chih-en for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>"
+                }
+                else if (aa[0].candidate === 2001591 && quickstats[1] < 35.0 ) {
+                  used=false
+                  if (used != true) {
+                              setInterval(function () {
+                                  used = true;
+                                  imgg = document.getElementsByClassName("person_image")[0];
+                                  if (imgg != null) {
+                                      imgg.src =  "https://image.cache.storm.mg/styles/smg-800x533-fp/s3/media/image/2019/12/26/20191226-035137_U14116_M580354_6d3d.jpg?itok=q9v0lqhT";
+                                  }
+                              }, 100);
+                          }
+                  return "<div style='overflow-y:scroll;height:250px;'> <h3>Narrow Victory in the Presidential Race: Hou You-yi Wins Presidency with Less Than 35% of Votes</h3> <p>In this intense multi-candidate competition, the DPP evidently lost its political stronghold, while the KMT's support base remained robust. Although several camps believed they could secure the presidency, the actual results were astonishing. Hou You-yi won the presidency with less than 35% of the vote, with the remaining 65% distributed among other candidates. This marks the lowest presidential vote percentage since the direct election of presidents. Nevertheless, you have secured the presidency, which may be challenging, but you did achieve it. After all, in a multi-candidate election, the support base is the most crucial factor.</p><p>In the Legislative Yuan, you maintain the status of the largest party but only lead the DPP by two seats. The upcoming parliament will undoubtedly involve party cooperation, and Han Kuo-yu is likely to become the next President of the Legislative Yuan without unexpected events. The TPP will inevitably become a crucial third force, and may your dealings with them be smooth! During your presidential term, challenges and opportunities will coexist. The difficulties presented by the challenging parliament and the diplomatic and domestic issues left by the DPP may be bothersome, but a reformed KMT government may gain more support and assistance from the people. The by-election for the mayor of New Taipei City and the 2026 county and city mayor elections will be your test. If you perform well, you may secure the nomination for reelection in 2028. However, if your performance is subpar, the KMT may prefer to nominate a new figure to replace you. Best of luck, President Hou You-yi!</p></div>"
+                }
+                //隐藏结局：2004重演。蓝白合输给民进党
+                else if (aa[0].candidate === 2001557 && quickstats[1] > 49.99 && quickstats[1] < 50.12 && aa[1].candidate === 2001591 ) {
+                  used=false
+                  if (used != true) {
+                              setInterval(function () {
+                                  used = true;
+                                  imgg = document.getElementsByClassName("person_image")[0];
+                                  if (imgg != null) {
+                                      imgg.src =  "https://rwnews.tw/upload/newstemp_13273/wide_j861buk_FotoJet-(72).jpg";
+                                  }
+                              }, 100);
+                          }
+                  return "<div style='overflow-y:scroll;height:250px;'><h3>Taiwan Election Deadlocked!</h3><p>Chairman Lai, something big has happened!</p><p>Your campaign office director, Yao Li-ming, hurriedly entered the hallway, finding you enjoying Taiwan's signature hand-shaken milk tea with extra sugar, evidently influenced by the locals in Tainan.</p><p>'Yao Director, what's the urgency?'</p><p>'Haven't you been watching? The vote count is at 95%, and there's still no winner declared!'</p><p>'I'm concerned about my health; high blood pressure, you know. What's going on?'</p><p>Yao quickly turned on the TV in your office, switching to SETN. Hou You-yi's and Lai Ching-te's images were swapping positions every half-minute, and their rankings kept changing. Each channel showed a different story, with Hou leading more on CTI, while Formosa TV and SETN favored Lai.</p><p>'Isn't there still 5% left? Let's wait until all votes are counted; I believe we'll win.'</p><p>One hour later, at the joint campaign headquarters of Hou You-yi and Ko Wen-je, the roar of car horns shattered the sky and everyone's hearts and ears.</p><p>'Everyone, please be quiet; President Hou can't speak in this noise.'</p><p>Hou You-yi stood silent on the stage.</p><p>'Chairman Ko, you go first.'</p><p>Ko Wen-je stepped forward, took the microphone, revealing an unprecedented solemnity in his expression.</p><p>'This is evidence of the DPP rigging the election. Their election staff used various methods, including disabling cameras, not singing the ballots, and much more. Our TPP and KMT supervisors have discovered many flaws in the electoral process, suspected of cheating... Please, everyone, look at the big screen.'</p><p>Hou You-yi added, 'The gap in our defeat is... very, very marginal. This slight difference is clouded in suspicion, raising many doubts. It gives the impression that this is an unfair election. We are preparing to file a lawsuit for the invalidation of the election.'</p><p>Supporters: 'Invalid! Invalid! Invalid!'</p><p>As the chants subsided, Hou You-yi continued, 'The second request is for the CEC to immediately seal all ballot boxes as a basis for future verification.'</p><p>Supporters: 'Verify! Verify! Verify!'</p><p>'If Taiwan really cannot lose, it's here. Everyone, right?'</p><p>Supporters: 'Yes!'</p><p>'Taiwanese people, democracy is our most effective weapon against the CCP. When we destroy this weapon, what other defenses do we have? Unfair elections not only make us hear about the doubts just mentioned but also clearly witness manipulative actions throughout the election. Everyone knows this, and we are using the most rational and gentle method to expose the deception carried out by Lai Ching-te and the DPP throughout this election. Let the whole world understand, shall we?'</p><p>Supporters: 'Go Hou-Ko! Go Hou-Ko!'</p><p>What happened in the world was unclear, but it was certain that Taiwan would once again enter bitter days of election violence and confrontation.</p></div>"
+                }
+                //白莲教赢过侯，侯大于23%
+                else if (aa[1].candidate === 2001622 && aa[2].candidate === 2001591 && quickstats[1] >= 23.1 && quickstats[1] < 30.0) {
+                    used=false
+                    if (used != true) {
+                                setInterval(function () {
+                                    used = true;
+                                    imgg = document.getElementsByClassName("person_image")[0];
+                                    if (imgg != null) {
+                                        imgg.src =  "https://imgcdn.cna.com.tw/www/webphotos/WebCover/800/20231223/1200x900_118527508580.jpg";
+                                    }
+                                }, 100);
+                            }
+                    return "<div style='overflow-y:scroll;height:250px;'> Is this the result of your self-sabotage? Well, I must say you succeeded because you managed to make a century-old political party lose to a third-party newcomer that has only been around for 5 years. It's quite a failure, and everyone on the internet is mocking you. </div>"
+                  }
+                  else if (aa[1].candidate === 2001622 && aa[2].candidate === 2001591 && quickstats[1] < 23.1 && quickstats[1] < 30.0) {
+                    used=false
+                    if (used != true) {
+                                setInterval(function () {
+                                    used = true;
+                                    imgg = document.getElementsByClassName("person_image")[0];
+                                    if (imgg != null) {
+                                        imgg.src =  "https://img.ltn.com.tw/Upload/news/600/2015/10/21/php4Ic3tg.jpg";
+                                    }
+                                }, 100);
+                            }
+                    return "<div style='overflow-y:scroll;height:250px;'>Your votes is even lower than Lien Chan's in 2000. I'm speechless. Now, Ko Wen-je and his supporters can openly mock the Kuomintang and you!</div>"
+                  }
+}
+
+// in-game achievements
+
+setInterval(endingPicker, 250);
+
+//注释代码
+function getTooltips(str) {
+    let matches = [];
+
+    tooltipList.forEach((tooltip, index) => {
+        // Adjust the regex to match searchString potentially surrounded by “ and followed by optional punctuation
+       let regex = new RegExp(`(?<=\\b|\\s|^|“)${tooltip.searchString}(?=[.,;!?]?\\b|\\s|”|$)`, 'g');
+
+
+        let match;
+        while ((match = regex.exec(str)) !== null) {
+            matches.push({
+                start: match.index + (match[0].startsWith('“') ? 1 : 0), // Adjust for potential starting “
+                end: match.index + match[0].length - (match[0].endsWith('”') ? 1 : 0) - (match[2] ? 1 : 0), 
+                tooltipIndex: index
+            });
+        }
+    });
+
+    // Sort by starting position; if two start at the same position, longer match comes first
+    matches.sort((a, b) => a.start - b.start || b.end - b.start - (a.end - a.start));
+
+    // Filter out overlaps
+    for (let i = 0; i < matches.length - 1; ) {
+        if (matches[i + 1].start < matches[i].end) {
+            matches.splice(i + 1, 1); // Remove the next match since it overlaps
+        } else {
+            i++; // Move to next match
+        }
+    }
+
+    return matches;
+}
+function applyTooltips(str) {
+    const matches = getTooltips(str);
+    let result = '';
+    let lastIndex = 0;
+
+    matches.forEach(match => {
+        const tooltip = tooltipList[match.tooltipIndex];
+        result += str.slice(lastIndex, match.start);
+        result += `<span class='mytooltip'>${tooltip.searchString}<span class='mytooltiptext'>${tooltip.explanationText}</span></span>`;
+        lastIndex = match.end;
+    });
+
+    result += str.slice(lastIndex); // Add the remainder of the original string
+    return result;
+}
+
+function applyTooltipsToObject(obj) {
+    for (let key in obj) {
+        if (typeof obj[key] === 'string') {
+            obj[key] = applyTooltips(obj[key]);
+        } else if (typeof obj[key] === 'object') {
+            applyTooltipsToObject(obj[key]); // Recursive call
+        }
+    }
+}
+
+applyTooltipsToObject(campaignTrail_temp.questions_json);
+applyTooltipsToObject(campaignTrail_temp.answers_json);
+applyTooltipsToObject(campaignTrail_temp.answer_feedback_json);

--- a/static/mods/2024ROC_Hou-KoWenJe.json
+++ b/static/mods/2024ROC_Hou-KoWenJe.json
@@ -1,0 +1,9199 @@
+e=campaignTrail_temp // this is redundant, but Decstar uses this because it looks nicer in the code.
+campaignTrail_temp.multiple_endings=true
+campaignTrail_temp.cyoa = true
+campaignTrail_temp.questions_json = [
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950011,
+        "fields": {
+            "priority": 0,
+            "description": "it's January 2023, congratulations on successfully securing re-election as the Mayor of New Taipei a month ago, with an impressive 62% of the votes. It appears that there is a high likelihood of your candidacy in the 2024 presidential election. According to Formosa's polls, you lead with a support rate of 39.9%, surpassing Lai Ching-te's 34.1%. Do you wish to participate in the 2024 election and potentially lead the KMT to regain the lost governance after 8 years?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950015,
+        "fields": {
+            "priority": 0,
+            "description": "More than a month after the Chinese New Year, on March 22nd, the KMT Central Standing Committee passed a resolution authorizing the party chairman, Eric Chu, to Drafting the party's presidential candidate. However, a primary election is scheduled before that. Your opponent in the primary is Terry Gou. Do you have any specific campaign strategies for the upcoming primary?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950016,
+        "fields": {
+            "priority": 0,
+            "description": "Currently, the primary have begun, and as the most popular candidate, your poll numbers are ahead of Terry Gou. What specific areas do you plan to focus on during the preliminary election competition?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950017,
+        "fields": {
+            "priority": 0,
+            "description": "Congratulations! In today's Central Standing Committee meeting, Chairman Eric Chu announced that you will be the Kuomintang (KMT) presidential candidate for 2024. Terry Gou also congratulated you on Facebook for receiving the party's draft. You will represent the KMT in the 2024 election, aiming to take down the incompetent DPP government!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950018,
+        "fields": {
+            "priority": 0,
+            "description": "On the same day you were drafted, Taiwan People's Party Chairman Ko Wen-je was also selected as the party's presidential candidate. This means that the opposition camp is divided into two parts for the election, which could potentially impact the overall prospects of the pan-blue votes. What is your overall strategy about the TPP?\n",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950019,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, it seems we've encountered trouble! A private kindergarten has been exposed for alleged child abuse by teachers, including the shocking revelation of feeding children Class III controlled substances like barbital and Class IV controlled substances like phenobarbital! Some parents have reported this to the police, and this issue has just come to our attention. We need to take immediate action, or the DPP will use this incident to launch a major attack against you!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950020,
+        "fields": {
+            "priority": 0,
+            "description": "In the midst of the kindergarten incident's escalation, your approval ratings have sharply declined, akin to falling off a cliff into the water. After addressing this matter, you engage in face-to-face discussions with students at National Chengchi University and Taiwan University. When students inquire about your stance on the One China Policy and the differences between you and Han Kuo-yu, how will you respond?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950021,
+        "fields": {
+            "priority": 0,
+            "description": "With a significant decline in your polls, your campaign is facing a major crisis. In many polls, your support is trailing behind Ko Wen-je. According to Formosa and TVBS polls in June, you had support rates of 23% and 17.1%, respectively, while Ko Wen-je had 33% and 28.6%. Even legislator Cheng Li-wen suggested replacing you with Han Kuo-yu due to your lower poll numbers. Additionally, there is uncertainty about Terry Gou's support. Some polls suggest that Gou might reconsider running. What measures do you plan to take to prevent further decline?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950022,
+        "fields": {
+            "priority": 0,
+            "description": "Finally, an hot fire in the snow! Former key strategist for Ma Ying-jeou's campaigns and former ROC representative to the U.S., King Pu-tsung, has agreed to serve as the campaign office chairman under your personal visit. He will assist in orchestrating your campaign!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950023,
+        "fields": {
+            "priority": 0,
+            "description": "\nOn July 1st, you were invited to attend a gathering organized by the Kuomintang's 'Huang Fuxing' branch, where you are expected to meet with Han Kuo-yu. Han's supporters have consistently expressed dissatisfaction with your candidacy, believing that Han Kuo-yu is a more suitable candidate. During the gathering, what do you plan to do to win them over and dispel the sentiment of 'Replacing Hou with Han'?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950024,
+        "fields": {
+            "priority": 0,
+            "description": "On July 3rd, you participated in an interview with Zhao Shao-kang, discussing the election strategy and campaign situation after being Drafted by the KMT. The aim was to gain more media exposure. Zhao mentioned that Han's supporters feel you were not actively supportive in 2020, and many of his fans do not favor you. the promised support from Terry Gou seems to be elusive, and there are rumors of him considering an independent run. What message would you like to convey during this interview?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950025,
+        "fields": {
+            "priority": 0,
+            "description": "On July 23rd, the KMT held a National Party Convention, officially nominating you as the candidate. This signifies that any rumors of replacement are baseless. During the event, Han Kuo-yu expressed his formal support, stating one of his three wishes for this year is for the KMT, under your leadership, to oust the corrupt and incompetent DPP.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950026,
+        "fields": {
+            "priority": 0,
+            "description": "Since the official commencement of your campaign, you have the first opportunity to visit various locations and boost support in specific areas. Where do you intend to concentrate your efforts primarily?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950027,
+        "fields": {
+            "priority": 0,
+            "description": "After 7 years of rule, DPP has left many vulnerable points for you to attack. From restricting freedom of speech to tense relations with the mainland, the widening wealth gap, rising prices, and numerous scandals highlighting incompetence and corruption. How do you plan to launch your strongest attacks against your main opponent?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950028,
+        "fields": {
+            "priority": 0,
+            "description": "As the election has passed its midpoint, you need to present more and better specific policies to attract KMT voters. Currently, your performance in opinion polls is still not favorable, and many are concerned that you might end up as the third in this election. How do you plan to consolidate your support base?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950029,
+        "fields": {
+            "priority": 0,
+            "description": "Some very bad news just came in... Business tycoon Terry Gou, who has been hesitant to support you since you officially entered the race, announced today that he is running for president as an independent candidate! He made this announcement during a press conference for the \"Mainstream Opinion Alliance.\" It seems like the pan-blue's voter base is being further divided. What should we do?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950030,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, it seems that the People's Party has proactively proposed a united plan: they hope to select the sole opposition candidate through comparative candidate polling, and whoever loses will withdraw from the election. What is your opinion on this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950031,
+        "fields": {
+            "priority": 0,
+            "description": "Among the voters, there is a significant portion who lack trust in your abilities and qualifications, with many expressing doubts about your diplomatic skills. A considerable number believe that you lack experience in handling international relations. To address this concern, the KMT Central Committee has decided to send you on an official visit to the United States. In This Trip,What key messages would you like to emphasize?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950032,
+        "fields": {
+            "priority": 0,
+            "description": "Since entering October, legislators nationwide have gradually intensified their activities, and your campaign may be entering its most critical period! At this juncture, Han Kuo-yu is putting aside all previous reservations and actively supporting your candidacy. Now, let's pass the microphone to Mayor Han. What are your thoughts on Mayor Hou?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950033,
+        "fields": {
+            "priority": 0,
+            "description": "Entering November, the joint ticket decision between the KMT and TPP remains undecided. Despite polls indicating that the opposition alliance consistently outperforms Lai Ching-te, both the KMT and the TPP are reluctant to take on a mere preparatory role as vice president, as they both aspire to wield the executive power of the presidency. As time gradually slips away, former President Ma Ying-jeou and Han Kuo-yu propose settling the matter through a nationwide poll, with the loser becoming the vice president. What are your thoughts on this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950034,
+        "fields": {
+            "priority": 0,
+            "description": "On November 15th, waking up in the morning, Taiwan's media and political circles were shocked by a piece of news: KMT-TPP has confirmed the formation of a joint ticket, endorsing a single presidential candidate. This is expected to severely impact Lai Ching-te's support. Chairman Zhu, Mayor Hou, former President Ma, and Chairman Ko have reached an agreement to introduce a set of candidates using the cumulative results of previous polls. This is considered a very intense competition... but due to the selection of fixed-time polls, your current efforts may not be of much use...The final results will be announced on the 18th.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950035,
+        "fields": {
+            "priority": 0,
+            "description": "Damn it... With Ko Wen-je's backtracking, there are only a few days left until the deadline for presidential candidate registration! We must complete the integration within these few days... or find our own vice presidential candidate! Terry Gou and Ko Wen-je invite you to the Taipei Grand Hyatt to discuss the last hope for Joint Tickets... We must rise to the challenge!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950036,
+        "fields": {
+            "priority": 0,
+            "description": "\nWith the breakdown of Joint Tickets, you must now find a vice presidential candidate! Otherwise, the KMT cannot continue participating in this election! Lai Ching-te has already chosen Hsiao Bi-Khim as the vice president, and Ko Wen-je is still undecided about his choice. You must now find a vice presidential candidate willing to sacrifice themselves to join you in this challenging battle!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950037,
+        "fields": {
+            "priority": 0,
+            "description": "After Hou You-yi chose Zhao Shao-kang as his VP, the entire pan-blue camp was shocked. They were disappointed with Ko Wen-je's reversal and the failure to reach a Joint Tickets agreement. In response, they decided to align themselves with the KMT. This has given you a boost in the polls, with an estimated 500,000 to 1 million additional votes expected for the KMT. However, the DPP is attempting to sow discord between you and Zhao Shao-kang, suggesting that you are merely a puppet and that the more charismatic Zhao Shao-kang is the true president. How do we counter this narrative?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950038,
+        "fields": {
+            "priority": 0,
+            "description": "As the presidential election enters its final stage, it has been discovered that Lai Ching-te's ancestral home is found to have violated building regulations. Although this issue has been known for quite some time, it has only recently been sensationalized. This could be our only opportunity to undermine Lai Ching-te before the election. Do you want to pursue this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950039,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, we have our own troubles. The Democratic Progressive Party (DPP) is attacking the Triumph Apartments owned by your wife, highlighting the high rent and claiming it exploits young people for your personal gain. They argue that you, appearing as a landlord, are unfit to discuss housing justice and social housing. How do you respond?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950040,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, at the final stretch of the election, we might need some advertisements or policies to boost our polling numbers. What policies or advertisements would you most like us to release?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950041,
+        "fields": {
+            "priority": 0,
+            "description": "As 2023 enters its final days, the presidential debates have commenced. Facing Lai Ching-te and Ko Wen-je in this intense battle, what is the most important message you want to convey to the people of Taiwan?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950042,
+        "fields": {
+            "priority": 0,
+            "description": "\nIt seems there is discord within our camp. Former President Ma Ying-jeou, in an interview with Deutsche Welle, mentioned that in the context of cross-strait relations, it is necessary to trust Xi Jinping. The media has widely circulated this, which may be a significant blow to the Kuomintang's electoral prospects. How do you respond to this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950851,
+        "fields": {
+            "priority": 0,
+            "description": "Today is the last day of the election. In which specific area of Taiwan do you plan to campaign to make a final push in these last stages?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950411,
+        "fields": {
+            "priority": 0,
+            "description": "Today is the last day before the election, and your polls have been consistently declining since your nomination. The deadlock with Ko Wen-je and the lead by Lai Ching-te have not been broken, and the situation persists until the registration of presidential candidates in November. There are hardly any individuals willing to be your vice president, until Hung Hsiu-chu, whose nomination was abolished in 2016, volunteered. It is only then that you have a vice presidential candidate to appear on the ballot. On the final day before the election, where do you plan to conduct your campaign activities?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950424,
+        "fields": {
+            "priority": 0,
+            "description": "Today is the last day before the election, On the final day before the election, \nAccording to the latest polls conducted 10 days before the election, your and Lai Ching-te's polls are within the margin of error. In other words, the presidential position hinges on a difference of just 500,000 votes.where do you plan to conduct your campaign activities?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950687,
+        "fields": {
+            "priority": 0,
+            "description": "On November 15th, waking up in the morning, Taiwan's media and political circles were shocked by a piece of news: KMT-TPP has confirmed the formation of a joint ticket, endorsing a single presidential candidate. This is expected to severely impact Lai Ching-te's support. Chairman Zhu, Mayor Hou, former President Ma, and Chairman Ko have reached an agreement to introduce a set of candidates using the cumulative results of previous polls. The terms include a provision that, if the polls fall within the margin of error, it will be considered a victory for Hou You-yi. This is widely seen as a sign that Hou You-yi is likely to win. The final results will be announced on the 18th.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950890,
+        "fields": {
+            "priority": 0,
+            "description": "With the formation of the Joint Tickets, Ko Wen-je has officially become your vice president, marking a political tornado in Taiwan. It's highly likely that Lai Ching-te will lose the presidential position. On the day of the presidential candidate registration, what capabilities of Ko Wen-je would you like to highlight?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950900,
+        "fields": {
+            "priority": 0,
+            "description": "In order to achieve cooperation between the blue and white camps, the cost you have to pay is to accept some reform demands and positions of the TPP. Among these proposals, which ones do you favor more and consider most likely to reach an agreement?\n",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950911,
+        "fields": {
+            "priority": 0,
+            "description": "\nIn this presidential election, facing a one-on-one debate with Lai Ching-te, although you are widely regarded as not the most eloquent, and even your proficiency in Mandarin is limited, your grassroots image in stark contrast to Lai Ching-te's elite image creates a strong juxtaposition. In the debate, what content do you want to emphasize?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950398,
+        "fields": {
+            "priority": 0,
+            "description": "Since you have withdrawn from the primary and essentially paved the way for Terry Gou to secure the presidential candidate position, how do you plan to support him in the upcoming electoral campaign?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950927,
+        "fields": {
+            "priority": 0,
+            "description": "Now, you are in a one-on-one battle with Lai Ching-te in the later stages of the election. Polls indicate that you currently have a lead by several percentage points, but this could be lost due to inappropriate campaign strategies or visiting mistakes. We must stabilize our current position!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950933,
+        "fields": {
+            "priority": 0,
+            "description": "This year's presidential debate has an unprecedented presence of four presidential candidates: yourself, Lai Ching-te, Ko Wen-je, and the former Chairman of Hon Hai Precision Industry, Terry Gou, who does not support you. In this year's presidential debate, what main points do you want to convey?\n",
+            "likelihood": 1
+        }
+    }
+]
+
+campaignTrail_temp.answers_json = [
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950012,
+        "fields": {
+            "question": 1950011,
+            "description": "I will steadfastly continue my course and move forward. Currently, my mission is to serve the citizens of New Taipei City, as they are my top priority and the ones I am most concerned about at the moment."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950013,
+        "fields": {
+            "question": 1950011,
+            "description": "Regardless of any challenges we may face, we will approach them earnestly. If in the future, the party central has any tasks to assign to me, I am more than willing to accept. However, at the moment, my primary focus is on doing things well in New Taipei City."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950014,
+        "fields": {
+            "question": 1950011,
+            "description": "At present, my sole intention is to diligently fulfill my role as the mayor and strive towards constructing a beautiful hometown. To make New Taipei City a great city, we must undertake significant initiatives. By connecting the development of Northern Taiwan through New Taipei, we can contribute to the betterment of Taiwan. A better Taiwan leads to shared prosperity, ensuring peace and stability for the Republic of China."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950388,
+        "fields": {
+            "question": 1950015,
+            "description": "In fact, I do not wish to participate in the primary election. Firstly, I've observed the outcome for Han Kuo-yu, and I believe it's not appropriate for me to run for president while holding my current position . Secondly, I believe Mr.Gou is a more suitable candidate than me. He is a devoted supporter of the Republic of China and can take good care of the country."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950389,
+        "fields": {
+            "question": 1950015,
+            "description": "Chairman Terry Gou is a steadfast supporter of the Republic of China and a patriot. I am pleased to compete alongside him, and if he emerges as the candidate, I will gracefully accept the outcome."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950390,
+        "fields": {
+            "question": 1950015,
+            "description": "I am deeply grateful to Chairman Eric Chu and the party central for giving me this opportunity. In the primary election, I will enhance myself and showcase a broader perspective on international affairs. I recognize the need to develop a more presidential demeanor as I progress."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950399,
+        "fields": {
+            "question": 1950398,
+            "description": "No. My intention in withdrawing from the primary was to focus on effectively managing the city. I didn't want to run for president before completing my term. Therefore, I plan to assist Chairman Terry Gou in his campaign during the later intense stages of the election."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950400,
+        "fields": {
+            "question": 1950398,
+            "description": "Absolutely! I will support him in the campaign, including rallying support for him in New Taipei City and endorsing him for legislative candidates nationwide after his official nomination. I hope he can bring down the Democratic Progressive Party!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950412,
+        "fields": {
+            "question": 1950411,
+            "description": "We have no choice but to stay in Taipei. We cannot afford to let Taipei, this stronghold of the blue camp, be lost!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950413,
+        "fields": {
+            "question": 1950411,
+            "description": "I don't want to lose my hometown. Please allow me to campaign in New Taipei City, and I hope Mayor Hou You-yi can come forward to assist us!\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950414,
+        "fields": {
+            "question": 1950411,
+            "description": "We must secure Taoyuan, the stronghold and vote bank of the Hakka people and the Kuomintang!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950415,
+        "fields": {
+            "question": 1950411,
+            "description": "On the final day, I must drive around the entire Taiwan! Let more people see us!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950425,
+        "fields": {
+            "question": 1950424,
+            "description": "We aim to secure victory in my hometown, New Taipei! Let's conduct the final day of the campaign activities in New Taipei City!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950426,
+        "fields": {
+            "question": 1950424,
+            "description": "Of course, it's in Taipei City. We will declare to all Taipei citizens that tomorrow, we are marching towards the Presidential Office!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950430,
+        "fields": {
+            "question": 1950424,
+            "description": "We plan to hold our last campaign event in Kaohsiung to counter Lai Ching-te and appeal to his support base!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950432,
+        "fields": {
+            "question": 1950424,
+            "description": "The swing state of Taichung is crucial for us, and we aim to secure victory in Taichung."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950441,
+        "fields": {
+            "question": 1950016,
+            "description": "I will visit various counties and cities across Taiwan and establish good relationships with local mayors. I hope to garner more support from these mayors."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950442,
+        "fields": {
+            "question": 1950016,
+            "description": "Let's make some friends in the Legislative Yuan! I will meet with current legislators and discuss campaign matters with them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950443,
+        "fields": {
+            "question": 1950016,
+            "description": "I should appear in the media to share my insights and future prospects in the mayoral election. This can bring me positive media exposure!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950444,
+        "fields": {
+            "question": 1950016,
+            "description": "Anyway, votes come from the voters, and I plan to participate in more offline events to increase my visibility among the electorate. Voters tend to prefer someone familiar and present in their communities!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950454,
+        "fields": {
+            "question": 1950017,
+            "description": "I appreciate Chairman Eric Chu's favor and the support of all the voters. I also want to thank Chairman Terry Gou for his full support. In 2024, we will return to governance, and I am honored to have the opportunity to run for the Kuomintang!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950460,
+        "fields": {
+            "question": 1950018,
+            "description": "Chairman Ko Wen-je has the authority to run for election on his own, and I just need to follow my own path. It's like two brothers climbing a mountain – each making their own effort. Currently, there is no need to discuss coalition votes to avoid affecting the unity and loyalty within our party."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950461,
+        "fields": {
+            "question": 1950018,
+            "description": "I must criticize Ko Wen-je and the TPP. It's widely known that the division within the opposition alliance will only pave the way for the DPP to secure the next term. Chairman Ko Wen-je should seriously consider whether he should indeed continue to run for the presidency!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950462,
+        "fields": {
+            "question": 1950018,
+            "description": "Everyone knows that 60% of the voters want a party alternation. We cannot afford to be divided into two camps. I will extend an olive branch to Chairman Ko . We should work together to bring down the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950463,
+        "fields": {
+            "question": 1950018,
+            "description": "Rather than concerning with Ko, let's focus on targeting Lai Ching-te! Over the past eight years, the DPP government has numerous vulnerabilities we can exploit. Let's concentrate our efforts on the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950477,
+        "fields": {
+            "question": 1950019,
+            "description": "The immediate priority is to investigate and determine what happened. We will promptly send the police to the kindergarten to inspect surveillance footage and search the teachers' personal computers for evidence."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950478,
+        "fields": {
+            "question": 1950019,
+            "description": "\nThe safety and health of the children are our top priorities. We will immediately arrange for them to undergo medical examinations to check if their health has been compromised in any way."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950479,
+        "fields": {
+            "question": 1950019,
+            "description": "The key priority is to calm the parents' emotions. I must hold private meetings with the parents, exchange views and information, and discuss the latest developments and concerns regarding their children."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950487,
+        "fields": {
+            "question": 1950020,
+            "description": "I hope I can handle things well. Let me explain to you why doing things properly is important; it's a matter of attitude because..."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950488,
+        "fields": {
+            "question": 1950020,
+            "description": "When I was a child, I used to hide under the desk and read comic books. My mom would ask, 'What are you doing?' and I would say, 'Studying knowledge by reading comic books.'....."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950489,
+        "fields": {
+            "question": 1950020,
+            "description": "When I was a criminal investigator in the past, combating crime involved collaborating with Interpol, but I always hoped for the exchange of intelligence....."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950490,
+        "fields": {
+            "question": 1950020,
+            "description": "The cross-strait relationship, regardless of the consensus, is entirely based on the Cross-Strait Act. and Only the Constitution of the ROC can bring stability to both sides. I am against Taiwan independence and the One Country, Two Systems!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950502,
+        "fields": {
+            "question": 1950021,
+            "description": "I must seek the recognition of party bosses.and arrange a meeting with the Lien Chan family to request their support. This would be a symbolic move."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950503,
+        "fields": {
+            "question": 1950021,
+            "description": "Allow me to seek the assistance of former party chairman Wu Poh-hsiung of Hakka descent, I need to strengthen my support in Hakka-dominant areas. I hope to gain his recognition!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950504,
+        "fields": {
+            "question": 1950021,
+            "description": "\nI will invite former President Ma Ying-jeou to serve as the Honorary Chairman of my campaign headquarters and request his endorsement and favorable statements for my candidacy."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950513,
+        "fields": {
+            "question": 1950021,
+            "description": "\nI am heading south to Kaohsiung to visit former Legislative Yuan Speaker Wang Jin-ping. I will seek his advice on campaign strategies and solutions to the current situation. I must secure his assistance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950521,
+        "fields": {
+            "question": 1950022,
+            "description": "I am delighted to have King Pu-tsung as a valuable aide in my campaign. He has a strong track record in dealing with the Democratic Progressive Party and will assist me in handling negotiations!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950523,
+        "fields": {
+            "question": 1950023,
+            "description": "I will formally apologize to Han during the gathering and appeal to his supporters to rally behind me. I will acknowledge my mistake in not accepting the position of campaign chairman for New Taipei City in 2020, as I was too focused on municipal affairs and neglected to assist him. I sincerely apologize."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950524,
+        "fields": {
+            "question": 1950023,
+            "description": "I do not need to apologize. Han Kuo-yu's popularity is not at a level where I must pull him back. Furthermore, getting too close to him might harm my image among moderate voters. There is no need to lower my own standing at this point."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950525,
+        "fields": {
+            "question": 1950023,
+            "description": "\nI don't need a formal apology, but let me build a rapport with Han Kuo-yu, present a very familiar and friendly appearance. We don't harbor any dislike for each other; we are good brothers. Let's move past this matter!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950535,
+        "fields": {
+            "question": 1950024,
+            "description": "I support the 1992 Consensus that aligns with the Constitution of the Republic of China. I have made my stance clear! I am against the \"One Country, Two Systems\" and Taiwan independence. I also oppose the Democratic Progressive Party's attempt to stigmatize the 1992 Consensus. It's that simple!\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950536,
+        "fields": {
+            "question": 1950024,
+            "description": "I am not against nuclear power, but rather, I support having nuclear power with proper nuclear safety measures. I assure you that I will ensure the end of the DPP's anti-nuclear policy, and I will restart nuclear power plants to guarantee stable electricity supply and lower electricity prices in Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950537,
+        "fields": {
+            "question": 1950024,
+            "description": "I hope Chairman Terry Gou, being the son of a police officer and a devout follower of Guan Gong, values loyalty and keeps his promises. I believe he will definitely assist me!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950550,
+        "fields": {
+            "question": 1950025,
+            "description": "I sincerely appreciate Mayor Han Kuo-yu's affirmation. I apologize for any previous actions towards him. Now, let's collaborate and work together to win the 2024 election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950558,
+        "fields": {
+            "question": 1950026,
+            "description": "Certainly, I will focus on strengthening my stronghold, Taipei, New Taipei, and Keelung. The northern region is the KMT's most solid base and a crucial vote bank for us!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950559,
+        "fields": {
+            "question": 1950026,
+            "description": "I hope to make efforts in the central region, particularly in Changhua, Taichung, and Nantou. These three areas are crucial in every election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950560,
+        "fields": {
+            "question": 1950026,
+            "description": "I must pay special attention to my hometown, Chiayi County and City. As a southerner, I aim to achieve victory in this deep-green states!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950561,
+        "fields": {
+            "question": 1950026,
+            "description": "\nBeing a southerner myself and proficient in Taiwanese, even though I am from the Kuomintang, I hope to achieve significant results in Tainan, Kaohsiung, and Pingtung. Perhaps, I can turn the tide in these areas!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950579,
+        "fields": {
+            "question": 1950027,
+            "description": "The DPP government has proven incapable of addressing the issue of fraud. Taiwan, once known for its hospitality, is now dubbed the \"Fraud Island.\" I am committed to taking strong measures to tackle the problem of fraud head-on."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950580,
+        "fields": {
+            "question": 1950027,
+            "description": "Under the rule of the Tsai government, we have witnessed increased pressure from the CCP on Taiwan. The median line in the Taiwan Strait has disappeared, and despite the DPP government claiming to resist China and protect Taiwan.we say no to war and yes to dialogue, no to warplanes and yes to business opportunities, no to crises and yes to diplomatic solutions!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950581,
+        "fields": {
+            "question": 1950027,
+            "description": "DPP government is corrupt and plagued by graft. Their digital development sector has squandered 20 billion NT dollars, achieving nothing substantial. In the end, all they managed to do was order takeout!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950582,
+        "fields": {
+            "question": 1950027,
+            "description": "Under the DPP's rule, dissenting voices are suppressed, and even after a court ruled in favor of CTiTV, the NCC continues to deny them the right to resume broadcasting on television. This is the authoritarian oppression of the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950593,
+        "fields": {
+            "question": 1950028,
+            "description": "We must restore law and order. there has been a rampant increase in firearms, drugs, and violent incidents on the streets. Only two death row inmates were executed in the past eight years. The DPP leans towards abolishing the death penalty, but due to public opinion, they refrain from doing so. This is not beneficial for Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950597,
+        "fields": {
+            "question": 1950028,
+            "description": "I will revive the Special Investigation Division. The DPP abolished this institution, responsible for investigating political corruption and official misconduct, as soon as they took office. Was it for their own convenience? I will revive the SPD, and regardless of political affiliation, if any official dares to engage in corruption, we will apprehend them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950599,
+        "fields": {
+            "question": 1950028,
+            "description": "I support housing justice and propose the implementation of a property hoarding tax targeting those with a significant number of properties. This is to ensure that more young people can afford homes. I also commit to continuing the construction of more public housing!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950600,
+        "fields": {
+            "question": 1950028,
+            "description": "My energy policy is clear: Green Sustainability, Reduce Coal with Nuclear, Move towards Coal-free, Transition with Gas. I never been against nuclear power and will include nuclear energy in carbon reduction efforts. If elected, I will complete the inspection and maintenance work for nuclear plants, ensuring safety and extending their operation."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950609,
+        "fields": {
+            "question": 1950029,
+            "description": "This damn Terry Gou! In 2019, he harmed Han Kuo-yu, and now he's doing the same to me this year! We must aggressively attack this untrustworthy guy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950610,
+        "fields": {
+            "question": 1950029,
+            "description": "I hope Chairman Gou can return to the blue camp. We can't afford more division. Persisting in this way will only pave the way for Lai Ching-te to become president!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950611,
+        "fields": {
+            "question": 1950029,
+            "description": "Let's not speak. Just release a campaign video featuring Hou Youyi and Guan Gong, emphasizing the loyalty, benevolence, and integrity of Guan Yu. This will naturally contrast with the untrustworthy behavior of Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950615,
+        "fields": {
+            "question": 1950030,
+            "description": "Polls are only based on phone inquiries and may not accurately reflect actual voting preferences. Let's propose a method for a democratic primary, allowing people across Taiwan to cast their votes to determine the opposition candidate with the highest support!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950616,
+        "fields": {
+            "question": 1950030,
+            "description": "The TPP should not make excessive demands. The KMT is a party with 14+1 county/city mayors and is the second-largest party in the legislature. Our party strength should be taken into account rather than solely relying on individual candidate polls. More people are consider giving their party vote to the KMT!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950617,
+        "fields": {
+            "question": 1950030,
+            "description": "Our current performance in various polls is not very good, but we cannot outright reject the proposal. Refusing it would shift the responsibility for the opposition's inability to integrate onto us. Let's not deny it for now, But we will delay the actual implementation!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950647,
+        "fields": {
+            "question": 1950031,
+            "description": "Everyone knows that the Three Principles of the People, particularly the democratic ideals of government by the people, for the people, and of the people, are closely related. Let's work together to advance these great principles and ensure that the system of liberal democracy continues to thrive in Taiwan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950648,
+        "fields": {
+            "question": 1950031,
+            "description": "Are you... Little Chuck? I didn't expect you to have grown so much. I'm happy to see you again! When I rescued you from the kidnappers all those years ago, you were just a baby. Now, I can hardly recognize you!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950649,
+        "fields": {
+            "question": 1950031,
+            "description": "I would say is my encounters with Mayor Adams of New York City. I even met with legislators from both the Democratic and Republican parties in Washington. AIT Chairman Rosenberger also had a meeting with me. This highlights the strength of the KMT and me in international relations!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950658,
+        "fields": {
+            "question": 1950032,
+            "description": "People have misunderstood Mayor Hou deeply. He genuinely cares about me! Please stop spreading rumors about our supposed discord. After my removal, he was the first to call and offer his comfort, asking if I needed any assistance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950659,
+        "fields": {
+            "question": 1950032,
+            "description": "Mayor Hou is a real man, someone who helped maintain public order in the midst of gunfire and chaos. Such individuals are what Taiwan needs the most—no flashy rhetoric, just someone dedicated to doing good things. I recommend him wholeheartedly!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950660,
+        "fields": {
+            "question": 1950032,
+            "description": "I want everyone to recognize that the DPP is corrupt, not only engaging in financial malfeasance but also steering Taiwan towards the deadly path of war. Only the Kuomintang and Mayor Hou can help Taiwan emerge from the shadows of conflict and restore normal relations with the mainland!\""
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950670,
+        "fields": {
+            "question": 1950033,
+            "description": "We have no choice but to accept the challenge, as time is running out. Even if our poll numbers are not high, we must face the battle. Otherwise, it may be perceived as a display of timidity."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950671,
+        "fields": {
+            "question": 1950033,
+            "description": "We must accept the challenge, and we believe we can surpass Ko Wen-je. We have to outperform him to ensure the Kuomintang's dominant position in the joint ticket alliance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950688,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950691,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950692,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950693,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950721,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950722,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950723,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950724,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950737,
+        "fields": {
+            "question": 1950035,
+            "description": "After receiving a text from Chairman Ko, he mentioned that he believes Terry Gou should find a reason to withdraw from the election, to avoid further disrupting the pan-blue camp. Can I read into this, Chairman Ko?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950738,
+        "fields": {
+            "question": 1950035,
+            "description": "I also brought Chairman Eric Chu and former President Ma Ying-jeou to witness this moment. There is no demand for the TPP to concede a 6% margin in the polls; instead, we will determine the outcome based on the respective margins of error in each poll, alright?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950739,
+        "fields": {
+            "question": 1950035,
+            "description": "Today is a crucial day that determines the future destiny of Taiwan and its people. I hope Chairman Terry Gou and President Ko can prioritize the overall situation. We must unite forces to bring down the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950740,
+        "fields": {
+            "question": 1950035,
+            "description": "Today is a crucial day that determines the future destiny of Taiwan and its people. I hope Chairman Terry Gou and President Ko can prioritize the overall situation. We must unite forces to bring down the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950751,
+        "fields": {
+            "question": 1950036,
+            "description": "I have no other choice; Han Kuo-yu and Ko Chih-en have been included in the party list as they aim to become legislators. I must now approach the prominent media figure Zhao Shao-kang to be my vice president. He will surely come to our rescue!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950755,
+        "fields": {
+            "question": 1950036,
+            "description": "\nI will personally visit Zhao Shao-kang and request him to be my vice president. I must leverage his powerful debating skills, high recognition, and positive reputation among the blue voters to strengthen my support base!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950764,
+        "fields": {
+            "question": 1950037,
+            "description": "(Zhao speaking to the media) The DPP likened Mayor Hou to Adou, but I disagree! I just like Zhao Zilong, loyal to Liu Bei. How could he be compared to a Adou? Just Like Zhao yun'ssteadfast and patriotic, with courage running through my veins."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950765,
+        "fields": {
+            "question": 1950037,
+            "description": "I feel that the DPP lacks professionalism, resorting to divisive tactics to win elections. This kind of maneuver seems quite low-level. If I am elected, Mayor Hou You-yi is the leader, the president, and I am the vice president - merely in a preparatory role!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950766,
+        "fields": {
+            "question": 1950037,
+            "description": "I won't give any attention to such tags. DPP has been in power for a considerable time, yet their election strategies seem to rely on questionable tactics. Can the people of Taiwan still believe in a party that governs without progress but resorts to such tactics during elections?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950781,
+        "fields": {
+            "question": 1950038,
+            "description": "Let's aggressively pursue this issue! Lai Ching-te is truly a candidate who disregards the law, even ignoring illegal construction on his own property. Can someone who disregards the law in such a manner be fit for the presidency?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950782,
+        "fields": {
+            "question": 1950038,
+            "description": "Launching a series of ads attacking Lai Ching-te would be an effective strategy to convey that he is an untrustworthy and arrogant candidate. Emphasize how he has tolerated illegal activities even within his own home, highlighting his lack of integrity. Portray him as someone not deserving of trust and as the people's greatest concern."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950783,
+        "fields": {
+            "question": 1950038,
+            "description": "Hold on, let's not get too carried away! Lai Ching-te's unauthorized construction has been years ago, and according to legal provisions, there is no requirement for demolition. It only needs to be documented and registered through photographs. Let's issue a statement acknowledging that Lai Ching-te's illegal actions technically violate the law, but we have chosen to show leniency and not pursue further action against him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950784,
+        "fields": {
+            "question": 1950038,
+            "description": "An excavator? Yes, right in the Zhongfu neighborhood of Wanli District. Go ahead and demolish his ancestral home for me!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950796,
+        "fields": {
+            "question": 1950039,
+            "description": "Firstly, this property is a legitimate part of my family's assets, and you have no right to interfere. Secondly, I have the right to set the rent at whatever amount I deem appropriate; it's determined by the free market!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950797,
+        "fields": {
+            "question": 1950039,
+            "description": "You're right. I'll discuss it with my wife immediately. I will reduce the rent by half, and after the contract expires, I will convert it into social housing. Is that satisfactory for you?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950798,
+        "fields": {
+            "question": 1950039,
+            "description": "you guys like to attack? Well, then I'll respond with an attack. Lai Ching-te, when will you tear down the unauthorized construction? You dare criticize me; have I committed any crimes? And attacking my wife? That property belongs to her, not me. Please refrain from involving my family in this matter."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950799,
+        "fields": {
+            "question": 1950039,
+            "description": "I won't give this fire any more oxygen. Don't respond to these issues, as it's all legal business operations. Voters will see through it naturally."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950814,
+        "fields": {
+            "question": 1950040,
+            "description": "We want to revisit President Ma Ying-jeou's classic campaign ad from 2008. Our formidable team of county and city mayors is making a comeback to support my campaign, symbolizing unity among ROC's local leaders from across the country. This ad aims to bring hope to the people!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950815,
+        "fields": {
+            "question": 1950040,
+            "description": "We must attack, attack, and attack again. Lai Ching-te and his DPP are highly corrupt, even morally corrupt. It's unknown how many are involved in extramarital affairs, adultery, or even cases of sexual harassment and crimes. This party, often associated with romantic and virtuous imagery, is full of hypocrisy and scandals!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950816,
+        "fields": {
+            "question": 1950040,
+            "description": "I will propose policies that appeal to young people. Many can't afford homes, so we will offer low-interest loans of up to 15 million, waiving the down payment. As long as young people are willing to borrow, we can provide them with this policy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950817,
+        "fields": {
+            "question": 1950040,
+            "description": "I will emphasize our various policies. If you dislike the NCC restricting free speech, despise opaque governance, and are against the DPP's one-party dominance, then join us because we aim to dismantle all of them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950818,
+        "fields": {
+            "question": 1950031,
+            "description": "I will deliver a speech in Washington, emphasizing the importance of the 3D strategy. Which 3Ds? Deterrence, Dialogue, and De-escalation. This can construct peace and stability across the Taiwan Strait while upholding our sovereignty."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950838,
+        "fields": {
+            "question": 1950041,
+            "description": "I understand that scams cause you concern, and the threat of war makes you worry. However, let's not be afraid. You deserve a better future! In the future, I will definitely stand with you!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950839,
+        "fields": {
+            "question": 1950041,
+            "description": "I declare to the people of Taiwan that I am committed to initiating a new era of democratic political reform. Advocating for a cabinet system is not something that can be achieved by one person or one party alone, but it is a task we must accomplish. Our shared goal is peace, integrity, fairness, and justice in governance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950840,
+        "fields": {
+            "question": 1950041,
+            "description": "Candidates, do you truly oppose or support the abolition of the death penalty? All I hear are ambiguous answers, but let me be clear—I am against the abolition of the death penalty. It is a significant harm to the families of the victims. Candidates, please make your stance clear!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950841,
+        "fields": {
+            "question": 1950041,
+            "description": "January 13th marks the day of Mr. Chiang Ching-kuo's passing. Fellow patriots, on this day, it is crucial to come out and vote, exercising your democratic rights. Mr. Chiang Ching-kuo once said, \"What you don't do today, you'll regret tomorrow!\" I am committed to safeguarding Taiwan's democratic system with my life!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950852,
+        "fields": {
+            "question": 1950042,
+            "description": "\nWe must distance ourselves from him. I have a different perspective, and our views do not align with those of President Ma Ying-jeou. To penalize him and minimize the impact, we must reject his attendance at our pre-election night event!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950853,
+        "fields": {
+            "question": 1950042,
+            "description": "I will strongly criticize President Ma Ying-jeou's remarks, as they diverge from the mainstream thoughts of the Taiwanese people! Under the leadership of Mayor Hou You-yi, the Kuomintang will establish new relations with the mainland, and we don't need to blindly trust anyone."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950858,
+        "fields": {
+            "question": 1950042,
+            "description": "Don't pay attention to him. In the critical situation of this election, addressing this issue will only bring about greater division among us!We cannot afford to take risks at this time!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950863,
+        "fields": {
+            "question": 1950851,
+            "description": "I will conduct campaign activities in my home turf, New Taipei and Taipei. At the New Taipei Sports Stadium, we will gather a crowd and defeat the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950864,
+        "fields": {
+            "question": 1950851,
+            "description": "\nI want to conduct activities in the deeply green cities of Tainan and Kaohsiung, engage in a battle in Lai Ching-te's stronghold, and show him that people in the southern region won't blindly support the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950865,
+        "fields": {
+            "question": 1950851,
+            "description": "We will drive through the Hakka region and finally organize our pre-election night event in Taoyuan City!\nThe Hakka and youth votes have been taken away by Ko Wen-je, and we must retain them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950866,
+        "fields": {
+            "question": 1950851,
+            "description": "We must focus on areas with fewer voters and less competition. Hualien, Taitung, Yilan, and Pingtung are our key areas of concern. We must secure the entire east coast!\n\n\n\n\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950891,
+        "fields": {
+            "question": 1950890,
+            "description": "Ko Wen-je is very popular among the youth, and we must emphasize this. Our alliance lacks support from the younger generation the most. Let Ko Wen-je campaign for our alliance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950892,
+        "fields": {
+            "question": 1950890,
+            "description": "The alliance between the KMT and TPP is a shared aspiration of the Taiwanese people, as evidenced by the polls. We are confident in defeating Lai Ching-te. Let's strengthen the unity and cooperation between the two parties and jointly overcome the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950893,
+        "fields": {
+            "question": 1950890,
+            "description": "\nCertainly, Chairman Ko's eloquence and formidable abilities will provide excellent support for me. In the vice presidential debate, I hope he can defeat Hsiao Mei-chin, while I will confront Lai Ching-te. Together, let's advance progress in Taiwan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950901,
+        "fields": {
+            "question": 1950900,
+            "description": "\nWe will create goals for the third wave of democratic reforms in Taiwan. We will promote a Parliamentary system instead of a presidential system where power is concentrated in one party's hands. This change will benefit the future of Taiwan, as democracy requires a system of checks and balances!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950902,
+        "fields": {
+            "question": 1950900,
+            "description": "In the future coalition government, KMT will take the lead in economic and developmental responsibilities, while the TPP will be responsible for oversight and checks and balances. This is much better than the authoritarian rule of the DPP. Our future government will be free from corruption, and anyone who dares to engage in corruption will be held accountable!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950903,
+        "fields": {
+            "question": 1950900,
+            "description": "\nNow, we represent the greatest consensus of the Taiwanese people. Let's unite and launch a full-scale attack on the DPP! The opposition alliance will surge and break through the DPP's base!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950912,
+        "fields": {
+            "question": 1950911,
+            "description": "Lai Ching-te has claimed to be a pragmatic advocate for Taiwan independence. Now he says Taiwan is already an independent country. This is just the opportunistic behavior of a politician without integrity.I has been loyal to the Republic of China  throughout his life, and I will sacrifice my life to protect it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950913,
+        "fields": {
+            "question": 1950911,
+            "description": "Taiwan cannot afford to be ruled by the DPP anymore. The past 8 years of their governance have exposed the rapid pace of corruption and moral decay within your political regime, making it impossible for the people to trust you any longer. Please believe in the Taiwan United Government under the KMT-TPP alliance; we will do better!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950914,
+        "fields": {
+            "question": 1950911,
+            "description": "\nWhat I insist on is the democratic freedom of the 23 million people in Taiwan. We must strengthen national defense, deter war, and hold the key to peace, security, and stability in the Taiwan Strait. The DPP's approach cannot help Taiwan achieve true peace!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950915,
+        "fields": {
+            "question": 1950911,
+            "description": "\nMy father is a veteran, and I am the son of a pork vendor from the rural areas of Chiayi. I understand the hardships of life and have climbed up from being the lowest-ranking police officer to my current position. I am grateful for the support and assistance from each and every one of you!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950928,
+        "fields": {
+            "question": 1950927,
+            "description": "Now it's a one-on-one battle between me and Lai Ching-te! We must rally our base to come back!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950934,
+        "fields": {
+            "question": 1950933,
+            "description": "Lai Ching-te has claimed to be a pragmatic advocate for Taiwan independence. Now he says Taiwan is already an independent country. This is just the opportunistic behavior of a politician without integrity.I has been loyal to the Republic of China throughout his life, and I will sacrifice my life to protect it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950935,
+        "fields": {
+            "question": 1950933,
+            "description": "Chairman Ko had once promised to pursue a blue-white coalition, but now he has backtracked. This proves that Chairman Ko is someone who prioritizes political interests over integrity. He changed his decision to personally sign the agreement due to opposition from his staff and family, which is truly embarrassing."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950936,
+        "fields": {
+            "question": 1950933,
+            "description": "Chairman Guo had once promised to support me, but the subsequent results are well known. Now the opposition is divided into three parts. Where is the benefit in that? I am the strongest candidate. On election day, we should abandon Guo and support Hou!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950946,
+        "fields": {
+            "question": 1950933,
+            "description": "\nI and Mr. Guo both advocate for the ROC, and we both love this country. However, he is not a viable winner. Please concentrate your votes on me; I am the only one with the potential to defeat the Democratic Progressive Party."
+        }
+    }
+
+]
+
+
+campaignTrail_temp.states_json = [
+    {
+        "model": "campaign_trail.state",
+        "pk": 251,
+        "fields": {
+            "name": "Tainan City",
+            "abbr": "Tainancity",
+            "electoral_votes": 1,
+            "popular_votes": 1120238,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 252,
+        "fields": {
+            "name": "Kaohsiung City",
+            "abbr": "Kaohsiungcity",
+            "electoral_votes": 1,
+            "popular_votes": 1636962,
+            "poll_closing_time": 180,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 253,
+        "fields": {
+            "name": "Pingtung County",
+            "abbr": "Pingtung",
+            "electoral_votes": 1,
+            "popular_votes": 475927,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 254,
+        "fields": {
+            "name": "Taidong County",
+            "abbr": "Taidong",
+            "electoral_votes": 1,
+            "popular_votes": 109941,
+            "poll_closing_time": 75,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 255,
+        "fields": {
+            "name": "Hualien County",
+            "abbr": "Hualien",
+            "electoral_votes": 1,
+            "popular_votes": 174157,
+            "poll_closing_time": 90,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 256,
+        "fields": {
+            "name": "Chiayi County",
+            "abbr": "ChiayiCounty",
+            "electoral_votes": 1,
+            "popular_votes": 292534,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 257,
+        "fields": {
+            "name": "Chiayi City",
+            "abbr": "ChiayiCity",
+            "electoral_votes": 1,
+            "popular_votes": 157656,
+            "poll_closing_time": 80,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 258,
+        "fields": {
+            "name": "Nantou County",
+            "abbr": "Nantou",
+            "electoral_votes": 1,
+            "popular_votes": 287296,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 259,
+        "fields": {
+            "name": "Yunlin County",
+            "abbr": "Yunlin",
+            "electoral_votes": 1,
+            "popular_votes": 380619,
+            "poll_closing_time": 130,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 260,
+        "fields": {
+            "name": "Changhua County",
+            "abbr": "Changhua",
+            "electoral_votes": 1,
+            "popular_votes": 741368,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 261,
+        "fields": {
+            "name": "Penghu County",
+            "abbr": "Penghu",
+            "electoral_votes": 1,
+            "popular_votes": 49277,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 262,
+        "fields": {
+            "name": "Taichung City",
+            "abbr": "Taichung",
+            "electoral_votes": 1,
+            "popular_votes": 1707203,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 263,
+        "fields": {
+            "name": "Yilan County",
+            "abbr": "Yilan",
+            "electoral_votes": 1,
+            "popular_votes": 267129,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 264,
+        "fields": {
+            "name": "Hsinchu County",
+            "abbr": "HsinchuCounty",
+            "electoral_votes": 1,
+            "popular_votes": 340310,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 265,
+        "fields": {
+            "name": "Hsinchu City",
+            "abbr": "HsinchuCity",
+            "electoral_votes": 1,
+            "popular_votes": 266389,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 266,
+        "fields": {
+            "name": "Miaoli County",
+            "abbr": "Miaoli",
+            "electoral_votes": 1,
+            "popular_votes": 318665,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 267,
+        "fields": {
+            "name": "New Taipei City",
+            "abbr": "Newtaipei",
+            "electoral_votes": 1,
+            "popular_votes": 2458480,
+            "poll_closing_time": 225,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 268,
+        "fields": {
+            "name": "Taipei City",
+            "abbr": "Taipei",
+            "electoral_votes": 1,
+            "popular_votes": 1542009,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 269,
+        "fields": {
+            "name": "Taoyuan City",
+            "abbr": "Taoyuan",
+            "electoral_votes": 1,
+            "popular_votes": 1350792,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 270,
+        "fields": {
+            "name": "Keelung City",
+            "abbr": "Keelung",
+            "electoral_votes": 1,
+            "popular_votes": 218781,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 271,
+        "fields": {
+            "name": "Kinmen County",
+            "abbr": "Kinmen",
+            "electoral_votes": 1,
+            "popular_votes": 45612,
+            "poll_closing_time": 70,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 272,
+        "fields": {
+            "name": "Lienchiang County",
+            "abbr": "Matsu",
+            "electoral_votes": 1,
+            "popular_votes": 6159,
+            "poll_closing_time": 50,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.issues_json = [
+    {
+        "model": "campaign_trail.issue",
+        "pk": 32,
+        "fields": {
+            "name": "Party coalition",
+            "description": 0,
+            "stance_1": "Deep Green",
+            "stance_desc_1": 0,
+            "stance_2": "Green",
+            "stance_desc_2": 0,
+            "stance_3": "Light Green",
+            "stance_desc_3": 0,
+            "stance_4": "Neutral",
+            "stance_desc_4": 0,
+            "stance_5": "Light Blue",
+            "stance_desc_5": 0,
+            "stance_6": "Blue",
+            "stance_desc_6": 0,
+            "stance_7": "Deep Blue",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 33,
+        "fields": {
+            "name": "Provincial differences",
+            "description": 0,
+            "stance_1": "Mostly Taiwanese",
+            "stance_desc_1": 0,
+            "stance_2": "Taiwanese and Hakka mixed",
+            "stance_desc_2": 0,
+            "stance_3": "Taiwanese,Hakka,Mainlanders mixed",
+            "stance_desc_3": 0,
+            "stance_4": "mixing of ethnic groups",
+            "stance_desc_4": 0,
+            "stance_5": "Aboriginal",
+            "stance_desc_5": 0,
+            "stance_6": "Taiwanese Hakka(Northern)",
+            "stance_desc_6": 0,
+            "stance_7": "Mostly Mainlanders",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 34,
+        "fields": {
+            "name": "Urban/rural differences",
+            "description": 0,
+            "stance_1": "Townships Rural",
+            "stance_desc_1": 0,
+            "stance_2": "Small towns and large towns",
+            "stance_desc_2": 0,
+            "stance_3": "Small cities and towns",
+            "stance_desc_3": 0,
+            "stance_4": "Medium-sized city",
+            "stance_desc_4": 0,
+            "stance_5": "Groups of Small Cities",
+            "stance_desc_5": 0,
+            "stance_6": "Large Cities",
+            "stance_desc_6": 0,
+            "stance_7": "Capitals",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 35,
+        "fields": {
+            "name": "Young population",
+            "description": 0,
+            "stance_1": "Very little",
+            "stance_desc_1": 0,
+            "stance_2": "Little",
+            "stance_desc_2": 0,
+            "stance_3": "Less",
+            "stance_desc_3": 0,
+            "stance_4": "Normal level",
+            "stance_desc_4": 0,
+            "stance_5": "Relatively much more",
+            "stance_desc_5": 0,
+            "stance_6": "Large young population",
+            "stance_desc_6": 0,
+            "stance_7": "Younger society",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 36,
+        "fields": {
+            "name": "Feelings about DPP Government",
+            "description": 0,
+            "stance_1": "DPP is the best!",
+            "stance_desc_1": 0,
+            "stance_2": "That's what we like!",
+            "stance_desc_2": 0,
+            "stance_3": "Pro-DPP",
+            "stance_desc_3": 0,
+            "stance_4": "no feelings for the DPP",
+            "stance_desc_4": 0,
+            "stance_5": "Hate green governance",
+            "stance_desc_5": 0,
+            "stance_6": "Mosquitoes, cockroaches, and the DPP",
+            "stance_desc_6": 0,
+            "stance_7": "Never support the Taiwan Independence Party!!",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.state_issue_score_json = [
+    //台北市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191111,
+        "fields": {
+            "state": 268,
+            "issue": 32,
+            "state_issue_score": 0.22,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191112,
+        "fields": {
+            "state": 268,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191113,
+        "fields": {
+            "state": 268,
+            "issue": 34,
+            "state_issue_score": 1,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191114,
+        "fields": {
+            "state": 268,
+            "issue": 35,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191115,
+        "fields": {
+            "state": 268,
+            "issue": 36,
+            "state_issue_score": 0.1,
+            "weight": 0.5
+        }
+    },
+    //新北市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191116,
+        "fields": {
+            "state": 267,
+            "issue": 32,
+            "state_issue_score": 0.15,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191117,
+        "fields": {
+            "state": 267,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191118,
+        "fields": {
+            "state": 267,
+            "issue": 34,
+            "state_issue_score": 0.65,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191119,
+        "fields": {
+            "state": 267,
+            "issue": 35,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191120,
+        "fields": {
+            "state": 267,
+            "issue": 36,
+            "state_issue_score": 0.0,
+            "weight": 0.5
+        }
+    },
+    //桃园市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191121,
+        "fields": {
+            "state": 269,
+            "issue": 32,
+            "state_issue_score": 0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191122,
+        "fields": {
+            "state": 269,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191122,
+        "fields": {
+            "state": 269,
+            "issue": 34,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191123,
+        "fields": {
+            "state": 269,
+            "issue": 35,
+            "state_issue_score": 0.75,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191124,
+        "fields": {
+            "state": 269,
+            "issue": 36,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    //新竹市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191125,
+        "fields": {
+            "state": 265,
+            "issue": 32,
+            "state_issue_score": 0.4,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191126,
+        "fields": {
+            "state": 265,
+            "issue": 33,
+            "state_issue_score": -0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191127,
+        "fields": {
+            "state": 265,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191128,
+        "fields": {
+            "state": 265,
+            "issue": 35,
+            "state_issue_score": 0.65,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191129,
+        "fields": {
+            "state": 265,
+            "issue": 36,
+            "state_issue_score": 0.35,
+            "weight": 0.5
+        }
+    },
+    //基隆市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191130,
+        "fields": {
+            "state": 270,
+            "issue": 32,
+            "state_issue_score": 0.5,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191131,
+        "fields": {
+            "state": 270,
+            "issue": 33,
+            "state_issue_score": 0.1,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191132,
+        "fields": {
+            "state": 270,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191133,
+        "fields": {
+            "state": 270,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191134,
+        "fields": {
+            "state": 270,
+            "issue": 36,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    //新竹县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191135,
+        "fields": {
+            "state": 264,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191136,
+        "fields": {
+            "state": 264,
+            "issue": 33,
+            "state_issue_score": 0.45,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191137,
+        "fields": {
+            "state": 264,
+            "issue": 34,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191138,
+        "fields": {
+            "state": 264,
+            "issue": 35,
+            "state_issue_score": 0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191139,
+        "fields": {
+            "state": 264,
+            "issue": 36,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    //苗栗縣
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191140,
+        "fields": {
+            "state": 266,
+            "issue": 32,
+            "state_issue_score": 0.85,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191141,
+        "fields": {
+            "state": 266,
+            "issue": 33,
+            "state_issue_score": 0.55,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191142,
+        "fields": {
+            "state": 266,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191143,
+        "fields": {
+            "state": 266,
+            "issue": 35,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191144,
+        "fields": {
+            "state": 266,
+            "issue": 36,
+            "state_issue_score": 0.85,
+            "weight": 0.5
+        }
+    },
+    //宜兰县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191145,
+        "fields": {
+            "state": 263,
+            "issue": 32,
+            "state_issue_score": -0.45,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191146,
+        "fields": {
+            "state": 263,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191147,
+        "fields": {
+            "state": 263,
+            "issue": 34,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191148,
+        "fields": {
+            "state": 263,
+            "issue": 35,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191149,
+        "fields": {
+            "state": 263,
+            "issue": 36,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    //台中市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191150,
+        "fields": {
+            "state": 262,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191151,
+        "fields": {
+            "state": 262,
+            "issue": 33,
+            "state_issue_score": 0,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191152,
+        "fields": {
+            "state": 262,
+            "issue": 34,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191154,
+        "fields": {
+            "state": 262,
+            "issue": 35,
+            "state_issue_score": 0.35,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191155,
+        "fields": {
+            "state": 262,
+            "issue": 36,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    //南投县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191156,
+        "fields": {
+            "state": 258,
+            "issue": 32,
+            "state_issue_score": 0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191157,
+        "fields": {
+            "state": 258,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191158,
+        "fields": {
+            "state": 258,
+            "issue": 34,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191159,
+        "fields": {
+            "state": 258,
+            "issue": 35,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191160,
+        "fields": {
+            "state": 258,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //花莲县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191161,
+        "fields": {
+            "state": 255,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191162,
+        "fields": {
+            "state": 255,
+            "issue": 33,
+            "state_issue_score": 0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191163,
+        "fields": {
+            "state": 255,
+            "issue": 34,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191164,
+        "fields": {
+            "state": 255,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191165,
+        "fields": {
+            "state": 255,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //台东县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191166,
+        "fields": {
+            "state": 254,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191167,
+        "fields": {
+            "state": 254,
+            "issue": 33,
+            "state_issue_score": 0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191168,
+        "fields": {
+            "state": 254,
+            "issue": 34,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191169,
+        "fields": {
+            "state": 254,
+            "issue": 35,
+            "state_issue_score": -0.33,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191170,
+        "fields": {
+            "state": 254,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //彰化县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191171,
+        "fields": {
+            "state": 260,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191172,
+        "fields": {
+            "state": 260,
+            "issue": 33,
+            "state_issue_score": -0.85,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191173,
+        "fields": {
+            "state": 260,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191174,
+        "fields": {
+            "state": 260,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191175,
+        "fields": {
+            "state": 260,
+            "issue": 36,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    //云林县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191176,
+        "fields": {
+            "state": 259,
+            "issue": 32,
+            "state_issue_score": -0.4,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191177,
+        "fields": {
+            "state": 259,
+            "issue": 33,
+            "state_issue_score": -0.85,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191178,
+        "fields": {
+            "state": 259,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191179,
+        "fields": {
+            "state": 259,
+            "issue": 35,
+            "state_issue_score": -0.85,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191180,
+        "fields": {
+            "state": 259,
+            "issue": 36,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    //澎湖
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191181,
+        "fields": {
+            "state": 261,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191182,
+        "fields": {
+            "state": 261,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191183,
+        "fields": {
+            "state": 261,
+            "issue": 34,
+            "state_issue_score": -0.9,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191184,
+        "fields": {
+            "state": 261,
+            "issue": 35,
+            "state_issue_score": -0.75,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191185,
+        "fields": {
+            "state": 261,
+            "issue": 36,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    //嘉义县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191186,
+        "fields": {
+            "state": 256,
+            "issue": 32,
+            "state_issue_score": -0.75,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191187,
+        "fields": {
+            "state": 256,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191188,
+        "fields": {
+            "state": 256,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191189,
+        "fields": {
+            "state": 256,
+            "issue": 35,
+            "state_issue_score": -0.9,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191190,
+        "fields": {
+            "state": 256,
+            "issue": 36,
+            "state_issue_score": -0.75,
+            "weight": 0.5
+        }
+    },
+    //嘉义市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191191,
+        "fields": {
+            "state": 257,
+            "issue": 32,
+            "state_issue_score": -0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191192,
+        "fields": {
+            "state": 257,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191193,
+        "fields": {
+            "state": 257,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191194,
+        "fields": {
+            "state": 257,
+            "issue": 35,
+            "state_issue_score": -0.6,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191195,
+        "fields": {
+            "state": 257,
+            "issue": 36,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+     //台南市
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191196,
+            "fields": {
+                "state": 251,
+                "issue": 32,
+                "state_issue_score": -0.85,
+                "weight": 1
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191197,
+            "fields": {
+                "state": 251,
+                "issue": 33,
+                "state_issue_score": -0.15,
+                "weight": 2
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191198,
+            "fields": {
+                "state": 251,
+                "issue": 34,
+                "state_issue_score": 0.55,
+                "weight": 0.5
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191199,
+            "fields": {
+                "state": 251,
+                "issue": 35,
+                "state_issue_score": 0.15,
+                "weight": 0.5
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191200,
+            "fields": {
+                "state": 251,
+                "issue": 36,
+                "state_issue_score": -0.75,
+                "weight": 0.5
+            }
+        },
+         //高雄市
+             {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191201,
+                "fields": {
+                    "state": 252,
+                    "issue": 32,
+                    "state_issue_score": -0.55,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191202,
+                "fields": {
+                    "state": 252,
+                    "issue": 33,
+                    "state_issue_score": -0.15,
+                    "weight": 2
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191203,
+                "fields": {
+                    "state": 252,
+                    "issue": 34,
+                    "state_issue_score": 0.65,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191204,
+                "fields": {
+                    "state": 252,
+                    "issue": 35,
+                    "state_issue_score": 0.15,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191205,
+                "fields": {
+                    "state": 252,
+                    "issue": 36,
+                    "state_issue_score": -0.75,
+                    "weight": 0.5
+                }
+            },
+            //屏东县
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191206,
+                "fields": {
+                    "state": 253,
+                    "issue": 32,
+                    "state_issue_score": -0.5,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191207,
+                "fields": {
+                    "state": 253,
+                    "issue": 33,
+                    "state_issue_score": -0.25,
+                    "weight": 2
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191208,
+                "fields": {
+                    "state": 253,
+                    "issue": 34,
+                    "state_issue_score": 0.25,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191209,
+                "fields": {
+                    "state": 253,
+                    "issue": 35,
+                    "state_issue_score": 0,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191210,
+                "fields": {
+                    "state": 253,
+                    "issue": 36,
+                    "state_issue_score": -0.55,
+                    "weight": 0.5
+                }
+            },
+              //金门县
+              {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191211,
+                "fields": {
+                    "state": 271,
+                    "issue": 32,
+                    "state_issue_score": 1,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191212,
+                "fields": {
+                    "state": 271,
+                    "issue": 33,
+                    "state_issue_score": 1,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191213,
+                "fields": {
+                    "state": 271,
+                    "issue": 34,
+                    "state_issue_score": -0.75,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191214,
+                "fields": {
+                    "state": 271,
+                    "issue": 35,
+                    "state_issue_score": -0.25,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191215,
+                "fields": {
+                    "state": 271,
+                    "issue": 36,
+                    "state_issue_score": 1,
+                    "weight": 0.5
+                }
+            },
+                //连江县
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191216,
+                    "fields": {
+                        "state": 272,
+                        "issue": 32,
+                        "state_issue_score": 1,
+                        "weight": 1
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191217,
+                    "fields": {
+                        "state": 272,
+                        "issue": 33,
+                        "state_issue_score": 1,
+                        "weight": 1
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191218,
+                    "fields": {
+                        "state": 272,
+                        "issue": 34,
+                        "state_issue_score": -1,
+                        "weight": 0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191219,
+                    "fields": {
+                        "state": 272,
+                        "issue": 35,
+                        "state_issue_score": 0.25,
+                        "weight": 0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191220,
+                    "fields": {
+                        "state": 272,
+                        "issue": 36,
+                        "state_issue_score": 1,
+                        "weight": 0.5
+                    }
+                },
+]
+campaignTrail_temp.candidate_issue_score_json = [
+    //赖清德
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 328,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 32,
+            "issue_score": -0.85 //深绿
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 329,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 33,
+            "issue_score": -0.75 //台湾本省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 330,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 34,
+            "issue_score": -0.35 //矿工之子
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 331,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 35,
+            "issue_score": 0.25 //年轻人支持度还行
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 332,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 36,
+            "issue_score": -1 //我就是现任副总统啊
+        }
+    },
+    //侯友谊
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 333,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 32,
+            "issue_score": 0.15 //浅蓝，甚至蓝皮绿谷
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 334,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 33,
+            "issue_score": -0.9 //比赖清德更本省
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 335,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 34,
+            "issue_score": -0.5 //嘉义乡下卖猪肉的
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 336,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 35,
+            "issue_score": -0.25 //年轻人不喜欢的老蓝男
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 337,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 36,
+            "issue_score": 0.25 //攻击性不强
+        }
+    },
+    //柯文哲
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 338,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 32,
+            "issue_score": -0.5 //我内心本质还是深绿的
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 339,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 33,
+            "issue_score": -0.75 //本省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 340,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 34,
+            "issue_score": 0.15 //家庭条件还可以
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 341,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 35,
+            "issue_score": 0.8 //阿北阿北我爱你
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 342,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 36,
+            "issue_score": 0.5 //攻击性很强，但并不把下架民进党当第一目标
+        }
+    },
+     //郭台铭
+     {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 343,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 32,
+            "issue_score": 0.7 //深蓝
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 344,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 33,
+            "issue_score": 0.75 //外省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 345,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 34,
+            "issue_score": 0.75 //城里人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 346,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 35,
+            "issue_score": -0.25 //老蓝男
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 347,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 36,
+            "issue_score": 0.4 //攻击性一般，下架民进党是说说听得口号
+        }
+    },
+]
+campaignTrail_temp.running_mate_issue_score_json = [
+  //萧美琴
+  {
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9343,
+    "fields": {
+        "candidate": 1002,
+        "issue": 32,
+        "issue_score": -0.7
+    }
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9344,
+    "fields": {
+        "candidate": 1002,
+        "issue": 33,
+        "issue_score": -0
+    }
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9345,
+    "fields": {
+        "candidate": 1002,
+        "issue": 34,
+        "issue_score": -0.25
+},
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9346,
+    "fields": {
+        "candidate": 1002,
+        "issue": 35,
+        "issue_score": 0.25 
+    }
+},
+    {
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9347,
+    "fields": {
+        "candidate": 1002,
+        "issue": 36,
+        "issue_score": -0.5
+    }
+    },
+    //蓝白联票
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9348,
+        "fields": {
+            "candidate": 50001,
+            "issue": 32,
+            "issue_score": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9349,
+        "fields": {
+            "candidate": 50001,
+            "issue": 33,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9350,
+        "fields": {
+            "candidate": 50001,
+            "issue": 34,
+            "issue_score": 0
+    },
+},
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9351,
+        "fields": {
+            "candidate": 50001,
+            "issue": 35,
+            "issue_score": 0.15 
+        }
+    },
+        {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9352,
+        "fields": {
+            "candidate": 50001,
+            "issue": 36,
+            "issue_score": 0.4
+        }
+        },
+        //赵少康
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93481,
+            "fields": {
+                "candidate": 50000,
+                "issue": 32,
+                "issue_score": 0.95
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93491,
+            "fields": {
+                "candidate": 50000,
+                "issue": 33,
+                "issue_score": 0.95
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93501,
+            "fields": {
+                "candidate": 50000,
+                "issue": 34,
+                "issue_score": 0.55
+        },
+    },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93511,
+            "fields": {
+                "candidate": 50000,
+                "issue": 35,
+                "issue_score": 0.1
+            }
+        },
+            {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93521,
+            "fields": {
+                "candidate": 50000,
+                "issue": 36,
+                "issue_score": 0.5
+            }
+            },
+            //韩国瑜
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 934812,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 32,
+                    "issue_score": 0.95
+                }
+            },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 934912,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 33,
+                    "issue_score": 0.95
+                }
+            },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935013,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 34,
+                    "issue_score": -0.25
+            },
+        },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935114,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 35,
+                    "issue_score": 0
+                }
+            },
+                {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935215,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 36,
+                    "issue_score": 0.65
+                }
+                },
+                //柯志恩
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9348121,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 32,
+                        "issue_score": 0.15
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9349121,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 33,
+                        "issue_score": -0.75
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9350131,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 34,
+                        "issue_score": -0.15
+                },
+            },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9351141,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 35,
+                        "issue_score": 0.5
+                    }
+                },
+                    {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9352151,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 36,
+                        "issue_score": 0.42
+                    }
+                    },
+                    //赖佩霞
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93481211,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 32,
+                            "issue_score": 0.1
+                        }
+                    },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93491211,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 33,
+                            "issue_score": 0
+                        }
+                    },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93501311,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 34,
+                            "issue_score": 0.25
+                    },
+                },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93511411,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 35,
+                            "issue_score": 0.15
+                        }
+                    },
+                        {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93521511,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 36,
+                            "issue_score": 0.15
+                        }
+                        },
+                        //白蓝联票
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410110,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 32,
+                                "issue_score": -0.1
+                            }
+                        },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410111,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 33,
+                                "issue_score": 0
+                            }
+                        },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410112,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 34,
+                                "issue_score": 0
+                        },
+                    },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410113,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 35,
+                                "issue_score": 0.75
+                            }
+                        },
+                            {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410114,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 36,
+                                "issue_score": 0.25
+                            }
+                            },
+                            //吴欣盈
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241000,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 32,
+                                    "issue_score": 0
+                                }
+                            },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241001,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 33,
+                                    "issue_score": 0
+                                }
+                            },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241002,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 34,
+                                    "issue_score": 0
+                            },
+                           },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241003,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 35,
+                                    "issue_score": 0.75
+                                }
+                            },
+                                {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241004,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 36,
+                                    "issue_score": 0.25
+                                }
+                        }
+    ]
+
+campaignTrail_temp.candidate_state_multiplier_json = [
+       //台南市
+       {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25191,
+        "fields": {
+            "candidate": 2001557,
+            "state": 251,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25192,
+        "fields": {
+            "candidate": 2001591,
+            "state": 251,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25693,
+        "fields": {
+            "candidate": 2001622,
+            "state": 251,
+            "state_multiplier": 0.17
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25694,
+        "fields": {
+            "candidate": 2001653,
+            "state": 251,
+            "state_multiplier": 0.07
+        }
+    },
+    //嘉义县
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25691,
+        "fields": {
+            "candidate": 2001557,
+            "state": 256,
+            "state_multiplier": 0.28
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25692,
+        "fields": {
+            "candidate": 2001591,
+            "state": 256,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25693,
+        "fields": {
+            "candidate": 2001622,
+            "state": 256,
+            "state_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25694,
+        "fields": {
+            "candidate": 2001653,
+            "state": 256,
+            "state_multiplier": 0.07
+        }
+    },
+      //花莲县
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25591,
+        "fields": {
+            "candidate": 2001557,
+            "state": 255,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25592,
+        "fields": {
+            "candidate": 2001591,
+            "state": 255,
+            "state_multiplier": 0.366
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25593,
+        "fields": {
+            "candidate": 2001622,
+            "state": 255,
+            "state_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25594,
+        "fields": {
+            "candidate": 2001653,
+            "state": 255,
+            "state_multiplier": 0.1
+        }
+    },
+      //屏东
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25391,
+        "fields": {
+            "candidate": 2001557,
+            "state": 253,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25392,
+        "fields": {
+            "candidate": 2001591,
+            "state": 253,
+            "state_multiplier": 0.23
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25393,
+        "fields": {
+            "candidate": 2001622,
+            "state": 253,
+            "state_multiplier": 0.14
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25294,
+        "fields": {
+            "candidate": 2001653,
+            "state": 253,
+            "state_multiplier": 0.07
+        }
+    },
+    //高雄
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25291,
+        "fields": {
+            "candidate": 2001557,
+            "state": 252,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25292,
+        "fields": {
+            "candidate": 2001591,
+            "state": 252,
+            "state_multiplier": 0.23
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25293,
+        "fields": {
+            "candidate": 2001622,
+            "state": 252,
+            "state_multiplier": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25294,
+        "fields": {
+            "candidate": 2001653,
+            "state": 252,
+            "state_multiplier": 0.07
+        }
+    },
+    //台东
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252912,
+        "fields": {
+            "candidate": 2001557,
+            "state": 254,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252922,
+        "fields": {
+            "candidate": 2001591,
+            "state": 254,
+            "state_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252932,
+        "fields": {
+            "candidate": 2001622,
+            "state": 254,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252942,
+        "fields": {
+            "candidate": 2001653,
+            "state": 254,
+            "state_multiplier": 0.1
+        }
+    },
+        //嘉义市
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114514,
+            "fields": {
+                "candidate": 2001557,
+                "state": 257,
+                "state_multiplier": 0.28
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114515,
+            "fields": {
+                "candidate": 2001591,
+                "state": 257,
+                "state_multiplier": 0.23
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114516,
+            "fields": {
+                "candidate": 2001622,
+                "state": 257,
+                "state_multiplier": 0.15
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114517,
+            "fields": {
+                "candidate": 2001653,
+                "state": 257,
+                "state_multiplier": 0.05
+            }
+        },
+        //南投
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 566666,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 258,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 666666,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 258,
+                        "state_multiplier": 0.31
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 6666666,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 258,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 66666666,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 258,
+                        "state_multiplier": 0.08
+                    }
+                },
+                //彰化
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 114514123,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 260,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1145141234,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 260,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 11451414,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 260,
+                        "state_multiplier": 0.19
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 21412412,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 260,
+                        "state_multiplier": 0.06
+                    }
+                },
+                //云林
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1111,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 259,
+                        "state_multiplier": 0.32
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2222,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 259,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 3333,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 259,
+                        "state_multiplier": 0.19
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 4444,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 259,
+                        "state_multiplier": 0.04
+                    }
+                },
+                //澎湖
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 5555,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 261,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 6666,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 261,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 7777,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 261,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 8888,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 261,
+                        "state_multiplier": 0.05
+                    }
+                },
+                //台中
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412241,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 262,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412411,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 262,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412412,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 262,
+                        "state_multiplier": 0.22
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412511,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 262,
+                        "state_multiplier": 0.05
+                    }
+                },
+                //新竹县
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101001,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 264,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101002,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 264,
+                        "state_multiplier": 0.29
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101003,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 264,
+                        "state_multiplier": 0.26
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101004,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 264,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //新竹市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010012,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 265,
+                        "state_multiplier": 0.285
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010022,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 265,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010032,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 265,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010042,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 265,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //苗栗
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2194,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 266,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2195,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 266,
+                        "state_multiplier": 0.35
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2196,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 266,
+                        "state_multiplier": 0.22
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2197,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 266,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //新北市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12194,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 267,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12195,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 267,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12196,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 267,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12197,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 267,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //台北市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 268,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 268,
+                        "state_multiplier": 0.34
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 268,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 268,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //桃园
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 269,
+                        "state_multiplier": 0.26
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 269,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 269,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 269,
+                        "state_multiplier": 0.13
+                    }
+                },
+                //基隆
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 270,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 270,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 270,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 270,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //金门
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19581,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 271,
+                        "state_multiplier": 0.05
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19582,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 271,
+                        "state_multiplier": 0.55
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19583,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 271,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19584,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 271,
+                        "state_multiplier": 0.15
+                    }
+                },         
+                 //宜兰
+                 {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195813,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 263,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195823,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 263,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195833,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 263,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195843,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 263,
+                        "state_multiplier": 0.08
+                    }
+                },       
+                  //连江
+                  {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195812,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 272,
+                        "state_multiplier": 0.05
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195822,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 272,
+                        "state_multiplier": 0.55
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195832,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 272,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195842,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 272,
+                        "state_multiplier": 0.15
+                    }
+                },      
+]
+
+
+campaignTrail_temp.answer_score_global_json = [
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13413,
+        "fields": {
+            "answer": 13408,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13415,
+        "fields": {
+            "answer": 13409,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950382,
+        "fields": {
+            "answer": 1950012,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950384,
+        "fields": {
+            "answer": 1950013,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950387,
+        "fields": {
+            "answer": 1950014,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950393,
+        "fields": {
+            "answer": 1950388,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950395,
+        "fields": {
+            "answer": 1950389,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950397,
+        "fields": {
+            "answer": 1950390,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950403,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950404,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950405,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950406,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950407,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.45
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950408,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950409,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.23
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950410,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950423,
+        "fields": {
+            "answer": 1950415,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950437,
+        "fields": {
+            "answer": 1950425,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950438,
+        "fields": {
+            "answer": 1950426,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950439,
+        "fields": {
+            "answer": 1950430,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950440,
+        "fields": {
+            "answer": 1950432,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950451,
+        "fields": {
+            "answer": 1950443,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.021
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950459,
+        "fields": {
+            "answer": 1950454,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950465,
+        "fields": {
+            "answer": 1950463,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950466,
+        "fields": {
+            "answer": 1950463,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950469,
+        "fields": {
+            "answer": 1950462,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950470,
+        "fields": {
+            "answer": 1950462,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950472,
+        "fields": {
+            "answer": 1950461,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950473,
+        "fields": {
+            "answer": 1950461,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950475,
+        "fields": {
+            "answer": 1950460,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950480,
+        "fields": {
+            "answer": 1950454,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950482,
+        "fields": {
+            "answer": 1950477,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.37
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950484,
+        "fields": {
+            "answer": 1950478,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.37
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950486,
+        "fields": {
+            "answer": 1950479,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.37
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950492,
+        "fields": {
+            "answer": 1950487,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950495,
+        "fields": {
+            "answer": 1950488,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950498,
+        "fields": {
+            "answer": 1950489,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950500,
+        "fields": {
+            "answer": 1950490,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950506,
+        "fields": {
+            "answer": 1950502,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.0354
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950508,
+        "fields": {
+            "answer": 1950503,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.005
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950516,
+        "fields": {
+            "answer": 1950504,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.0354
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950528,
+        "fields": {
+            "answer": 1950525,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950531,
+        "fields": {
+            "answer": 1950524,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950533,
+        "fields": {
+            "answer": 1950523,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950539,
+        "fields": {
+            "answer": 1950535,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950541,
+        "fields": {
+            "answer": 1950521,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950542,
+        "fields": {
+            "answer": 1950521,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": 5.3
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950545,
+        "fields": {
+            "answer": 1950536,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950547,
+        "fields": {
+            "answer": 1950537,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950548,
+        "fields": {
+            "answer": 1950537,
+            "candidate": 2001591,
+            "affected_candidate": 1950365,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950552,
+        "fields": {
+            "answer": 1950550,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950595,
+        "fields": {
+            "answer": 1950593,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950601,
+        "fields": {
+            "answer": 1950597,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950606,
+        "fields": {
+            "answer": 1950600,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950622,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950623,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950624,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950626,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950627,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950629,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950635,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950636,
+        "fields": {
+            "answer": 1950615,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950637,
+        "fields": {
+            "answer": 1950615,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950638,
+        "fields": {
+            "answer": 1950579,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950639,
+        "fields": {
+            "answer": 1950580,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950640,
+        "fields": {
+            "answer": 1950581,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950641,
+        "fields": {
+            "answer": 1950582,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950642,
+        "fields": {
+            "answer": 1950616,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950644,
+        "fields": {
+            "answer": 1950617,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950654,
+        "fields": {
+            "answer": 1950647,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950655,
+        "fields": {
+            "answer": 1950648,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950656,
+        "fields": {
+            "answer": 1950649,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950663,
+        "fields": {
+            "answer": 1950658,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950665,
+        "fields": {
+            "answer": 1950659,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950668,
+        "fields": {
+            "answer": 1950660,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950674,
+        "fields": {
+            "answer": 1950658,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950675,
+        "fields": {
+            "answer": 1950659,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950676,
+        "fields": {
+            "answer": 1950660,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950677,
+        "fields": {
+            "answer": 1950670,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950678,
+        "fields": {
+            "answer": 1950671,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950681,
+        "fields": {
+            "answer": 1950600,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950682,
+        "fields": {
+            "answer": 1950599,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950684,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950685,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950686,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950698,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950699,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950700,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950701,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950702,
+        "fields": {
+            "answer": 1950692,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950703,
+        "fields": {
+            "answer": 1950692,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950704,
+        "fields": {
+            "answer": 1950693,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950705,
+        "fields": {
+            "answer": 1950693,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950729,
+        "fields": {
+            "answer": 1950721,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950730,
+        "fields": {
+            "answer": 1950721,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950731,
+        "fields": {
+            "answer": 1950722,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950732,
+        "fields": {
+            "answer": 1950722,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950733,
+        "fields": {
+            "answer": 1950723,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950734,
+        "fields": {
+            "answer": 1950723,
+            "candidate": 2001591,
+            "affected_candidate": 0,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950735,
+        "fields": {
+            "answer": 1950724,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950736,
+        "fields": {
+            "answer": 1950724,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950742,
+        "fields": {
+            "answer": 1950737,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950744,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950745,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950748,
+        "fields": {
+            "answer": 1950739,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950749,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950750,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950758,
+        "fields": {
+            "answer": 1950751,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950759,
+        "fields": {
+            "answer": 1950755,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950760,
+        "fields": {
+            "answer": 1950751,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.14
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950761,
+        "fields": {
+            "answer": 1950755,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.14
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950768,
+        "fields": {
+            "answer": 1950766,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950769,
+        "fields": {
+            "answer": 1950766,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950772,
+        "fields": {
+            "answer": 1950765,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950773,
+        "fields": {
+            "answer": 1950765,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950775,
+        "fields": {
+            "answer": 1950764,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950776,
+        "fields": {
+            "answer": 1950764,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950777,
+        "fields": {
+            "answer": 1950737,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950778,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950779,
+        "fields": {
+            "answer": 1950739,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950780,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950786,
+        "fields": {
+            "answer": 1950784,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950787,
+        "fields": {
+            "answer": 1950784,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950791,
+        "fields": {
+            "answer": 1950782,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950792,
+        "fields": {
+            "answer": 1950782,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950793,
+        "fields": {
+            "answer": 1950783,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950794,
+        "fields": {
+            "answer": 1950781,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950795,
+        "fields": {
+            "answer": 1950781,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950801,
+        "fields": {
+            "answer": 1950796,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950802,
+        "fields": {
+            "answer": 1950796,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950806,
+        "fields": {
+            "answer": 1950797,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950810,
+        "fields": {
+            "answer": 1950799,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950811,
+        "fields": {
+            "answer": 1950798,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950812,
+        "fields": {
+            "answer": 1950798,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950820,
+        "fields": {
+            "answer": 1950818,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950823,
+        "fields": {
+            "answer": 1950814,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950826,
+        "fields": {
+            "answer": 1950815,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950827,
+        "fields": {
+            "answer": 1950815,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.034
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950830,
+        "fields": {
+            "answer": 1950816,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950831,
+        "fields": {
+            "answer": 1950816,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950835,
+        "fields": {
+            "answer": 1950817,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950836,
+        "fields": {
+            "answer": 1950814,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950844,
+        "fields": {
+            "answer": 1950838,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950848,
+        "fields": {
+            "answer": 1950840,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.021
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950855,
+        "fields": {
+            "answer": 1950852,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950860,
+        "fields": {
+            "answer": 1950858,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950861,
+        "fields": {
+            "answer": 1950853,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950883,
+        "fields": {
+            "answer": 1950863,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950884,
+        "fields": {
+            "answer": 1950864,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950885,
+        "fields": {
+            "answer": 1950865,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950886,
+        "fields": {
+            "answer": 1950866,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950887,
+        "fields": {
+            "answer": 1950863,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950888,
+        "fields": {
+            "answer": 1950864,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950906,
+        "fields": {
+            "answer": 1950903,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950909,
+        "fields": {
+            "answer": 1950901,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950925,
+        "fields": {
+            "answer": 1950914,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950930,
+        "fields": {
+            "answer": 1950928,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950931,
+        "fields": {
+            "answer": 1950928,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950938,
+        "fields": {
+            "answer": 1950936,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950939,
+        "fields": {
+            "answer": 1950936,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.059
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950941,
+        "fields": {
+            "answer": 1950935,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950942,
+        "fields": {
+            "answer": 1950935,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950944,
+        "fields": {
+            "answer": 1950934,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950945,
+        "fields": {
+            "answer": 1950934,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950949,
+        "fields": {
+            "answer": 1950946,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950950,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950951,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -5
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_issue_json = [
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950385,
+        "fields": {
+            "answer": 1950013,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950446,
+        "fields": {
+            "answer": 1950441,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.155
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950448,
+        "fields": {
+            "answer": 1950442,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950467,
+        "fields": {
+            "answer": 1950463,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950476,
+        "fields": {
+            "answer": 1950460,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950493,
+        "fields": {
+            "answer": 1950487,
+            "issue": 35,
+            "issue_score": -0.15,
+            "issue_importance": 0.3
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950496,
+        "fields": {
+            "answer": 1950488,
+            "issue": 35,
+            "issue_score": -0.15,
+            "issue_importance": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950499,
+        "fields": {
+            "answer": 1950489,
+            "issue": 35,
+            "issue_score": -0.15,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950501,
+        "fields": {
+            "answer": 1950490,
+            "issue": 35,
+            "issue_score": -0.1,
+            "issue_importance": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950527,
+        "fields": {
+            "answer": 1950525,
+            "issue": 32,
+            "issue_score": -0.04,
+            "issue_importance": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950532,
+        "fields": {
+            "answer": 1950524,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950534,
+        "fields": {
+            "answer": 1950523,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950540,
+        "fields": {
+            "answer": 1950535,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950546,
+        "fields": {
+            "answer": 1950536,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950549,
+        "fields": {
+            "answer": 1950537,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950553,
+        "fields": {
+            "answer": 1950550,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950555,
+        "fields": {
+            "answer": 1950550,
+            "issue": 36,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950584,
+        "fields": {
+            "answer": 1950579,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950587,
+        "fields": {
+            "answer": 1950580,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950588,
+        "fields": {
+            "answer": 1950580,
+            "issue": 36,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950589,
+        "fields": {
+            "answer": 1950581,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950591,
+        "fields": {
+            "answer": 1950582,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950592,
+        "fields": {
+            "answer": 1950582,
+            "issue": 36,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950596,
+        "fields": {
+            "answer": 1950593,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950602,
+        "fields": {
+            "answer": 1950597,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950604,
+        "fields": {
+            "answer": 1950599,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950607,
+        "fields": {
+            "answer": 1950600,
+            "issue": 34,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950608,
+        "fields": {
+            "answer": 1950600,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950625,
+        "fields": {
+            "answer": 1950609,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950628,
+        "fields": {
+            "answer": 1950610,
+            "issue": 32,
+            "issue_score": 0.02,
+            "issue_importance": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950630,
+        "fields": {
+            "answer": 1950611,
+            "issue": 32,
+            "issue_score": 0.03,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950631,
+        "fields": {
+            "answer": 1950559,
+            "issue": 33,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950632,
+        "fields": {
+            "answer": 1950560,
+            "issue": 33,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950633,
+        "fields": {
+            "answer": 1950561,
+            "issue": 33,
+            "issue_score": -0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950634,
+        "fields": {
+            "answer": 1950513,
+            "issue": 33,
+            "issue_score": -0.03,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950643,
+        "fields": {
+            "answer": 1950616,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950645,
+        "fields": {
+            "answer": 1950617,
+            "issue": 32,
+            "issue_score": 0.02,
+            "issue_importance": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950653,
+        "fields": {
+            "answer": 1950647,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950657,
+        "fields": {
+            "answer": 1950649,
+            "issue": 32,
+            "issue_score": 0.15,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950662,
+        "fields": {
+            "answer": 1950658,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950666,
+        "fields": {
+            "answer": 1950659,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950669,
+        "fields": {
+            "answer": 1950660,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950679,
+        "fields": {
+            "answer": 1950671,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950680,
+        "fields": {
+            "answer": 1950670,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950762,
+        "fields": {
+            "answer": 1950751,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950763,
+        "fields": {
+            "answer": 1950755,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950770,
+        "fields": {
+            "answer": 1950766,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950804,
+        "fields": {
+            "answer": 1950796,
+            "issue": 35,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950805,
+        "fields": {
+            "answer": 1950797,
+            "issue": 35,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950809,
+        "fields": {
+            "answer": 1950799,
+            "issue": 35,
+            "issue_score": -0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950813,
+        "fields": {
+            "answer": 1950798,
+            "issue": 35,
+            "issue_score": -0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950821,
+        "fields": {
+            "answer": 1950818,
+            "issue": 32,
+            "issue_score": 0.015,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950824,
+        "fields": {
+            "answer": 1950814,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950829,
+        "fields": {
+            "answer": 1950816,
+            "issue": 35,
+            "issue_score": 0.02,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950833,
+        "fields": {
+            "answer": 1950817,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950834,
+        "fields": {
+            "answer": 1950817,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950846,
+        "fields": {
+            "answer": 1950839,
+            "issue": 32,
+            "issue_score": 0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950850,
+        "fields": {
+            "answer": 1950841,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950857,
+        "fields": {
+            "answer": 1950852,
+            "issue": 32,
+            "issue_score": -0.04,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950862,
+        "fields": {
+            "answer": 1950853,
+            "issue": 32,
+            "issue_score": -0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950897,
+        "fields": {
+            "answer": 1950891,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950898,
+        "fields": {
+            "answer": 1950892,
+            "issue": 32,
+            "issue_score": 0.07,
+            "issue_importance": 0.11
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950899,
+        "fields": {
+            "answer": 1950893,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950910,
+        "fields": {
+            "answer": 1950902,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950917,
+        "fields": {
+            "answer": 1950912,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950919,
+        "fields": {
+            "answer": 1950913,
+            "issue": 35,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950921,
+        "fields": {
+            "answer": 1950913,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950924,
+        "fields": {
+            "answer": 1950915,
+            "issue": 33,
+            "issue_score": -0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950926,
+        "fields": {
+            "answer": 1950914,
+            "issue": 32,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950932,
+        "fields": {
+            "answer": 1950928,
+            "issue": 32,
+            "issue_score": 0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950948,
+        "fields": {
+            "answer": 1950946,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_state_json = [
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950420,
+        "fields": {
+            "answer": 1950412,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950421,
+        "fields": {
+            "answer": 1950413,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950422,
+        "fields": {
+            "answer": 1950414,
+            "state": 269,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950428,
+        "fields": {
+            "answer": 1950425,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.0355
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950434,
+        "fields": {
+            "answer": 1950426,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950435,
+        "fields": {
+            "answer": 1950430,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950436,
+        "fields": {
+            "answer": 1950432,
+            "state": 262,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950452,
+        "fields": {
+            "answer": 1950444,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950453,
+        "fields": {
+            "answer": 1950444,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950509,
+        "fields": {
+            "answer": 1950503,
+            "state": 264,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950510,
+        "fields": {
+            "answer": 1950503,
+            "state": 266,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950511,
+        "fields": {
+            "answer": 1950503,
+            "state": 269,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950512,
+        "fields": {
+            "answer": 1950503,
+            "state": 265,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950517,
+        "fields": {
+            "answer": 1950513,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950518,
+        "fields": {
+            "answer": 1950513,
+            "state": 260,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950519,
+        "fields": {
+            "answer": 1950513,
+            "state": 259,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950520,
+        "fields": {
+            "answer": 1950513,
+            "state": 255,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950563,
+        "fields": {
+            "answer": 1950558,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950564,
+        "fields": {
+            "answer": 1950558,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950565,
+        "fields": {
+            "answer": 1950558,
+            "state": 270,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950568,
+        "fields": {
+            "answer": 1950559,
+            "state": 262,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950569,
+        "fields": {
+            "answer": 1950559,
+            "state": 258,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950570,
+        "fields": {
+            "answer": 1950559,
+            "state": 260,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950572,
+        "fields": {
+            "answer": 1950560,
+            "state": 256,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950573,
+        "fields": {
+            "answer": 1950560,
+            "state": 257,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950575,
+        "fields": {
+            "answer": 1950561,
+            "state": 253,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950576,
+        "fields": {
+            "answer": 1950561,
+            "state": 251,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950577,
+        "fields": {
+            "answer": 1950561,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950871,
+        "fields": {
+            "answer": 1950863,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950872,
+        "fields": {
+            "answer": 1950863,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950873,
+        "fields": {
+            "answer": 1950864,
+            "state": 251,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950874,
+        "fields": {
+            "answer": 1950864,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950875,
+        "fields": {
+            "answer": 1950865,
+            "state": 264,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950876,
+        "fields": {
+            "answer": 1950865,
+            "state": 265,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950877,
+        "fields": {
+            "answer": 1950865,
+            "state": 269,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950878,
+        "fields": {
+            "answer": 1950865,
+            "state": 266,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950879,
+        "fields": {
+            "answer": 1950866,
+            "state": 254,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950880,
+        "fields": {
+            "answer": 1950866,
+            "state": 263,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950881,
+        "fields": {
+            "answer": 1950866,
+            "state": 255,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950882,
+        "fields": {
+            "answer": 1950866,
+            "state": 253,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950889,
+        "fields": {
+            "answer": 1950560,
+            "state": 259,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+
+]
+
+campaignTrail_temp.answer_feedback_json = [
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950381,
+        "fields": {
+            "answer": 1950012,
+            "candidate": 2001591,
+            "answer_feedback": "Over the past few months, you have consistently employed vague municipal rhetoric when addressing the media. Whether it's to manage troublesome press interactions or conceal your true intentions, you should start preparing for the presidential election sooner rather than later."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950383,
+        "fields": {
+            "answer": 1950013,
+            "candidate": 2001591,
+            "answer_feedback": "Even though you claim to be focusing on municipal affairs at the moment, your statement 'Regardless of any challenges' has been interpreted by the media as a precursor hinting at your intention to run for president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950386,
+        "fields": {
+            "answer": 1950014,
+            "candidate": 2001591,
+            "answer_feedback": "While you consistently emphasize your current focus on municipal affairs, a presidential election demands a significant amount of time and energy. Do you believe you can effectively balance your responsibilities in local governance while engaging in a campaign?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950392,
+        "fields": {
+            "answer": 1950388,
+            "candidate": 2001591,
+            "answer_feedback": "On May 17th, Terry Gou was drafted as the KMT's presidential candidate, and your qualification for the primary elections came to an end. In the time ahead, you can now focus exclusively on handling municipal affairs in New Taipei City."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950394,
+        "fields": {
+            "answer": 1950389,
+            "candidate": 2001591,
+            "answer_feedback": "While polite words may suggest otherwise, it's worth noting that you currently enjoy a leading advantage in the polls, and Terry Gou has yet to fully regain his Kuomintang membership."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950396,
+        "fields": {
+            "answer": 1950390,
+            "candidate": 2001591,
+            "answer_feedback": "The media spotlight has now turned towards you, with headlines from China Times and United Daily News: 'Mayor Hou Youyi Officially Announces Presidential Bid?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950401,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "answer_feedback": "Understood. It seems you have chosen to continue focusing on municipal affairs, but I hope you won't acquire a reputation for being indifferent to party matters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950402,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "answer_feedback": "Terry Gou is very grateful for your assistance and promises that he will bring down the Democratic Progressive Party. He assures you a position in the cabinet once elected."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950416,
+        "fields": {
+            "answer": 1950415,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950417,
+        "fields": {
+            "answer": 1950414,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950418,
+        "fields": {
+            "answer": 1950413,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950419,
+        "fields": {
+            "answer": 1950412,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950427,
+        "fields": {
+            "answer": 1950425,
+            "candidate": 2001591,
+            "answer_feedback": "You spent the final day in your hometown. Wishing you good luck and hoping that you will be elected as the president tomorrow!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950429,
+        "fields": {
+            "answer": 1950426,
+            "candidate": 2001591,
+            "answer_feedback": "On Ketagalan Boulevard, amidst the bustling crowd of voters hoping for a political change, best of luck tomorrow!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950431,
+        "fields": {
+            "answer": 1950430,
+            "candidate": 2001591,
+            "answer_feedback": "You held the final event near the military dependents' village next to Kaohsiung Harbor, hoping that this would impact Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950433,
+        "fields": {
+            "answer": 1950432,
+            "candidate": 2001591,
+            "answer_feedback": "Absolutely, Taichung City serves as the dividing line between northern and southern Taiwan, making it a crucial region. Wishing you good luck!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950445,
+        "fields": {
+            "answer": 1950441,
+            "candidate": 2001591,
+            "answer_feedback": "\nYou are rallying support from mayors across the country, and with the impressive lineup of 14+1 KMT-supported mayors this year, it will be a significant boost to your campaign."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950447,
+        "fields": {
+            "answer": 1950442,
+            "candidate": 2001591,
+            "answer_feedback": "Building good relationships with legislators is also a wise choice. If elected, you will rely on their support in the Legislative Yuan. Regional legislators can also positively influence your campaign in different areas."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950449,
+        "fields": {
+            "answer": 1950443,
+            "candidate": 2001591,
+            "answer_feedback": "In your interview on TVBS's Situation Room with Zhao Shao-kang, you spoke confidently and it brought you some media exposure. You also appeared on this program before the 2018 mayoral election.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950450,
+        "fields": {
+            "answer": 1950444,
+            "candidate": 2001591,
+            "answer_feedback": "Your participation in the completion events of various construction projects and local festivals in New Taipei City and Taipei City has increased your exposure and familiarity among the voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950458,
+        "fields": {
+            "answer": 1950454,
+            "candidate": 2001591,
+            "answer_feedback": "Terry Gou stated on Facebook: 'Mayor Hou is the most solid popular support within the Kuomintang. It is only natural and the best choice for him to take on greater responsibilities. He will keep his promises and exert utmost effort to support Mayor Hou's victory'."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950464,
+        "fields": {
+            "answer": 1950463,
+            "candidate": 2001591,
+            "answer_feedback": "\nFocusing your energy primarily on the DPP can shape a blue-green confrontation atmosphere, but be cautious. Balance your critiques, as the public is weary of excessive attacks rather than positive campaigning."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950468,
+        "fields": {
+            "answer": 1950462,
+            "candidate": 2001591,
+            "answer_feedback": "As now, Ko Wen-je has not supported your request. He mentioned that it is difficult to cooperate due to differences in policy and ideology between him and the Kuomintang."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950471,
+        "fields": {
+            "answer": 1950461,
+            "candidate": 2001591,
+            "answer_feedback": "Initiating infighting within the opposition camp this early is not good news. It will only benefit the DPP and create a negative impression of the KMT, portraying it as solely focused on attacks without a clear vision.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950474,
+        "fields": {
+            "answer": 1950460,
+            "candidate": 2001591,
+            "answer_feedback": "Currently, this strategy ensures the independence of your party. However, there will come a day when you need to discuss collaboration against the DPP, so please be prepared."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950481,
+        "fields": {
+            "answer": 1950477,
+            "candidate": 2001591,
+            "answer_feedback": "\nUnfortunately, parents cannot wait until the slow administrative and police investigations conclude. Taking advantage of the situation, DPP legislators, along with some parents, held a press conference attacking the efficiency of Mayor Hou's government in handling the case. Your Polls have plummeted as if falling from a skyscraper."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950483,
+        "fields": {
+            "answer": 1950478,
+            "candidate": 2001591,
+            "answer_feedback": "With children claiming they were fed 'colorful potions,' and some showing signs of barbital, awaiting confirmation through hair tests, the credibility of the city government has been damaged. It is essential to conduct a thorough investigation into other kindergartens to prevent any potential issues. This incident has left parents across Taiwan concerned."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950485,
+        "fields": {
+            "answer": 1950479,
+            "candidate": 2001591,
+            "answer_feedback": "You and your city government are facing severe criticism for this incident. Parents are questioning why they reported the case in mid-May and attempted to contact through the mayor's mailbox, but did not receive a response from the government at that time."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950491,
+        "fields": {
+            "answer": 1950487,
+            "candidate": 2001591,
+            "answer_feedback": "Your response at National Chengchi University was disliked by young people; they feel you didn't directly answer the questions. Your standard-style responses are derogatorily referred to as HOHOGPT."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950494,
+        "fields": {
+            "answer": 1950488,
+            "candidate": 2001591,
+            "answer_feedback": "The video of your evasive answers at National Chengchi University has been widely circulated on various news media platforms, drawing a lot of mockery from young people. Even legislator Ko Chih-en believes that this has caused significant damage to your image.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950497,
+        "fields": {
+            "answer": 1950490,
+            "candidate": 2001591,
+            "answer_feedback": "\nBefore to this, you spoke about housing prices for ten minutes, and even your more normal responses were drowned out by online ridicule and the attacks from opponents on the kindergarten incident."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950505,
+        "fields": {
+            "answer": 1950502,
+            "candidate": 2001591,
+            "answer_feedback": "Lien Chan, despite his 87-year-old frame, has released an open letter in his own name, urging all members of the Kuomintang to support Hou You-yi."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950507,
+        "fields": {
+            "answer": 1950503,
+            "candidate": 2001591,
+            "answer_feedback": "\nWu Poh-hsiung, leaning on his cane, strongly supports Hou You-yi, referring to him as \"brothers in adversity.\" He mentioned that the more people get to know him, the more they like him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950514,
+        "fields": {
+            "answer": 1950504,
+            "candidate": 2001591,
+            "answer_feedback": "Ma Ying-jeou has agreed to assist you, and he will recruit a highly valuable individual to support your campaign. As for the specific person, it cannot be disclosed at this moment."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950515,
+        "fields": {
+            "answer": 1950513,
+            "candidate": 2001591,
+            "answer_feedback": "Speaker Wang Jin-ping has successfully organized a legislative support group for you. At the very least, you have the support of the party organization and legislative members, and they have decided to fully support Hou You-yi in the upcoming campaign."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950522,
+        "fields": {
+            "answer": 1950521,
+            "candidate": 2001591,
+            "answer_feedback": "With this news, the media has begun discussing the impact and assistance that 'Little Knife King' (金小刀) might bring to your campaign. After all, he played a crucial role in helping Ma defeat Tsai in 2012, and at that time, Tsai was already a formidable opponent who would become the president in 2016."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950526,
+        "fields": {
+            "answer": 1950525,
+            "candidate": 2001591,
+            "answer_feedback": "You might think it's a clever move, but in reality, the keen-eyed media has caught onto your subtle actions. They interpret your move of pulling a chair next to Han Kuo-yu as a deliberate attempt to cozy up to him, and this has been met with mockery."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950529,
+        "fields": {
+            "answer": 1950523,
+            "candidate": 2001591,
+            "answer_feedback": "While your apology to Han Kuo-yu is accepted, his supporters remain unconvinced and continue to harbor resentment towards you. To win them over, it may require direct intervention and efforts from Han himself."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950530,
+        "fields": {
+            "answer": 1950524,
+            "candidate": 2001591,
+            "answer_feedback": "you serious? Not offering an apology to Han Kuo-yu in this situation might make it challenging to win back his supporters. The swing voters may not necessarily lean towards you, and as for Han's fans, if presented with other options, you know where they might turn."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950538,
+        "fields": {
+            "answer": 1950535,
+            "candidate": 2001591,
+            "answer_feedback": "\nIt seems like your campaign has finally returned to the right track. Many people find it difficult to accept KMT candidates who do not adhere to the 1992 Consensus, while others simply do not accept the consensus at all."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950543,
+        "fields": {
+            "answer": 1950537,
+            "candidate": 2001591,
+            "answer_feedback": "Businessmen worship Guan Gong just to seek his blessings for them to earn more money."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950544,
+        "fields": {
+            "answer": 1950536,
+            "candidate": 2001591,
+            "answer_feedback": "There are several nuclear power plants in New Taipei, However, due to concerns about safety, you have not allowed them to insert nuclear fuel rods, and there is no particularly specific and feasible plan for nuclear waste."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950551,
+        "fields": {
+            "answer": 1950550,
+            "candidate": 2001591,
+            "answer_feedback": "After this , a portion of Han's supporters has shifted their support towards you, solidifying unity within the party!This marks the beginning of your resurgence in the polls!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950562,
+        "fields": {
+            "answer": 1950558,
+            "candidate": 2001591,
+            "answer_feedback": "Strengthening our base is always essential, but we must be cautious as Ko Wen-je and Terry Gou may divert crucial pan-blue votes!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950566,
+        "fields": {
+            "answer": 1950559,
+            "candidate": 2001591,
+            "answer_feedback": "\nCapturing the crucial central region is indeed a priority, especially focusing on Changhua, where a significant number of Minnan people reside. You might have a good chance to perform well there!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950571,
+        "fields": {
+            "answer": 1950560,
+            "candidate": 2001591,
+            "answer_feedback": "It seems like you must secure victory in your hometown; otherwise, it might not look good. At least ensure that Puzi City stays blue, alright?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950574,
+        "fields": {
+            "answer": 1950561,
+            "candidate": 2001591,
+            "answer_feedback": "Although holding a KMT membership in the south often means not winning, your southern identity and local Taiwanese flavor could work in your favor."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950578,
+        "fields": {
+            "answer": 1950489,
+            "candidate": 2001591,
+            "answer_feedback": "Angry students demand direct answers from you... Shifting topics here is not a good move."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950583,
+        "fields": {
+            "answer": 1950579,
+            "candidate": 2001591,
+            "answer_feedback": "The DPP government indeed lacks effective measures against fraud, and their anti-fraud task force is seen as a waste of time and money. However, it remains questionable how many votes you can sway on this issue."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950585,
+        "fields": {
+            "answer": 1950580,
+            "candidate": 2001591,
+            "answer_feedback": "Since 2022, the military threat from the mainland towards Taiwan has intensified. The DPP government, however, has yet to proactively ease the situation. Nevertheless, this can stir up the green base and anti-China sentiments."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950586,
+        "fields": {
+            "answer": 1950581,
+            "candidate": 2001591,
+            "answer_feedback": "While the digital development department, led by Tang Feng, is widely seen as a failure, the current government is reluctant to replace him. Moreover, this issue is not a top concern for the voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950590,
+        "fields": {
+            "answer": 1950582,
+            "candidate": 2001591,
+            "answer_feedback": "This strategy aims to strengthen your deep blue support base. However, many green supporters in Taiwan see CTiTV as pro-China media that could undermine Taiwan's free and democratic system."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950594,
+        "fields": {
+            "answer": 1950593,
+            "candidate": 2001591,
+            "answer_feedback": "death penalty is a sensitive point for the DPP. They have to moderate their stance on this issue. They might argue that Taiwan has not abolished the death penalty, but the number of executions during the DPP's term is significantly lower than during Ma Ying-jeou's presidency."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950598,
+        "fields": {
+            "answer": 1950597,
+            "candidate": 2001591,
+            "answer_feedback": "DPP criticizes your approach, claiming that it aims to return to the era of one-party rule, and they argue that there would be no oversight for the SPD. However, this is undoubtedly well-received among supporters of the blue camp!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950603,
+        "fields": {
+            "answer": 1950599,
+            "candidate": 2001591,
+            "answer_feedback": "This is your attempt to attract young people, but it doesn't seem to be effective. All candidates support the construction of public housing and a property hoarding tax, so it may not have a unique appeal."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950605,
+        "fields": {
+            "answer": 1950600,
+            "candidate": 2001591,
+            "answer_feedback": "on this issue, the KMT and DPP have completely opposite policies, with significant differences. Nuclear power also offers the advantage of generating electricity at a lower cost."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950612,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "answer_feedback": "Hey, isn't your attack a bit too much? You might be angry with him, but opposition voters don't want to see more attacks and divisions. This will only help Ko Wen-je gain more support."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950613,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "answer_feedback": "These are empty words and useless statements; Terry Gou has already announced his independent candidacy, and he won't stop now.\n\n\n\n\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950614,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "answer_feedback": "This is a very interesting advertisement that has caught the media's attention. Many believe that you released this video to satirize Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950618,
+        "fields": {
+            "answer": 1950615,
+            "candidate": 2001591,
+            "answer_feedback": "This is a favorable proposal for you, but it's evident that TPP won't accept it as their party members and support base are lower than yours. Anyway, you've tossed the ball back to them."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950620,
+        "fields": {
+            "answer": 1950616,
+            "candidate": 2001591,
+            "answer_feedback": "While what you say is true, it might create an image of you overpowering a smaller party, and TPP supporters may perceive you as timid, hiding behind the strength of the KMT."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950621,
+        "fields": {
+            "answer": 1950617,
+            "candidate": 2001591,
+            "answer_feedback": "Certainly, negotiations will continue, but you must reach an agreement before November 24th; otherwise, this election will turn into a three-way competition!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950650,
+        "fields": {
+            "answer": 1950649,
+            "candidate": 2001591,
+            "answer_feedback": "\nCompared to Vice President Lai Ching-te, you have indeed met with more important figures. This will be helpful for you and add more points to your international diplomatic efforts."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950651,
+        "fields": {
+            "answer": 1950647,
+            "candidate": 2001591,
+            "answer_feedback": "\nThree Principles of the People encompass nationalism, democracy, and people's livelihood. However, it also has a complex historical relationship with by the people, for the people.and of the people.Unfortunately, in modern times, few Taiwanese can comprehend your political discourse."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950652,
+        "fields": {
+            "answer": 1950648,
+            "candidate": 2001591,
+            "answer_feedback": "In November 1997, when criminals broke into the home of a South African military attaché and kidnapped his entire family, you helped rescue the baby. The infant, who was in your arms back then, has grown up, touching the hearts of many."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950661,
+        "fields": {
+            "answer": 1950658,
+            "candidate": 2001591,
+            "answer_feedback": "This will significantly alleviate the differences between Hou and Han, bringing back the majority of Han's supporters into the Kuomintang camp!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950664,
+        "fields": {
+            "answer": 1950659,
+            "candidate": 2001591,
+            "answer_feedback": "This can enhance Mayor Hou's image in terms of law and order, helping boost his scores in public safety. It will contribute to an improvement in Mayor Hou You-yi's standings in the polls."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950667,
+        "fields": {
+            "answer": 1950660,
+            "candidate": 2001591,
+            "answer_feedback": "Stirring up hatred against the DPP and instilling fear of war is a common tactic. However, here, you mentioned that Mayor Hou You-yi will unite more people who believe in these ideas around him!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950672,
+        "fields": {
+            "answer": 1950670,
+            "candidate": 2001591,
+            "answer_feedback": "From now on, polls will begin to assess your specific data. This will determine the fate of Taiwan. Good luck, Mayor Hou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950673,
+        "fields": {
+            "answer": 1950671,
+            "candidate": 2001591,
+            "answer_feedback": "From now on, polls will begin to assess your specific data. This will determine the fate of Taiwan. Good luck, Mayor Hou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950694,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "answer_feedback": "Tremble, Lai Ching-te, for the opposition alliance is united! President Hou You-yi, hello! Vice President Ko Wen-je, hello!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950695,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "answer_feedback": "After calculations by polling experts, it is not surprising that you emerge victorious and become the presidential candidate, with Ko Wen-je as your running mate for the vice presidency. On January 13th next year, you have a high likelihood of winning!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950696,
+        "fields": {
+            "answer": 1950692,
+            "candidate": 2001591,
+            "answer_feedback": "Damn... Under the interference of Ko Wen-je, his staff, and family, on the 18th, TPP's polling experts suggested excluding all indoor phone polls, and the margin of error in other polls became a contentious issue... "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950697,
+        "fields": {
+            "answer": 1950693,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je's supporters and TPP immediately started spreading online that the margin of error the KMT needs to concede is not the commonly perceived 3% but rather a range of plus or minus 3%. This implies that the KMT is asking Ko Wen-je to concede a margin of error of 6%."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950725,
+        "fields": {
+            "answer": 1950721,
+            "candidate": 2001591,
+            "answer_feedback": "It seems there's a big problem... Both sides are in constant dispute over the margin of error and which poll each side won. No decision was made on the 18th... Is this reaching a breaking point?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950726,
+        "fields": {
+            "answer": 1950722,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je's supporters and TPP immediately started spreading online that the margin of error the KMT needs to concede is not the commonly perceived 3% but rather a range of plus or minus 3%. This implies that the KMT is asking Ko Wen-je to concede a margin of error of 6%."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950727,
+        "fields": {
+            "answer": 1950723,
+            "candidate": 2001591,
+            "answer_feedback": "It seems there's a big problem... Both sides are in constant dispute over the margin of error and which poll each side won. No decision was made on the 18th... Is this reaching a breaking point?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950728,
+        "fields": {
+            "answer": 1950724,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je's supporters and TPP immediately started spreading online that the margin of error the KMT needs to concede is not the commonly perceived 3% but rather a range of plus or minus 3%. This implies that the KMT is asking Ko Wen-je to concede a margin of error of 6%."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950741,
+        "fields": {
+            "answer": 1950737,
+            "candidate": 2001591,
+            "answer_feedback": "Ko agrees but immediately counterattacks, stating that revealing private conversations is something only internet trolls and unscrupulous media outlets would do. Fortunately, this ensures Terry Gou's withdrawal as they announce that he will not register as a presidential candidate."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950743,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "answer_feedback": "Regardless of how you explain it, it's too late. Joint tickets have already failed since the time when the polls became controversial."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950746,
+        "fields": {
+            "answer": 1950739,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je refuses to withdraw from the election, declaring that as long as his supporters don't give up, he won't either. The only consolation is that Terry Gou has withdrawn from the election and stated that he will not continue to participate."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950747,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "answer_feedback": "both Ko Wen-je and Gou believe they have the right to independently continue their candidacies. Despite Gou's low polling numbers, he still managed to gather 940,000 citizen signatures. With the situation completely collapsing, you might need to prepare for a concession speech."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950756,
+        "fields": {
+            "answer": 1950751,
+            "candidate": 2001591,
+            "answer_feedback": "\nAfter careful consideration, Zhao requests you to make a final call to Ko Wen-je. Upon learning that Ko Wen-je and Cynthia Wu have already registered as presidential candidates, Zhao immediately joins you in heading to the Central Election Commission (CEC) and registers as a candidate alongside you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950757,
+        "fields": {
+            "answer": 1950755,
+            "candidate": 2001591,
+            "answer_feedback": "\nAfter careful consideration, Zhao requests you to make a final call to Ko Wen-je. Upon learning that Ko Wen-je and Cynthia Wu have already registered as presidential candidates, Zhao immediately joins you in heading to the Central Election Commission (CEC) and registers as a candidate alongside you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950767,
+        "fields": {
+            "answer": 1950766,
+            "candidate": 2001591,
+            "answer_feedback": "This is a direct criticism of the DPP. Considering that the Kuomintang might be perceived as too focused on attacks, you must offer the people a new hope to have a chance at winning.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950771,
+        "fields": {
+            "answer": 1950765,
+            "candidate": 2001591,
+            "answer_feedback": "Unfortunately, during the policy statement event, you mistakenly referred to \"Hou You-yi\" as \"Lai Ching-te,\" turning it into a big joke. Damn it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950774,
+        "fields": {
+            "answer": 1950764,
+            "candidate": 2001591,
+            "answer_feedback": "We understand that the story of the Three Kingdoms is popular and interesting, but the DPP continues to question the relationship between you and Hou. They still portray Hou as your puppet..."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950785,
+        "fields": {
+            "answer": 1950784,
+            "candidate": 2001591,
+            "answer_feedback": "You might think it's cool, but the news of violent demolition of Lai Ching-te's ancestral home has triggered a backlash among swing voters and the green base. The public is showing even more sympathy towards him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950788,
+        "fields": {
+            "answer": 1950783,
+            "candidate": 2001591,
+            "answer_feedback": "\nThat's the correct choice. Lai Ching-te's unauthorized construction was built a long time ago and hasn't posed any safety hazards. Most people aren't very concerned about this issue, so it's best not to overreact."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950789,
+        "fields": {
+            "answer": 1950782,
+            "candidate": 2001591,
+            "answer_feedback": "\nPerhaps Lai Ching-te hasn't handled this issue well, but regardless, many local residents support him. Your ads have inadvertently backfired, generating a negative impact with excessive aggression. It might be more beneficial to reconsider the tone and approach to avoid alienating potential supporters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950790,
+        "fields": {
+            "answer": 1950781,
+            "candidate": 2001591,
+            "answer_feedback": "\nLai may indeed lack transparency in this matter, and his teary performance may not garner much sympathy. However, pursuing an attack specifically targeting personal and family matters may not be the best choice, as such tactics are generally unpopular. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950800,
+        "fields": {
+            "answer": 1950796,
+            "candidate": 2001591,
+            "answer_feedback": "This response is indeed very good. it further enhance the negative image among young people and the DPP. While these are facts, it seems that the Taiwanese public might not be receptive to such a stance.nice try."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950803,
+        "fields": {
+            "answer": 1950797,
+            "candidate": 2001591,
+            "answer_feedback": "\nThis helps to immediately stop the bleeding. However, your image as a landlord has already become disliked by some young people, and they won't easily change their minds because of this."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950807,
+        "fields": {
+            "answer": 1950798,
+            "candidate": 2001591,
+            "answer_feedback": "Mutual attacks will only make things worse and strengthen the support bases on both sides. If that's what you prefer, then let it be."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950808,
+        "fields": {
+            "answer": 1950799,
+            "candidate": 2001591,
+            "answer_feedback": "While your image among young people may have further deteriorated, fortunately, most pan-blue and swing voters seem to understand. They recognize that this issue doesn't involve personal character but rather legal business operations."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950819,
+        "fields": {
+            "answer": 1950818,
+            "candidate": 2001591,
+            "answer_feedback": "This will strengthen the Kuomintang's image in national defense and help alleviate concerns among Americans about KMT's pro-China stance."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950822,
+        "fields": {
+            "answer": 1950814,
+            "candidate": 2001591,
+            "answer_feedback": "The effectiveness of this advertisement may not match the one from 2008, but it still resonates and is quite impactful. Well done!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950825,
+        "fields": {
+            "answer": 1950815,
+            "candidate": 2001591,
+            "answer_feedback": "Choosing to engage in close combat with the DPP has its benefits as you can inflict damage, but the downside is that people have less hope for you, only seeing more of your attacks."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950828,
+        "fields": {
+            "answer": 1950816,
+            "candidate": 2001591,
+            "answer_feedback": "This policy is not considered very favorable. While the loan amount is flexible, the substantial monthly repayments pose a heavy burden for young people. Failing to repay could potentially ruin their lives."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950832,
+        "fields": {
+            "answer": 1950817,
+            "candidate": 2001591,
+            "answer_feedback": "This will solidify your base, as most of the opposition voters are reluctant to vote for the DPP. However, winning will still depend on the preferences of swing voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950843,
+        "fields": {
+            "answer": 1950838,
+            "candidate": 2001591,
+            "answer_feedback": "Mayor Hou, you and your supporters sincerely hope for your victory.They hope you can address Taiwan's public safety and fraud issues!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950845,
+        "fields": {
+            "answer": 1950839,
+            "candidate": 2001591,
+            "answer_feedback": "This is a very ambitious goal, and if it involves amending the constitution, it will require bipartisan cooperation. But at least you have set a clear objective."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950847,
+        "fields": {
+            "answer": 1950840,
+            "candidate": 2001591,
+            "answer_feedback": "Over 80% of Taiwanese people support the death penalty, while the DPP has been ambiguous on this issue, reducing the number of executions. Ko believes that if the death penalty is to be abolished, life imprisonment must be maintained."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950849,
+        "fields": {
+            "answer": 1950841,
+            "candidate": 2001591,
+            "answer_feedback": "This will rally your deep-blue supporters and boost their voter turnout. Hopefully, on the anniversary of Mr. Chiang Ching-kuo's passing, you can achieve victory!\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950854,
+        "fields": {
+            "answer": 1950852,
+            "candidate": 2001591,
+            "answer_feedback": "\nWhether it's good or bad, this highlights internal divisions and ideological issues within the Kuomintang. Hopefully, this won't cause you too much harm."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950856,
+        "fields": {
+            "answer": 1950853,
+            "candidate": 2001591,
+            "answer_feedback": "As a light-blue presidential candidate, attacking our only former president is a very serious matter. You may risk losing some core support base votes. Is it really worth it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950859,
+        "fields": {
+            "answer": 1950858,
+            "candidate": 2001591,
+            "answer_feedback": "\nWhile this avoids the emergence of internal party disputes, it may lead to disapproval from the moderate voters. Hopefully, your base is solid enough."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950867,
+        "fields": {
+            "answer": 1950866,
+            "candidate": 2001591,
+            "answer_feedback": "After the final campaign event with our native friends, you had a good night's sleep and am ready to cast you vote tomorrow."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950868,
+        "fields": {
+            "answer": 1950865,
+            "candidate": 2001591,
+            "answer_feedback": "In Taoyuan, you have connected well with the Hakka community, strengthening your support base. Best of luck to you in tomorrow's election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950869,
+        "fields": {
+            "answer": 1950864,
+            "candidate": 2001591,
+            "answer_feedback": "If Lai Ching-te were to fall from grace over one thing, it would be the loss of his stronghold. You and Zhao Shao-kang have delivered speeches in Tainan and Kaohsiung using Taiwanese, snatching away votes!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950870,
+        "fields": {
+            "answer": 1950863,
+            "candidate": 2001591,
+            "answer_feedback": "\nStrengthening your own stronghold is always a good move. New Taipei City is an enormously important vote bank, equivalent to four Changhua Counties. Any presidential candidate cannot afford to lose here."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950894,
+        "fields": {
+            "answer": 1950891,
+            "candidate": 2001591,
+            "answer_feedback": "\nHe can attract many young votes for you; however, since he formed an alliance with the KMT, some of the lightly green-leaning young people have distanced themselves from him. He cannot transfer all of his votes to you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950895,
+        "fields": {
+            "answer": 1950892,
+            "candidate": 2001591,
+            "answer_feedback": "At present, you are leading in the polls, but you must be cautious about unforeseen events. It's best not to make significant moves at this time!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950896,
+        "fields": {
+            "answer": 1950893,
+            "candidate": 2001591,
+            "answer_feedback": "To achieve this alliance, you must accept some of the TPP's political positions and reform demands. If this is the collective will of the Taiwanese people, then you will be elected on January 13 next year."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950905,
+        "fields": {
+            "answer": 1950903,
+            "candidate": 2001591,
+            "answer_feedback": "In the last presidential election, the Democratic Progressive Party (DPP) secured 8.17 million votes. Can you, with the consensus of the majority of the Taiwanese people, surpass this historical record?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950907,
+        "fields": {
+            "answer": 1950902,
+            "candidate": 2001591,
+            "answer_feedback": "The checks and balances between political parties could be the optimal way to ensure a democratic system, but the downside is that your governance may face constraints.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950908,
+        "fields": {
+            "answer": 1950901,
+            "candidate": 2001591,
+            "answer_feedback": "The Parliamentary system is indeed a challenging goal. Even if you win, amending the constitution or pushing through extensive reforms will require cooperation from the DPP. Gaining more seats in the parliament becomes crucial in this context.\n\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950916,
+        "fields": {
+            "answer": 1950912,
+            "candidate": 2001591,
+            "answer_feedback": "Lai Ching-te may be a flip-flopper, but you have to understand that his base will tolerate him no matter what. The room for maneuvering among the swing voters in the center has diminished considerably."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950918,
+        "fields": {
+            "answer": 1950913,
+            "candidate": 2001591,
+            "answer_feedback": "This is a direct confrontation between the blue and green camps, and we hope you can emerge victorious here!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950922,
+        "fields": {
+            "answer": 1950914,
+            "candidate": 2001591,
+            "answer_feedback": "This will weaken the DPP's red-baiting tactics against you and help restore the KMT's anti-communist image. Moreover, being a true local, your Taiwan-centric image is even stronger than that of Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950923,
+        "fields": {
+            "answer": 1950915,
+            "candidate": 2001591,
+            "answer_feedback": "Lai Ching-te also comes from a humble background; however, his current image carries more of an elite vibe, while you appear similar to an ordinary uncle on the street.\n"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950929,
+        "fields": {
+            "answer": 1950928,
+            "candidate": 2001591,
+            "answer_feedback": "The current lead you have in the polls may easily disappear due to scandals or failed strategies; public opinion is fluid, so proceed with caution!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950937,
+        "fields": {
+            "answer": 1950936,
+            "candidate": 2001591,
+            "answer_feedback": "Guo is definitely trailing in this election, and your appeal to his voters will not be ignored!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950940,
+        "fields": {
+            "answer": 1950935,
+            "candidate": 2001591,
+            "answer_feedback": "Although some in the TPP doubt whether you are only aiming to defeat Ko Wen-je and secure the second position, rather than focusing on attacking Lai Ching-te, the votes are likely to flow significantly between opposition parties."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950943,
+        "fields": {
+            "answer": 1950934,
+            "candidate": 2001591,
+            "answer_feedback": "Lai Ching-te may be a flip-flopper, but you have to understand that his base will tolerate him no matter what. The room for maneuvering among the swing voters in the center has diminished considerably."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950947,
+        "fields": {
+            "answer": 1950946,
+            "candidate": 2001591,
+            "answer_feedback": "\nHe indeed cannot win this election, so the hope for the Pan-Blue Coalition's victory lies here: whoever can secure the support of Terry Gou's voters will be able to win!"
+        }
+    }
+]
+
+cyoAdventure = function (a) {
+    ans = campaignTrail_temp.player_answers[campaignTrail_temp.player_answers.length-1];
+    if (ans == 13019 || 13020 || 13021 ){
+        campaignTrail_temp.election_json[0]["fields"].advisor_url = "https://i.imgur.com/BZlgvel.jpeg";
+    }
+    if (ans == 1950388 ){
+        campaignTrail_temp.questions_json[2] = {
+            "model": "campaign_trail.question",
+            "pk": 1950398,
+            "fields": {
+              "priority": 1,
+              "description": "Since you have withdrawn from the primary and essentially paved the way for Terry Gou to secure the presidential candidate position, how do you plan to support him in the upcoming electoral campaign?",
+              "likelihood": 1
+            }
+          }
+        }
+        if (ans == 1950399 ){
+            campaignTrail_temp.candidate_json[2]["fields"].first_name = "";
+            campaignTrail_temp.candidate_json[2]["fields"].last_name = "Terry Gou";
+            campaignTrail_temp.candidate_json[6]["fields"].last_name = "None";
+            campaignTrail_temp.candidate_last_name = 'Terry Gou';
+            campaignTrail_temp.candidate_image_url = 'https://www.foxconn.com/img/about/group-profile/founder-m.png?5f65a';
+            campaignTrail_temp.running_mate_image_url = 'https://img.ltn.com.tw/Upload/news/600/2015/10/07/phpbfQCOW.jpg';
+            campaignTrail_temp.running_mate_last_name = 'Hong Xiuzhu';
+            campaignTrail_temp.question_number = 28;
+            campaignTrail_temp.questions_json[29] = {
+                "model": "campaign_trail.question",
+                "pk": 1950411,
+                "fields": {
+                  "priority": 1,
+                  "description": "Today is the last day before the election, and your polls have been consistently declining since your nomination. The deadlock with Ko Wen-je and the lead by Lai Ching-te have not been broken, and the situation persists until the registration of presidential candidates in November. There are hardly any person willing to be your vice president, until Hong Xiu-Zhu, whose nomination was abolished in 2016, volunteered. It is only then that you have a vice presidential candidate to appear on the ballot. On the final day before the election, where do you plan to conduct your campaign activities?",
+                  "likelihood": 1
+                }
+              }
+        }
+        if (ans == 1950400 ){
+            campaignTrail_temp.candidate_json[2]["fields"].first_name = "";
+            campaignTrail_temp.candidate_json[2]["fields"].last_name = "Terry Gou";
+            campaignTrail_temp.candidate_json[6]["fields"].last_name = "None";
+            campaignTrail_temp.candidate_last_name = 'Terry Gou';
+            campaignTrail_temp.candidate_image_url = 'https://www.foxconn.com/img/about/group-profile/founder-m.png?5f65a';
+            campaignTrail_temp.running_mate_image_url = 'https://i.imgur.com/ZmWU9KE.png';
+            campaignTrail_temp.running_mate_last_name = 'Lai Pei-hsia';
+            campaignTrail_temp.question_number = 28;
+            campaignTrail_temp.questions_json[29] = {
+                "model": "campaign_trail.question",
+                "pk": 1950424,
+                "fields": {
+                  "priority": 1,
+                  "description": "Today is the last day before the election, On the final day before the election,  According to the latest polls conducted 10 days before the election, your and Lai Ching-te's approval ratings are within the margin of error. In other words, the presidential position hinges on a difference of just 500,000 votes.where do you plan to conduct your campaign activities?",
+                  "likelihood": 1
+                }
+              }
+        }      
+        if (ans == 1950740 ){
+            campaignTrail_temp.questions_json[27] = {
+                "model": "campaign_trail.question",
+                "pk": 1950933,
+                "fields": {
+                  "priority": 1,
+                  "description": "This year's presidential debate has an unprecedented presence of four presidential candidates: yourself, Lai Ching-te, Ko Wen-je, and the former Chairman of Hon Hai Precision Industry, Terry Gou, who does not support you. In this year's presidential debate, what main points do you want to convey?                  ",
+                  "likelihood": 1
+                }
+              }
+        }
+        
+        if (ans == 1950751 || ans == 1950755 ){
+            campaignTrail_temp.running_mate_image_url = 'https://i.imgur.com/W8ycwUr.png';
+            campaignTrail_temp.running_mate_last_name = 'Zhao';
+        }
+        //蓝白合
+        if (ans == 1950688 || ans == 1950691 ){
+            campaignTrail_temp.running_mate_image_url = 'https://i.imgur.com/3fQuylW.jpeg';
+            campaignTrail_temp.running_mate_last_name = 'Ko';  
+            campaignTrail_temp.questions_json[21] = {
+                "model": "campaign_trail.question",
+                "pk": 1950890,
+                "fields": {
+                  "priority": 1,
+                  "description": "With the formation of the Joint Tickets, Ko Wen-je has officially become your vice president, marking a political tornado in Taiwan. It's highly likely that Lai Ching-te will lose the presidential position. On the day of the presidential candidate registration, what capabilities of Ko Wen-je would you like to highlight?",
+                  "likelihood": 1
+                }
+              },
+              campaignTrail_temp.questions_json[22] = {
+                "model": "campaign_trail.question",
+                "pk": 1950927,
+                "fields": {
+                  "priority": 1,
+                  "description": "Now, you are in a one-on-one battle with Lai Ching-te in the later stages of the election. Polls indicate that you currently have a lead by several percentage points, but this could be lost due to inappropriate campaign strategies or visiting mistakes. We must stabilize our current position!",
+                  "likelihood": 1
+                }
+              },
+              campaignTrail_temp.questions_json[23] = {
+                "model": "campaign_trail.question",
+                "pk": 1950900,
+                "fields": {
+                  "priority": 1,
+                  "description": "In order to achieve cooperation between the blue and white camps, the cost you have to pay is to accept some reform demands and positions of the TPP. Among these proposals, which ones do you favor more and consider most likely to reach an agreement?                  ",
+                  "likelihood": 1
+                }
+              },
+              campaignTrail_temp.questions_json[27] = {
+                "model": "campaign_trail.question",
+                "pk": 1950911,
+                "fields": {
+                  "priority": 1,
+                  "description": "In this presidential election, facing a one-on-one debate with Lai Ching-te, although you are widely regarded as not the most eloquent, and even your proficiency in Mandarin is limited, your grassroots image in stark contrast to Lai Ching-te's elite image creates a strong juxtaposition. In the debate, what content do you want to emphasize?",
+                  "likelihood": 1
+                }
+              }                   
+        }     
+               
+        let pop_vote = e.current_results[0];
+        let playerPolling = (pop_vote.find(p => p.pk === e.candidate_id)).pvp;
+        let i = 0;
+
+        pop_vote.sort((a, b) => {
+            return a.pk - b.pk;
+        });
+        //侯输
+         if (e.player_answers.includes(1950671) || e.player_answers.includes(1950670) && playerPolling < pop_vote[1].pvp ){
+            campaignTrail_temp.questions_json[20] = {
+              "model": "campaign_trail.question",
+              "pk": 1950034,
+              "fields": {
+                "priority": 1,
+                "description": "On November 15th, waking up in the morning, Taiwan's media and political circles were shocked by a piece of news: KMT-TPP has confirmed the formation of a joint ticket, endorsing a single presidential candidate. This is expected to severely impact Lai Ching-te's support. Chairman Zhu, Mayor Hou, former President Ma, and Chairman Ko have reached an agreement to introduce a set of candidates using the cumulative results of previous polls. This is considered a very intense competition... but due to the selection of fixed-time polls, your current efforts may not be of much use...The final results will be announced on the 18th.",
+                "likelihood": 1
+              }
+            }
+           }
+            //侯胜/侯平
+        if (e.player_answers.includes(1950671) || e.player_answers.includes(1950670) && playerPolling >= pop_vote[2].pvp ){
+          campaignTrail_temp.questions_json[20] = {
+            "model": "campaign_trail.question",
+            "pk": 1950687,
+            "fields": {
+              "priority": 1,
+              "description": "On November 15th, waking up in the morning, Taiwan's media and political circles were shocked by a piece of news: KMT-TPP has confirmed the formation of a joint ticket, endorsing a single presidential candidate. This is expected to severely impact Lai Ching-te's support. Chairman Zhu, Mayor Hou, former President Ma, and Chairman Ko have reached an agreement to introduce a set of candidates using the cumulative results of previous polls. The terms include a provision that, if the polls fall within the margin of error, it will be considered a victory for Hou You-yi. This is widely seen as a sign that Hou You-yi is likely to win. The final results will be announced on the 18th.",
+              "likelihood": 1
+            }
+          }
+         }
+                //赵子龙
+                getResults = function (out, totv, aa, quickstats) {
+                    if( aa[0].candidate === 2001591 && aa[2].candidate === 2001622 && aa[1].candidate === 2001557 && e.player_answers.includes(1950537) && e.player_answers.includes(1950611) && e.player_answers.includes(1950764)) {
+                        unlockAchievement("Three Kingdom Romance");
+                          }
+                         }
+                    //三民主义
+                        getResults = function (out, totv, aa, quickstats) {
+                       if( aa[0].candidate === 2001591 && e.player_answers.includes(1950647) && e.player_answers.includes(1950740)) {
+                           unlockAchievement("Three Principles of People");
+                             }
+                            }
+                       //果冻获胜
+                        getResults = function (out, totv, aa, quickstats) {
+                       if( aa[0].candidate === 2001591 && e.player_answers.includes(1950388) && e.player_answers.includes(1950400)){
+                           unlockAchievement("New Taipei Has A Mayor");
+                             }
+                            }
+                        //嘉义之子
+                        getResults = function (out, totv, aa, quickstats) {
+                            let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 256);
+                            let stateResulttwo = campaignTrail_temp.final_state_results.find((x) => x.state == 257);
+                            let stateResultthree = campaignTrail_temp.final_state_results.find((x) => x.state == 267);
+                        if( aa[0].candidate === 2001591 && stateResult.result[0].candidate == 2001591 && stateResulttwo.result[0].candidate == 2001591 && stateResultthree.result[0].candidate == 2001591) {
+                            unlockAchievement("Chiayi favorite son");
+                        }
+                    }
+                 //主流民意获胜
+                 getResults = function (out, totv, aa, quickstats) {
+                                if( aa[0].candidate === 2001591 && quickstats[1] > 59.9) {
+                                    unlockAchievement("Main Stream Opinion Wins");
+                                }
+                            }
+                 //南部孩子回家了
+                 getResults = function (out, totv, aa, quickstats) {
+                    let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 256);
+                    let stateResulttwo = campaignTrail_temp.final_state_results.find((x) => x.state == 257);
+                    let stateResultthree = campaignTrail_temp.final_state_results.find((x) => x.state == 259);
+                    let stateResultfour = campaignTrail_temp.final_state_results.find((x) => x.state == 260);
+                    let stateResultfive = campaignTrail_temp.final_state_results.find((x) => x.state == 263);
+                    let stateResultsix = campaignTrail_temp.final_state_results.find((x) => x.state == 253);
+                    
+                    if( aa[0].candidate === 2001591 && stateResult.result[0].candidate == 2001591 && stateResulttwo.result[0].candidate == 2001591 && stateResultthree.result[0].candidate == 2001591 && stateResultfour.result[0].candidate == 2001591 && stateResultfive.result[0].candidate == 2001591 && stateResultsix.result[0].candidate == 2001591) {
+                        unlockAchievement("Southern Boys Returning Home");
+                    }
+                }
+            
+                getResults = function (out, totv, aa, quickstats) {
+                    if( aa[1].candidate === 2001591 && quickstats[1] < 31.04) {
+                        unlockAchievement("Challenge the Bottom Line");
+                    }
+                }
+    //各党标题
+    if ( ans == 1950012 || ans == 1950013 || ans == 1950014 ){    
+        nct_stuff.themes[nct_stuff.selectedTheme].coloring_window = "#f4f4ee" 
+        nct_stuff.themes[nct_stuff.selectedTheme].coloring_title = "#13366e" 
+        $(".container")[0].style.backgroundColor = "#6848ff" 
+        $("#game_window")[0].style.borderColor = "#99A0A8" 
+        $(".container")[0].style.backgroundColor = "#F4F4EE" 
+        $("#game_window")[0].style.borderColor = "#f4f4ee" 
+        $("#game_window")[0].style.backgroundImage = "url(https://imgur.com/3praAwi.jpg)" 
+        document.getElementById("header").src = "https://i.imgur.com/I7YpjTe.jpeg" 
+        document.body.background = "https://i.imgur.com/EvtXFUE.jpeg"
+    }
+    //破局换成侯康
+    if ( ans == 1950751 || ans == 1950755){    
+        document.body.background = "https://i.imgur.com/cknN16g.jpg"
+    }
+    //2004噩梦
+    getResults = function (out, totv, aa, quickstats) {
+        if( aa[0].candidate === 2001557 && aa[1].candidate === 2001591 && quickstats[1] <= 50.12 && quickstats[1] >= 49.88 ) {
+            unlockAchievement("2004 The Nightmare KMT ONLY");
+        }
+    }
+    }
+
+  
+
+campaignTrail_temp.jet_data = [{}
+]
+
+campaignTrail_temp.candidate_image_url = "https://i.imgur.com/GCeTdoX.png";
+campaignTrail_temp.running_mate_image_url = "https://i.imgur.com/KLN8hlP.jpeg";
+campaignTrail_temp.candidate_last_name = "Hou";
+campaignTrail_temp.running_mate_last_name = "For KMT 2024";
+campaignTrail_temp.running_mate_state_id = '265';
+campaignTrail_temp.player_answers = [];
+campaignTrail_temp.player_visits = [];
+campaignTrail_temp.answer_feedback_flg = 1;
+campaignTrail_temp.game_start_logging_id = '3660822';
+
+const style_overwrite = document.createElement("style");
+style_overwrite.innerHTML = 
+`#campaign_sign {
+  background-color: #13366e;
+  border-color: #b22525;
+}
+#menu_container {
+  background-color: #c3c3c3;
+}
+#overall_result_container {
+  background-color: #c3c3c3;
+}
+#state_info h3 {
+  background-color: #ffffff;
+}
+#overall_result h3 {
+  background-color: #ffffff;
+}`
+;
+document.head.appendChild(style_overwrite);
+
+
+let style = document.createElement('style');
+style.type = 'text/css';
+style.id = 'dynamic-style';
+
+style.innerHTML = `
+  .inner_window_question h3 {
+    background-color: #e1e1e1;
+  }
+  .overlay_window h3 {
+    background-color: #b4b4b4;
+  }
+`;
+
+document.head.appendChild(style);
+
+
+function checkIfCanAddMap() {
+    map = document.getElementById("map_container");
+    
+    if(map) {
+        map.style.backgroundImage = "url('https://images.rawpixel.com/image_800/czNmcy1wcml2YXRlL3Jhd3BpeGVsX2ltYWdlcy93ZWJzaXRlX2NvbnRlbnQvbHIvdjk5Ni0wMDlfMS1rcm9pcjRkay5qcGc.jpg')"; 
+    }
+}
+
+setInterval(checkIfCanAddMap, 250);
+
+(function(e, t, n, r, i) {
+    function s(e, t, n, r) {
+        r = r instanceof Array ? r : [];
+        var i = {};
+        for (var s = 0; s < r.length; s++) {
+            i[r[s]] = true
+        }
+        var o = function(e) {
+            this.element = e
+        };
+        o.prototype = n;
+        e.fn[t] = function() {
+            var n = arguments;
+            var r = this;
+            this.each(function() {
+                var s = e(this);
+                var u = s.data("plugin-" + t);
+                if (!u) {
+                    u = new o(s);
+                    s.data("plugin-" + t, u);
+                    if (u._init) {
+                        u._init.apply(u, n)
+                    }
+                } else if (typeof n[0] == "string" && n[0].charAt(0) != "_" && typeof u[n[0]] == "function") {
+                    var a = Array.prototype.slice.call(n, 1);
+                    var f = u[n[0]].apply(u, a);
+                    if (n[0] in i) {
+                        r = f
+                    }
+                }
+            });
+            return r
+        }
+    }
+    var o = 1010,
+        u = 500,
+        a = 50;
+    var f = {
+        stateStyles: {
+            fill: "#333",
+            stroke: "#666",
+            "stroke-width": 1,
+            "stroke-linejoin": "round",
+            scale: [1, 1]
+        },
+        stateHoverStyles: {
+            fill: "#33c",
+            stroke: "#000",
+            scale: [1.1, 1.1]
+        },
+        stateHoverAnimation: 500,
+        stateSpecificStyles: {},
+        stateSpecificHoverStyles: {},
+        click: null,
+        mouseover: null,
+        mouseout: null,
+        clickState: {},
+        mouseoverState: {},
+        mouseoutState: {},
+        showLabels: true,
+        labelWidth: 20,
+        labelHeight: 15,
+        labelGap: 6,
+        labelRadius: 3,
+        labelBackingStyles: {
+            fill: "#333",
+            stroke: "#666",
+            "stroke-width": 1,
+            "stroke-linejoin": "round",
+            scale: [1, 1]
+        },
+        labelBackingHoverStyles: {
+            fill: "#33c",
+            stroke: "#000"
+        },
+        stateSpecificLabelBackingStyles: {},
+        stateSpecificLabelBackingHoverStyles: {},
+        labelTextStyles: {
+            fill: "#fff",
+            stroke: "none",
+            "font-weight": 300,
+            "stroke-width": 0,
+            "font-size": "10px"
+        },
+        labelTextHoverStyles: {},
+        stateSpecificLabelTextStyles: {},
+        stateSpecificLabelTextHoverStyles: {}
+    };
+    var l = {
+        _init: function(t) {
+            this.options = {};
+            e.extend(this.options, f, t);
+            var n = this.element.width();
+            var i = this.element.height();
+            var s = this.element.width() / o;
+            var l = this.element.height() / u;
+            this.scale = Math.min(s, l);
+            this.labelAreaWidth = Math.ceil(a / this.scale);
+            var c = o + Math.max(0, this.labelAreaWidth - a);
+            this.paper = r(this.element.get(0), c, u);
+            this.paper.setSize(n, i);
+            this.paper.setViewBox(-500, 0, c, u, false);
+            this.stateHitAreas = {};
+            this.stateShapes = {};
+            this.topShape = null;
+            this._initCreateStates();
+            this.labelShapes = {};
+            this.labelTexts = {};
+            this.labelHitAreas = {};
+            if (this.options.showLabels) {
+                this._initCreateLabels()
+            }
+        },
+        _initCreateStates: function() {
+            var t = this.options.stateStyles;
+            var n = this.paper;
+            var r = {
+                Tainancity:"m178.94 309.54c1.821 0.85976 1.9013 1.8004 3.9722 1.3601 0.52002 1.6719-1.5712 1.0502-1.4009 2.6113 0.8704 0.21983 2.3913 0.20091 2.5009 1.2003 2.4514 1.3001-0.0196 1.501 0.46065 3.6413 2.191-0.12068 3.2917 1.4299 5.2733 1.8898 0.13963 1.4005-0.8306 1.1807-1.6207 1.8011-1.0903 0.85976-1.1105 1.2309-1.181 2.6706-0.0698 1.411-0.89063 5.8318 0.97023 6.032 0.0496 0.85128 0.0496 1.7515 0 2.6008-0.82081 0.37966-1.1705 1.4814-1.1105 2.3405 0.5807 0.0202 1.2006 0.03 1.7806 0.06 0.17029 0.33986 0.2897 0.71103 0.39083 1.0607 1.7114-0.20939 1.8902 1.5512 3.2813 1.8904 0.16051-0.81019 1.3415-1.1305 1.7219-0.3503 0.0692 0 0.55983-0.0104 0.61072 0 0.84039-1.4103 2.5114-1.3803 2.8611-3.2414 0.73077 1.1709 1.2312 1.6308 2.6314 1.7411 1.4909 0.10959 2.4716-0.39988 3.8418-0.0998 0.76079 1.1598 1.6618 0.69994 1.8817-0.36074 0.39931 0.31051 0.63942 0.76061 0.63029 1.3007-0.15986 0.0398-0.30014 0-0.45021 0.06-0.12984 1.3803-0.89063 1.4599-1.6501 2.4606-0.97023 1.2694-0.14094 1.9498-0.3804 3.1696-0.3308 1.6608-3.2924 3.1214-4.3331 4.6817-1.5007 2.2616-2.7815 3.6608-3.7217 6.3217-0.85083 2.4208-1.6612 4.5519-3.9122 5.5415-2.3711 1.0496-3.1919 3.0013-4.8727 4.8018-0.71055 0.74886-1.9209 1.7593-2.8317 2.1696-1.4204 0.63993-2.4814 0.69081-3.1815 2.3412-0.21009 0.50098-0.16051 1.4899-0.4502 1.8611-0.53047 0.68038-0.94022 0.39009-1.581 0.75996-1.0707 0.62036-1.4707 1.6112-2.281 2.6217-1.0505 1.291-1.0603 2.12-1.6906 3.5917-0.52068 1.2303-1.5509 2.2799-2.2915 3.3706-0.74056 1.0711-1.4707 2.1814-2.0312 3.1312-0.46065 0.77953 0.15007 1.1905-0.97088 1.3197-0.79015 0.0998-1.1705-0.12916-1.0603-0.96936-0.64008-0.0307-1.3108-0.0307-1.9509 0-1.2006 1.4703-2.7515 1.5004-4.0323 2.7711-1.0707 1.0705-0.46065 1.2303-2.0011 1.5695-0.89062 0.21005-2.3809 0.51991-2.1812-0.84019-1.8008-0.15982-3.432-0.77039-5.4827-0.69081-1.3604 0.0502-3.862-0.33008-4.8531 0.43053-1.3708-0.99153-4.3024-0.48011-4.8524-2.9113-1.641 0.95044-6.023-1.3503-7.784 0.42923-0.26034-1.9707-0.0803-4.4417-0.65052-5.7913-0.99045-2.3803-1.2103-4.501-3.1619-6.2114-2.0612-1.8102-4.8929-2.9609-6.513-5.122-1.4009-1.8806-2.9916-3.0216-5.3731-3.8415-5.5428-1.9009-6.4536-7.8024-2.5009-11.954 1.1608-1.2198 1.4811-1.2603 1.5007-3.2107 0.01-1.4606-0.20031-3.1207 0.15985-4.501 0.63029-2.3901 3.1521-3.9714 4.0225-6.3817 0.98067-2.7208-0.42019-5.6817 0.86062-8.4522 0.65051-1.4005 0.52002-2.7606 0.97022-4.1612 0.35038-1.1305 0.68053-0.7306 1.331-1.6308 0.52002-0.72016 0.39018-0.96087 0.49001-1.8813 0.21009-1.9198 0.97022-2.3601 1.7806-3.7815 1.4609 0.61123 2.4911 1.8709 4.0323 2.3008 0.1703 0.8702 0.81037 1.561 1.0603 2.4508 0.51024-0.0404 1.0903 0.09 1.611 0.0502 0.15007 1.9707 3.6819 4.7417 3.5618 1.1598 0.2499 0.3503 0.49001 0.45989 0.6603 0.96935 0.77057 0.0802 1.6012 1.1814 2.3111 1.0202 0.50045-0.11025 0.80059-1.1814 1.1608-1.6713 0.86062-1.1807 2.1108-1.7711 2.3613-3.4704 1.4211-1.5701 4.8028 0.42988 4.2822-2.8311-1.121-0.58122-0.30014-1.8513 0.65052-1.9113 0.98066-0.06 1.271 1.1403 2.6914 0.55121-0.30993-1.3614-1.2808-2.4221 0.31058-3.5512 1.4811-1.0405 2.8513 0.25897 2.7417-2.261 0.84038 0.0404 1.731 0.27006 2.6412 0.14025 1.5405-0.21984 0.94022-0.34965 1.9907-1.3001 1.3806-1.261 3.1521-1.0907 5.013-1.3705 1.611-0.24005 2.9316-1.0007 4.6626-1.0007 1.4707 0 3.9618 1.1102 5.0025-0.34965 0.97936 0.81476 2.5198 1.3144 3.6708 1.8546z",
+                Kaohsiungcity:"m156.17 440.89c0.0502 0.35029 0.20031 0.66993 0.12984 1.0502-0.0803-0.0111-0.15985 0-0.23032-0.0111-0.27991-0.50033-0.60027-0.33986-1.0309-0.58905-0.39996-0.24006-0.4502-0.63014-0.67009-0.96152-0.44042-0.67973-1.1105-1.3301-1.6312-1.9498-1.0707-1.291-2.0612-2.6908-3.0516-4.002-0.20031-0.27006-0.29035-0.8004-0.56047-0.93021-0.0202-0.06 0.01-0.12003-0.0202-0.17026-0.2499-0.34964-0.93043-0.3803-1.2404-0.63993 0.48022-0.15916 1.1608-0.0691 1.6808-0.0489-0.0202 0.17874 0.0803 0.30007 0.0803 0.47881 0.73077-0.0998 0.16051 0.93086 0.85083 0.96152 0.0202 0.0489-0.0104 0.12916 0.0202 0.17026 0.16964 0.14938 0.42998 0.17873 0.57026 0.30007 0.13963 0.12981 0.2897 0.47032 0.42998 0.63014 0.4502 0.49055 0.67009 0.78018 0.93043 1.3307 0.10961 0.2394 0.18986 0.5199 0.39017 0.72995 0.23033 0.24984 0.45021 0.2805 0.66031 0.47033 0.39018 0.36986 0.55068 0.78996 1.0603 1.06 0.12984 0.51012 0.52002 1.1103 0.78035 1.5408 0.0503 0.01 0.0998 0.01 0.15986 0.0196 0.0515 0.37052 0.29166 0.62036 0.69162 0.56035zm102.79-136.88c-0.15007 0-0.25968 0.0104-0.27012 0.0496-0.24011 0.69082-0.0502 1.1409 0.77057 1.3307 0.30992 1.6406 0.55982 2.8402 0.33994 4.6113-1.5203 0.24984-4.1014-0.3503-4.3226 1.5395-0.03 0.28116 0.51023 0.45011 0.51023 0.82063 0 0.77952-0.28969 0.71038-0.47043 1.2101-0.35038 0.93934-0.79014 1.5401-0.67009 2.6002 1.8015-0.20092 1.0309 0.68037 2.0109 1.3307 0.79015 0.53947 1.8413 0.33986 2.7717 0.39009-0.0692 0.3503 0.20096 0.81019 0.19052 1.0705 1.4609-0.61057 3.342 2.9113 3.1417 4.0412-1.0205 0.36987-1.1705 1.0705-0.95065 1.7704-0.8704 0.52056-2.052 0.29029-2.9818 0.6308-1.2006 0.42988-2.0409 1.3803-3.2115 1.9302-1.331 0.61122-2.4716 0.88129-3.832 1.2009-1.731 0.41031-2.2615 1.1507-3.3315 2.3412-0.7497 0.8291-1.4511 2.291-2.3411 2.9609-0.82929 0.61906-2.7012 0.25897-3.3113 1.2303-0.57026 0.92043 0.14028 3.2114-0.0202 4.3106-0.0698 0.54012-0.45021 0.92043-0.5011 1.4906-0.06 0.75996 0.29035 1.4514 0.17095 2.1703-0.28056 1.6204-1.6716 1.2616-2.3515 2.6608-0.30014 0.63014 0.21009 1.1807-0.35038 1.8011-0.39018 0.42075-1.4211 0.53034-1.9411 0.57013-0.27012 1.03 0.81037 1.291 1.611 1.5004 0.14028 2.6504 0.4104 5.9629-0.0998 8.5135-0.1703 0.91912-0.77057 2.0294-1.3604 2.8311-0.47043 0.63928-0.88997 0.75996-1.0498 1.5904-0.2101 1.0907 0.21988 0.88128 0.54025 1.5316 0.33015 0.66929 1.7604 2.621 0.96044 3.4808-0.89063 0.96087-2.9414-0.47098-3.462 1.1898-0.44108 1.4103 1.3108 2.0711 0.30013 3.6308-0.6205 0.95044-2.2419 1.6406-3.0118 2.4208-1.9809 2.0105-3.1514 6.702-1.6005 9.2728 0.24011-0.0189 0.55982 0.0802 0.79014 0.0502 0.53046 1.3999-0.06 3.1312 0.18009 4.6322 0.27012 1.6608 2.1212 2.0796 2.0305 3.651 1.9711-0.24005 1.7408 0.76061 1.8315 2.3308 2.0305 0.0189 1.3911 1.0705 0.28056 1.6497-0.0502-0.12916-0.11027-0.2394-0.18008-0.3503-0.74056-1.0796-3.5012-2.3901-4.7924-2.2799-1.4609 0.12916-2.3215 1.1298-3.5116 1.6797-1.2103 0.56035-2.1714 0.19048-2.0214 2.1409-2.251 0.10959-4.1125-0.60079-4.5021-3.1214-1.641-1.0705-2.9218-2.3105-4.8126-3.0209-1.1307-0.4201-1.7206-0.54012-2.9916-0.33007-1.2404 0.20091-1.5007 0.60013-2.4716 1.0202-0.30014 0.8702-1.4909 1.7293-2.071 2.5408-2.0011-2.0907-2.8122-4.2303-5.9936-3.561-1.38 0.28963-2.4409 1.2205-3.8013 1.7-1.1307 0.39074-2.9224 0.27006-3.8431 1.0802-0.90042 0.79062-1.0309 1.9707-1.8308 2.7104-0.71055 0.64972-1.791 1.9204-2.6314 2.3803-2.0312 1.1005-5.9232 0.28898-7.724-0.50098-1.0505-0.46054-2.3913-0.88064-3.6519-0.55056-1.5712 0.4214-1.4309 1.1703-1.3408 2.8409 0.0502 0.91064 0.73012 3.1996 0.33994 4.0014-0.45999 0.93021-1.1705 0.17874-1.6808 0.77887-0.35038 0.41097-0.15986 1.4814-0.15986 2.0516 0.01 2.7815 0 5.5617 0 8.3321 0 1.2101 0.2499 2.9309-0.36995 3.972-0.84038 1.4097-1.4707 1.079-1.4609 3.1996v4.3327c0 1.5604-0.39996 2.3706-0.68053 3.6602-0.58005 2.7815 0.28057 5.4221 0.64008 8.0118 0.18008 1.2407 0.39018 2.7411 0.2101 4.0014-0.32037 2.1514-1.2606 1.0007-2.3411 2.1709-1.3604 1.4814-0.50045 6.3817-0.50045 8.3321v0.21005c-0.92064-0.63993-1.301-0.42141-2.6614-0.54013-2.4213-0.23092-3.0118-2.5806-5.043-3.6308-1.4211-0.72995-2.1316-0.82911-3.2519-1.9107-0.96044-0.93086-2.4416-2.2009-3.2617-3.1918-0.2499-0.52055-0.8704-1.291-1.4309-1.5206 0.11027-0.53034 0.39018-0.50034 0.93043-0.47033 0.01 0.06 0 0.11024 0.0202 0.15982 0.03 0.0104 0.0698 0.0196 0.0998 0.03 0.0502 0.18982 0.15986 0.2805 0.2101 0.47032 0.2499 0.11024 0.69032 0.21005 0.86061 0.3914 0.24011 0.2394 0.2101 0.69994 0.50045 0.85911 0.28056 0.15982 0.91085-0.0189 1.1908-0.0496 0.46065-0.0404 0.72034 0.0404 1.181 0.14025 0.0104 0.69929 0.90041 0.25049 1.2508 0.7306 0.15007-0.97066-1.2208-1.2407-1.8713-1.7006-0.33994-0.24005-0.82016-0.45988-1.1105-0.74038-0.39997-0.39075-0.36995-0.78997-0.57026-1.2401-0.40976-0.8702-1.7108-0.54012-2.3809-1.3105-0.38039-0.42988-0.24011-0.88064-0.5807-1.3001-0.25968-0.33008-0.71054-0.60014-0.99045-0.93935-0.30993-0.36986-0.75035-0.66993-1.1307-1.0111-0.42019-0.39074-0.7001-0.91064-1.0303-1.3797-0.61071-0.83041-1.2006-1.6504-2.0116-2.231 0.42019-0.0307 1.331-0.17091 1.6912 0.03 0.40975 0.23027 0.36995 0.93086 0.55982 1.3803 0.38039 0.17026 1.4106 0.63015 1.3708 1.06 0.81037 0-0.35038-1.1011-0.56048-1.1898-0.19052-0.42075-0.23032-0.82975-0.49-1.1703-0.25969-0.33072-0.61007-0.48011-0.82995-0.86041-0.2499-0.44945-0.23032-0.57992-0.80058-0.84998-0.46-0.22048-0.86062-0.16047-1.3408-0.29028-0.81037-0.24006-1.5307-1.15-2.1714-1.6993-0.94021-0.81018-0.88084-1.3999-0.88084-2.6217v-2.1807c0-0.33073-0.0698-0.71038 0.1305-0.94 0.15985-0.19048 0.6603-0.23092 0.89062-0.42075 0.36017-0.31964 0.81037-1.06 0.91086-1.5206 0.15985-0.80105-0.29036-1-0.63029-1.6106-0.06-0.0307-0.12985-0.0496-0.18009-0.0698 0.39997-0.24984 0.70011 0.12981 0.96044 0.36073 0.40976 0.34965 0.47044 0.40966 1.1007 0.37965 0.0502-0.88976-0.0502-1.8891-0.38039-2.6706-0.97023-0.0907-0.88084 0.31051-1.1203 1.0405-0.50045 0.06-0.59049-1.3196-0.69032-1.73-0.16051-0.68103-0.74056-1.261-0.8704-1.9413-0.0698-0.39987 0.0698-0.77039-0.12984-1.1207-0.1703-0.30007-0.61072-0.45989-0.79015-0.75996-0.35037-0.61123 0.11027-1.2701-0.48022-1.8206 0.23033-1.4103-1.5307-2.2505-2.1616-3.1612-0.57026-0.82128-0.7001-1.6915-0.82995-2.6608-0.29035-2.0405-0.54024-1.5904-1.8713-2.9713-0.88084-0.91064-0.64008-1.3301-0.8306-2.6713-0.32036-2.2505-1.4811-4.1716-1.5105-6.4919-0.0202-2-0.53046-3.8911-1.3604-5.6517-1.1405-0.27006-1.581-1.4508-1.7806-2.9002 1.761-1.7802 6.1437 0.52055 7.784-0.42988 0.55003 2.4312 3.4816 1.9198 4.8524 2.9113 0.99046-0.76061 3.492-0.38031 4.8531-0.43054 2.0514-0.0796 3.6819 0.53034 5.4827 0.69147-0.20031 1.3601 1.2906 1.0496 2.1812 0.84019 1.5405-0.33986 0.93043-0.50098 2.0011-1.5701 1.2808-1.2707 2.8317-1.3007 4.0323-2.7711 0.64008-0.03 1.3108-0.03 1.9509 0-0.10962 0.84019 0.27012 1.0705 1.0603 0.97 1.121-0.12981 0.51023-0.54012 0.97088-1.3203 0.55982-0.94978 1.2906-2.06 2.0312-3.1312 0.74055-1.09 1.7708-2.1403 2.2915-3.3706 0.63029-1.471 0.64008-2.3008 1.6906-3.591 0.81037-1.0111 1.2103-2.0007 2.281-2.6223 0.64008-0.36922 1.0505-0.0796 1.5809-0.75996 0.29035-0.36922 0.24011-1.3601 0.45021-1.8611 0.7001-1.6504 1.761-1.7 3.1815-2.3405 0.91085-0.41031 2.1212-1.4214 2.8317-2.1703 1.6808-1.8011 2.5009-3.7515 4.8727-4.8018 2.251-0.99023 3.0614-3.1207 3.9122-5.5415 0.94021-2.6608 2.221-4.0614 3.7217-6.321 1.0407-1.561 4.0023-3.0216 4.3324-4.6824 0.24011-1.2198-0.58984-1.9002 0.38104-3.1696 0.76013-1.0007 1.5203-1.0802 1.6501-2.4606 0.15007-0.06 0.29035-0.0202 0.4502-0.06 0.0104-0.54012-0.23097-0.99088-0.63028-1.3007 0.01-0.0496 0.0189-0.10959 0.03-0.17026 0.12919-1.0496-0.43063-2.4306-0.71054-3.3308-0.65052-2.0509-1.3911-4.9316-0.64008-7.1521 0.8704-0.14025 2.8115-0.12916 3.6519 0.14025 1.5209 0.51012 0.67009 1.8513 1.9809 2.5114 2.8715 1.4508 2.482-2.7013 4.0121-3.8409 1.1405-0.85128 1.9809-0.11089 3.171-0.66145 0.35038-0.15982 1.9509-1.8402 2.1714-2.1305 0.65052-0.85063 0.5011-2.1207 1.4909-2.7515 0.98066-0.61971 2.6516-0.25963 3.8124-0.31964 0.28056-1.4306 0.39996-2.5506 1.821-3.1918 0.96109-0.42075 3.3315 0.25049 4.0519-0.39922 0.36995-0.33986 0.77122-2.8918 1.1105-3.6015 0.53046-1.1103 0.86061-2 1.2103-3.1514 0.38039-1.3105 0.82081-2.2805 2.1714-2.7593 1.2006-0.43053 3.0908 0.23941 4.0114-0.70059 0.21009-0.21983 0.36995-1.3601 0.6205-1.7202 0.27991-0.41031 0.93043-1.0802 1.3206-1.3418 1.0302-0.66928 2.4011-0.8004 3.5514-0.94978 1.1816-0.14025 1.9914-0.2094 2.6914-1.1298 0.79015 0.0802 1.821-0.27984 2.4018-0.88977 0.24989-0.0691 0.50044-0.12981 0.74055-0.18004 1.2208-0.24984 1.0903-0.11024 2.1714 0.36987 1.5509 0.69081 2.9316 0.59035 4.8022 0.69994 0.0104 0.33008 0.25055 0.55056 0.2101 0.93087 0.35037-0.0104 0.74055 0.27985 1.1307 0.23027 0.14942 0.98109-0.26033 1.7104-0.29035 2.6217 0.14028-0.0104 0.32037 0.0104 0.46065 0.0404 0.0176 0.12981-0.0124 0.30986-0.0124 0.45924z",
+                Pingtung:"m166.08 473.61c0.38039 0.47033 0.52002 0.84019 0.50045 1.4403-0.0398 0-2.1408 2.4514-2.3515 2.681-0.8704 0.88912-2.5212 1.7104-2.9016-0.16047 1.2808-0.74952 0.64008-2.0405 1.3206-3.1116 0.71054-1.1279 2.2615-0.91913 3.432-0.84933zm69.867-77.268c0.47044 1.2205-0.3693 2.9909 0.65052 4.0907 0.52002 0.57013 2.9218 1.4305 3.7119 1.7906 1.121 0.51012 1.121-0.18982 1.5007 1.1598 0.19052 0.6608 0.10961 1.9198 0.12984 2.5414 0.0692 1.8611-0.53046 2.5806-2.1016 3.4912 0.61137 1.8317 1.1307 5.6928-0.85017 7.1521-1.0107 0.75017-2.7613-0.18983-4.0121 0.32029-0.88997 0.36074-1.6605 1.4814-2.5414 2.1207-1.4106 1.0411-1.9607 1.03-3.802 1.2205-1.0603 0.10959-2.822-0.19047-3.5318 0.78997-0.73077 0.99153 0.25968 2.6413-0.1305 3.8722-0.39018 1.2205-1.6312 2.06-2.0005 3.3412-0.35038 1.2094-0.2499 1.8806-1.0002 2.9498-0.73077 1.0405-1.2906 1.76-1.701 2.8807-0.77057 2.0907-1.0303 4.201-1.1601 6.4828-3.0314 0.03 0.39932 5.3817 0.74056 6.1919 0.7001 1.6797 1.1608 5.4508 0.63029 7.0425-0.32037 0.96935-1.2006 2.1507-0.51024 3.4612 0.76079 1.4299 1.8015 0.21004 2.9616 1.0404 1.2704 0.90021 1.9013 5.1312 1.6808 6.6022-1.6612 0.0698-4.0114 0.74039-4.472 2.3601-0.25055 0.87085-0.0411 2.1011-0.18008 3.0013-0.10962 0.77105-0.46 1.6915-0.30014 2.471 0.48022-0.0802 0.8704 0.21983 1.2808 0.21983 0.45021 2.0516 2.0011 1.5401 3.5318 2.6419 1.671 1.1807 1.581 2.4808 1.4707 4.6406-2.2412 0.03-2.3711 1.6902-2.2817 3.5004 0.86061-0.0685 2.9414 0.40053 3.6421 0.82063 1.9711 1.1703-0.77058 1.8017-0.47044 3.1807 0.90042-0.12003 1.1908 0.50163 1.0002 1.3418 1.8511 0.0992 2.1212 0.57013 3.4712 1.1807 1.1908 0.53947 3.2421-0.0307 3.5318 1.6412 1.8008-0.23092 1.5907 1.9498 3.4418 0.99936 0.73077-0.38031 1.9711-1.7208 2.681-2.4508 0.33081 1.1598 0.67009 2.3608 0.39997 3.3608-0.2101 0.82062-0.6205 1.0907-0.71055 2.1207-0.09 0.91977-0.12984 1.7208-0.30013 2.5506-0.56048 2.7398 0.29035 6.411 0.0998 9.5931-0.98066 0.4201-1.2612 1.8206-0.97022 2.8611 0.38039 1.3601 0.94021 1.4292 2.4716 1.3601 0.09 0.48011 0.09 1.1403 0 1.6106-0.73077 0.6608-1.4511 0.59035-1.8113 1.531-0.33015 0.8702 0.0111 2.5617 0.0111 3.501 0 0.98044-0.27012 2.4103-0.0111 3.3406 0.32036 1.1011 1.2508 1.2101 0.98067 2.6308-0.61985 0.12981-1.2006 0.24006-1.7806 0.39988-0.0411 0.55056-0.21989 1.0404-0.21989 1.6002-1.5509 0.40966-0.93042 0.77104-1.4707 1.8702-0.70076 1.3908-0.68053 0.85976-2.3013 1.2003-2.5212 0.53034-2.0409 2.4814-2.0409 4.8011 0 1.8506-0.60028 4.9218 0.72033 6.2923 0.67988 0.69994 1.151 0.45989 1.6207 1.3712 0.29035 0.58971 0.38039 2.4808 0.30014 3.1507-1.7708 0.45989-1.8106-1.2309-2.7606-2.1905-0.51024-0.51991-0.95066-0.4899-1.3911-1.1207-0.34972-0.5199-0.4104-1.2198-0.82994-1.8004-1.0603-1.4703-1.8811-0.78018-3.5018-1.3608-0.71054-0.25962-1.2906-0.91977-1.9907-1.1814-0.59048-0.21983-1.3506-0.18982-1.9711-0.36008-0.79014-1.5003-4.5021-2.561-5.3327-0.44032-0.49001 1.2401 0.79014 1.6008 0.63029 2.8011-0.16965 1.3203-1.6606 1.3705-2.6712 1.8206-0.53046-0.78018-1.6605-1.4606-2.0011-2.1507-0.47956-0.97001-0.1592-2.7208-0.1592-3.8311 0-1.3007 0.1703-2.7208 0-4.0014-0.23097-1.7606-0.99111-1.5401-1.962-2.711-0.83973-1-0.69945-1.8891-1.0798-3.0809-0.20096-0.63079-0.65052-0.79061-0.63029-1.5506 0.03-0.82976 0.50958-0.75996 0.66944-1.501 0.12071-0.55056-0.25903-1.5095 0-2 0.51023-0.96087 0.56047-0.12068 1.331-0.66081 0.81038-0.55056 1.8511-2.1311 0.53046-2.8611-0.24011-0.39987-0.43063-0.99088-0.50109-1.4508 0.44041 0.0802 1.0107-0.12982 1.4518-0.0496 0.20944-1.2505 0.42933-2.4814 0.36016-3.8115-0.0998-1.8806-0.36995-1.8206-1.4707-3.0411-1.6906-1.8904-0.35038-4.8911-1.0309-7.2923-0.35038-1.2309-1.4909-1.8402-1.8008-3.1709-0.30013-1.291-0.13962-2.4599-0.54024-3.6608-0.8704-2.5695-3.1521-3.0007-4.3722-5.3014-0.60027-1.1292-0.46064-2.471-0.46064-3.8715 0-1.6112-0.46065-2.3608-1.0009-3.6713-0.84038-2.0405-2.0409-3.6817-3.7217-5.291-0.85082-0.82063-1.7304-1.2805-2.1108-2.381-0.54025-1.5395-0.65051-1.79-1.7108-3.1612-1.6508-2.1403-3.1019-2.7208-5.4632-4.0105-1.0714-0.5897-2.7117-0.83954-3.5018-1.8311-1.3904-0.17939-3.3518-0.50034-4.3722-1.2903-0.89063-0.7006-1.3108-1.8409-2.131-2.6719-1.7708-1.7906-4.8531-2.3797-6.0034-4.3706-0.72033-1.2401-0.95065-1.8617-2.1212-2.8709-0.2101-0.17026-0.39018-0.31051-0.55004-0.42075v-0.2094c0-1.9504-0.86061-6.852 0.50045-8.3321 1.0805-1.1703 2.0214-0.0202 2.3411-2.1709 0.18008-1.2603-0.03-2.7593-0.2101-4.0014-0.36017-2.591-1.2208-5.2316-0.64008-8.0118 0.28057-1.291 0.68053-2.1011 0.68053-3.6602v-4.3327c-0.0104-2.1207 0.62051-1.79 1.4609-3.1996 0.6205-1.0411 0.36995-2.7606 0.36995-3.972 0-2.7711 0.01-5.5519 0-8.3321 0-0.57013-0.19052-1.6412 0.15986-2.0516 0.51023-0.60014 1.2208 0.15003 1.6808-0.77888 0.39018-0.8017-0.2897-3.0907-0.33994-4.002-0.09-1.6712-0.23032-2.4208 1.3408-2.8402 1.2606-0.33007 2.6014 0.09 3.6519 0.55056 1.8008 0.78997 5.6935 1.6002 7.724 0.50099 0.84039-0.45989 1.9209-1.7306 2.6314-2.3803 0.80123-0.74039 0.93042-1.9198 1.8308-2.7111 0.92064-0.80953 2.7117-0.69016 3.8431-1.0796 1.3604-0.47946 2.4213-1.4103 3.802-1.7 3.1815-0.66994 3.9912 1.4703 5.993 3.561 0.58071-0.81019 1.7708-1.6706 2.071-2.5408 0.97022-0.4214 1.2306-0.82127 2.4716-1.0202 1.271-0.21005 1.8615-0.09 2.9916 0.33008 1.8909 0.71038 3.1717 1.9504 4.8126 3.0209 0.39083 2.5206 2.251 3.231 4.5021 3.1214-0.15007-1.9504 0.81037-1.5806 2.0214-2.1409 1.1908-0.54991 2.052-1.5506 3.5116-1.6797 1.2912-0.1109 4.0519 1.2003 4.7931 2.2799 0.0672 0.10763 0.12789 0.21787 0.17747 0.34703z",
+                Taidong:"m327.47 304.02c-0.32036 0.81019-0.64007 1.6302-0.96044 2.5004-0.7001 1.9204-0.23097 3.9309-0.55068 5.9518-0.27013 1.7417-1.1601 3.3412-1.4407 5.0627-0.25055 1.5904-0.0196 4.8415-1.181 6.0614-1.0903 1.1598-3.1417 1.2309-4.3122 2.6908-1.3108 1.6412-1.6508 2.9713-1.761 5.2519-0.0803 1.5708 0.36995 4.6217-0.50045 5.8116-0.76079 1.0607-2.852 0.77105-3.5723 2.3712-0.63095 1.4208-0.0698 3.651 0.0692 5.0712 0.29035 2.8611-0.1703 8.1527 3.7322 7.8129-1.0798 0.39009-1.35 1.6002-2.2308 2.1403-0.63029 0.39922-1.3004-0.0496-2.0116 0.50033-0.47956 0.36073-0.58983 1.1403-0.93042 1.3608-1.8211 1.1598-5.4827 0.12981-4.8126 3.9413 0.0502 1.7104-0.68053 3.561-1.331 4.8311-0.61072 1.1703-0.32037 2.4599-0.71055 3.621-0.42998 1.2805-1.4909 2.441-1.9607 3.732-0.44042 1.1807-0.36995 2.2199-1.0407 3.3216-1.301 2.1305-4.1621 2.5108-4.9229 4.8716-0.4502 1.3803-0.0907 2.3405-0.88084 3.591-0.59048 0.93021-1.0498 1.9504-1.7003 2.8611-0.42085 0.60013-0.98067 0.85063-1.2912 1.4814-0.25968 0.51991-0.10048 1.319-0.3693 1.8304-0.70075 1.2707-2.1114 0.97001-1.992 2.8409-2.2204 0.12003-6.4138-0.59035-7.4441 2.0607-1.0798 2.7698 0.82082 4.9603 1.6312 7.1319 0.71054 1.8898-0.31971 2.0411-1.5007 2.7111-1.5607 0.88063-1.1301 1.1403-1.331 2.9609-0.24989 2.2799-3.1619 3.1696-4.5223 5.1605-0.03 0.0502 0.01 0.39139-0.0104 0.48011-0.97023 0.75995-2.3913 1.1298-3.312 1.8904-0.93042 0.75996-1.2006 2.321-2.3313 2.9707-1.0107 0.59035-2.5212 0.14938-3.7021 0.6308-1.2208 0.50098-1.6312 1.5199-2.5009 2.5004-1.6012 1.8102-4.4022 2.1109-5.9232 3.9218-0.64008 0.74104-0.90041 2.3803-1.2103 3.2916-0.39931 1.2003-0.57026 2.4006-0.63029 3.7013-0.12005 2.5004-0.17029 4.3712-2.2014 5.8116-1.1203 0.78996-1.9202 0.91064-2.6308 1.9909-0.66095 0.99023-1.1908 2.1605-1.6716 3.3301-0.52003 1.2609-0.4202 2.5206-0.8704 3.8011-0.44042 1.2401-1.181 2.2805-1.5105 3.5408-0.63942 2.4821-0.44042 5.0327-1.181 7.4724-1.8308 0.47098-1.5607 4.6824-2.2713 6.203-0.88997 1.9002-1.2997 3.651-1.9111 5.5904-0.57026 1.8108-1.2208 4.4123-2.8017 5.5722-0.85017 0.6308-0.43977 2.3405-0.8293 3.6608-0.28121 0.91978 0.33016 7.2023 0.33016 8.1723 0 0.69016 0.24011 1.5004 0.47956 2.351-0.71054 0.72995-1.9502 2.0705-2.681 2.4508-1.8511 0.95043-1.6416-1.2303-3.4418-0.99936-0.28969-1.6719-2.3411-1.1011-3.5318-1.6412-1.35-0.61058-1.6201-1.0802-3.4712-1.1807 0.19052-0.84019-0.0998-1.4606-1.0002-1.3418-0.30013-1.379 2.4409-2.0105 0.47044-3.1807-0.70076-0.42009-2.7815-0.88911-3.6421-0.82062-0.09-1.8096 0.0411-3.4704 2.2817-3.5004 0.10962-2.1612 0.20031-3.4612-1.4707-4.6406-1.5307-1.1011-3.0816-0.59035-3.5318-2.6419-0.41041 0-0.80059-0.30007-1.2808-0.21983-0.15985-0.77953 0.19052-1.7 0.30014-2.471 0.14028-0.90021-0.0698-2.1305 0.18008-3.0014 0.46-1.6197 2.8115-2.2903 4.472-2.3601 0.21989-1.471-0.4104-5.702-1.6808-6.6022-1.1601-0.8291-2.2014 0.39074-2.9616-1.0405-0.69032-1.3105 0.18987-2.4906 0.51023-3.4612 0.53046-1.5904 0.0698-5.3628-0.63029-7.0425-0.33994-0.81019-3.772-6.1618-0.74056-6.1919 0.12919-2.2805 0.39018-4.3908 1.1601-6.4828 0.41041-1.1207 0.97023-1.8396 1.701-2.8807 0.75034-1.0705 0.65052-1.7404 1.0002-2.9498 0.3693-1.2805 1.611-2.1207 2.0005-3.3412 0.39083-1.2309-0.60028-2.8807 0.13049-3.8722 0.70989-0.98044 2.4716-0.68037 3.5318-0.78996 1.8406-0.19048 2.3913-0.17939 3.802-1.2205 0.88084-0.63927 1.6508-1.76 2.5414-2.1207 1.2508-0.50947 3.0027 0.42988 4.012-0.31964 1.9809-1.4599 1.4609-5.321 0.85018-7.1527 1.5712-0.91064 2.1714-1.6302 2.101-3.4912-0.0196-0.62036 0.0607-1.8806-0.12919-2.5414-0.38039-1.3497-0.38039-0.64971-1.5007-1.1598-0.79079-0.36008-3.1926-1.2205-3.7119-1.7906-1.0205-1.1011-0.18008-2.8702-0.65051-4.0907 1.1105-0.58057 1.7512-1.6308-0.28057-1.6497-0.0907-1.5701 0.14028-2.5708-1.8315-2.3308 0.0907-1.5701-1.7604-1.9902-2.0305-3.6511-0.24011-1.501 0.35038-3.231-0.18008-4.6322-0.23032 0.03-0.55069-0.0691-0.79015-0.0502-1.5509-2.5695-0.38039-7.2623 1.6005-9.2728 0.77057-0.77952 2.3913-1.4703 3.0118-2.4208 1.0107-1.561-0.74121-2.2205-0.30014-3.6302 0.52002-1.6615 2.5708-0.23092 3.462-1.1905 0.80059-0.85976-0.63028-2.8115-0.96044-3.4808-0.32036-0.65037-0.75034-0.44097-0.54024-1.5317 0.15985-0.8291 0.58004-0.94978 1.0498-1.5904 0.59048-0.80171 1.1908-1.9113 1.3604-2.8311 0.51024-2.5506 0.24011-5.8618 0.0998-8.5135-0.80058-0.2094-1.8811-0.47033-1.611-1.5004 0.52003-0.0404 1.5509-0.14938 1.9411-0.57013 0.55982-0.62036 0.0502-1.1709 0.35038-1.8011 0.67988-1.3999 2.071-1.0405 2.3515-2.6608 0.12005-0.72017-0.23098-1.4103-0.17095-2.1703 0.0502-0.57013 0.43063-0.95044 0.5011-1.4899 0.16051-1.1011-0.55004-3.3908 0.0202-4.3112 0.61072-0.97 2.4814-0.61122 3.3113-1.2303 0.89062-0.66993 1.5907-2.1318 2.3411-2.9609 1.0714-1.1905 1.6012-1.9309 3.3315-2.3405 1.3604-0.32029 2.5009-0.59036 3.832-1.2016 1.1705-0.54991 2.0109-1.5004 3.2115-1.9302 0.93043-0.33986 2.1114-0.11024 2.9818-0.6308 0.17943 0.65037 0.66031 1.3105 1.0309 1.7208 0.99046 1.1103 2.1401 2.0516 2.4905 3.7111 0.36082 1.7404 0.0111 2.8311 1.2508 4.2114 0.97023 1.0705 3.2617 0.81018 3.4118 2.09 1.4002 0.0907 4.1217-0.14938 5.133 0.69081 1.5209 1.2609 0.36016 3.1918 3.0014 3.3412 1.5509 0.09 3.3022-1.4508 4.8531-0.33986 1.3108 0.94979 1.4302 3.1996 1.5098 4.8115 0.81038 0.0489 1.6508 0.01 2.4514 0.06 0.06 1.03-0.03 2.1305 0.19052 3.1312 0.30014 1.3503 2.1414 2.1807 3.4816 2.03-0.33994 1.5095 0.63029 1.561 1.8315 1.501 0.21988 0.94 1.2208 1.4703 1.7408 2.2603 0.52002 0.79061 0.58918 1.9707 1.611 2.3908 2.131 0.89043 4.7226-0.91064 6.6533-1.03 0.11027-1.2694-0.28057-2.3712-0.14094-3.6413 0.0998-0.93934 0.9611-2.0105 0.9611-2.8696 0.0104-1.3203-1.2704-1.7606-1.2912-2.972-0.0196-1.2101 1.0603-2.2407 2.3013-2.0209 0.88084-2.3405 1.671-4.7117 2.8317-7.0118 0.63029-1.2505 0.03-2.6008 0.53046-3.8115 0.47044-1.1605 1.9914-1.3908 2.6308-2.4906 0.70011-1.2094 0.42998-2.6308 0.54025-4.0014 0.12071-1.4703 0.70989-2.2205 1.1705-3.501 0.15007-0.4201 0.0411-1.3503 0.48022-1.6406 0.50045-0.33007 1.5607 0.57013 2.2014-0.06 0.69031-0.69994 0.28969-2.6217 1.1503-3.471 1.0009-0.99153 2.5316-0.66993 1.5007-2.1709-0.30014-0.42988-2.1708-1.8304-2.6412-2.0202-0.10961-1.8709 0.12985-3.3914 0.84039-4.9414 1.2306-0.71038 0.7001-3.6308 2.2713-3.4012 0.68053-0.97001 2.4605-0.45011 2.2308-2.2707 1.0909-0.64972 2.9113-0.31964 3.9722 0.14025 0.41041 0.18004 1.1405 0.85128 1.5307 0.96087 0.62572 0.18004 1.1164-0.10894 1.7564-0.1396zm-3.9279 119.23-0.0202-0.18004c0.23097-0.12003 4.063-0.30985 4.3722-0.0189 1.5209-0.91064 2.4018-0.82975 2.6614 0.99088 0.15986 0.0404 0.29035 0.0196 0.45021 0.06-0.48022 0.80105-0.81037 1.7704-1.0002 2.7815-0.79015 0.12916-0.75035 0.21984-0.95066 0.82911 0.27013-0.0496 0.66031 0.0802 0.94022 0.0502-0.0607 0.78018 0.09 1.6302 0.33994 2.2694-1.5412 0.83041-3.4522-1.6706-5.1128-1.9902-0.21988-0.40053-0.29035-0.98044-0.17029-1.441 1.7003-0.91978-1.5509-2.3301-2.052-3.0307 0.1318-0.3105 0.29231-0.30007 0.5422-0.32029zm19.79 101.38c0.68053 1.6706 0.32037 2.231 0.33994 3.9518-1.301 0.17939-2.3222-0.39922-3.6121-0.33986-1.3611-2.1709-2.5616-3.0307-5.0025-3.171-0.60028-1.2609-2.6112-2.2407-3.573-3.4312-0.70989-0.88064-0.47043-2.1905-0.79014-3.201-0.27013-0.84019-1.7408-2.1005-1.3108-2.8109 0.8704-0.0802 1.5712 0.20026 2.4513 0.15982 0.0405 0.15916 0 0.30006 0.0502 0.44945 1.8106 0.0907 5.5428 0.55969 6.9834-0.41031 0.23098 0.81018 0.11027 0.33007 0.64008 0.8004 0.0104 0.58122 0.03 1.1905 0.0405 1.7802 0.15986 0.0404 0.30014 0.0104 0.46065 0.0502 0.2101 1.09-0.47043 1.1807-0.65052 1.6706-0.21988 0.61122-0.36995 1.1102-0.30014 1.9504 1.0903-0.18005 1.1105 0.85063 1.1608 1.6608 0.82994 0.03 0.68052 0.0496 1.0009 0.66994 0.70076-0.0398 1.4615 0.0307 2.1114 0.22048z",
+                Hualien:"m262.01 324.77c-0.21989-0.69994-0.0698-1.3999 0.95065-1.7704 0.20031-1.1298-1.6808-4.6517-3.1417-4.0411 0.0104-0.25897-0.25903-0.72017-0.19052-1.0705-0.93043-0.0496-1.9809 0.14938-2.7717-0.39009-0.98001-0.65037-0.20944-1.5317-2.0109-1.3307-0.12006-1.06 0.32036-1.6602 0.67009-2.6002 0.18008-0.50098 0.47043-0.43053 0.47043-1.2101 0-0.36921-0.54025-0.53947-0.50958-0.82062 0.21988-1.8898 2.8017-1.291 4.3226-1.5395 0.21988-1.7717-0.0307-2.972-0.33994-4.6113-0.82081-0.18983-1.0107-0.63993-0.77057-1.3307 0.0104-0.0404 0.12005-0.0496 0.27012-0.0496 0.2897-0.0196 0.72033-0.0104 0.84039-0.12981 0.20031-0.2094 0.15985-0.61057 0.47956-0.88977 0.8704-0.74104 0.48022-0.69081 1.7108-0.94978 0.72033-0.15004 1.4707-0.15004 2.1414-0.36987 0.14941-2.4906-2.191-1.9504-1.3108-4.3112 0.61985-1.6497 1.3304-3.3301 2.3802-4.8004 1.8713-2.6413 7.6137-2.561 10.085-0.72016 0.49001-0.7704 1.331-0.90021 2.0116-1.3405 0.10961-1.8311-0.2101-3.5715-0.0998-5.4417 1.6312-0.48011 1.4106-0.72017 1.7806-2.1709-0.27012 0.06-0.68053-0.0998-0.95065-0.0496-0.13963-0.78018-0.24011-1.6308 0.61136-1.8409 0.03-0.12003-0.0307-0.34899 0.06-0.43966 1.1601-0.5597 2.0514 0.60013 2.972 0.31963 0.48022-0.14025 1.4309-1.9002 1.5209-2.321 1.0198-0.71104 1.1908 0.20939 1.9411 0.20026 0.57026-0.0104 1.1014-0.32029 1.6716-0.42988 0.50045-0.71038 0.10961-1.3503 0.3693-2.1311 0.33994-1.0502 0.72033-0.5897 1.1712-1.3803 0.55982-1.0007-0.16051-2.3608 0.2499-3.441 0.39017-1 1.7003-1.7404 1.9111-3.0209 0.16051-0.9002-0.59049-1.5003-0.51023-2.3308 0.0907-0.8291 0.73011-1.2505 0.84038-2.3308 0.09-0.88064 0.0998-1.9707 0.01-2.8402-0.23946-2.1207-1.81-2.2805-2.0109-4.1612-0.2897-2.8213-0.2897-2.651-2.972-3.201-0.27991-1.4808 1.331-3.6113 2.7822-3.8311-0.17095-1.4103-0.24011-2.9211 0.21988-4.2812 0.53046 0 0.77971-0.2805 1.2808-0.39074 0.69031-1.3405 0.51023-3.06 1.1503-4.471 0.23097-0.5199 0.69031-0.65037 0.88083-1.1703 0.14094-0.3803 0.0411-0.93087 0.16051-1.3307 0.27013-0.84019 0.70011-1.2609 1.0303-1.9804 0.21988 0.0404 0.55003-0.0202 0.78036-0.0502 0.0698-1.3803-0.80059-5.8018 1.331-5.6615 0.1703-3.3816 0.51024-6.7822 0.33994-10.124-0.69945-0.0404-1.4204-0.01-2.1205-0.0502-0.12005-2.4808 0.64008-3.4312 1.3206-5.4717 0.42998-1.2903 0.75034-2.0607 1.3708-3.291 0.73011-1.4508 0.47108-2.4006 0.6205-3.8813 0.21988-2.2505 0.96109-1.0196 2.4611-1.8709 0.85996-0.47945 1.5405-1.6706 2.2112-2.4306 1.2912-1.4703 2.1812-4.9414 0.45999-6.1716-0.82994-0.59035-2.3313-0.90021-3.2513-1.5708-1.181-0.8702-1.0707-1.2903-2.8513-1.3105-0.23098-0.72017-0.3308-1.6902-0.0698-2.351 0.30013-0.72995 0.97022-0.77039 1.2208-1.2505 0.3804-0.70973 0.03-1.5304 0.32037-2.2199 0.42019-0.97979 0.4104-0.5199 1.3708-0.95043 1.6012-0.71038 2.4213-1.1814 3.6023-2.2205 1.2201-1.06 1.9411-0.93022 3.6721-1.0196 0.17943-0.80105 0.14028-1.6712-0.78036-1.8408-0.0998-1.1605 0.1305-1.5904 0.55069-2.1612 0.16964-0.21983 0.36995-0.47033 0.60028-0.8004 0.47108-0.67972 0.82994-2.3706 1.5209-2.9707 0.94087-0.82063 2.7326-0.0802 3.312-1.0307 0.59048-0.97979-0.35038-3.0607-0.01-4.1723 0.44042-1.4103 1.7304-1.4201 2.5205-2.4899 0.53046-0.74104-0.01-0.95043 0.82082-1.5108 0.49-0.33986 1.151-0.20026 1.7108-0.66994 0.78036-0.63014 1.7519-1.5095 2.1218-2.3301 0.50045-1.1403-0.30079-2.8317 0.20031-3.972 0.24011-0.54991 1.4504-1.7098 2.2412-2.1807 0.0411 0.0907 0.0907 0.18004 0.15007 0.27006 0.4104 0.60014 0.93956 0.39074 1.5712 0.59035 0.74056 0.23027 1.1705 0.87999 1.8811 1.2003 0.46064 0.21005 1.0009 0.27006 1.4302 0.54012 0.44107 0.27006 0.72033 0.59035 1.0805 0.93022 0.15986 0.15003 0.32037 0.25962 0.5011 0.39074 0.2897 0.18982 0.19052 0.21983 0.41041 0.0992 0.3693-0.19048 0.48022-0.66015 1.0407-0.50033 0.24011 0.0691 0.27013 0.21983 0.58005 0.24984 0.25055 0.0202 0.38039-0.0502 0.59049-0.0802 0.45021-0.0698 0.93043-0.06 1.3715 0.0411 0.61006 0.12916 1.1503 0.30985 1.7904 0.36921 0.41106 0.0404 0.84038 0 1.2508 0.0502 0.98067 0.0998 1.151 1.1905 1.761 1.8206 0.62051 0.63928 0.8306 1.3301 1.8106 1.4606 0.81037 0.10959 1.5809 0.01 2.3613 0.2094 0.39018 0.0998 0.82016 0.26027 1.2397 0.22048 0.26034-0.0307 0.47108-0.12981 0.74121-0.0907 0.23946 0.03 0.42019 0.15003 0.66944 0.12068-0.0998-0.25049-0.0398-0.53034-0.0803-0.82062-0.0502-0.47946-0.23032-0.45924-0.60027-0.80954-0.17943-0.17091-0.33015-0.28963-0.27013-0.55969 0.06-0.29029 0.03-0.14938 0.21989-0.14025 0.12984 0.0202 0.15006 0.18004 0.32036 0.17026 0.18987-0.0104 0.30014-0.19048 0.42998-0.31051 0.20031-0.20092 0.41041-0.65037 0.70076-0.72995 0.28904-0.0802 0.39018 0.21983 0.6205 0.10959 0.23946-0.10959 0.21988-0.63015 0.28904-0.84998 0.0901-0.27006 0.30014-0.53034 0.54025-0.66993 0.0502 0.24005 0.23098 0.48011 0.46065 0.53033 0.42019 0.11025 0.40975-0.1409 0.71054 0.23027 0.15986 0.20027 0.2897 0.78018 0.59049 0.58057 0.16964-0.11024 0.16964-0.61057 0.18987-0.80953 0.03-0.27006 0.0803-0.69994 0.0104-0.96087-0.11027-0.42989-0.44955-0.33986-0.74056-0.66016-0.19052-0.21004-0.19052-0.45988-0.33994-0.67972-0.2003-0.27984-0.55982-0.39009-0.6603-0.77039-0.20031-0.75017 0.49001-1.6308 1.2404-1.1305 0.32037 0.21984 0.68053 0.68038 0.95066 0.96022 0.33015 0.3503 0.63942 0.69995 0.98066 1.0411 1.1503 1.1507 0.0803-1.1011 1.2006-0.76061 0.24011 0.0802 0.36016 0.44032 0.55003 0.63015 0.38039 0.3803 0.90041 0.51011 1.2612 0.92043 0.36017 0.41031 0.66031 0.84997 1.1099 1.1598 0.35038 0.25049 0.66095 0.19048 1.0805 0.25049 0.46064 0.0691 0.53046 0.3105 0.90041 0.50033 0.39996 0.21005 0.96109-0.0404 1.3904 0.12003 0.29035 0.11024 0.59049 0.36073 0.8704 0.5199 0.53046 0.29028 0.99111 0.61123 1.5816 0.79062 0.46 0.14938 0.93043 0.12002 1.4204 0.12002 0.53046-0.01 0.92064 0.12982 1.4106 0.29029 0.61985 0.19048 1.4713 0.0196 2.0514 0.33986 0.33994 0.18983 0.60093 0.54012 0.93108 0.72995 0.2897 0.17026 0.58136 0.23027 0.90042 0.31051 0.49066 0.12981 1.5405 0.7606 2.022 0.3803 0.0196-0.01 0.0405-0.03 0.0405-0.0496 0.0796 0.42988 0.18987 0.96022 0.0411 1.3405-0.15007 0.43053-0.76078 0.27006-0.87105 0.88064-2.0905 1.3112-2.9414 2.9218-3.2219 5.4019-0.18987 1.7104-0.15985 2.2805-1.8811 2.8807-1.3708 0.48011-2.1904 0.8702-3.3518 1.6406 0.06 1.1305-1.0107 2.3908-1.9313 2.8311-0.57027 0.2805-1.2802 0.44032-1.8406 0.68037-0.95065 0.39009-1.0707 0.74952-1.7512 1.4508-0.99111 1.0196-1.4217 1.7606-1.5105 3.4006-0.0404 0.92043-0.33993 3.8011 0.61007 4.1416 0.57091 1.9615 0.39083 4.5115-1.2606 5.702-0.63943 0.4501-1.4707 0.72016-2.0612 1.1514-0.61071 0.44945-1.4511 1.3705-1.9411 1.9707-1.8504 2.2812-1.9307 8.5428-0.0698 10.763 0.39997 0.47032 1.0414 0.91064 1.5809 1.0502 0.97023 1.4508 1.7715 3.5506 0.62051 5.2016-0.36017-0.03-0.62051 0.16047-0.95066 0.17026-0.0496 0.1709-0.12919 0.29028-0.17029 0.46054-0.39997 0.0998-0.81037 0.19047-1.2097 0.29028-0.0998 0.23027-0.18987 0.21983-0.2897 0.45989-3.002 0.20026-1.7512 9.1221-1.8615 11.283-0.0907 1.8304-0.86062 3.8611-1.3611 5.5219-0.60028 1.9602-0.44042 3.8813-0.76079 5.972-0.17943 1.2303-1.0603 2.3706-1.8811 3.351-1.1601 1.4005-1.2397 2.1409-1.2397 4.0314 0 1.7508 0.68053 3.9818 0.12006 5.6322-0.53046 1.5806-1.9711 2.5004-2.4912 4.2512-1.0407 3.5708 0.0698 8.1723-1.5607 11.684-0.91085 1.9707-2.0807 2.2107-2.4513 4.5617-0.32037 2.0405 0.23032 4.2114 0.01 6.2623-0.21009 1.8611-1.4002 3.2805-1.761 4.9909-0.41041 1.9609-0.0796 3.9211-0.74056 5.762-0.59049 1.6706-2.1316 4.0907-0.12006 5.4913-0.57026 2.7411-1.4818 5.0418-2.4416 7.4926-0.64008 0.03-1.1307 0.31898-1.7519 0.13959-0.39018-0.10959-1.1203-0.77952-1.5307-0.96087-1.0603-0.45924-2.8813-0.78996-3.9723-0.14025 0.23097 1.8206-1.5503 1.3007-2.2308 2.2707-1.5712-0.23092-1.0407 2.6908-2.2713 3.4012-0.71054 1.5499-0.95065 3.0705-0.83973 4.9414 0.47043 0.18982 2.3411 1.5904 2.6412 2.0202 1.0309 1.501-0.5011 1.1814-1.5007 2.1709-0.86061 0.85063-0.45999 2.7711-1.151 3.471-0.63943 0.63015-1.7004-0.27006-2.2014 0.06-0.44042 0.28964-0.33015 1.2205-0.47957 1.6406-0.46064 1.2805-1.0505 2.0307-1.1705 3.501-0.11092 1.3712 0.1592 2.7906-0.54025 4.0014-0.64008 1.1011-2.1616 1.3301-2.6314 2.4906-0.5011 1.2094 0.0998 2.561-0.53046 3.8115-1.1601 2.3001-1.9502 4.6713-2.8317 7.0118-1.2397-0.21983-2.3215 0.81019-2.3006 2.0216 0.0196 1.2101 1.3004 1.6497 1.2906 2.9713 0 0.85977-0.86061 1.9302-0.96044 2.8702-0.13963 1.2694 0.25055 2.3712 0.14028 3.6406-1.9307 0.12068-4.5223 1.9204-6.6533 1.03-1.0198-0.4201-1.0903-1.6002-1.611-2.3908-0.52067-0.78996-1.5209-1.319-1.7408-2.2603-1.2006 0.06-2.1714 0.0104-1.8308-1.501-1.3415 0.14938-3.1821-0.67972-3.4822-2.03-0.21988-1.0007-0.12919-2.1011-0.19052-3.1312-0.80059-0.0502-1.641-0.0104-2.4513-0.06-0.0803-1.6112-0.20031-3.8618-1.5098-4.8115-1.5509-1.1102-3.3028 0.42988-4.8531 0.33986-2.6412-0.14938-1.4811-2.0803-3.0014-3.3412-1.0107-0.83954-3.7322-0.60014-5.133-0.69081-0.15007-1.2799-2.4416-1.0196-3.4118-2.09-1.2404-1.3803-0.89063-2.471-1.2508-4.2114-0.35037-1.6608-1.5013-2.6008-2.4911-3.7104-0.37778-0.41814-0.858-1.0783-1.0381-1.7287z",
+                ChiayiCity:"m184.85 297.29c0.06 1.2094-0.28056 1.4703-1.301 1.9994-0.12984 0.89042-0.33994 2.5317-1.6005 1.8017-0.42019-0.24005-0.55069-0.76061-1.0805-0.89042-0.39017-0.10959-1.2808-0.14938-1.671-0.09-0.75034 0.12003-1.4707 1.1005-1.9907 1.6706-0.51023 0.57013-1.4113 1.5506-2.3313 1.4005-0.48022-0.50164-0.2499-1.1709-0.67988-1.711-0.52002-0.64972-0.99046-0.55056-0.93043-1.5904-0.71054-0.0404-1.4309 0.0104-2.1414-0.03-0.0698-1.1011-1.1803-0.61057-1.8308-0.55056-0.98001 0.0992-1.4106-0.69994-0.27012-1.0404 0.0998-0.63993 0.76078-1.5904-0.39997-1.501-0.42019-0.53034-0.53046-1.4899-0.6205-2.1403-0.12984-0.97001-0.01-0.91978 0.94022-1.261 0.4502-0.17025 0.91085-0.42988 1.181-0.82062 0.0998-0.0104 0.21989 0.0104 0.30993 0 0.0502 0.33986 0.12005 0.66081 0.19052 0.98044 0.77057-0.0404 0.99045-0.63014 1.6605-0.82062 0.62051-0.17939 1.3911-0.0698 2.0612-0.0998-0.18009-1.3601 1.2606-0.94979 2.1714-1 0.0196-0.34899 0.17029-0.63014 0.42998-0.8291 0.33994 0.21983 0.26034 0.50033 0.48022 0.78018 0.20031 0.27985 0.63029 0.4488 0.79014 0.70973 0.49001 0.77952 0.03 1.2701 1.3004 1.1709 0.0998-0.29029 0.1703-0.57013 0.19053-0.89042 0.38039 0.03 1.5105 0.24005 1.7512 0.49054 0.32036 0.33008 0.24989 1.2101 0.33993 1.6497 0.93108 0.17026 1.3004 0.84019 2.3013 0.85976 0.03 0.4899 0.0398 0.93087 0.10961 1.3914 0.22967 0.17026 0.33994 0.2805 0.64008 0.36073z",
+                ChiayiCounty:"m205.81 336.38c-0.21988 1.0607-1.1216 1.5206-1.8817 0.36073-1.3708-0.30007-2.3515 0.2094-3.8418 0.0998-1.4002-0.11024-1.9013-0.57013-2.6314-1.741-0.35038 1.8611-2.0207 1.8311-2.8611 3.2414-0.0502-0.0104-0.54025 0-0.61071 0-0.38039-0.78018-1.5614-0.45988-1.7219 0.3503-1.3904-0.33986-1.5705-2.1011-3.2813-1.8904-0.0998-0.34965-0.22053-0.72017-0.39083-1.0607-0.5807-0.03-1.2006-0.0398-1.7806-0.06-0.0607-0.85912 0.2897-1.9609 1.1105-2.3405 0.0496-0.85063 0.0496-1.7508 0-2.6008-1.8615-0.20026-1.0414-4.6211-0.97023-6.032 0.0692-1.4397 0.09-1.8096 1.181-2.6706 0.79014-0.62036 1.761-0.39922 1.6207-1.8011-1.9816-0.45989-3.0816-2.0105-5.2733-1.8898-0.48022-2.1403 1.9914-2.3412-0.46064-3.6413-0.10962-0.99936-1.6312-0.98045-2.5009-1.2003-0.1703-1.561 1.9209-0.93935 1.4009-2.6112-2.071 0.44032-2.1512-0.50033-3.9723-1.3601-1.1503-0.54012-2.6915-1.0404-3.6721-1.8506-1.0407 1.4599-3.5318 0.34965-5.0025 0.34965-1.731 0-3.0516 0.76061-4.6626 1.0007-1.8609 0.27985-3.6317 0.10959-5.013 1.3705-1.0505 0.95044-0.45021 1.0802-1.9907 1.3001-0.91085 0.12982-1.8008-0.0998-2.6412-0.14025 0.10961 2.5206-1.2606 1.2205-2.7417 2.261-1.5907 1.1298-0.6205 2.1905-0.31057 3.5512-1.4204 0.58905-1.7108-0.61123-2.6915-0.55056-0.95065 0.06-1.7708 1.3294-0.65051 1.9106 0.52002 3.261-2.8618 1.2609-4.2822 2.8311-0.24989 1.7-1.5007 2.291-2.3613 3.471-0.36016 0.4899-0.6603 1.5604-1.1608 1.6706-0.71054 0.15982-1.5405-0.93934-2.3111-1.0196-0.17029-0.51012-0.40975-0.61971-0.6603-0.97 0.12005 3.5812-3.4118 0.81018-3.5618-1.1598-0.52003 0.0405-1.1007-0.0907-1.611-0.0502-0.2499-0.88912-0.89063-1.5806-1.0603-2.4508-1.5405-0.42989-2.5714-1.6908-4.0323-2.3001 0.03-0.0607 0.0698-0.12068 0.0998-0.17939 0.74056-1.3607-0.0404-3.7313 1.4811-4.471 0.21988-0.1109 0.48022-0.15982 0.7001-0.24006 0.30014-0.12133 0.42019-0.25962 0.67074-0.39074 0.10962-0.0607 0.76014-0.16047 0.82016-0.23092 0.67988-0.80106-2.3815-1.4201-2.6712-1.5199 1.8909-0.17025 6.6232-0.12068 4.6521-3.1814-0.36995-0.0411-0.55003 0.31051-0.80058 0.55969-0.53046-0.42074-1.2103-1.5506-0.93043-2.1011 0.20031-0.39987 0.58005-0.45989 0.56047-0.96935-0.0202-0.45011-0.33993-0.42988-0.0698-0.93087-0.48022-0.0104-0.86061-0.54012-0.81037-1.0104 0.06-0.62036 0.78036-0.88064 1.0505-1.3196 0.49001-0.79127 0.06-2.4019-1.0505-1.9309-0.44042 0.18983-0.44042 0.85977-1.1203 0.69081-0.53046-0.12981-0.70076-0.76061-0.44042-1.2309 0.35038-0.63993 0.78036-0.34965 1.3108-0.5199 0.7001-0.22114 0.38039-0.82128 0.38039-1.441 0-1.2401 0.88084-1.441 1.5607-2.2499 0.72033-0.86042 0.38039-2.0516-0.99046-1.5506-0.18987 0.0796-0.36995 0.31898-0.57026 0.37965-0.25968 0.0907-0.55003-0.0196-0.82016 0.0496-0.27012 0.0607-0.39996 0.33073-0.60027 0.39075-0.36995 0.11024-0.42019-0.0907-0.70076-0.15982-0.21988-0.06-0.63029 0.0104-0.82016-0.0998-0.42998-0.25049-0.17029-0.39922-0.30992-0.75996-0.20031-0.50098-0.73077-0.54012-0.94087-0.99087-0.27991-0.58971 0.21988-1.1905 0.36995-1.7104 0.0803-0.25962 0.0803-0.55969 0.20031-0.79061 0.13963-0.31051 0.36996-0.40966 0.50045-0.69081 0.47043-0.11025 0.58005 0.20091 0.96044 0.33072 0.33994 0.11025 0.80059 0.0405 1.1608 0.0405 0.58005 0 1.8909 0.25962 1.611-0.62036-0.12006-0.36008-0.66031-0.4201-0.55004-0.87999 0.06-0.27006 0.33994-0.35029 0.48022-0.59035 0.70011 0.45989 1.2006 0.95044 1.0505 2.0607 0.32036-0.0502 0.79014 0.12981 1.1105 0.06 0.42019 0.75996 2.9714 0.95044 3.862 1.1403 1.6508 0.35029 3.2317 0.85063 4.8224 1.1605 2.0312 0.39922 3.8724 0.40966 3.522-2.1709-0.0998-0.66994-0.89063-1.3601-0.98067-1.8617-0.14028-0.78997 0.38039-1.5304 0.50045-2.2805 0.33015-0.01 1.5607-0.21983 1.8113-0.03 0.63029 0.47098 0 1.0913 0.36996 1.6412 0.92064 1.3712 2.221 0.69081 1.9907-0.93021 1.9209-0.63993 1.1705-1.1403 2.101-2.7404 0.85082-1.441 1.6207-0.68038 3.342-0.82063-0.10049-0.63993-0.59049-1.1102-0.61072-1.7802 1.0407-0.09 2.161 0.18983 3.1214 0.4501 0.0405-2.2707 0.15007-2.651 2.3515-2.8122 1.4106-0.0998 3.0314-1.0405 2.7019-2.8004 0.88019-0.36008 1.9809-0.17939 2.9414-0.23027-0.2101-1.6615 1.9013-3.0516 3.3615-2.972 1.5007 0.0698 2.3515 2.9511 4.5125 1.6804 0.77057-0.4501 0.54025-1.3203 1.5307-1.6804 0.76013-0.27006 2.1512 0 2.9616 0 0.90041 0 1.9411 0.14025 2.8017-0.0398 0.96044-0.19048 1.38-0.86041 2.5114-0.60013 0.2499 1.3105 1.6207 1.8806 1.7206 3.1109 0.23098-0.0189 0.55004 0.0802 0.78036 0.06 0.80059 4.1514 4.6123 2.6112 7.694 3.3014 1.7114 0.39074 2.8115 1.291 4.8531 1.1703 1.7519-0.10959 3.1514-0.85976 4.9627-0.81019 0.35038 2.1514 0.06 3.1012 2.6614 2.4514 0.24011-0.49055 0.46064-0.47946 0.82994-0.79062 0.20096 2.0516 2.452 0.69994 3.5423 0.65037 1.4811-0.0692 3.6121 1.4103 5.0025 1 1.1007-0.33008 0.80059-0.71038 0.79015-1.8311 0-0.53034 0.09-2.0209-0.12071-2.5114-0.25903-0.62036-1.2306-0.4899-1.3604-1.3405-0.06-0.42988 0.64007-1.2003 1.1405-1.4305 0.2101 0.12068 0.5011 0.21983 0.89062 0.27006 1.2006 0.17026 2.5714-0.20026 3.9723-0.14025 0.0104 0.32029 0.19053 0.4899 0.2101 0.78018 0.75034 0.0502 1.5307 0.0202 2.2817 0.06 0.92064 0.68038 0.52002 1.4005 1.6906 1.8213 0.79014 0.27006 2.3111 0 3.1521-0.0404 0.0502-0.15004 0.01-0.29029 0.0502-0.45011 0 0 0.47957-0.0202 0.44955 0.0104 0.36995 0.66081 1.0903 1.3908 1.2012 2.1403 0.0692 0.55056-0.31123 1.9204-0.33994 2.6608-0.0502 0.98045-0.12985 1.6908-0.70011 2.4606-0.53046 0.7293-1.5007 0.77953-1.4511 1.8506 0.15986 0.0489 0.30014 0.0104 0.46065 0.0489 0.06 1.5904 0.70989 2.9811 1.01 4.4815 0.25055 1.2309 0.16051 3.7711 1.6508 4.1918 0.06 2.2499 0.52003 2.2805 2.6915 2.3001 1.6201 0.0196 3.0516 0.45011 4.6417 0.31116 0.39997-2.242 7.5844-0.54012 9.1849-0.44097 0 0-0.06 0.30007-0.0802 0.30007 0.0698 0.22049 0.28056 0.36074 0.29035 0.63993 0.45999-0.0698 0.94021-0.21005 1.4002-0.33008-0.58071 0.61058-1.6116 0.97001-2.4018 0.88977-0.7001 0.91978-1.5098 0.99088-2.6914 1.1298-1.151 0.14938-2.5212 0.27985-3.5514 0.94978-0.39084 0.26028-1.0414 0.93087-1.3206 1.3412-0.2499 0.36073-0.41041 1.501-0.6205 1.7208-0.92064 0.93934-2.8115 0.27006-4.0114 0.69994-1.3506 0.47946-1.791 1.4508-2.1714 2.76-0.35038 1.1507-0.67988 2.0411-1.2103 3.1514-0.33994 0.71038-0.74056 3.261-1.1105 3.6015-0.72033 0.64971-3.0908-0.0196-4.0519 0.39987-1.4204 0.63993-1.5398 1.76-1.821 3.1918-1.1601 0.06-2.8317-0.30007-3.8124 0.31899-0.99046 0.63145-0.84039 1.9009-1.4909 2.7522-0.21988 0.28898-1.821 1.9707-2.1714 2.1305-1.1901 0.55056-2.0305-0.18982-3.171 0.66081-1.5307 1.1403-1.1412 5.291-4.0121 3.8415-1.3108-0.6608-0.45999-2-1.9809-2.5114-0.84038-0.27006-2.7815-0.2805-3.6519-0.14025-0.75035 2.2205-0.01 5.1012 0.64008 7.1521 0.27991 0.90086 0.83973 2.2812 0.71054 3.3308-9e-3 0.0626-0.0189 0.12264-0.0287 0.17222zm-22.262-37.091c1.0198-0.53033 1.3604-0.78996 1.301-1.9994-0.30014-0.0802-0.41106-0.19048-0.64008-0.36008-0.0698-0.46054-0.0803-0.90151-0.10961-1.3914-1.0009-0.0196-1.3708-0.69081-2.3013-0.85976-0.09-0.43967-0.0202-1.3196-0.33993-1.6497-0.24012-0.25049-1.3708-0.46054-1.7512-0.49054-0.0202 0.32029-0.09 0.60013-0.19053 0.89042-1.2704 0.0992-0.81037-0.3914-1.3004-1.1709-0.1605-0.25963-0.59048-0.42988-0.79014-0.70973-0.21988-0.28115-0.14028-0.56035-0.48022-0.78018-0.25969 0.20026-0.41041 0.47946-0.42998 0.8291-0.91085 0.0502-2.3515-0.36008-2.1714 1-0.67009 0.03-1.4407-0.0796-2.0612 0.0998-0.67009 0.19048-0.89062 0.77953-1.6605 0.82062-0.0698-0.31963-0.14028-0.63992-0.19052-0.98044-0.09 0.0104-0.2101-0.0104-0.30993 0-0.27012 0.39074-0.73077 0.65037-1.181 0.82063-0.95066 0.33986-1.0707 0.28963-0.94022 1.2603 0.09 0.65037 0.20031 1.6112 0.6205 2.1409 1.1608-0.0907 0.50045 0.85976 0.39997 1.5004-1.1405 0.33986-0.70989 1.1403 0.27012 1.0411 0.65052-0.0607 1.761-0.55121 1.8308 0.55057 0.71055 0.0398 1.4309-0.0104 2.1414 0.03-0.06 1.0405 0.41041 0.94 0.93043 1.5904 0.42998 0.53947 0.20031 1.2094 0.67988 1.7104 0.92064 0.14938 1.821-0.82976 2.3313-1.3999 0.52002-0.57013 1.2404-1.5506 1.9907-1.6706 0.39018-0.0607 1.2808-0.0196 1.671 0.09 0.53047 0.12982 0.66031 0.65037 1.0805 0.89042 1.2606 0.7293 1.4707-0.91194 1.6005-1.8024z",
+                Nantou:"m217.09 275.91c-0.88997-0.5199-0.50958-1.5506-1.671-2.351-1.581-1.0907-0.96044 0.88977-1.7806 1.79-0.74056 0.81019-2.9805-0.4899-3.0314 0.98109-1.4818 0.0692-2.7515-0.20091-4.1125-0.33986-0.39084-0.82975-0.2101-1.8206-0.57027-2.6106-1.121 0.36009-1.7806 2.1905-2.9316 1.9504-0.39997-2.0307-0.12071-3.3308 0.25968-5.1918 0.36082-1.7515 1.4909-2.7906 1.9118-4.4214 0.36017-1.3307-0.35038-1.3001-0.7001-2.2009-0.36017-0.91065-0.27991-1.6504-0.32037-2.6706-0.0404-0.66993-0.58005-2.351-0.18008-3.0013 0.47109-0.77952 1.5209-0.47032 2.4716-0.52055 0.10962-2.0607-0.15986-3.7913-0.63942-5.6406-0.26034-1.0202-0.54025-1.2505-1.0903-1.9805 0.18987 0 0.39997-0.03 0.57027-0.0502-0.0698-0.8004 0.51023-1.2003 0.88997-1.7802 1.7519-0.41031 2.972-0.95043 4.9425-1.0496-0.01-0.0698-0.01-0.39074 0-0.4501-0.49 0-0.82994-0.31051-1.2808-0.39009-0.03-0.4899-0.27991-0.90021-0.21988-1.4403-0.33994-0.33008-0.86062-0.59035-1.2808-0.66994 0.03 1.7515-3.8118 0.54013-4.0519-0.50033-1.6605-0.42988-1.4609-2.9107-2.7815-3.0509 0.50958-1.2707-0.21989-6.3021 1.2697-6.8422 0.0698-1.1403-0.09-2.3308 0.32036-3.351 0.21989-0.55056 0.71055-0.6608 0.8815-1.291 0.12005-0.47032 0-1.1605-0.0307-1.6406-0.23032 0.03-0.55004-0.0802-0.77971-0.0502-0.0907-1.561-0.55003-3.2708-0.33015-4.7815 3.1208 0.12003 3.2806-4.201 1.9411-6.002-0.47043 0.09-0.85017-0.19048-1.2704-0.21983-0.3693-4.1012 4.553-0.39009 5.8931-2.6706 0.28057 0.15982 0.58071 0.29029 0.91086 0.36922 1.2006 0.3105 2.9218-0.0104 4.1726-0.0104 1.8106 0 2.3913 0.31116 3.8424 0.80105 3.342 1.1396 4.6221-0.93086 6.4543-3.1814 0.66944-0.81997 1.5007-1.7704 1.8902-2.7704 0.42085-1.1011 0.62051-2.8813 1.6912-3.6413 0.82081-0.58057 1.9711-0.3503 2.942-0.39987 0.12005-2.4808-0.21989-5.0516 0.65051-7.3119 0.47957-1.2101 1.2906-1.9602 2.7019-1.3203 0.58005 0.25962 0.75034 0.97 1.3004 1.2003 0.73077 0.29029 0.82015-0.03 1.6808-0.17938 0.44955 1.1102-0.33081 2.9211 0.23032 3.9302 0.88084 1.5904 2.4011 0.48011 2.6314-0.96023 0.19052-1.1605-1.1105-3.321 0.84038-3.0007 1.3408 0.20939 1.121 1.8898 2.9616 1.4703 0.54025-1.1814 1.7708-1.1814 2.8409-1.6602 2.3613-1.09 4.4825-0.32029 7.234 0.0196 0.33994-1.0196 0.79015-1.8402 2.052-1.73 0.09-2.291 1.151-4.0111 3.631-4.1012 2.6014-0.09 3.6023-0.40053 5.6635-1.6712 1.8308-1.1298 2.3711-2.8702 3.9618-4.1612 1.5614-1.2799 4.4434-0.58905 6.4738-0.69929 0.12919-1.4814 0.0496-2.7411 1.3604-3.1409 1.0198-0.3105 2.9414-0.63014 4.0023-0.50033 0.55982 0.0802 1.0498 0.60992 1.6312 0.47033 0.42998-0.0998 0.81037-0.95044 1.5398-1.1305 0.70076-0.17939 1.4217-0.12916 2.1714-0.33986 0.66096-0.19048 0.84039-1.2205 1.3604-0.19048 0.72033 0.0404 1.5509 0.10046 2.2713 0.06 1.1405-0.0691 0.48022 0.48011 1.2006-0.69994 0.82016-1.3497 0.99111-2.6406 3.1417-2.3105-0.33994 2.1507 1.6201 1.0411 2.2204 2.1103 0.7001 0.12002 1.4818 0.0502 2.1108-0.15982 0.24011-2.0105 6.0934-0.0202 6.7936 1.0202-0.0802 0.19048-0.0502 0.28963-0.0698 0.47946 0.0196 0 0.03 0.0104 0.0502 0-0.42019 0.57013-0.65052 1-0.55069 2.1612 0.92064 0.17025 0.96044 1.0404 0.78036 1.8402-1.731 0.0907-2.452-0.0404-3.6728 1.0202-1.181 1.0404-2.0005 1.5101-3.6023 2.2205-0.96044 0.42988-0.95065-0.03-1.3708 0.95043-0.29035 0.69016 0.06 1.5101-0.32036 2.2199-0.2499 0.48011-0.92064 0.5199-1.2208 1.2505-0.26033 0.66081-0.16051 1.6308 0.0692 2.351 1.7806 0.0202 1.6716 0.44032 2.852 1.3105 0.92064 0.66993 2.4213 0.98044 3.2513 1.5708 1.7212 1.2303 0.82995 4.7013-0.45999 6.1716-0.67009 0.76061-1.3506 1.9504-2.2112 2.4306-1.5007 0.85128-2.2419-0.38031-2.4611 1.8709-0.14942 1.4814 0.10961 2.4312-0.62051 3.8813-0.61985 1.2303-0.94021 2.0007-1.3708 3.291-0.67988 2.0405-1.4407 2.9909-1.3206 5.4717 0.7001 0.0411 1.4211 0.0104 2.1205 0.0502 0.17095 3.3412-0.16964 6.7418-0.33994 10.124-2.1323-0.14025-1.2612 4.2812-1.331 5.6615-0.23097 0.03-0.56047 0.09-0.78035 0.0502-0.33016 0.72016-0.76079 1.1403-1.0303 1.9804-0.12005 0.39988-0.0202 0.95044-0.16051 1.3307-0.19052 0.5199-0.65051 0.65037-0.88084 1.1703-0.64007 1.4103-0.45999 3.1305-1.1503 4.471-0.5011 0.10959-0.75034 0.39074-1.2815 0.39074-0.45999 1.3608-0.39017 2.8702-0.21988 4.2812-1.4511 0.21983-3.0608 2.351-2.7815 3.8311 2.6817 0.54991 2.6817 0.3803 2.972 3.201 0.20097 1.8806 1.7715 2.0405 2.0109 4.1612 0.0907 0.8702 0.0802 1.9602-0.01 2.8402-0.11027 1.0802-0.75034 1.501-0.84039 2.3308-0.0802 0.83041 0.67009 1.4306 0.51024 2.3308-0.2101 1.2805-1.5209 2.0209-1.9111 3.0209-0.4104 1.0802 0.31058 2.441-0.25055 3.441-0.44955 0.78997-0.82994 0.33008-1.1705 1.3803-0.25904 0.77953 0.13049 1.4208-0.3693 2.1311-0.57092 0.10959-1.1014 0.42075-1.6716 0.42988-0.74969 0.0104-0.92064-0.91064-1.9411-0.20026-0.09 0.42075-1.0407 2.1807-1.5209 2.321-0.92064 0.2805-1.8113-0.88064-2.972-0.31964-0.0907 0.0907-0.03 0.31964-0.0607 0.43966-0.85017 0.21005-0.74969 1.0607-0.61072 1.8409 0.27013-0.0502 0.68053 0.10959 0.95066 0.0496-0.36995 1.4508-0.15007 1.6908-1.7806 2.1709-0.11027 1.8702 0.21009 3.6106 0.0998 5.4417-0.68053 0.44032-1.5209 0.57014-2.0116 1.3405-2.4716-1.8396-8.214-1.9198-10.085 0.72017-1.0498 1.4703-1.761 3.1507-2.3802 4.8004-0.8815 2.3608 1.4602 1.8206 1.3108 4.3112-0.67009 0.21984-1.4217 0.21984-2.1414 0.36987-1.2306 0.25897-0.84039 0.20874-1.7108 0.94978-0.32036 0.2805-0.28056 0.68038-0.48022 0.88977-0.12005 0.12068-0.55003 0.11025-0.84038 0.12981 0-0.14938 0.0307-0.33007 0.0111-0.45988-0.14028-0.03-0.32037-0.0502-0.46065-0.0405 0.03-0.91064 0.44042-1.6412 0.29035-2.6217-0.39083 0.0496-0.78036-0.24005-1.1307-0.23027 0.0411-0.3803-0.20031-0.60079-0.2101-0.93086-1.8713-0.10959-3.2513-0.0104-4.8022-0.69995-1.0805-0.48011-0.95065-0.6197-2.1714-0.36986-0.24011 0.0502-0.49 0.11024-0.74055 0.18004-0.46 0.12003-0.94022 0.25897-1.4002 0.33007-0.0104-0.2805-0.21989-0.42074-0.29035-0.63993 0.0202 0 0.0802-0.30006 0.0802-0.30006-1.6012-0.0992-8.7849-1.8011-9.1849 0.44097-1.5907 0.14025-3.0216-0.29029-4.6417-0.31116-2.1714-0.0196-2.6314-0.0502-2.6915-2.3001-1.4909-0.42074-1.4002-2.9609-1.6508-4.1918-0.30014-1.5003-0.95066-2.8911-1.01-4.4815-0.16051-0.0398-0.30014 0-0.46065-0.0489-0.0502-1.0711 0.92064-1.1213 1.4511-1.8506 0.57026-0.77104 0.65052-1.4814 0.70011-2.4606 0.03-0.74039 0.4104-2.1103 0.33994-2.6608-0.11027-0.74952-0.82995-1.4808-1.2006-2.1403 0.03-0.03-0.44955-0.0104-0.44955-0.0104-0.0411 0.16047 0 0.30007-0.0502 0.4501-0.84039 0.0405-2.3613 0.31051-3.1521 0.0405-1.1705-0.42075-0.77057-1.1409-1.6906-1.8213-0.75034-0.0398-1.5314-0.01-2.2817-0.06-0.0196-0.29028-0.20031-0.46054-0.21009-0.78017-1.4002-0.06-2.7717 0.31115-3.9723 0.14024-0.39083-0.0489-0.68053-0.14873-0.89063-0.26875z",
+                Yunlin:"m204.7 249.7c0.55004 0.72995 0.82929 0.96022 1.0903 1.9805 0.47957 1.8506 0.7497 3.5806 0.63943 5.6406-0.95066 0.0502-2.0005-0.25897-2.4716 0.52055-0.39932 0.65037 0.14028 2.3308 0.18008 3.0014 0.0411 1.0196-0.0405 1.7606 0.32037 2.6706 0.35037 0.90021 1.0603 0.8702 0.7001 2.2009-0.42085 1.6308-1.5503 2.6706-1.9118 4.4214-0.38039 1.8611-0.6603 3.1612-0.25968 5.1918 1.151 0.24006 1.8106-1.5904 2.9316-1.9504 0.36017 0.78997 0.17943 1.7802 0.57026 2.6106 1.3604 0.14025 2.6308 0.41032 4.1125 0.33986 0.0502-1.471 2.2908-0.17025 3.0314-0.98109 0.82147-0.90021 0.20097-2.88 1.7806-1.79 1.1608 0.8004 0.78036 1.8304 1.671 2.351-0.50045 0.23092-1.2006 1.0007-1.1405 1.4305 0.12984 0.84998 1.1014 0.72017 1.3604 1.3405 0.2101 0.49055 0.12071 1.9804 0.12071 2.5114 0.01 1.1207 0.30992 1.501-0.79015 1.8311-1.3904 0.41031-3.522-1.0705-5.0025-1-1.0903 0.0496-3.342 1.3999-3.5416-0.65037-0.36996 0.31116-0.59049 0.30007-0.8306 0.79062-2.6014 0.64971-2.3111-0.30007-2.6614-2.4514-1.8113-0.0496-3.2115 0.7006-4.9627 0.81019-2.0409 0.12068-3.141-0.77953-4.8531-1.1703-3.0816-0.69016-6.8934 0.85063-7.694-3.3008-0.23032 0.0196-0.55003-0.0802-0.78036-0.0607-0.0992-1.2303-1.4707-1.8004-1.7206-3.1109-1.1307-0.25962-1.5509 0.41032-2.5114 0.60014-0.86061 0.17939-1.902 0.0398-2.8017 0.0398-0.81037 0-2.2014-0.27006-2.9616 0-0.9911 0.36009-0.76078 1.2303-1.5307 1.6804-2.1616 1.2707-3.0118-1.6106-4.5125-1.6804-1.4609-0.0802-3.5723 1.3105-3.3615 2.972-0.96044 0.0502-2.0612-0.13046-2.9414 0.23027 0.33015 1.7606-1.2912 2.7013-2.7019 2.8004-2.2014 0.15982-2.3111 0.54012-2.3515 2.8122-0.96044-0.26027-2.0807-0.54012-3.1214-0.4501 0.0202 0.66994 0.51024 1.1403 0.61072 1.7802-1.7212 0.14025-2.4912-0.62036-3.342 0.82063-0.93043 1.6002-0.18009 2.1005-2.101 2.7404 0.23033 1.6197-1.0707 2.3001-1.9907 0.93021-0.36996-0.54991 0.25968-1.1703-0.36996-1.6412-0.25055-0.18982-1.4811 0.0202-1.8113 0.0307-0.12006 0.74952-0.64008 1.4899-0.50045 2.2799 0.09 0.50164 0.88084 1.1905 0.98067 1.8617 0.35038 2.5806-1.4909 2.5708-3.522 2.1709-1.5907-0.31116-3.1717-0.81019-4.8224-1.1605-0.89063-0.18983-3.4418-0.38031-3.862-1.1403-0.32037 0.0698-0.79015-0.11024-1.1105-0.06 0.15006-1.1102-0.35038-1.6008-1.0505-2.0607 0.0405-0.0496 0.06-0.11024 0.0803-0.18004 0.26033-1.0705-0.55004-0.88912-0.95066-1.5304-0.0502-0.0104-0.11026 0-0.1605-0.0196-0.0503-0.87085-0.06-1.8011-0.01-2.6804 0.0405-0.71038 0.27991-0.36987 0.50045-0.81019 0.21988-0.45988-0.21989-0.63993-0.4202-0.88977-0.57026-0.71038-0.38039-1.6908-0.33015-2.621 0.0202-0.52056 0.30014-0.66994 0.36995-1.0607 0.0803-0.40966-0.24011-0.75017-0.31057-1.1403-0.0803-0.48011 0.0202-1.0405-0.01-1.5304-0.36995-0.13047-1.151-0.74104-1.0505-1.2107 0.0998-0.5199 0.85082-0.27006 1.1105-0.80105 0.18008-0.36922 0.0104-1.2505 0.0104-1.6797 0-0.72017 0.32036-0.94 0.50044-1.5708 0.18009-0.62036 0.4202-1.0098 0.88084-1.5101 0.49001-0.53034 0.6205-0.84019 0.85996-1.5095 0.24011-0.66993 0.39018-1.09 0.45021-1.7906 0.0398-0.56035 0.27012-0.89043 0.64008-1.3007 0.57026-0.62036 2.2112-1.6008 1.7206-2.6308-0.21989-0.45989-0.45021-0.48989-0.48022-1.1403-0.03-0.4201 0.0998-0.97979-0.0803-1.3601-0.21009-0.44945-0.48022-0.3803-0.85082-0.30985-0.32037 0.06-0.20031 0.36008-0.57026 0.10959-0.18009-0.12068-0.27992-0.33986-0.26034-0.56034 0.12005-0.97979 1.8413-0.62036 2.5016-0.70973 0.0398-0.8702-0.15007-1.7404-0.18008-2.6008-0.0398-0.99022 0.20031-1.2505 0.70076-2 0.81037-0.0404 2.681 0.30007 3.1214-0.44032-0.0998-0.52055-0.20031-0.99088-0.20031-1.561 0-0.27985-0.0803-0.69016 0.0802-0.93021 0.18009-0.27007 0.55069-0.27007 0.73077-0.50034-0.6603-0.30007-0.88084 0.2505-1.181 0.66994-0.27991 0.39987-0.81037 0.75996-1.0205 1.1905-0.45021 0.12003-0.72033 0.63993-1.121 0.87999-0.32037 0.19047-0.67988 0.12068-0.99046 0.25049-0.24011 0.0998-0.42019 0.30007-0.67987 0.30007-0.09-0.68038-0.59049-1.2101-1.0205-1.7215-0.51024-0.6197-0.47043-1.0796-0.49001-1.8806 0.21988 0.51011 0.70011 1.0307 1.3004 0.93999 0.52002-0.0907 0.59049-0.54991 0.78036-1.0007 0.38039-0.89042 0.47043-1.8904 0.42019-2.8807-0.68053 0.0698-1.0309 0.24984-1.5105 0.74038-0.46065 0.45989-0.78036 0.58057-1.3506 0.8702-0.09-0.50033 0.74055-1.0307 1.1105-1.2903 0.47043-0.33986 0.68053-0.7306 1.1307-1.0711 0.39018-0.28898 0.89063-0.74952 1.3708-0.9002 0.88084-0.28964 1.3206-0.57013 1.9711-1.2094 0.6205-0.62036 1.2906-1.1703 2.1616-1.4005 0.75034-0.21005 3.3015 0.46054 2.9414-1-0.15007-0.60014-0.88084-0.63928-0.24011-1.3001 0.27991-0.2805 0.67009-0.36987 1.0603-0.39075 0.30014 0.12068 0.74056 0.18005 1.1307 0.11025 0.67009 2.0516 3.5919 0.81997 4.3918 2.2805 2.3411 0.66015 4.3226 0.86042 6.9736 0.86042 1.1908 0 2.681 0.24984 3.8418 0.01 1.4009-0.30007 1.9013-1.2903 3.1319-0.20026 0.97023-2.0516 1.7708-1.8102 4.0323-1.8102 0.92064 0 1.8308-0.06 2.6216 0.21005 1.0407 0.35029 1.241 0.9002 2.5212 0.82062-0.0398 0.27006 0.11027 0.66994 0.06 0.94 0.20031 0.20026 0.20031 0.01 0.33015 0.33986 1.581 0.0907 2.4611 0.06 3.6317 0.69081 0.99045 0.53034 1.7212 1.3307 2.6614 1.6608 2.651 0.90999 5.593 0.20939 8.3543 0.33986 0.4104 0.0202 1.4818-0.0189 1.8413 0.16047 0.47043 0.23092 0.73012 1.06 1.1908 1.3105 0.91085 0.47097 2.7417 0.48011 3.802 0.53034 1.6801 0.0802 3.3818 0.17025 5.0626 0.14938 1.9111-0.0189 2.0214-0.0802 3.141 1.4814 0.0215 0.0157 0.0313 0.0359 0.0418 0.0555z",
+                Penghu:"m30.865 336.76c0.46065 0.0698 0.20031 0.18004-0.06003 0.3503-0.51023 0.33986-0.21988 1.15-0.59049 1.6504-0.15007 0.20026-0.32036 0.4788-0.49001 0.64906-0.23032 0.21005-0.47043 0.0907-0.7001 0.25114-0.28056 0.20027-0.14028 0.50947-0.2499 0.8004-0.09004 0.24006-0.27012 0.39988-0.32036 0.66994-0.04045 0.24006 0.0098 0.50033-0.33015 0.50033-0.1703-0.21983-0.40975-0.47032-0.60028-0.69016-0.15986-0.19047-0.56048-0.33072-0.6603-0.53034-0.10962-0.23027 0.1305-0.58904 0.16051-0.80953 0.02023-0.18982 0.02023-0.52055-0.06981-0.69081-0.21988-0.41031-0.76078-0.48989-1.0009-0.90021-0.03001-0.0698-0.05024-0.19047-0.09983-0.24005-0.09983-0.0998-0.18987-0.0405-0.30014-0.11024-0.1703-0.09-0.25968-0.4488-0.47043-0.45989 0.45021 0 0.90041-0.03 1.3506-0.0405 0.32036 0 0.39018-0.0411 0.61072-0.21983 0.23032-0.19048 0.2897-0.18004 0.64008-0.18004 0.48022 0 0.95065 0.0404 1.3708-0.12003 0.20031-0.0698 0.36016-0.0502 0.56047-0.0998 0.27012-0.0607 0.15986-0.22049 0.33994-0.31116 0.10896 0.4214 0.56961 0.48076 0.90955 0.53099zm9.855-23.999c0.12006 0.36008 0.21988 0.66015 0.06981 1.06-0.15986 0.4214-0.55004 0.48011-0.59049 0.96087-0.02023 0.42075 0.24011 0.69994 0.4104 1.0496-0.73077 0.11024-4.3827 0.0907-4.3925-0.78996 0.33015-0.0202 0.60028-0.19048 0.6603-0.50034 0.80058-0.41031 1.3904-1.1905 1.3108-2.0803-0.09983-0.0104-0.2101-0.0307-0.31058-0.0307-0.55982-0.66015-0.09004-0.97-0.09983-1.6497 0-0.54013-0.64008-1.3412 0.26034-1.6713 0.13963-0.03 0.33994 0.17026 0.48022 0.17939 0.11027 0.78997 0.51023 0.0998 0.85082 0.15982 0.81037 0.12981 0.2499 0.25049 0.58005 0.75017 0.1703 0.25898 0.73077 0.42989 0.82016 0.60014 0.24011 0.4201-0.2101 0.85063-0.24011 1.06-0.06916 0.55186 0.03067 0.38226 0.19052 0.90216zm4.2326 0.90021c0.01957 0.25962 0.06981 0.21005-0.1703 0.34964-0.12006 0.0607-0.29035 0.12134-0.43063 0.18004-0.53046 0.25898-0.40975-0.20091-0.85017-0.24983-0.31058-0.0411-0.20031 0.18982-0.33015 0.33986-0.08025 0.11024-0.11027 0.0998-0.2101 0.17025-0.09983 0.0613-0.24011 0.16047-0.36995 0.24006-0.0098 0.22048 0.08025 0.55056-0.1703 0.65036-0.36995 0.12982-0.40975-0.33007-0.45999-0.55056-0.50045 0.03-0.43063-0.69994-0.43063-1.0404 0.33015 0 0.6603 0.0104 0.99046-0.0111 0.09004-0.25898 0.08025-0.57013 0.06003-0.85911-0.11027-0.0111-0.23032-0.0998-0.24011-0.22049-0.04045-0.3105 0.24011-0.14025 0.38039-0.25962 0.11027-0.0998 0.03001-0.27007 0.11027-0.34965 0.10962-0.0907 0.39997 0 0.49001 0.12981 0.20031 0.31051-0.1703 0.55056 0.33994 0.60014 0.19052 0.0196 0.42019-0.12981 0.5807-0.09 0.14028 0.03 0.15007 0.14938 0.2499 0.20874 0.09983 0.0613 0.2101 0.0111 0.30014 0.10046 0.1703 0.15134 0.15072 0.46185 0.16051 0.66146zm0.24011-20.209c-0.21988 0.4201-0.13963 0.91978-0.16964 1.3901-0.90041 0.0502-1.6012 0.2805-2.4213 0.20027-0.42019-0.0489-0.7399-0.16961-1.1503 0-0.32036 0.13046-0.09983 0.63993-0.73077 0.55121-0.0398-0.18004-0.15986-0.21983-0.20031-0.39074-0.21988 0.0411-0.50045-0.0607-0.72033-0.03-0.06003-0.6308 0.71054-0.60079 0.6603-1.1507 0.73012 0.17874 1.7108-0.22048 2.3913-0.42988 0.77057-0.25049 1.4909-0.2107 2.3411-0.14025zm0.26034-23.275c0.19052 0.0998 0.19052 0.8402 0.09004 1.09-0.6603 1.6112-2.3913 0.72016-3.7419 1.2609-0.02023 0.74952-0.0098 0.82975 0.30014 1.4299 0.30014 0.55056 0.36995 0.75017 0.33015 1.4606-0.04045 0.95044 0.15986 2.7019-1.2103 2.6106-0.14028 0.53034 0.98002 1.8011-0.25055 1.8409-0.01957 0.33986-0.12006 0.90021-0.01957 1.2401 0.09983 0.3105 0.43977 0.45989 0.57026 0.75995 0.44042 1.0705-0.38039 1.1807-1.2208 1.1403 0.02023-0.12068-0.0398-0.2805-0.01957-0.39075-0.76078-0.0404-1.7512-0.53034-2.4018-0.09 0.30014 1.3405-1.6207 0.0496-1.611 1.06-0.69032-0.0802-1.0805 0.32029-1.8008 0.25049-0.39997-0.98044 0.06981-1.1102 0.75034-1.5095 0.58005-0.33986 0.27012-0.3803 0.57026-0.81018 0.2101-0.31116 0.1703-0.52056 0.72033-0.58122 0.30992 0.51012 0.51023 0.61971 1.0505 0.60079 0.26034-0.0111 1.1412-0.27006 1.331-0.42075 0.60028-0.50099 0.67009-2.1507 0.38039-2.9211-1.3911 0-1.4009-1.3412-0.08026-0.86041 0.03001-0.61123-0.03001-0.92043 0.32036-1.3803 0.33015-0.44032 0.76078-0.42075 0.85082-1.09-0.14028 0.03-0.33994-0.0502-0.48022-0.03 0.02023-0.11024-0.0398-0.28115-0.02023-0.39074-0.24011-0.0404-0.47043-0.16047-0.73012-0.11024 0.27012-0.8004-0.2499-1.9198 0.09004-2.6406 0.85017-0.0104 0.70989-0.25049 0.98002-0.85063 0.2101-0.44032 0.61072-0.66015 0.75034-1 0.36995-0.8004-0.18008-0.69016 0.75034-1.0802 0.45021-0.19048 0.86061-0.46054 1.3108-0.65037l0.03001 0.0698c0.1305-0.01 0.27012-0.01 0.40062 0.0104-0.2101 0.36074-0.39018 0.6608-0.63029 1.0111-0.29035 0.39922-0.69032 0.39922-0.51024 1.0496 0.77057-0.0502 1.3708 0.57013 2.2412 0.3503 0.21923-0.0587 0.71902-0.52838 0.90955-0.42858zm8.5742-4.4032c-0.23032 1.3803 1.641 2.2205 1.5007 3.8109-0.36995 0.0202-0.76078 0.0104-1.1405 0.0307-0.26034 0.38031-0.32036 1.2401-0.2499 1.7208 0.84039-0.19048 0.82995 0.8004 0.39018 1.1703-0.63029-0.0404-0.50045 0.63014-0.47043 1.0802 1.5307 0.03 1.2912 1.1005 1.2208 2.4208-0.4104 0.03-0.89063-0.2805-1.2306-0.48989-0.7001-0.45011-0.29035-0.48011-0.59049-1.2505-0.39018-1.0411-1.761-0.57013-1.3206-1.9915 0.54025-0.09 0.33015-1.1096 0.31058-1.5806-0.86061 0.0411-0.49001-0.77953-0.75034-1.2603-0.16051-0.29029-0.53046-0.33986-0.65052-0.66994-0.09983-0.24984 0-0.72016-0.01957-0.99023-0.8704-0.26027-2.191-0.63014-2.0814 0.63928-0.53046-0.0196-0.44042 0.52056-0.74056 0.78018-0.50045-0.3803-0.69032-0.93935-1.331-0.65037 0.09004-0.06 0.01044-0.16047 0.08025-0.27984h0.09004c0.31058-0.76061-0.38039-1.1905-0.32036-1.9009 0.56048 0.10959 0.84039-0.36987 1.4009-0.43054 0.54025-0.0691 1.2306 0.0998 1.8211 0.0698-0.04045-0.15982 0.06003-0.39987 0.03001-0.56035 0.41041-0.03 1.0309 0.17026 1.0805-0.33007 0.7001-0.21005 0.84039 0.41031 1.3408 0.63014 0.52981 0.22179 1.0505-0.058 1.6305 0.032zm1.592-17.163c0.09004 0.40966 0.1703 0.78997 0.16051 1.2205-0.18008-0.0411-0.45021 0.0691-0.64008 0.03-0.04045 0.78996-0.31058 0.85976-0.67009 1.3999-0.23032 0.33986-0.15007 1.4606-0.91085 1.2401 0.02023-0.1396-0.08025-0.18004-0.09983-0.24005-0.0098-0.66016-0.10962-1.3503 0.27012-1.9009 0.30014-0.44031 1.1307-0.55056 1.1405-1.1703-0.32036-0.06-0.52002-0.33987-0.59049-0.66994-0.39018 0.0411-0.65052-0.20026-0.64008-0.57992 0.78036-0.21005 1.1803 0.78018 1.9803 0.67059zm0.75687 4.9772c0.27012 0.19048 1.1405 1.0007 1.0009 1.4208-0.14028 0.42988-1.4811 0.24984-1.8511 0.39988-0.5807 0.24005-1.0603 0.92043-1.2306 1.5708-0.39018-0.31116-0.47043-0.78996-0.42998-1.291-0.24011 0.0411-0.43063-0.10959-0.64008-0.10959-0.19052-0.63014 0.40975-0.54012 0.67009-0.9002 0.25968-0.36009 0.23032-0.60014 0.24011-1.0705 0.45999-0.0907 0.78036-0.80105 0.99046-1.1814 0.25968 0.75147 0.64986 0.75147 1.2501 1.1611zm9.1868 29.42c1.0309 0.25049 1.4211 0.16047 1.3904 1.4097-1.1608 0.0913-2.5812 1.0411-2.5009-0.88912-1.3506-0.0698-2.8415-0.14025-4.1523-0.0907-0.82016 0.0307-1.2704 0.22049-1.5007 0.91064-0.2499 0.72017 0.02023 1.1207-0.82995 1.4208-0.30014 0.11024-0.64008-0.0405-0.92064 0.0998-0.35038 0.17939-0.45021 0.52055-0.73012 0.74952-0.46065 0.39074-1.0009 0.33986-1.3408 0.84019-0.75034 1.1103 0.81037 2.8918-0.08026 3.9818-0.30992 0.37965-0.89063 0.25897-1.4204 0.23027-0.43063-1.561-2.0011 0.12068-3.1019 0.17939-0.61072 0.0404-1.4009-0.14939-1.5907-0.82976-0.14028-0.50033 0.42998-1.2394-0.06003-1.7704-0.49001-0.55056-1.2404 0.0998-1.8308-0.50033-0.47043-0.47032-0.21988-1.1605-0.77057-1.5617-0.44042-0.31899-1.5509 0.0698-1.7708-0.64972-0.18987-0.58056 0.55069-0.82062 0.6205-1.3412 0.43063-0.20027 0.30014-0.66015 0.5807-1 1.2103-0.33007-0.02023 2.3412 1.3108 2.1703 0.27991 0.72016 0.75034 1.0104 0.69032 1.8904 0.52002 0.14938 0.8704-0.0998 0.8306-0.63993 1.6207-0.0796 0.81037 0.53034 1.2508 1.6412 1.0407 0.20026 1.2906-0.66994 1.2508-1.561 0.67988 0.0496 2.9616 1.6204 2.5512 0.0111-0.0398-0.19048-0.45999-0.27007-0.48022-0.52121-0.04045-0.47946 0.30014-0.45924 0.50045-0.66929 0.27012-0.30006 0.49001 0.0496 0.51023-0.59035 0-0.12981-0.28056-0.63014-0.36016-0.74039-1.1007-1.3901-2.101 0.20092-3.1417 0.33073-0.97023 0.12003-2.6216-0.76061-2.4911-1.9009 0.68053-0.0691 1.7108 1.2101 2.2412 0.24006 0.65052-1.2101-1.0407-1.4703-1.7408-1.2401-0.09004 0.48011-0.59049 0.31116-1.0107 0.31964 0.15007-0.88977 0.31058-1.1801 1.151-1.6002 0.12006-0.68038-0.98067-1.6106-0.6603-2.0607 0.2499-0.33986 2.0311-0.01 2.4716 0-0.33994-0.90021 0.33994-0.85911 1.0205-0.82911 0.03001 0.66929-0.18008 1.9994 0.36995 2.471 0.09983 0.09 1.0303 0.30007 1.1405 0.26941 0.67009-0.17939 0.39997-0.36987 0.44042-0.94 0.10962-1.6902 0.96044-0.33986 1.5705-1.15 0.64008-0.84084-0.65052-1.4703-0.85017-1.9009-0.12006-0.03-0.1703-0.06-0.2499-0.0998 0.45021-0.12002 0.82016-0.67972 1.4302-0.50033 0.53046 0.16047 0.35038 0.88977 1.2306 0.4899-0.12006-0.74104 0.91085-1.1403 1.2808-0.4899 0.16051 0.28963-0.36016 0.99023-0.42998 1.3405-0.09004 0.4501-0.09983 1.3001 0 1.7508 0.10962 0.48011 0.58005 1.1514 1.0903 0.50099-0.26034-0.36987-0.18008-1.5506-0.06981-1.9413 0.27991-1.0196 0.88084-0.30007 1.8008-0.41031 0.06982-1.3999-0.16051-2.1709 1.5007-1.8898 0.09983 0.67972 0.33015 1.1292 0.36016 1.8898 0.2499-0.03 0.55069 0.0502 0.81037 0.03 0.06981 0.0802 0.09004 0.0907 0.1703 0.17091-0.04045 0.19048 0.02023 0.45989 0.02023 0.72016 0.76078-0.0802 0.23032-1.1605 0.39997-1.6608 0.24011-0.66016 0.76078-0.51991 1.4909-0.48011 0.02023 0.4501-0.15007 1.2205 0.01044 1.6504 0.23032 0.59035 0.52002 0.57991 0.59049 1.3307 0.09722 1.1285-0.05285 2.2884 0.0072 3.409z",
+                Changhua:"m211.1 246.37c-0.01 0.0607-0.01 0.3803 0 0.4501-1.9711 0.0998-3.1919 0.63928-4.9425 1.0496-0.38039 0.58057-0.96044 0.98044-0.88997 1.7802-0.17095 0.0202-0.38039 0.0502-0.57026 0.0502-0.0111-0.0202-0.0202-0.0411-0.0411-0.06-1.1203-1.561-1.2306-1.501-3.141-1.4814-1.6808 0.0202-3.3824-0.0692-5.0632-0.14938-1.0603-0.0502-2.8918-0.0607-3.8013-0.53034-0.46064-0.24984-0.72033-1.0802-1.1908-1.3105-0.36017-0.18004-1.4309-0.14025-1.8413-0.16047-2.7606-0.12981-5.7033 0.57013-8.3543-0.33986-0.94022-0.33008-1.671-1.1298-2.6614-1.6608-1.1705-0.63014-2.0514-0.60014-3.6317-0.69016-0.12984-0.33007-0.12984-0.13959-0.33015-0.33986 0.0502-0.26941-0.0998-0.66928-0.06-0.93934-1.2802 0.0802-1.4805-0.47033-2.5212-0.82063-0.79015-0.27006-1.7004-0.21004-2.6216-0.21004-2.2608 0-3.0614-0.24006-4.0323 1.8102-1.2306-1.0907-1.731-0.0998-3.1319 0.20027-1.1608 0.24005-2.651-0.01-3.8418-0.01-2.6517 0-4.6326-0.20091-6.9736-0.86041-0.80059-1.4606-3.7217-0.23093-4.3918-2.2805-0.39018 0.0698-0.8306 0.01-1.1307-0.11024 0.18009-0.01 0.36996-0.01 0.54025 0 0.60028 0.03 1.4309 0.27006 1.8909-0.21983 0.48022-0.53034-0.18008-0.72017-0.32036-1.3503-0.20031-0.90021 0.59048-1.6008 1.4309-1.561 0.11027-0.69081 0.0803-0.91065 0.8306-0.93022 0.6205-0.0202 1.5105 0.17026 2.0514-0.12981 0.4502-0.25049 0.84038-1.0502 1.0903-1.4814 0.30014-0.53033 0.20031-1.1102 0.42998-1.6406 0.53046-1.2205 1.4309-2.1103 2.2112-3.1312 0.33015-0.43967 0.60028-1.1011 0.77057-1.6204 0.06-0.21004 0.0202-0.57013 0.12984-0.75017 0.19053-0.30985 0.36996-0.23027 0.50045-0.60992 0.10962-0.31051 0.06-0.94 0.06-1.2603-1.1007-0.29028-2.071-0.40053-1.3506-1.6608 0.54025-0.95043 1.3806-1.7 1.731-2.8506 0.27012-0.89042 0.43063-1.8506 1.0009-2.6713 0.15985-0.23027 0.36016-0.36921 0.52002-0.63927 0.12984-0.23093 0.12005-0.48011 0.35037-0.63015 0.50045-0.32029 1.3911 0.30007 1.8811-0.0698 0.33993-0.25049 0.39017-1.0907 0.48022-1.4703 0.15985-0.66994 0.35037-1.3503 0.78035-1.8898 0.58071-0.72016 1.181-1.1807 1.3206-2.1103 0.14028-0.88064 0.7001-1.3712 1.3604-1.9407 0.48022-0.42074 1.9711-0.97 2.131-1.5101 0.88083-0.15004 2.6014-0.66994 2.4213-1.8709-1.0002-0.0802-2.131 0.11024-3.1717 0.0502-0.80058-0.0404-0.78036-0.21983-0.71054-0.95044 0.0502-0.44031-0.0405-1.09 0.0803-1.5506 0.28057-1.1305 1.761-1.1605 2.7613-1.2505 0.57026-0.0502 1.0707-0.26028 1.611-0.31116 0.56047-0.0496 1.1412 0 1.6912 0 0.61071 0 1.5809 0.21005 1.9209-0.42923 0.27991-0.53034 0.0196-1.3412-0.06-1.8709-0.0998-0.65037 0.12984-1.09 0.26034-1.7006 0.13963-0.5897 0.09-1.3196 0.06-1.9302-0.53046-0.0202-1.0309-0.06-1.5607-0.0691-0.77057-0.0104-0.71054 0.0802-0.75034 0.8004-0.06 0.0202-0.11027 0-0.1703 0.0202-0.0202 0.33986 0 0.70059-0.0202 1.0496-0.64007-0.09-0.28056 1.1011-0.44042 1.4906-0.84038 0.0502-1.9914-0.21984-2.8011 0.0111-0.57026 0.1696-0.40061 0.69929-0.95065 0.99022-0.15007 0.0802-0.45021 0.0404-0.61071 0.09-0.2897 0.0907-0.3804 0.33987-0.73012 0.29029 0.21988-1.1703 1.1608-1.4208 1.8511-2.2407 0.76078-0.91065 1.4407-1.8506 2.251-2.7104 0.7001-0.74039 1.5007-1.5108 2.2713-2.2812 0.33015-0.33008 0.67988-0.72017 0.92064-1.1403 0.29035-0.53034 0.36016-1.0502 0.81037-1.4906 1.0205-1.0007 3.0216-0.43053 4.4322-0.51011 0-0.53947 0.06-0.5199-0.12005-0.99023-0.45021-1.2603 0.92064-1.4403 1.4002-2.3608 0.27012-0.53034 0.2003-1.2701 0.71054-1.7202 0.96109-0.85063 2.7913-0.50033 4.0121-0.31116-0.0405-0.12002-0.0803-0.23027-0.12071-0.31963 0.0803 0.03 0.15986 0.0691 0.24011 0.11024 0.0803 1.3497 0.11027 2.2903 0.54025 3.4612 0.42084 1.15 1.0714 1.8402 1.5007 2.8409 0.49001 1.1703 0.0907 2.9002 0.7001 3.9713 0.72033 1.2505 2.0312 0.78997 3.1019 1.2303 0.09 0.68037 0.67009 0.81018 1.331 0.66015-0.0692 0.32029 0.12984 0.80105 0.06 1.1102 1.1405 0.58122 2.0011 1.0502 3.3028 1.2003 1.4106 0.15982 2.6712-0.0802 3.9723 0.36073-0.09 1.8004 0.58005 1.8102 1.2404 3.1012 0.58984 1.15 0.3804 3.0007 2.2706 2.5604-0.11027 0.46054 0.0202 0.21983-0.28056 0.51012-0.0803 0.96022-0.93043 1.5604-1.0303 2.471-0.11027 0.98044 0.33994 2.1005 0.36017 3.1403 0.64007 0.03 1.3108 0.03 1.9509 0-0.0802-0.38031 0.1305-0.91 0.0502-1.2903 2.1512 0.25962 3.2017 2.6106 5.0626 3.621-1.3408 2.2805-6.2631-1.4306-5.8931 2.6706 0.42084 0.03 0.80123 0.30986 1.2704 0.21983 1.3408 1.8004 1.181 6.1221-1.9418 6.002-0.21988 1.5101 0.24011 3.2212 0.3308 4.7815 0.23033-0.03 0.55004 0.0802 0.77971 0.0502 0.03 0.47945 0.15007 1.1703 0.03 1.6406-0.17029 0.63015-0.6603 0.74039-0.88084 1.291-0.4104 1.0196-0.24989 2.2107-0.32036 3.351-1.4909 0.54012-0.76078 5.5715-1.2697 6.8422 1.32 0.14025 1.1203 2.621 2.7815 3.0509 0.24011 1.0404 4.0825 2.2512 4.0519 0.50033 0.42019 0.0802 0.93956 0.33986 1.2808 0.66994-0.06 0.54012 0.19052 0.95043 0.21988 1.4403 0.45151 0.0776 0.79145 0.38813 1.2821 0.38813z",
+                Taichung:"m182.09 177.11c-0.03-0.84997-0.10962-2.0907 0.38039-2.8004 0.42998-0.63015 1.5209-1.4606 2.3515-1.5206-0.0411-0.8004 0.47957-1.09 0.0496-1.8604-0.27012-0.4899-0.80058-0.80106-1.2097-1.1814 1.2397 0.63993 2.5707 0.71038 2.6712 2.4814 0.33015 0.0398 0.57026-0.20092 0.80124-0.36987 0.11027-0.91065 0.26947-1.0202 1.121-1.0705 0.21988-0.97979-0.93108-0.39988-1.0603-1.291-0.74121-0.12982-1.5209-0.21005-2.2817-0.20027 0.82995 0 1.3108-0.48989 1.8713-1 0.3693-0.33986 0.39932-0.29028 0.47957-0.81018 0.06-0.36009 0.0907-0.74039 0.0502-1.1103-0.0692-0.03-0.11027-0.0502-0.18008-0.0802 0.43063 0.0104 1.1307-0.0802 1.701-0.06 0.96044 0.0411 0.76078 0.11024 1.0009 0.8702 0.40975-0.01 0.81037-0.09 1.1705-0.25897 0.0405-0.33073 0.31058-1.1703 0.12005-1.4103-0.0803-0.0998-0.52002-0.15003-0.6603-0.21004-0.24011-0.10959-0.32036-0.32029-0.75034-0.30986 0.41105-0.44097 1.6207 0.0992 1.9809-0.30007 0.56047-0.63079-0.17943-1.9504 0.0411-2.6719 0.2897-0.96936 1.4909-1.5206 2.0801-2.2701 0.97022-1.2205 0.17094-2.591 0.80123-3.8813 0.39018-0.78018 1.1105-1.15 1.761-1.7306 0.60028-0.54012 1.1803-1.2394 1.5698-1.9504 0.32037-0.57991 0.97088-1.1598 1.1816-1.7704 0.24011-0.65036 0.16051-1.1102 0.63942-1.6908 0.8306-1.0104 2.0716-1.4906 2.7019-2.6106 0.0196-0.03 0.0404-0.0691 0.06-0.0998 1.4106 1.1305 1.5105 2.7815 2.5512 4.2114 1.0707 1.4514 2.8709 1.9707 4.0917 3.6217 1.121 1.5003 2.0612 2.351 3.4627 3.591 0.74969 0.66015 1.0407 1.5506 1.9907 1.9602 1.0909 0.47946 1.7212 0.06 2.8017 0.8702 1.7806 1.3405 3.2017 3.2714 5.163 4.4912 2.1212 1.3203 4.9829 0.7006 6.834 2.1807 0.88084 0.70973 1.4609 1.8702 2.4318 2.5806 1.0798 0.78018 2.0605 0.41031 3.4522 0.20092 2.4514-0.36987 5.4821 0.50946 7.6737-0.33073 3.2017-1.2198 0.0998-4.6211 1.6201-6.882 1.4413-2.1096 4.6423 0.0998 6.3831 0.3803 2.2119 0.36008 5.7333-0.30007 7.174 1.8702 0.35038 0.53034 0.15985 1.2505 0.53046 1.7704 0.2499 0.3503 0.93956 0.48011 1.2508 0.74039 1.2306 1.0307 1.4407 1.5708 3.1919 1.4305 0.14028-0.69994 0.63029-1.1507 0.88084-1.7802 1.5907-0.0307 1.5405-1.3803 2.482-1.7006 1.2306-0.41031 1.5712 0.8402 2.6712 0.68038 0.33994-0.0502 2.0514-1.0104 2.3313-1.1703 1.32-0.78997 0.55917-1.0502 1.3708-2.1409 0.36995-0.50033 1.1014-0.33007 1.4609-0.69016 0.38039-0.3803 0.33015-0.8702 0.63029-1.2101 0.89062-1.03 1.151-0.84019 2.542-1.1292 2.3006-0.47098 3.1514-1.2505 4.2013-3.3021 2.221-0.39922 2.052-1.0705 2.1616-3.1703 0.69032-0.12067 1.4602-0.0202 2.1212 0.15917 0.31058 1.501 0.70011 2.8618 2.5205 1.6804 1.1014-0.72995 1.1412-2.03 2.6419-2.561 0.47044-1.1703-0.0802-2.6106 0.39018-3.7809 0.81038 0.0404 1.4106-0.39988 1.9411-0.87999v0.1396c1.6208 0.0802 3.4627 0.0802 5.043-0.15982 1.32-0.20092 2.4905-0.84019 3.4118-1.7802 0.0411 0.03 0.0803 0.0502 0.12071 0.0698 0.2499 0.15982 0.51023 0.28963 0.7001 0.5199 0.20031 0.25962 0.26948 0.60014 0.42998 0.87998 0.33081 0.60014 0.2101 1.1703 0.2101 1.8506-0.01 0.35029-0.0502 0.65036-0.2101 0.92043-0.14941 0.25962-0.35037 0.48011-0.42998 0.78017-0.0607 0.24984-0.18008 0.74039-0.0698 1.0007 0.11027 0.30007 0.49001 0.45989 0.74056 0.63928 0.28056 0.21004 0.44042 0.52055 0.68053 0.78018 0.29035 0.32029 0.42998 0.29028 0.8704 0.29028 0.83059 0 2.0109-0.20092 2.7019 0.17026 0.31971 0.18004 0.91085 0.29028 1.121 0.57991 0.17029 0.23092 0.0998 0.76061 0.0998 1.0411 0 0.82062-0.0202 1.6908 0.82929 2.0111 0.38039 0.14025 0.90041 0.17939 1.3206 0.12003 0.49-0.0691 0.55003-0.3105 0.85017-0.66015 0.2499-0.29028 0.56047-0.3803 0.89062-0.58122 0.41041-0.2394 0.68053-0.21983 1.1412-0.30985 0.50045-0.0998 1.0107-0.12003 1.5607-0.12003 0.35038 0 0.39996 0 0.65051-0.15982 0.16051-0.11024 0.26034-0.28115 0.46065-0.33986 0.48022-0.12981 1.0505-0.12981 1.5307-0.0992 0.73012 0.03 0.85083 0.2094 1.2808 0.76061 0.24011 0.30986 0.25968 0.17939 0.61071 0.30007 0.5807 0.20027 0.70076 0.61971 0.79015 1.1703 0.03 0.20027 0.0802 0.38031 0.14941 0.5597-0.79014 0.47097-2.0005 1.6308-2.2412 2.1814-0.50045 1.1396 0.30014 2.8311-0.20031 3.9713-0.36995 0.81997-1.3415 1.7-2.1212 2.3301-0.56048 0.47098-1.2208 0.33073-1.7114 0.66994-0.82995 0.56035-0.2897 0.77039-0.82081 1.5108-0.79015 1.0705-2.0801 1.0796-2.5205 2.4899-0.33993 1.1103 0.60028 3.1918 0.01 4.1723-0.58005 0.95044-2.3711 0.2094-3.312 1.0307-0.69032 0.60014-1.0498 2.291-1.5209 2.9707-0.23032 0.33007-0.43063 0.58056-0.60028 0.8004-0.0202 0.0104-0.03 0-0.0502 0 0.0196-0.19048-0.0104-0.28963 0.0698-0.47946-0.70011-1.0411-6.5534-3.0307-6.7936-1.0202-0.63029 0.21005-1.4106 0.27985-2.1108 0.15982-0.60027-1.0705-2.5616 0.0411-2.2204-2.1103-2.1512-0.33008-2.3222 0.96087-3.1417 2.3105-0.72033 1.1807-0.06 0.63079-1.2006 0.69994-0.72033 0.0411-1.5509-0.0202-2.2706-0.06-0.52067-1.03-0.70011 0-1.3611 0.19048-0.74969 0.21004-1.4707 0.16047-2.1708 0.33986-0.73012 0.18004-1.1105 1.0307-1.5405 1.1305-0.5807 0.1396-1.0707-0.39009-1.6312-0.47032-1.0603-0.13047-2.9818 0.18982-4.0023 0.50033-1.3115 0.39987-1.2312 1.6602-1.3604 3.1409-2.0312 0.11024-4.9125-0.58057-6.4732 0.69929-1.5907 1.291-2.1323 3.0307-3.9625 4.1618-2.0612 1.2694-3.0614 1.5806-5.6628 1.6706-2.482 0.09-3.5423 1.8102-3.6317 4.1012-1.2606-0.11024-1.7108 0.70973-2.052 1.7306-2.7515-0.33986-4.8727-1.1103-7.234-0.0202-1.0707 0.47945-2.3006 0.47945-2.8409 1.6602-1.8406 0.4201-1.6207-1.2603-2.9616-1.4703-1.9509-0.32029-0.65052 1.8402-0.84039 3.0007-0.23032 1.4403-1.7512 2.5506-2.6314 0.96087-0.55983-1.0111 0.21988-2.8206-0.23033-3.9309-0.86061 0.14938-0.95065 0.47033-1.6808 0.18004-0.55003-0.23092-0.72033-0.93999-1.3004-1.2009-1.4113-0.63928-2.221 0.10959-2.7019 1.3203-0.8704 2.261-0.53046 4.8318-0.65052 7.3119-0.97023 0.0502-2.1212-0.18004-2.9414 0.39988-1.0714 0.76061-1.271 2.5408-1.6919 3.6413-0.39018 0.99936-1.2201 1.9498-1.8902 2.7711-1.8315 2.2499-3.1123 4.3216-6.4543 3.1807-1.4511-0.48989-2.0305-0.80105-3.8424-0.80105-1.2508 0-2.9714 0.32029-4.1726 0.0111-0.3308-0.0802-0.63094-0.21005-0.91085-0.36987-1.8608-1.0104-2.9113-3.3608-5.0625-3.621 0.0803 0.38031-0.12984 0.91064-0.0502 1.2903-0.63943 0.03-1.3108 0.03-1.9509 0-0.0196-1.0405-0.47043-2.1605-0.36016-3.1403 0.0998-0.91064 0.95065-1.5101 1.0302-2.471 0.30014-0.29029 0.1703-0.0502 0.28057-0.51012-1.8902 0.44032-1.6801-1.4103-2.2706-2.5604-0.66096-1.291-1.331-1.3007-1.2404-3.1012-1.301-0.44097-2.5616-0.20091-3.9723-0.36073-1.301-0.14938-2.1616-0.61971-3.3022-1.2003 0.0692-0.3105-0.12984-0.78996-0.0607-1.1102-0.6603 0.15003-1.2404 0.0202-1.331-0.66015-1.0707-0.43967-2.3809 0.0202-3.1019-1.2303-0.61007-1.0711-0.20945-2.8011-0.69946-3.9714-0.43063-1.0007-1.0805-1.6908-1.5013-2.8409-0.42932-1.1703-0.45999-2.1103-0.54024-3.4612-0.0796-0.0411-0.15921-0.0802-0.23946-0.11024-0.60028-1.2303-2.0612-0.78018-3.0614-1.5206-0.55069-0.40053-0.86061-0.63993-1.5007-0.84019-0.60027-0.18004-0.96044-0.33008-1.4811-0.67059 0.33015-0.12003 0.64008-0.25897 0.92064-0.45989 0.50045-0.3803 0.48022-0.58057 0.6205-1.1005 0.11027-0.4501 0.26034-0.72995 0.46065-1.1305 0.15007-0.30985 0.17029-0.8004 0.48022-0.99022-0.06 0.57013-0.0196 1.3999 0.06 1.9811 0.12005 0.7704 0.67987 0.90021 0.88018 0.12003 0.15007-0.57991-0.20031-1.4606 0.44042-1.6902 0.51024-0.18004 1.4217 0.21983 1.9209 0.30985 0.14029-0.57013 0.0502-1.0404 0.0803-1.6197 0.0202-0.56034 0.16051-1.1213 0.17029-1.6804-0.33994-0.0698-0.53046 0.27006-0.72033 0.51012-0.44042 0.55056-0.32036 0.50033-0.90041 0.44031-0.87562-0.10437-0.94609 0.2655-1.2958 1.0359z",
+                Yilan:"m393.17 81.6c0.64987 0.54012 1.0505 1.2003 1.0002 2.0405-0.0404 0.04044-0.0692 0.0698-0.12005 0.12068-1.1014 0.06915-3.342 0.46054-3.2519-1.1011-0.20031-0.06001-0.4104-0.12981-0.60027-0.21005-0.0104-0.03979-0.0104-0.06915-0.0104-0.10959h0.0196c0.36995 0.06067 0.81037 0.12981 1.2103 0.10959 0.18987-0.39922 0.11027-0.87998 0.53046-1.12 0.4613-0.25962 0.89193 0 1.2221 0.27006zm-72.209 76.407c-0.0692-0.17938-0.12006-0.36008-0.14942-0.55969-0.0907-0.55056-0.21009-0.97-0.79014-1.1709-0.35038-0.12003-0.36995 0.0104-0.61072-0.30007-0.43063-0.55056-0.55068-0.72995-1.2808-0.76061-0.48022-0.03-1.0505-0.03-1.5307 0.0998-0.20096 0.06-0.30013 0.23092-0.46064 0.33986-0.2499 0.15982-0.30014 0.15982-0.65052 0.15982-0.55003 0-1.0603 0.0196-1.5614 0.12002-0.45999 0.09-0.73011 0.0692-1.1412 0.30986-0.33015 0.20091-0.63943 0.29028-0.88998 0.58122-0.30013 0.3503-0.36016 0.5897-0.85082 0.66015-0.42019 0.06-0.93956 0.0202-1.32-0.12003-0.85017-0.32029-0.82994-1.1905-0.82994-2.0111 0-0.2805 0.0698-0.81019-0.0992-1.0411-0.21009-0.28898-0.80123-0.39922-1.1216-0.57992-0.69032-0.36986-1.87-0.17025-2.7012-0.17025-0.44042 0-0.58005 0.03-0.8704-0.29029-0.24011-0.25962-0.39996-0.57013-0.68053-0.78018-0.2499-0.17938-0.63029-0.33986-0.74056-0.63927-0.10961-0.26028 0.0104-0.75018 0.0692-1.0007 0.0803-0.30007 0.28056-0.5199 0.43063-0.78018 0.15986-0.27006 0.20096-0.57078 0.2101-0.92043 0-0.67972 0.12005-1.2505-0.2101-1.8506-0.16051-0.27984-0.23032-0.62036-0.43063-0.87998-0.19053-0.23092-0.44956-0.36008-0.69945-0.5199 0.39017-0.73061 0.31971-1.8311 0.79014-2.5708 0.27012-0.41031 0.77057-0.36922 1.0107-0.66015 0.2101-0.24984 0.24011-0.80106 0.39018-1.1305 0.24011-0.57013 0.73012-1.7404 1.2103-2.06 0.47043-0.32029 0.90041-0.0698 1.3904-0.25114 0.63942-0.23027 0.29035-0.5199 0.74056-0.84998 0.0998-0.71038 0.53046-0.62036 1.0107-0.81997 0.75034-0.31116 0.5807-0.17026 0.75034-1.0007 0.30014-1.4103 1.0107-0.84997 2.1616-1.2603 0.31057-1.1011-0.23033-1.7515 0.93108-2.2505 0.91998-0.40966 1.2508-0.33986 1.0798-1.4906-0.15986-1.1103-1.1301-3.7313-0.34973-4.6915 0.39018-0.47946 1.1705-0.44032 1.6312-0.95044 0.74969-0.85911 0.0692-0.95043-0.35038-1.6902-0.16051-0.28963-0.24011-0.66928-0.24011-1.0705-0.0104-1.06 0.50045-2.3105 1.3708-2.6217 0.71054-0.24984 1.1608-0.01 1.7114-0.72017 0.46-0.60013 0.44042-1.3001 0.65052-2.0105 0.41041-1.4208 1.4609-1.8709 2.5714-2.681 0.21988-0.66928 0.57026-1.9009 0.27991-2.5004-0.30993-0.66015-0.72033-0.46054-0.45999-1.2394 0.12005-0.33008 0.47043-0.77105 0.71054-1.0307 0.67009-0.74039 2.3411-0.88129 3.5618-0.95044 0.2101 0 0.39997-0.0111 0.57026-0.0202 0.88149-0.0404 1.2704-0.06 2.0011-0.43053 0.58005-0.28898 1.0805-0.77953 1.7708-0.92043 0.70989-0.14025 1.5307 0.0607 2.1812-0.20026 0.35038-0.14025 0.63029-0.4201 0.98067-0.54991 0.2897-0.0998 0.67988-0.0802 0.92064-0.23093 0.86061-0.50033 0.54025-1.7802 1.0714-2.5108 0.53959-0.76061 2.4905-0.91064 3.432-0.90021 1.2208 0 1.5907-0.40966 1.5098-1.6602 2.7026 0.12003 2.7326-2.0705 1.9711-4.0712-0.33016-0.87998-0.44042-1.7508 0-2.6908 0.33015-0.69016 1.2097-1.8304-0.0503-2.2603 0-0.12068 0.0405-0.26028 0.0503-0.33986 0.0692-1.4299 2.3613-1.6197 3.3518-1.6497 1.1105-0.04045 0.85017-0.20092 1.0002-1.1709 0.0998-0.60014 0.36017-1.1096 0.85083-1.4808 1.0302-0.76061 2.7913-0.69016 4.0721-0.77039 1.3806-0.08024 2.7515-0.02022 4.1524-0.09067 0.0398-0.69016-0.12071-1.5506 0.33015-2.1005 0.36995-0.44945 1.151-0.63014 1.6012-0.97 0.49-0.36922 0.81037-1 1.1705-1.4299 0.65052-0.78018 2.3006-1.7306 3.312-1.9302 1.3408-0.26028 2.7404 0.21983 3.9416-0.48011 1.1601-0.66015 1.6116-1.6106 2.9009-2.0105 0.29035-0.56035 0.86061-0.66994 0.75034-1.3007-0.0998-0.57992-0.7001-0.62036-0.38039-1.4208 1.4009-0.0098 0.94021-1.7202 1.4106-2.5004 1.2097-0.24984 2.3913-0.3503 3.6525-0.3503 0.53047 0 1.2808 0.0698 1.7004-0.23027 0.3693-0.26028 0.68053-0.72016 1.1405-1.0202 0.58071-0.36987 2.0801-1.2003 2.2315-1.9107 0.21989-1.06-1.0805-1.9805-2.1414-1.9413-0.42998-1.4403 0.26033-2.0796 1.1712-3.0711 1.1014-1.1703 2.2608-0.84019 3.8215-0.91064 0.6603-0.04044 1.4296-0.02022 2.0801-0.15004 0.82081-0.14938 1.0805-0.60014 1.5705-1.12 0.84039-0.91064 2.0912-1.5206 3.2722-1.6504 0.46-0.04958 1.4309-0.01957 1.8517-0.23027 0.56961-0.2805 0.60028-0.88064 1.2312-1.1305 1.2006-0.47033 2.2008 0.42988 3.3916 0.36987-0.11027 0.30007-0.15007 0.66015-0.0998 1.1103-1.4106-0.05023-2.882 0.66015-4.1432 1.2094-0.39931 0.17091-1.181 0.32029-1.3708 0.69081-0.19053 0.39009 0.15985 1.0796-0.44042 1.2394-0.0202 0.03001 0 0.0698-0.0104 0.10959-0.4215 0.28115-0.64008 0.6608-1.0303 0.97066-0.36995 0.31051-0.71054 0.91064-1.2103 0.96022-0.42084 0.4899-0.93108 1.0202-1.6312 1.1605-0.39018 0.08024-0.50045 0.08024-0.82929 0.33008-0.25969 0.20092-0.68053 0.42988-0.8306 0.75017-0.2897 0.63014 0.16051 1.4808 0.16051 2.1311-0.0104 0.6608-0.65052 1.3203-1.1705 1.6602-0.24011 0.17091-0.52067 0.30007-0.72033 0.50098-0.18987 0.19048-0.49001 0.41031-0.68053 0.63014-0.4489 0.53034-0.84039 1.1298-1.3604 1.5701-0.47957 0.41031-1.0107 0.98044-1.4413 1.4403-0.47892 0.53034-0.88932 0.8291-1.0407 1.5604-0.12984 0.63014-0.49 1.1103-0.76013 1.6902-0.31058 0.6608-0.53046 1.4103-0.82081 2.0907-0.60028 1.3901-0.47043 2.9811-0.58984 4.5219-0.0502 0.61058-0.09 1.2805-0.25903 1.8402-0.12984 0.45989-0.2512 0.85063-0.3308 1.3301-0.0796 0.50098-0.18987 0.97066-0.28057 1.4305-0.27012 1.3307-0.0502 2.7906-0.0502 4.1514 0 1.2303 0.2101 2.5702 0.51024 3.7509 0.27012 1.0705 1.1014 2.1703 1.6312 3.0901 0.27991 0.46054 0.40976 0.69081 0.44042 1.2101 0.03 0.44945 0.0796 0.85976 0.1703 1.291 0.12984 0.69081 0.36995 1.3999 0.3308 2.1207-0.03 0.60014-0.0411 1.2205-0.0411 1.8402 0 0.60013 0.0496 1.1814 0.0802 1.7802 0.0196 0.48989 0.26947 0.93021 0.31971 1.4208 0.0405 0.36008-0.0998 0.67972-0.0411 1.0496 0.12136 0.74104 0.72033 1.2909 0.93173 1.9915 0.28904 0.93021 0.17878 1.7 0.79014 2.4899 0.47044 0.61057 0.68053 1.501 1.3708 1.9009 0.65052 0.38031 1.1014 0.5199 1.8413 0.66081 0.20879 0.0404 0.39997 0.14024 0.61985 0.17025-0.0111 0.31051 0.23946 1.2205-0.36995 1.1207-0.2101-0.0404-0.33015-0.35029-0.50045-0.47032-0.2101-0.15004-0.30014-0.15004-0.58135-0.16047-0.49001-0.01-1.0407-0.0998-1.4106 0.24984-0.34973 0.33007-0.28057 0.8702-0.2499 1.3307 0.25969 0.12981 0.45999 0.36986 0.74056 0.47032 0.20944 0.0698 0.44107 0.0698 0.66095 0.17091 0.0992 0.15982 0.21989 0.33986 0.30014 0.50033 0.12006-0.0998 0.21989-0.21004 0.30014-0.33986 0.18987-0.0196 0.39083 0.0196 0.57026 0.0907 0.0104 0.28049-0.17943 1.1403 0.12071 1.2094 0.18987 0.32029-0.14028 0.36987-0.3693 0.43054-0.48022 0.12068-0.51024 0.03-0.56048 0.61057-0.0998 1.09-0.03 2.1898 0.03 3.2805 0.68053-0.17026 0.4502 1.4005 0.4502 1.8011 0 0.68038 0.28057 1.7097-0.50109 1.9602-0.72034 0.21983-1.4511 0.06-2.1212 0.57078-0.28904 0.2094-0.52067 0.40966-0.88084 0.47032-0.54024 0.09-1.0407 0.0196-1.3715 0.57992-0.25055 0.42075-0.22054 1.0307-0.1703 1.5101 0.0411 0.33986 0.0998 0.66994 0.30014 0.93935 0.25968 0.35029 0.68053 0.29028 0.95065 0.55121 0.25969 0.24005 0.1703 0.63014 0.25969 0.96022 0.14028 0.53034 0.39018 0.78018 0.82081 1.1207 0.17943 0.14025 0.82016 0.72995 0.84038 0.92043 0.0398 0.31116-0.73077 0.32029-0.99176 0.33008-1.4707 0.0698-2.3606 1.2407-3.4411 2.1318-0.31971 0.25897-0.88084 0.57992-1.0714 0.95044-0.20031 0.3803-0.1703 1.0104-0.30014 1.4208-0.63942 0.06-1.181 1.1807-1.6305 1.6308-0.35038 0.33986-0.63094 0.66993-0.90107 1.0802-0.20031 0.30986-0.53046 0.60014-0.70989 0.91-0.17029 0.32029-0.25968 0.74038-0.39083 1.0907-0.14028 0.36987-0.2101 0.81997-0.24011 1.2101-0.0796 0.96022-0.06 1.9504-0.25968 2.8702-0.18987 0.8702-0.27013 1.7306-0.31058 2.6308-0.0411 0.75017-0.31971 1.3105-0.73012 1.9204-0.49001 0.71038-0.82081 1.3503-0.8704 2.2505-0.0405 0.8702-0.25055 1.6706-0.25055 2.5512 0 0.63015-0.0411 1.2505-0.0496 1.8696-0.0104 0.36074 0.15986 1.0502-0.0998 1.3307 0 0.0202-0.0196 0.0411-0.0405 0.0502-0.48022 0.38031-1.5314-0.24984-2.0214-0.3803-0.31971-0.0802-0.61137-0.14025-0.90107-0.31051-0.33015-0.18983-0.58983-0.54012-0.93108-0.72995-0.58005-0.32029-1.4302-0.15003-2.0514-0.33986-0.49001-0.16047-0.88084-0.30007-1.4106-0.28963-0.49001 0-0.96109 0.03-1.4204-0.12068-0.59048-0.17939-1.0505-0.50033-1.5816-0.78997-0.27991-0.15982-0.58005-0.40966-0.8704-0.5199-0.42933-0.15982-0.99045 0.09-1.3904-0.12003-0.3693-0.18982-0.44042-0.42988-0.90041-0.50098-0.4202-0.06-0.73012 0-1.0805-0.24984-0.44955-0.31051-0.74969-0.75017-1.1099-1.1605-0.36082-0.41032-0.88084-0.54013-1.2612-0.92043-0.18987-0.19048-0.30992-0.55056-0.55003-0.63015-1.1203-0.33986-0.0502 1.9113-1.2006 0.76061-0.33994-0.33986-0.65052-0.69016-0.98067-1.0404-0.27013-0.27985-0.63029-0.74039-0.95066-0.96022-0.75034-0.50099-1.4407 0.3803-1.2404 1.1298 0.0998 0.3803 0.46065 0.48989 0.6603 0.77105 0.15007 0.21983 0.15007 0.47032 0.33994 0.67972 0.2897 0.31964 0.63029 0.23027 0.74056 0.66015 0.0698 0.25962 0.0196 0.69016-0.0104 0.96022-0.0202 0.20092-0.0202 0.69994-0.18987 0.81019-0.30014 0.20026-0.43063-0.38031-0.59049-0.58057-0.30013-0.36987-0.29035-0.12068-0.71054-0.23093-0.23098-0.0502-0.41041-0.28963-0.46065-0.53033-0.24011 0.13959-0.4502 0.39922-0.54024 0.66928-0.0692 0.21983-0.0503 0.74104-0.2897 0.85063-0.23033 0.11024-0.33015-0.19048-0.61985-0.10959-0.29035 0.0802-0.5011 0.53034-0.70076 0.7293-0.12984 0.12068-0.24011 0.30007-0.42998 0.31116-0.17029 0.01-0.19052-0.15004-0.32036-0.17026-0.19053-0.0104-0.16051-0.15004-0.21989 0.14025-0.06 0.27006 0.0907 0.39009 0.27013 0.55904 0.36995 0.3503 0.55003 0.33008 0.60027 0.81019 0.0411 0.29028-0.0202 0.57013 0.0803 0.81997-0.2499 0.03-0.42998-0.09-0.66944-0.12003-0.27013-0.0404-0.48022 0.06-0.74121 0.09-0.42019 0.0411-0.85017-0.12003-1.2397-0.21983-0.78036-0.20027-1.5509-0.0998-2.3613-0.21005-0.98002-0.12981-1.1908-0.81997-1.8106-1.4599-0.61071-0.6308-0.7797-1.7215-1.761-1.8206-0.41041-0.0502-0.83973-0.0111-1.2508-0.0502-0.63943-0.06-1.181-0.24005-1.7904-0.36986-0.44107-0.0992-0.92064-0.11025-1.3715-0.0405-0.2101 0.03-0.33994 0.0992-0.59049 0.0802-0.30992-0.03-0.33994-0.18004-0.58005-0.25049-0.56047-0.15917-0.67009 0.31115-1.0407 0.50098-0.21988 0.12003-0.12071 0.09-0.41041-0.0998-0.18008-0.13047-0.33994-0.24006-0.5011-0.39009-0.36016-0.33986-0.63942-0.66016-1.0798-0.93022-0.42998-0.27006-0.97023-0.33007-1.4309-0.54012-0.71055-0.32029-1.1405-0.97001-1.8811-1.2003-0.63094-0.20091-1.1608 0.01-1.5712-0.59035-0.0574-0.0855-0.10701-0.17548-0.14746-0.2655z",
+                HsinchuCounty:"m293.48 147.63c0.0196-0.71104-0.09-1.4514-0.0502-2.1514 0.03-0.55969 0.18987-1.1807 0.0698-1.73-0.12005-0.56034-0.58005-0.84019-0.91085-1.2707-0.2897-0.38031-0.67009-0.63015-1.0002-0.96023-0.67988-0.71103-1.2312-1.5812-1.9118-2.2805-0.60027-0.61123-1.2704-1.1102-1.7604-1.8011-0.55982-0.80041 0.47043-1.3705 0.19052-2.1403-0.25968-0.66993-1.0002-1.1703-1.5705-0.70973-0.69097 0.57013-1.5509 0.16961-2.2315 0.69016-0.30014 0.23027-0.52002 0.57079-0.88084 0.66015-0.36017 0.0907-0.88997 0.0111-1.2508 0-0.35038-0.01-0.66944-0.03-1.0002 0-0.39997 0.0411-0.58071 0.24006-0.93108 0.32029-0.47044 0.12003-0.61072-0.12981-0.95066-0.30985-0.34972-0.19048-0.72946-0.12068-1.1203-0.14025-0.69032-0.0307-1.0498-0.93086-1.7108-0.48011-0.25968 0.16961-0.38039 0.62036-0.61072 0.73974-0.18008 0.10045-0.82015 0.0502-1.0205 0-0.39018-0.10959-0.43064-0.51012-0.76079-0.69995-0.30014-0.19048-0.6205-0.06-0.90041 0.11025-0.21988 0.12981-0.3693 0.28963-0.55004 0.48011-0.24011 0.26027-0.47043 0.35029-0.79014 0.53033-0.30014 0.16961-0.44042 0.24984-0.67988 0.4899-0.24011 0.23027-0.33015 0.33986-0.6603 0.3803-0.69097 0.0692-1.3604-0.0607-1.8615-0.39074-0.52067-0.3503-1.1705-0.0691-1.791-0.24984-0.15985-0.2805-0.44955-0.47032-0.58005-0.78996-0.14028-0.3503-0.0802-0.75017-0.13049-1.1207-0.0998-0.66994-0.74056-1.3901-0.2499-2.0516 0.23032-0.32029 0.54025-0.36008 0.91085-0.43967 0.53047-0.0998 0.36996-0.18004 0.60093-0.57013 0.20945-0.3503 0.58984-0.55056 0.66031-1.0104 0.0692-0.42009-0.24011-0.4501-0.5011-0.62036-0.2897-0.20026-0.61072-0.48989-0.84039-0.77039-0.23946-0.2805-0.50958-0.5199-0.80058-0.75996-0.3804-0.32029-0.89063-0.74039-1.3604-0.95043-0.0803-0.47033 0.76078-0.33987 1.0407-0.44032 0.32037-0.12068 0.53046-0.36074 0.58136-0.72017 0.10961-0.78018 0.3693-1.5003 0.85996-2.1305 0.35038-0.46054 0.39083-0.9002 0.70989-1.3307 0.27012-0.36008 0.65051-0.66015 0.55134-1.1703-0.15007-0.78018-1.0414-1.0502-1.2808-1.711-0.17095-0.47033 0.12919-0.69994-0.33994-1.0405-0.39018-0.27006-0.73011-0.25049-0.99045-0.66993-0.23098-0.36009-0.29035-0.74039-0.81037-0.59036-0.30014 0.09-0.99111 0.48011-1.0407 0.76061-0.22053-0.0802-0.39996-0.41031-0.55069-0.58057-0.24011-0.27006-0.52002-0.48989-0.7797-0.74038-0.65052-0.6308-1.3115-1.0104-2.2119-1.3301-0.58983-0.21005-0.81037-0.78996-1.4106-1.0111-0.14942-0.0496-0.3693-0.03-0.50045-0.0802-0.2101-0.0991-0.12984-0.0691-0.25968-0.30007-0.19053-0.31964-0.20031-0.39009-0.57027-0.50033-0.19052-0.41031 0-0.89042-0.09-1.3307-0.10961-0.50033-0.60027-0.3503-1.0805-0.36987-0.80059-0.0496-1.1099-0.69016-1.5607-1.2394-0.23098-0.27985-0.54025-0.47033-0.76078-0.76061-0.30993-0.39009-0.43977-0.88129-0.78036-1.2505-0.21989-0.23092-0.54025-0.3105-0.77971-0.51011-0.25968-0.21984-0.35038-0.54013-0.64007-0.69016-0.54025-0.2805-0.91086-0.0411-0.66031-0.81019 0.12984-0.39987 0.50045-0.62036 0.76013-0.96022 0.33016-0.44097 1.2508-1.4814 0.82995-2.1612-0.27012-0.44945-1.4811-0.43053-1.9111-0.29028-0.64008 0.21005-0.33994 1-1.1705 0.8702-0.78036-0.12003-0.76079-1.0104-1.5907-0.5897-0.2897 0.14025-0.39018 0.3105-0.70011 0.0991-0.18008-0.10959-0.39083-0.47946-0.42084-0.66015-0.0196-0.0202-0.0502-0.0404-0.0803-0.06 1.2612-1.0104 0.11027-3.2212 0.85148-4.5213 0.8293-0.29028 1.8008-0.15003 2.7215-0.20092 0.0496-0.97001-0.15007-2.1207 0.65051-2.8206 0.76079-0.66015 2.1408 0.02022 2.6112-0.91064 0.2499-0.4899 0.13963-0.93021 0.47957-1.4403 0.30014-0.4501 0.41041-0.63014 0.94022-0.7306 0.74055-0.15004 1.9711 0.66015 2.1812 1.3203 0.2897 0.01044 0.60028 0.01957 0.89063 0.03001 0.0398 0.20026 0.18987 0.31964 0.18987 0.54991 0.5807 0.46054 0.28056 1.0307 0.49001 1.6804 0.33015 1.0307 0.63029 0.27985 1.2397 0.08024 0.90106-0.28963 1.1712 0.09915 0.91085-1.1403-0.10962-0.53034-0.15986-1.3601-0.33994-1.9204-0.19052-0.60014-0.64986-0.91064-0.98067-1.4305-0.38039-0.60014-0.33015-1.1096-0.33015-1.8396 0-1.5101-0.65051-1.9909-1.84-2.7508-0.64008-0.41031-1.0603-1.0104-1.7519-1.2401-0.89063-0.30007-1.3708-0.0698-1.8406-0.99023-0.88084-0.06067-1.4602-0.21005-2.2204-0.45989-0.73077-0.23092-1.6207 0.0098-2.2921-0.36987-1.35-0.76061-1.4211-2.651-3.0216-2.8311 0.0404-0.06001 0.0698-0.11024 0.0404-0.19048 0.0992-2.471 1.9202-1.6008 2.9218-3.1709 0.4502-0.71038-0.03-1.9107 0.14028-2.7508 0.26034-1.2401 1.0205-2.3105 1.6312-3.3908 0.5011-0.85976 0.66096-1.9805 1.3115-2.6908 0.4202-0.44945 0.93043-0.78996 1.4407-1.12 0.47956 0.12981 1.1705 0.12981 1.5607 0.03979 0.61006-0.1396 0.82995-0.7293 1.4407-0.90021 0.63029-0.17939 1.1908 0.2805 1.8106 0.3803 0.8704 0.13046 1.35-0.24006 2.0807-0.39922 0.61072-0.12981 1.4707-0.01044 1.9907 0.27006 0.41041 0.21983 1.3806 0.8702 1.6606 1.1703 0.81037 0.88977 0.0202 2.9713 0.27012 4.1416 0.26034 1.2205 2.4716 1.09 3.5925 1.5708 0.66944 0.28898 1.0107 0.54991 1.8308 0.5199 0.69032-0.03001 1.3506-0.11024 2.071-0.0698-0.11027 0.54012-0.06 1.2003-0.23032 1.7404 0.0992-0.33008 1.4511 0.63993 1.4602 0.65037 0.70011 0.24006 1.9509 0.01044 2.7019 0.01044 0.71055 0 2.2204 0.33986 2.4213 1 0.0405 0.14025-0.24011 0.36074-0.17029 0.58057 0.0992 0.36008 0.3693 0.19048 0.47957 0.44032 0.15006 0.33986 0.15985 1.12 0.16964 1.5003 0.0111 0.66994-0.0496 0.84998-0.47957 1.3307-0.36995 0.40966-0.82016 0.42075-0.6603 1.1403 0.30014-0.03001 0.47957 0.0698 0.72033 0.19048 0.20031 0.09981 0.52002 0.67972 0.78036 0.85976 0.28969 0.20026 0.74969 0.39987 1.0798 0.5199 0.55069 0.19048 1.7108 0.14938 1.5907 1.0104 0.86061-0.1396 1.181 0.56035 1.331 1.2505 1.0407 0.33008 1.6808 1.5708 2.8918 1.3307 0-0.18004 0.14028-0.33986 0.11027-0.54991 0.53046-0.08024 1.0413 0.09915 1.5614 0.08024 0.03 0.66928-0.26034 1.6706 0.51023 1.8206 0.63942 0.12003 1.2606-0.72016 1.8308-0.75017 0.91085-0.03979 0.57091 0.92043 1.1705 1.3405 0.39018 0.27006 1.4002 0.43053 1.9013 0.51012-0.03 0.59035 0.01 1.3412 0.3693 1.8206 0.45021 0.60014 0.99111 0.29028 1.6312 0.67972 0.0998 0.06001 0.31058 0.3803 0.5011 0.50098 0.30014 0.20026 0.6205 0.33008 0.85082 0.4899 0.65052 0.44945 0.78036 0.55969 1.581 0.74039 1.3004 0.30007 2.2014 1.6706 1.9209 3.0914-0.12984 0.66015-0.67988 0.93021-0.82995 1.5003-0.15985 0.55969 0.0104 1.3803 0.18008 1.9009 0.21989 0.0502 0.12071 0.0802 0.2499 0.17026 0.11027-0.0202 0.27013 0.0202 0.39083 0.0202 0.41041 1.8004-1.3911 2.9707-0.72033 4.8115 0.12984 0 0.2499 0.03 0.38039 0 0.44042-0.48011 1.5509-0.51012 2.2713-0.39988 0.93957 0.1396 0.80059 0.50034 1.3108 1.1905 0.33994 0.45989 0.88084 0.76061 1.0198 1.3901 0.16051 0.71038 0 1.4703 0.18008 2.1507 0.39018 0.0202 1.6312-0.17939 1.9209 0.0802 0.31906 0.2805 0.17943 1.411 0.14942 1.8506-0.03 0.61123-0.14942 1.0502 0.2499 1.5708 0.45999 0.61057 0.80124 0.66994 0.76013 1.5904 1.4609-0.28898 0.30014 3.2812 0.33994 4.002 0.86061 0.50033 0.74056 1.7508 1.5809 2.2512 0.76079 0.01 1.2508 0.77039 1.8413 0.99023 0.73012 0.27984 1.8902 0.0502 2.6712-0.0502 0 0.39987 0.0802 0.78018 0.24011 1.0711 0.42019 0.74039 1.1007 0.82976 0.35038 1.6902-0.46065 0.50947-1.2404 0.47033-1.6312 0.95044-0.78036 0.96022 0.19052 3.5806 0.35038 4.6909 0.1703 1.1507-0.15986 1.0802-1.0805 1.4906-1.1608 0.50098-0.6205 1.1507-0.93042 2.2505-1.1516 0.41031-1.8622-0.15004-2.1616 1.2603-0.17029 0.8304 0 0.69081-0.74969 1.0007-0.48022 0.20026-0.91085 0.10959-1.0113 0.81997-0.44956 0.33008-0.0992 0.62036-0.74056 0.85063-0.49001 0.17939-0.92064-0.0698-1.3904 0.25049-0.48022 0.32029-0.97088 1.4906-1.2103 2.0607-0.14942 0.33008-0.17943 0.88064-0.39018 1.1298-0.24011 0.29028-0.74056 0.24984-1.0107 0.66015-0.47043 0.74104-0.39997 1.8402-0.79015 2.5708-0.0411-0.0202-0.0802-0.0404-0.1207-0.0698-0.91999 0.94-2.0905 1.5812-3.4118 1.7802-1.5809 0.24005-3.4222 0.24005-5.043 0.15982 6.5e-4 -0.0437 6.5e-4 -0.0939 6.5e-4 -0.14351z",
+                HsinchuCity:"m239.48 98.926c0.2101-0.57078 0.27012-0.55121 0.82995-0.91064 0.30013-0.19048 0.85996-0.51012 1.1209-0.81019 0.25904-0.30007 0.20031-0.63014 0.30993-0.98044 0.0803-0.27006 0.24011-0.77953 0.11027-1.0802-0.14942-0.36008-0.63029-0.4201-0.91086-0.60014-0.24989-0.14025-0.58135-0.4899-0.42084-0.8291 0.0998-0.20092 0.28056-0.12068 0.39083-0.29028 0.09-0.14938 0.03-0.46054 0.03-0.63014 0-0.71038-0.0502-1.4501 0-2.1611 0.0196-0.34965 0.10962-0.5897 0.24011-0.8702 0.12006-0.26941 0.39018-0.4201 0.55069-0.66015 0.18987-0.31051 0.21989-0.7006 0.40976-1.0196 0.21988-0.3803 0.47956-0.4501 0.51023-0.91064 0.0196-0.33986-0.03-0.68037 0.0803-1.0007 0.11027-0.30985 0.3693-0.5199 0.5396-0.78996 0.20096-0.30985 0.41106-0.4899 0.64008-0.74039 0.23032-0.24006 0.42019-0.53034 0.6205-0.84019 0.38039-0.55969 0.42019-1.4103-0.25969-1.7306-0.30013-0.14025-0.63029-0.21983-0.95065-0.24984 0.06-0.4899 2.5616-0.16047 3.0314-0.27985 0.03-0.06001 0.0692-0.0998 0.09-0.14025 1.6005 0.17939 1.6716 2.0705 3.0216 2.8311 0.67009 0.3803 1.5614 0.1396 2.2921 0.36987 0.75948 0.24984 1.3408 0.39922 2.2204 0.45989 0.47109 0.91978 0.95066 0.69016 1.8406 0.99023 0.69032 0.23027 1.1105 0.83041 1.7512 1.2401 1.1908 0.76061 1.8406 1.2401 1.8406 2.7508 0 0.72995-0.0502 1.2394 0.33015 1.8396 0.33015 0.52055 0.79014 0.83041 0.98067 1.4305 0.18008 0.56035 0.23097 1.3908 0.33993 1.9204 0.25969 1.2394-0.0104 0.85063-0.91085 1.1403-0.61006 0.20026-0.9102 0.95044-1.2397-0.08024-0.21009-0.65037 0.09-1.2205-0.49001-1.6804 0-0.23092-0.15006-0.3503-0.18986-0.54991-0.29036-0.01109-0.60028-0.02022-0.89063-0.03001-0.2101-0.6608-1.4407-1.4703-2.1812-1.3203-0.53046 0.0998-0.64008 0.27985-0.94021 0.7306-0.33994 0.51012-0.23033 0.95044-0.48022 1.4403-0.47044 0.93021-1.8511 0.24984-2.6112 0.91064-0.80059 0.69994-0.60028 1.8506-0.65052 2.8206-0.91999 0.05023-1.8902-0.09002-2.7215 0.20092-0.74055 1.3001 0.40976 3.5108-0.85082 4.5212-0.42019-0.29028-1.1608-0.33007-1.7206-0.33007-0.8306 0-1.2912-0.14025-1.2808-1.0411 0-0.63928-0.03-1.1298-0.4104-1.6197-0.14094-0.18004-0.41106-0.36986-0.51024-0.54991-0.12984-0.21983-0.0907-0.50098-0.16964-0.74104-0.69097-0.19048-1.1105 1.4103-1.791 1.5401-0.31123 0.06-1.0903 0.03-1.3715-0.09-0.40062-0.15004-0.44955-0.44032-0.91085-0.46054-0.0111-0.06002-0.0202-0.11024 0-0.15004 0.0189-0.20026 0.20944-0.2805 0.3693-0.4201 0.24272-0.2094 0.27273-0.28963 0.37256-0.54926z",
+                Miaoli:"m246.9 103.34c0.03 0.0202 0.06 0.0404 0.0803 0.06 0.03 0.18004 0.24011 0.54991 0.42019 0.66015 0.31123 0.21005 0.41106 0.0411 0.70076-0.0992 0.82994-0.42075 0.81037 0.47032 1.5907 0.5897 0.82994 0.12981 0.53046-0.66015 1.1705-0.8702 0.42998-0.14025 1.641-0.16047 1.9111 0.29028 0.42084 0.67973-0.50045 1.7202-0.82995 2.1612-0.25968 0.33986-0.63094 0.5597-0.76013 0.96022-0.2512 0.7704 0.12005 0.53034 0.6603 0.81019 0.29035 0.14938 0.38039 0.47032 0.63943 0.69016 0.24011 0.20026 0.56047 0.27984 0.78036 0.51011 0.33993 0.36922 0.47043 0.86042 0.78035 1.2505 0.21989 0.29028 0.53046 0.48011 0.76079 0.76061 0.44955 0.54991 0.76078 1.1905 1.5607 1.2394 0.48022 0.0202 0.97088-0.12916 1.0805 0.36987 0.09 0.44032-0.0998 0.92043 0.09 1.3307 0.36995 0.10959 0.38039 0.18004 0.57026 0.50033 0.12985 0.23093 0.0502 0.20092 0.25969 0.30072 0.13049 0.0496 0.35038 0.03 0.50044 0.0796 0.60028 0.22048 0.82016 0.80105 1.4106 1.0111 0.90042 0.31964 1.5607 0.69929 2.2112 1.3301 0.26034 0.25049 0.54025 0.47032 0.78036 0.74039 0.15007 0.17025 0.33015 0.50033 0.55004 0.58056 0.0502-0.27984 0.74121-0.66928 1.0414-0.76061 0.52002-0.14938 0.5807 0.23093 0.80971 0.59036 0.26034 0.42009 0.60093 0.39987 0.99111 0.66993 0.47044 0.33986 0.1703 0.57013 0.33994 1.0405 0.24011 0.66015 1.1307 0.93021 1.2815 1.711 0.0992 0.51012-0.28122 0.81019-0.55134 1.1703-0.31906 0.42988-0.36017 0.8702-0.70989 1.3307-0.49001 0.63015-0.74969 1.3497-0.86062 2.1305-0.0496 0.36009-0.25968 0.60014-0.5807 0.72017-0.27991 0.0991-1.1203-0.03-1.0407 0.44032 0.47043 0.21004 0.98067 0.63014 1.3604 0.95043 0.29035 0.24006 0.55982 0.48011 0.80058 0.75996 0.23098 0.2805 0.55004 0.57013 0.84039 0.77039 0.25968 0.17026 0.57026 0.20092 0.5011 0.62036-0.0698 0.45989-0.45021 0.66015-0.66096 1.0104-0.23032 0.39074-0.0692 0.47033-0.60028 0.57013-0.3693 0.0802-0.68053 0.12068-0.91085 0.43967-0.49001 0.6608 0.14942 1.3803 0.2499 2.0516 0.0502 0.36921-0.01 0.77039 0.13049 1.1207 0.12919 0.32029 0.4202 0.51012 0.58005 0.78996 0.6205 0.18004 1.2704-0.0998 1.791 0.24984 0.50045 0.33008 1.1705 0.46054 1.8609 0.39075 0.3308-0.0411 0.42084-0.15004 0.66095-0.38031 0.24011-0.24005 0.38039-0.32029 0.67988-0.48989 0.31971-0.18005 0.55003-0.27007 0.79014-0.53034 0.17943-0.19048 0.33016-0.3503 0.55004-0.48011 0.28056-0.17026 0.60027-0.30007 0.90041-0.11025 0.33015 0.19048 0.36996 0.59036 0.76079 0.69995 0.20031 0.0502 0.84038 0.10045 1.0205 0 0.23032-0.12003 0.34972-0.57013 0.61071-0.73974 0.6603-0.4501 1.0205 0.44945 1.7108 0.48011 0.39017 0.0196 0.77057-0.0502 1.1203 0.14025 0.33994 0.17939 0.48022 0.42923 0.95066 0.30986 0.35037-0.0802 0.53046-0.27985 0.93042-0.3203 0.33081-0.03 0.65052-0.01 1.0009 0 0.36016 0.0111 0.89062 0.0907 1.2508 0 0.36016-0.09 0.5807-0.42988 0.88084-0.66015 0.68053-0.5199 1.5405-0.12002 2.2315-0.69016 0.57026-0.46054 1.3108 0.0398 1.5698 0.70973 0.28121 0.7704-0.74969 1.3405-0.19052 2.1409 0.49 0.69016 1.1608 1.1898 1.761 1.8004 0.67988 0.69929 1.2306 1.5702 1.9118 2.2805 0.33015 0.33007 0.71054 0.58056 1.0002 0.96022 0.33015 0.43053 0.79015 0.71038 0.91085 1.2707 0.12006 0.54991-0.0404 1.1703-0.0698 1.73-0.0405 0.69995 0.0698 1.4403 0.0502 2.1514-0.53046 0.47946-1.1307 0.91977-1.9411 0.87998-0.47108 1.1703 0.0803 2.6106-0.39083 3.7809-1.5007 0.53034-1.5398 1.8311-2.6412 2.561-1.8211 1.1814-2.2112-0.17939-2.5212-1.6804-0.6603-0.17939-1.4302-0.27985-2.1212-0.15917-0.10962 2.1005 0.0607 2.7704-2.161 3.1703-1.0505 2.0516-1.9013 2.8311-4.2019 3.3021-1.3904 0.28898-1.6501 0.0991-2.5414 1.1292-0.30013 0.33986-0.24989 0.83041-0.63029 1.2101-0.36081 0.36008-1.0903 0.19048-1.4609 0.69016-0.81038 1.0907-0.0502 1.3503-1.3715 2.1409-0.28057 0.16048-1.9914 1.12-2.3306 1.1703-1.1014 0.15982-1.4407-1.0907-2.6719-0.68037-0.93956 0.32029-0.88997 1.6706-2.4814 1.7-0.2499 0.6308-0.74056 1.0802-0.88084 1.7802-1.7519 0.14025-1.9607-0.39988-3.1926-1.4306-0.31058-0.25962-1.0002-0.39009-1.2508-0.74039-0.3693-0.5199-0.17943-1.2401-0.53046-1.7704-1.4407-2.1709-4.9627-1.5101-7.1739-1.8702-1.7408-0.2805-4.9425-2.4899-6.3832-0.3803-1.5209 2.261 1.5809 5.6615-1.6201 6.882-2.191 0.8402-5.2224-0.0404-7.6744 0.33073-1.3911 0.2094-2.3711 0.58057-3.4522-0.20091-0.96958-0.71038-1.5509-1.8709-2.4311-2.5806-1.8511-1.4808-4.7128-0.85976-6.834-2.1807-1.9613-1.2205-3.3824-3.1507-5.163-4.4912-1.0805-0.81019-1.7108-0.39074-2.8017-0.8702-0.95065-0.40966-1.2404-1.3001-1.9913-1.9602-1.4002-1.2401-2.3411-2.0907-3.462-3.5917-1.2208-1.6497-3.0216-2.1696-4.0917-3.621-1.0414-1.4299-1.1405-3.0809-2.5512-4.2114 0.58984-0.96935 1.6312-1.7202 2.5414-2.4599 0.47044-0.39074 1.1908-0.75017 1.5614-1.2003 0.38039-0.46054 0.17943-0.91064 0.33994-1.4305 0.2897-0.92043 1.1705-1.4906 1.5607-2.3608 0.4502-1.0007 0.91085-1.6908 1.5614-2.6008 0.30013-0.42923 0.49-1.15 0.55982-1.6602 0.11027-0.84019 0.11027-1.1403 0.69097-1.8096 0.54025-0.63993 0.63942-0.99088 0.67988-1.8004 0.06-1.2309 0.5807-2.5617 0.88083-3.762 0.36996-1.4703 1.6312-2.1005 2.4109-3.381 0.50045-0.83041 0.61072-1.7906 1.1705-2.651 0.36995-0.55904 0.92064-1.5206 1.5607-1.6602 1.0413-0.24006 4.1928 1 3.7824-1.2394-0.54025-0.22048-0.92064 0.12916-1.4106 0.0992-0.0411-0.23027 0.5807-1.1298 0.74056-1.4103 0.30013-0.53034 0.68053-0.92043 0.86061-1.5304 0.33994-1.1305 0.65051-1.9407 1.6201-2.6706 0.70076-0.53034 1.562-1.3007 2.5218-1.4403 1.1803-0.18004 2.3802-0.39988 3.5618-0.50099 0.59049-0.06 1.2103 0.0202 1.8008-0.01 0.2499-1.3503 1.2208-2.621 2.5009-3.1312 0.0907-0.98045 1.0505-1.1103 1.5809-1.7802 0.49001-0.6197 0.44107-1.2805 0.49001-2.0803 0.0607-0.81997 0.53046-1.4703 1.0805-2.0307 0.44042-0.44032 0.97088-1.3307 1.562-1.5401-0.0202 0.04044-0.0111 0.09067 0 0.15004 0.45999 0.0202 0.50958 0.30985 0.91085 0.46054 0.27991 0.12003 1.0603 0.14938 1.3715 0.09 0.68053-0.12981 1.1007-1.7306 1.7904-1.5401 0.0803 0.24006 0.0404 0.52056 0.17029 0.74104 0.0992 0.17939 0.3693 0.36922 0.50958 0.54991 0.3804 0.4899 0.41106 0.98044 0.41106 1.6204-0.0111 0.90021 0.44956 1.0405 1.2808 1.0405 0.56112-5e-3 1.301 0.0346 1.7212 0.32486z",
+                Taipei:"m351.36 53.383c0.0104 0.32029 0.0104 0.65037 0 0.97066-0.52002-0.02022-1.0407 0.06915-1.5705 0.09915-0.25968 0.01044-0.5807-0.06001-0.82994 0.02022-0.20031 0.0698-0.4202 0.36008-0.56048 0.39987-0.50045 0.14938-0.96044-0.11024-1.5307-0.09067-0.63029 0.03066-0.92064 0.32029-1.4909 0.44097-0.90042 0.19048-2.3313-0.39987-3.141 0.17026-0.20096 0.1396-0.10962 0.44032-0.28056 0.63014-0.15986 0.17026-0.42933-0.05023-0.58984 0.26028-0.35038 0.66928 0.3693 0.87998 0.82016 1.0196 0.0692 1.2805-1.0303 5.092 1.0909 4.8318 0.06 0.3503 1.3004 0.54991 1.6605 0.66994 0.25968 0.96935-0.47043 0.77953-1.151 0.81997-0.82995 0.05023-0.77123 0.41031-1.4106 0.66928-0.59049 0.22048-1.2208-0.2394-1.761-0.31964-0.61071-0.09981-1.3708 0.23027-1.5098-0.59035-0.67009 0.13046-1.0414 0.65037-1.7414 0.57013-0.55004-0.06001-0.85996-0.47032-1.1601-0.92043-0.47108-0.67972-1.3506-1.6804-1.2704-2.5708-0.3804 0.02022-0.8704-0.03001-1.1705-0.2394-0.39997-0.2805-0.25969-0.74104-0.47044-0.94-0.72033-0.66994-1.4609 0.47032-1.9117 0.83041-0.01-1.2009 1.791-2.1905 0.74121-3.3412-0.44107-0.48011-0.97023-0.68037-1.4009-1.1703-0.44042-0.50098-0.60028-0.96087-1.3604-0.90021-0.82016 0.06001-1.0505 0.72016-1.4909 1.2505-0.61072 0.74039-0.79015 0.88977-1.3604 0.09981-0.46065-0.63928-0.42019-0.95044-0.55982-1.681-0.0907-0.43967-0.61137-1.1801-0.59049-1.5904 0.06-1.06 2.2308-1.06 2.8115-2.0209 0.59049-0.94 0.61137-2.8011 0.61137-3.9818 0-1.2205-0.73077-2.1507-1.5816-2.9811-0.41041-0.39922-0.69032-0.8004-1.2501-1.0196-0.57091-0.21983-1.2404-0.10959-1.8315-0.24984-0.52002-0.12981-1.0603-0.20092-1.5607-0.39987-0.84038-0.32029-0.75034-0.42075-0.79014-1.1905-0.0202-0.54991-0.19053-1.2903 0.03-1.8095 0.0992-0.23092 1.2306-1.0202 1.2208-0.69081 0.0405-0.8004-0.2101-1.7606 0.42998-2.2407 0.7001-0.53034 1.331-0.10959 1.2612-1.3999 1.0309-0.06001 1.2097 0.12981 1.4909-0.85063 0.16051-0.57992 0.28056-0.97 0.65052-1.5003 0.28904-0.42075 0.67987-1.1011 1.1803-1.2609 0.54025-0.17026 1.4211 0.01957 1.9914 0 0.19052-1.1703-0.0802-1.8102 1.3415-1.8206 0.5807-0.01044 1.0002-0.06915 1.4902-0.25962 0.24011-0.09067 0.89062-0.3803 1.0205-0.57013 0.2101-0.36008-0.1605-1.06 0.0502-1.4403 0.21989-0.39074 0.89063-0.4899 1.1301-0.80105 0.18008-0.23027 0.36082-1.03 0.64007-1.1703 0.58005-0.28963 0.96045 0.42075 1.3904 0.65037-0.33994 1.6308 0.90041 1.8617 2.191 1.9309 0.60028 1.5003-0.03 3.3308 0.76013 4.822 0.14942 0.27006 0.50958 0.50033 0.61072 0.7293 0.15007 0.36987 0.0202 0.86042 0.06 1.2707 0.0698 0.85063 0.53046 1.2401 1.151 1.7704 0.20944 0.77105 0.85996 0.80105 0.85082 1.8206-0.0111 1.1011-0.69097 0.98044-1.0909 1.8311-0.10962 0.21983-0.13963 0.82976-0.0803 1.0907 0.14029 0.51012 0.0104 0.30007 0.66944 0.40966 0.78036 0.12981 1.3917 0.60014 2.1512 0.68037 0.0307 1.0405 1.1908 0.69994 1.4309 1.6504 0.2499 0.93935-0.48022 2.9707-1.0002 3.6706-0.85083 1.1507-0.63029 1.0705-0.33015 2.4208 0.32036 1.4808 2.0011 2.8011 3.2519 3.3301 0.53047 0.23092 1.1007 0.3803 1.7512 0.42075 0.76666 0.04175 1.1966-0.49838 1.8974-0.23875z",
+                Newtaipei:"m400.14 55.204c1.2012 4.4117-4.7722 2.1905-5.6935 4.7613-1.1901 0.06001-2.1904-0.84019-3.3909-0.36987-0.6316 0.25049-0.66161 0.85063-1.2319 1.1305-0.4202 0.21005-1.3911 0.18004-1.8511 0.23092-1.181 0.12916-2.4318 0.74039-3.2722 1.6497-0.49001 0.5199-0.7497 0.97001-1.5705 1.12-0.65051 0.12981-1.4211 0.1109-2.0801 0.15003-1.562 0.0698-2.7221-0.25962-3.8215 0.91064-0.91085 0.99023-1.6012 1.6308-1.1712 3.0711 1.0609-0.04044 2.3613 0.88064 2.1414 1.9407-0.15007 0.71038-1.6508 1.5401-2.2315 1.9107-0.46 0.30007-0.77122 0.76061-1.1405 1.0202-0.42085 0.30007-1.1705 0.23027-1.7004 0.23027-1.2612 0-2.4416 0.09981-3.6526 0.3503-0.47043 0.78018-0.0104 2.4906-1.4106 2.5004-0.31972 0.80105 0.28056 0.84084 0.38039 1.4208 0.11027 0.6308-0.46 0.74104-0.75035 1.3007-1.2906 0.39988-1.7408 1.3503-2.9009 2.0105-1.2012 0.69994-2.6008 0.21983-3.9416 0.48011-1.0113 0.20026-2.6614 1.15-3.312 1.9302-0.36082 0.42988-0.67988 1.06-1.1705 1.4305-0.4502 0.33986-1.2312 0.5199-1.6012 0.96935-0.4502 0.54991-0.29035 1.4103-0.33015 2.1005-1.4009 0.0698-2.7717 0.01044-4.1523 0.09067-1.2808 0.08024-3.0418 0.0098-4.0721 0.77039-0.49 0.36987-0.75034 0.88064-0.85082 1.4814-0.15007 0.96935 0.11027 1.1298-1.0002 1.1703-0.99046 0.03001-3.282 0.21983-3.3518 1.6497-0.0104 0.08024-0.0502 0.21983-0.0502 0.33986 1.2606 0.42988 0.38039 1.5701 0.0502 2.2603-0.44042 0.94-0.33015 1.8108 0 2.6908 0.76078 2.0007 0.73077 4.1912-1.9711 4.0712 0.0803 1.2505-0.28905 1.6602-1.5098 1.6602-0.94021-0.01-2.8924 0.14025-3.4327 0.9002-0.53046 0.72995-0.20944 2.0105-1.0707 2.5108-0.24011 0.15003-0.63029 0.13046-0.92064 0.23092-0.35038 0.12981-0.63029 0.40966-0.98066 0.54991-0.65052 0.26027-1.4707 0.06-2.1812 0.20026-0.69097 0.1409-1.1908 0.6308-1.7708 0.92043-0.73077 0.36987-1.1203 0.39074-2.0011 0.43053-0.1703 0.0104-0.36017 0.0202-0.57026 0.0202 0.01-0.92043 0.0398-1.8409-0.0104-2.7508-0.94022 0.11024-0.91086-0.74039-1.6312-1.1814-0.42084-0.24984-0.54024-0.33986-1.0205-0.4201-0.36016-0.0502-0.85017 0.11024-1.151-0.0998-0.64007-0.42989-0.21988-1.3301-0.54025-1.9602-0.26033-0.51011-0.72033-1.0307-1.0407-1.5206-0.75035-1.15-1.4511-2.1605-1.8615-3.501-0.17029-0.57013-0.21988-1.3197-0.33015-1.9198-0.20031-0.98044-0.14028-1.2009 0.60028-1.6412 1.0603-0.63014 1.3715-1.9302 2.7215-2.1201 0.31123-0.2805 0.29035-0.76061 0.2499-1.2205-2.3411 0.1409-0.99959-2.6504-1.7304-3.6811-0.39997-0.57013-1.3004-0.06001-1.6906-0.99023-1.1105 0.12003-1.6612-1.8709-2.2315-2.4514-0.68053-0.69016-2.7019-1.5806-3.5919-0.7306-0.44956 0.43053-0.30014 1.0711-1.1601 1.2505-0.81037 0.17091-1.331-0.58057-1.9209-0.91978-1.3108-0.74104-2.5009-0.59035-3.9918-0.68037-0.21988-1.0502 2.0612-1.3007 2.7319-1.3307 0.03-0.44097 0.0803-0.82976-0.21988-1.1814-0.2101-0.24984-0.91086-0.21983-1.0805-0.57992-0.43063-0.89042 1.6808-1.1403 1.3408-1.9909-0.24989-0.61058-1.1705 0.08024-1.6207-0.23092-0.36017-0.25962-0.38039-1.2303-0.33994-1.6602-0.12005 0-0.28056-0.04044-0.39018-0.03001-0.35038-0.30007-0.39083-1.0007-0.76078-1.2407-0.31123-0.20026-1.0205 0.01109-1.3415-0.24006-0.69031-0.53034 0.0405-1.4808-0.0104-2.4103-0.30992-0.01044-0.63029-0.01044-0.91085-0.0698 0.0202-0.14025 0.0411-0.90021 0.11092-0.93021 0.23946-0.09981 0.44956-0.23092 0.72033-0.27006 0.15007-0.3803 0.19052-1.1807 0.01-1.4906-0.30993-0.54012-0.72033-0.14025-1.0707-0.4899-0.42998-0.42988 0-1.1005 0.39997-1.2603 0.36016-0.15003 1.1007 0.01044 1.4909-0.01044 0.12005-0.77953-0.33994-1.2805-0.49001-1.9909-0.14093-0.71038-0.19052-1.5095-0.16051-2.2505 0.0104-0.33986-0.0802-1.0705 0.0992-1.3405 0.30014-0.4501 0.44107-0.21005 0.90041-0.33008 0.74121-0.18983 1.3115-0.30007 2.1016-0.1396 1.1301 0.23027 3.0118 0.57013 4.1523 0.14938 1.1301-0.43053 0.74056-2 2.4011-1.9407 0.19052-0.39987 0.77057-0.82976 1.1705-1 0.0398-0.54012 0.03-0.8702-0.30014-1.2603-0.18987-0.21983-0.72033-0.21005-0.84039-0.57013-0.32036-0.96087 1.3604-1.0307 1.9711-1.0007-0.03-0.92043-0.58984-1.0405-0.88019-1.7606-0.31058-0.74039-0.09-1.8004 0.12984-2.4599-0.0411-0.01044-0.09-0.02022-0.14028-0.03001-0.0405-0.2805-0.0998-0.55056-0.19052-0.81019-0.99111-0.24006-0.94022-0.55969-1.0002-1.5003-0.31123-0.0698-0.54025-0.2805-0.5807-0.58057-1.1712-0.12003-2.052-0.54991-3.2422-0.60014-0.76078-0.02022-1.6012-0.44032-2.071-0.93021-0.30992-0.32029-0.33015-0.63993-0.53046-0.98044-0.32036-0.53034-0.5011-0.44032-0.90041-0.75017-0.68053-0.51012-1.3611-0.90021-1.6808-1.6602-1.0303-0.02022-2.0912-0.05023-3.1417-0.11024-0.0692-0.20026-0.18008-0.24984-0.20031-0.47033-0.36995-0.29028-0.5807-0.67972-1.0714-0.8702-0.47957-0.19048-1.0002-0.0411-1.4407-0.36987-0.66031-0.5199-0.42933-1.9107-0.39932-2.8109 0.21989-0.01044 0.39018-0.02022 0.46065-0.05023 0.42933-0.15003 1.7512-0.15982 2.5505-0.33008 1.8817-0.39074 3.5729-0.15003 5.5128-0.24006 0.86061-0.0411 1.5007-0.17026 2.2419-0.76061 1.0198-0.81019 1.32-1.3705 2.7515-2.0007 0.0404-0.21983 0.90041-0.28963 1.0009-0.50033 1.9809-1.1011 6.8738-4.0509 2.7815-5.702 1.5307-0.33986 0.9102-1.3105 1.4609-2.3105 0.47043-0.86042 1.7512-1.6106 2.2112-2.3007 0.94022-1.4299 1.9509-3.2603 1.8413-5.4006 0-0.13046 2.4311-0.0698 2.6712-0.18004 1.2103-0.60014 1.0002-1.3601 1.7806-2.2603 1.3408-1.5604 3.402-2.561 4.5523-4.3112 1.2508 0.01109 4.703 0.96087 3.4816-1.4899 0.67009 0.33986 0.53046-0.05023 1.0205 0.66015 1.38 0.08024 3.8418 0.53034 4.6521-0.62036 0.80058 0.63014 1.0407 0.69016 2.0214 0.4501 0.12071 0.21983-0.0202 0.44032 0.0803 0.66928 1.2006 0.20092 1.7408 1.0202 2.7117 1.5401 1.2606 0.66994 0.59048 0.66015 2.251 0.74952 0.06 0.97 1.3708 1.6804 1.7003 2.5917 0.42085 1.1801 0.12985 2.8604 0.33994 4.1201 0.55917-0.12003 1.3604 0.20092 1.9202 0.08024-0.25903 2.2805 1.5712 2.6308 1.581 4.6713 0.96109 0.04044 1.962 0.04044 2.9224 0 0.69032-1.0007 2.071-0.93021 2.9916-1.9302 0.1703 2.2603-1.9613 3.1709-2.1616 4.9322 0.0502-0.4899 1.5105 0.7704 2.4716 1.6308-1.1399 0.53034-1.9307 1.0796-2.9505 1.7208-0.47043 0.29028-0.43063 1.2094-1.0505 1.4508-0.66944 0.25962-1.9907-0.01044-2.7215 0.03001-0.65052 1.8409-2.3913 1.4103-4.0023 1.501-0.12984 0.40966-0.12984 1.2603 0 1.6706 0.58071-0.14938 1.3708 0.0411 1.9209-0.17026 0.09 1.711-0.26034 6.0209 2.0005 6.002 0.03 0.27985-0.03 0.65037 0.0802 0.92043 0.42998-0.02022 1.0009 0.14938 1.4211 0.07958 0.42085 1.1403 1.4511 1.5708 2.5512 0.81019-0.21009 0.15982-0.43063 0.55056-0.7797 0.78018 0-0.01957 0.0796 0.55056 0.06 0.58057 1.4504-0.30007 2.5708 0.5199 2.5009 2.0007 2.0801 0.12003 3.5619 1.0405 5.5323 1.2205 0.47108 0.05023 1.0107 0.44945 1.6912 0.33008 0.60027-0.09981 0.48022-1.06 1.0414-1.2101 1.2697-0.34965 2.7515 0.58057 3.2121-1.0405 0.36017-1.2603-0.95065-2.1709-1.9711-2.3001 0.0998-1.8311-0.13963-3.1312-1.4504-4.2218 1.0498-0.24006 1.8406-1.1103 2.9009-1.2505 1.2012-0.16047 2.0605 0.78996 3.4712 0.47098-0.09-0.63993 0.33994-1.1103 0.33015-1.6713 0.3308 0.0698 0.84038-0.12003 1.1705-0.08024 0.0613-0.32029 0.39148-1.09 0.42149-1.4208v-0.03001c0.36017 0.01044 0.73012 0.01957 1.0805 0.03001-0.12136 0.55969 0.20031 1.3607 0.0796 1.9204 1.1099 0.07958 1.6612-0.84019 2.2504-0.92043 1.271-0.15982 1.8622 0.33008 2.7117 0.46054 1.4211 0.23027 4.7526-0.42075 5.043 1.2094 1.1405 0.18983 2.6216 0.39009 2.7515-0.92043 0.53046 0.06001 1.4811-0.28898 1.7108-0.28898-0.42084 0.74039-0.33015 1.5695-0.21009 2.4599 0.23097 0.0698 0.44042 0 0.67074 0.08024 0.36017 1.4299-2.5714 5.9316 0.2499 6.002 0.24011 1.1801 0.7908 1.7202 0.98067 2.9009 0.14028 0.85976-0.2101 2.4899-0.15007 3.5206 2.4115 1.5701 4.2535 0.91064 7.1739 1.0802 0.41106 1.1507 2.512 0.84084 3.6225 0.71038zm-48.785-0.84998c0.0104-0.32029 0.0104-0.65037 0-0.97066-0.69946-0.25962-1.1301 0.2805-1.9013 0.24006-0.65052-0.0411-1.2201-0.19048-1.7512-0.42075-1.2508-0.53034-2.9316-1.8506-3.2519-3.3301-0.30014-1.3503-0.52002-1.2701 0.33015-2.4208 0.52068-0.69994 1.2508-2.7313 1.0002-3.6706-0.24011-0.95044-1.4002-0.61123-1.4302-1.6504-0.76013-0.08024-1.3715-0.55056-2.1512-0.68037-0.66096-0.10959-0.53046 0.09981-0.67009-0.40966-0.06-0.26028-0.03-0.8702 0.0802-1.0907 0.40062-0.85063 1.0805-0.72995 1.0909-1.8311 0.01-1.0196-0.64008-1.0496-0.85083-1.8206-0.6205-0.53034-1.0805-0.91978-1.151-1.7704-0.0405-0.41031 0.0907-0.90021-0.06-1.2707-0.0998-0.23027-0.46064-0.45924-0.61071-0.7293-0.79015-1.4906-0.15986-3.3216-0.76013-4.822-1.2912-0.06915-2.5316-0.30007-2.191-1.9309-0.43063-0.23027-0.81037-0.93935-1.3904-0.65037-0.28056 0.14025-0.46065 0.94-0.64008 1.1703-0.23945 0.31116-0.91085 0.41031-1.1301 0.80105-0.2101 0.3803 0.15986 1.0802-0.0502 1.4403-0.12984 0.19048-0.78036 0.47946-1.0198 0.57013-0.49066 0.19048-0.91085 0.24984-1.4909 0.25962-1.4211 0.01044-1.151 0.65037-1.3415 1.8206-0.57027 0.01957-1.4511-0.17026-1.9914 0-0.50045 0.15982-0.89063 0.84019-1.1803 1.2609-0.36995 0.53034-0.49001 0.92043-0.65051 1.5003-0.28057 0.98044-0.46 0.78996-1.4909 0.85063 0.0692 1.2909-0.56047 0.8702-1.2606 1.3999-0.64008 0.47946-0.39084 1.4403-0.43064 2.2407 0.0104-0.33008-1.1203 0.46054-1.2208 0.69081-0.21989 0.5199-0.0502 1.2603-0.03 1.8095 0.0398 0.77039-0.0502 0.8702 0.79015 1.1905 0.50044 0.20026 1.0407 0.27006 1.5607 0.39988 0.59049 0.14025 1.2612 0.03001 1.8315 0.24984 0.55982 0.21983 0.84038 0.62036 1.2508 1.0196 0.85017 0.83041 1.5809 1.7606 1.5809 2.9811 0 1.1807-0.0202 3.0411-0.61137 3.9818-0.5807 0.96022-2.7515 0.96022-2.8115 2.0209-0.0202 0.41031 0.50044 1.1507 0.59048 1.5904 0.14029 0.7306 0.0992 1.0411 0.55983 1.681 0.57026 0.78996 0.75034 0.63993 1.3604-0.0998 0.44042-0.53034 0.67009-1.1905 1.4909-1.2505 0.76078-0.06067 0.92064 0.39922 1.3604 0.90021 0.43063 0.4899 0.9611 0.69016 1.4009 1.1703 1.0498 1.15-0.75034 2.1396-0.74121 3.3412 0.45021-0.36074 1.1908-1.501 1.9118-0.83041 0.2101 0.20026 0.0692 0.66015 0.47043 0.94 0.30014 0.2094 0.79015 0.25962 1.1705 0.2394-0.0803 0.89042 0.80124 1.8904 1.2704 2.5708 0.30013 0.4501 0.61071 0.86042 1.1608 0.92043 0.7001 0.08024 1.0707-0.43967 1.7408-0.57013 0.13963 0.82062 0.90041 0.4899 1.5098 0.59035 0.54025 0.08024 1.1705 0.54012 1.761 0.31964 0.64008-0.25897 0.58071-0.61971 1.4106-0.66928 0.68053-0.04044 1.4106 0.14938 1.151-0.81997-0.36017-0.12068-1.6012-0.32029-1.6606-0.66994-2.1212 0.25962-1.0198-3.5512-1.0909-4.8318-0.45021-0.14025-1.1705-0.3503-0.82016-1.0196 0.1605-0.31116 0.43063-0.09067 0.58983-0.26028 0.17095-0.18983 0.0803-0.4899 0.28057-0.63014 0.81037-0.57013 2.2412 0.02022 3.141-0.17026 0.57026-0.12068 0.85996-0.41031 1.4909-0.44097 0.57027-0.01957 1.0309 0.24006 1.5307 0.09067 0.14093-0.0411 0.36081-0.33008 0.56047-0.39988 0.2499-0.08024 0.57026-0.01044 0.82995-0.02022 0.53372-0.03066 1.0537-0.12068 1.5744-0.10046z",
+                Taoyuan:"m324.59 106.65c0.0502 0.91065 0.0202 1.8304 0.0104 2.7508-1.2208 0.0691-2.8918 0.21005-3.5619 0.95044-0.24011 0.25962-0.59048 0.69994-0.71054 1.0307-0.26034 0.78018 0.15007 0.57991 0.45999 1.2394 0.29035 0.60079-0.06 1.8311-0.27991 2.5004-1.1105 0.81019-2.1616 1.2609-2.5714 2.681-0.2101 0.71038-0.19053 1.4103-0.65052 2.0105-0.55069 0.71038-1.0009 0.47033-1.7114 0.72017-0.8704 0.3105-1.3806 1.561-1.3708 2.621-0.78035 0.0998-1.9418 0.33008-2.6719 0.0502-0.58984-0.21983-1.0798-0.98044-1.8406-0.99088-0.84039-0.50033-0.72033-1.7508-1.5809-2.2505-0.0405-0.72017 1.1209-4.291-0.33994-4.002 0.0411-0.92043-0.30014-0.97979-0.76013-1.5904-0.39997-0.5199-0.28057-0.96087-0.2499-1.5708 0.03-0.43967 0.16964-1.5701-0.15007-1.8506-0.2897-0.25963-1.5307-0.06-1.9202-0.0802-0.18008-0.67972-0.0202-1.4403-0.18008-2.1507-0.13963-0.63014-0.67988-0.93021-1.0198-1.3901-0.51023-0.69081-0.36995-1.0502-1.3115-1.1905-0.72033-0.11025-1.8308-0.0802-2.2706 0.39987-0.12984 0.03-0.2499 0-0.38039 0-0.67009-1.8409 1.1301-3.0111 0.72033-4.8115-0.12005 0-0.27991-0.0411-0.39018-0.0202-0.12984-0.09-0.03-0.12068-0.2499-0.17026-0.17029-0.52055-0.33993-1.3412-0.18008-1.9009 0.15007-0.57013 0.70011-0.84019 0.82995-1.501 0.28056-1.4208-0.6205-2.79-1.9209-3.0907-0.80059-0.18004-0.93043-0.28963-1.581-0.74104-0.23097-0.15917-0.55068-0.28898-0.85082-0.4899-0.19052-0.12003-0.39997-0.44032-0.5011-0.50033-0.63943-0.39009-1.181-0.08024-1.6312-0.67972-0.36016-0.48011-0.39931-1.2303-0.3693-1.8206-0.50109-0.08024-1.5105-0.24006-1.9013-0.51012-0.60028-0.4201-0.26034-1.3803-1.1705-1.3405-0.57026 0.03001-1.1908 0.8702-1.8315 0.75017-0.77057-0.15004-0.47957-1.1514-0.50958-1.8206-0.52068 0.01957-1.0309-0.16047-1.5614-0.08024 0.03 0.2094-0.11027 0.36922-0.11027 0.54991-1.2097 0.24006-1.8511-1.0007-2.8918-1.3307-0.15007-0.69081-0.47109-1.3901-1.331-1.2505 0.12006-0.86042-1.0414-0.81997-1.5907-1.0104-0.33015-0.12068-0.79015-0.32029-1.0805-0.5199-0.25968-0.18004-0.5807-0.75996-0.7797-0.85976-0.24011-0.12003-0.42085-0.21983-0.72033-0.19048-0.15986-0.72016 0.29035-0.7306 0.66095-1.1403 0.42933-0.48011 0.49001-0.66015 0.47957-1.3307-0.01-0.3803-0.0196-1.1605-0.16964-1.5003-0.11027-0.24984-0.38039-0.08024-0.48022-0.44032-0.0692-0.21983 0.21009-0.44097 0.17095-0.58057-0.20097-0.66015-1.7108-1.0007-2.422-1.0007-0.74969 0-2.0005 0.23092-2.7012-0.0098-0.0104-0.01044-1.3611-0.98044-1.4609-0.65037 0.17094-0.54012 0.1207-1.2003 0.23097-1.7404-0.72033-0.04044-1.3806 0.0411-2.071 0.0698-0.82081 0.03001-1.1608-0.23092-1.8315-0.5199-1.121-0.48011-3.3309-0.3503-3.5919-1.5708-0.2499-1.1703 0.54025-3.2505-0.27012-4.1423-0.27991-0.30007-1.2508-0.95044-1.6606-1.1703-0.52002-0.27985-1.3806-0.39922-1.9907-0.27006-0.73077 0.16047-1.2103 0.53034-2.0814 0.39987-0.61985-0.09981-1.1803-0.55904-1.81-0.3803-0.61137 0.17026-0.8306 0.76061-1.4407 0.90021-0.39083 0.09067-1.0805 0.09067-1.5614-0.03979 0.45999-0.30007 0.92064-0.60014 1.2704-0.99088 0.60028-0.66015 1.9307-2.561 2.2308-3.4514 0.47043-1.3901-0.39018-4.4208 1.271-4.7313 0.49-2.7411 2.2608-4.6909 4.6326-6.002 2.1714-1.2003 5.133-1.0104 5.9532-3.6706 0.66096-0.04958 0.82016-0.44945 1.4217-0.58057 0.0692-4.3014 8.9037-0.39009 9.8347-3.9211 2.512-0.54012 4.6221-2.5708 6.9534-3.6113 3.0118-1.3405 4.6025-0.98044 7.5145-1.9302 0.35038-0.10959 1.3806-0.0998 1.9914-0.12003-0.03 0.90021-0.25968 2.291 0.39931 2.8109 0.44108 0.33008 0.9611 0.18004 1.4407 0.36987 0.49 0.19048 0.7001 0.57992 1.0714 0.8702 0.0202 0.21983 0.12984 0.27006 0.20031 0.47032 1.0505 0.06001 2.1114 0.09002 3.1417 0.11024 0.32036 0.75996 1.0009 1.15 1.6808 1.6602 0.39996 0.30985 0.5807 0.21983 0.90041 0.75017 0.20031 0.33986 0.21988 0.66015 0.53046 0.98044 0.47044 0.4899 1.3108 0.91064 2.071 0.93021 1.1908 0.05023 2.0716 0.48011 3.2421 0.60014 0.0405 0.30007 0.27013 0.51012 0.5807 0.57992 0.06 0.94065 0.01 1.2609 1.0002 1.501 0.09 0.25962 0.14941 0.53034 0.19052 0.80953 0.0502 0.01044 0.0992 0.02022 0.14028 0.03001-0.21988 0.6608-0.44042 1.7215-0.12984 2.4606 0.2897 0.72017 0.85017 0.84019 0.88084 1.7606-0.61137-0.03001-2.2921 0.04044-1.9711 1.0007 0.12006 0.36008 0.65052 0.34965 0.84039 0.57013 0.33015 0.39009 0.33994 0.72017 0.30014 1.2603-0.40062 0.17026-0.98067 0.60014-1.1705 1-1.6605-0.06067-1.2704 1.5095-2.4011 1.9407-1.1405 0.42075-3.0223 0.08024-4.1523-0.14938-0.79015-0.16047-1.3604-0.05023-2.101 0.1396-0.46064 0.12003-0.60092-0.12068-0.90106 0.33008-0.17943 0.27006-0.09 1-0.0992 1.3405-0.03 0.74039 0.0196 1.5401 0.16051 2.2505 0.14942 0.71038 0.61072 1.2094 0.49001 1.9909-0.39083 0.02022-1.1307-0.14025-1.4909 0.01044-0.39997 0.15982-0.82995 0.82976-0.39997 1.2603 0.35038 0.3503 0.76078-0.05023 1.0707 0.4899 0.18008 0.31051 0.14093 1.1103-0.01 1.4906-0.27012 0.03979-0.48022 0.1696-0.72033 0.27006-0.0698 0.03001-0.0907 0.78996-0.11027 0.93021 0.28057 0.06001 0.60028 0.06001 0.91086 0.0698 0.0502 0.93021-0.67988 1.8806 0.0104 2.4103 0.32036 0.24984 1.0302 0.04044 1.3415 0.24006 0.3693 0.24006 0.41041 0.94 0.76078 1.2407 0.10962-0.01109 0.27013 0.03001 0.39018 0.03001-0.0404 0.42988-0.0202 1.3999 0.33994 1.6602 0.44956 0.31051 1.3708-0.3803 1.6201 0.23027 0.33994 0.85128-1.7708 1.1011-1.3408 1.9915 0.1703 0.36008 0.8704 0.33008 1.0805 0.57992 0.30013 0.3503 0.25055 0.74039 0.21988 1.1807-0.67009 0.03001-2.9511 0.28115-2.7319 1.3307 1.4909 0.09067 2.681-0.06001 3.9918 0.68037 0.59049 0.33986 1.1105 1.09 1.9209 0.92043 0.85996-0.17939 0.71054-0.81997 1.1601-1.2505 0.89062-0.84998 2.912 0.0411 3.5925 0.7306 0.56961 0.57992 1.1203 2.5708 2.2308 2.4508 0.39018 0.93021 1.2906 0.42075 1.6906 0.99088 0.73077 1.0307-0.61072 3.8207 1.7304 3.6811 0.0411 0.46054 0.0607 0.94-0.2499 1.2205-1.35 0.18983-1.6605 1.4906-2.7215 2.1201-0.74056 0.44032-0.80059 0.66015-0.60028 1.6406 0.10962 0.60014 0.15986 1.3503 0.33015 1.9204 0.41041 1.3405 1.1105 2.351 1.8615 3.501 0.31971 0.4899 0.7797 1.0104 1.0407 1.5206 0.32037 0.63014-0.0998 1.5304 0.54025 1.9602 0.30014 0.21005 0.79015 0.0502 1.151 0.0998 0.48022 0.0802 0.60028 0.17025 1.0205 0.42009 0.71577 0.44684 0.6851 1.2975 1.626 1.1872z",
+                Keelung:"m354.05 44.801c-1.1007 0.76061-2.131 0.33008-2.5505-0.81019-0.42085 0.0698-0.99176-0.09915-1.4217-0.08024-0.10962-0.26941-0.0502-0.63928-0.0803-0.91978-2.2615 0.01892-1.9111-4.2916-2.0005-6.002-0.55069 0.2094-1.3415 0.01957-1.9209 0.17026-0.12984-0.40966-0.12984-1.2603 0-1.6706 1.611-0.09067 3.3518 0.33986 4.0023-1.501 0.73077-0.04044 2.052 0.23092 2.7215-0.03001 0.6205-0.24006 0.58135-1.1598 1.0505-1.4508 1.0205-0.63993 1.8106-1.1905 2.9511-1.7208 0.46064 0.42988 0.80972 0.76061 0.82016 0.77039 1.4811 1.0502 2.6621 1.0705 4.6326 1.1801 0.4502 1.8617-0.28057 2.7906-0.14942 4.4423 0.68053-0.86042 1.7004-1.4005 1.7304-2.6908 2.4611-1.3203 4.0525 1.6706 6.6742 0.7306-0.11027 0.4899 0.17878 1.2003 0.0796 1.6902 0.52068 0.02022 1.0498 0.03001 1.5907 0.05023v0.03001c-0.03 0.33008-0.36016 1.1005-0.42084 1.4208-0.33015-0.04044-0.84039 0.15004-1.1705 0.08024 0.0104 0.56035-0.42084 1.0307-0.33015 1.6706-1.4106 0.32029-2.2706-0.63014-3.4718-0.47032-1.0603 0.14025-1.8511 1.0104-2.9009 1.2505 1.3108 1.0907 1.5503 2.3908 1.4511 4.2212 1.0198 0.13046 2.3306 1.0411 1.9711 2.3007-0.46064 1.6204-1.9418 0.69016-3.2121 1.0405-0.55982 0.15003-0.44042 1.1103-1.0407 1.2101-0.68053 0.12003-1.2208-0.2805-1.6912-0.33008-1.9711-0.18004-3.4516-1.1011-5.5323-1.2205 0.0698-1.4814-1.0505-2.3007-2.5009-2.0007 0.0196-0.03001-0.06-0.60014-0.06-0.58057 0.34907-0.23027 0.56896-0.62036 0.77971-0.78018z",
+                Kinmen:"m41.675 107.89c-0.0762 4e-3 -0.14595 0.0243-0.18718 0.0468-0.0375 0.0225-0.0711 0.0402-0.0936 0.0702l-0.0468 0.0936c-0.05235 0.16473-0.0159 0.38094-0.0234 0.53817-0.77124 0.0375-1.3965-0.23867-2.1526-0.16379-0.17222 0.015-0.27516 0.0412-0.32758 0.0936-0.015 8e-3 -9e-3 9e-3 -0.0234 0.0234-0.09735 0.11235-0.102 0.2967-0.30418 0.49137-0.21714 0.20217-0.453 0.4034-0.46797 0.72537-0.0075 0.41931 0.2527 0.74409 0.1404 1.1933-0.09735 0.34443-0.40246 0.4268-0.51478 0.74877-0.08985 0.2471 0.015 0.66641 0 0.93596-0.0225 0.3669-0.1095 0.46984-0.49137 0.51477-0.15724 0.0225-0.32666 0.0524-0.49138 0-0.09735-0.0225-0.24522-0.1563-0.32757-0.16379-0.75626-0.0973-0.35661 1.154-0.3042 1.521 0.045 0.34443-0.0135 0.56532-0.1404 0.84236-0.1422 0.32946-0.03375 0.42867-0.0936 0.79557-0.045-7e-3 -0.0795 0-0.117 0-0.03 0.10485-0.1011 0.16098-0.0936 0.28078-0.38936 0.0748-0.53722-0.27891-0.88916-0.23398-0.0225 0.11235 0.07485 0.23959 0.1872 0.37438 0.03 0.0375 0.072 0.0795 0.117 0.117 0.15723 0.1497 0.32384 0.27611 0.42117 0.35097 0.0375 0.0225 0.087 0.0552 0.117 0.0702 0.1422 0.0599 0.26301 0.0468 0.39778 0.0468 0.09735 8e-3 0.20778 0.0328 0.32758 0.0702 0.11235 0.0375 0.21434 0.10485 0.30418 0.1872 0.05235 0.0375 0.1029 0.0954 0.1404 0.1404 0.0375 0.0448 0.0795 0.0954 0.117 0.1404l0.0702 0.0468 0.0468 0.0702c0.1797 0.1797 0.39498 0.30699 0.70197 0.18719 0.35192-0.1347 0.1161-0.47265 0.28078-0.77216 0.22462-0.41182 0.906-0.78433 1.3103-0.88917 0.21789-0.0598 0.66546-0.25176 0.91256-0.117 0.23211 0.1497 0.1104 0.43898 0.1404 0.67857 0.0075 0.0748 0.0411 0.1347 0.0936 0.1872 0.015-0.0225 0.0243-0.0318 0.0468-0.0468 0.1497-0.1497 0.41368-0.27705 0.60837-0.37438 0.25458-0.1347 0.5026-0.33975 0.77217-0.44459 0.07485-0.26206-0.10395-0.43615-0.35098-0.42117-0.11235-0.45675-0.0468-0.63364 0.32758-0.86577 0.31448-0.20965 0.58497-0.3697 0.95936-0.44457 0.36688-0.0823 0.69354-0.0795 1.0529 0.0702 0.2995 0.11985 0.55222 0.34349 0.88916 0.35099 0.1497-0.20966 0.0486-0.47079 0.0936-0.72537 0.015-0.12735-0.04215-0.20685 0.0702-0.30419 0.09735-0.0898 0.25272 0.0206 0.32758-0.0468 0.26208-0.20965 0.045-0.94999 0.1872-1.2869 0.0225-0.0448 0.0243-0.072 0.0468-0.117 0.0375-0.0899 0.0795-0.19842 0.117-0.28078 0.0225-0.0448 0.0477-0.0795 0.0702-0.117 0.03-0.0523 0.072-0.0795 0.117-0.117 0.11985-0.11235 0.24615-0.19374 0.35098-0.35099 0.22462-0.37438 0.0543-1.0389 0.0468-1.4507-0.2471-0.0225-0.57 0.0263-0.77217-0.0936-0.05235-0.03-0.1188-0.072-0.16378-0.117-0.03-0.03-0.0636-0.0561-0.0936-0.0936-0.05985-0.0748-0.09645-0.1591-0.1638-0.23398-0.03-0.0375-0.0795-0.0795-0.117-0.117-0.4268-0.3594-0.98836-0.45674-1.3103-0.93596-0.0225-0.0375-0.0243-0.0881-0.0468-0.1404-0.0225-0.0524-0.0636-0.10395-0.0936-0.16378-0.0375-0.0824-0.0645-0.18158-0.117-0.23399-0.0225-0.0225-0.0477-0.0318-0.0702-0.0468-0.18718-0.11235-0.59433-0.0468-0.81896-0.0468-0.15162 0-0.47348-0.0594-0.70197-0.0468zm32.666-14.206c-0.71882-0.05985 0.19842 0.96028 0.28078 1.1699v0.0234c0.03 0.07485 0.0468 0.17596 0.0468 0.28078 0 0.21714-0.0468 0.45114-0.0468 0.60837 0 0.3669 0.0402 0.51946-0.30418 0.63177-0.20217 0.06735-0.3332 0.08805-0.46798 0.1404-0.05235 0.0225-0.10395 0.0327-0.16378 0.0702-0.03 0.015-0.0561 0.0477-0.0936 0.0702-0.10485 0.06735-0.21526 0.13575-0.32758 0.2106-0.11235 0.08235-0.22276 0.15818-0.32758 0.21058-0.1422 0.06735-0.29482 0.0702-0.44458 0.0702-0.05235 0.0075-0.11145 0-0.16378 0-0.06735 0-0.14325 9e-3 -0.21058 0.0234-0.0375 0.0075-0.0795 9e-3 -0.117 0.0234-0.25458 0.07485-0.44085 0.21058-0.72537 0.21058-0.07485 0.12735-0.1338 0.30513-0.1638 0.51478-0.04485 0.45675 0.06645 1.0408 0.35098 1.3103 0.0375 0.0375 0.072 0.0711 0.117 0.0936 0.0075 0.0075 0.0159 0 0.0234 0 0.04485 0.015 0.0954 0.0393 0.1404 0.0468v-0.117c0-0.015-0.0075-0.0318 0-0.0468v-0.0234c-0.0075-0.0075 0.0075-0.0159 0.0234-0.0234-0.0075-0.0075-0.0075-0.0159 0-0.0234-0.0075-0.0225-0.01515-0.0318 0-0.0468-0.0075-0.03 9e-3 -0.0711 0.0234-0.0936 0.0075-0.03-0.0075-0.0402 0-0.0702 0-0.015 0.01605-0.0234 0.0234-0.0234v-0.0468c0.0225-0.07485 0.04035-0.14325 0.0702-0.2106 0.0225-0.06735 0.0477-0.12735 0.0702-0.18718 0.015-0.0225 0.0159-0.0711 0.0234-0.0936 0.08235-0.0075 0.19281-0.0075 0.32758 0 0.05985 0 0.13575-0.0075 0.2106 0 0.0375 0 0.072 0.0234 0.117 0.0234 0.0225 0 0.0318-0.0075 0.0468 0 0.0375 0 0.0795-0.0075 0.117 0 0.08985 0.0075 0.19936 0.0318 0.30418 0.0468l0.0936 0.0234h0.0234c0.05985 0.0075 0.10395 9e-3 0.16378 0.0234 0.05985 0.015 0.1347 0.0318 0.18718 0.0468 0.05235 0.0225 0.08805 0.0552 0.1404 0.0702 0.04485 0.015 0.1029 0.0402 0.1404 0.0702 0.05985 0.0225 0.0954 0.0561 0.1404 0.0936 0.045 0.03 0.0945 0.07215 0.117 0.117 0.045 0.06735 0.0777 0.12825 0.0702 0.21058v0.0234c-0.0075 0-0.0318-0.0159-0.0468-0.0234h-0.0231c-0.18718-0.015-0.42117 0.0216-0.60837-0.0234-0.22462-0.04485-0.33694-0.19467-0.56157-0.18718h-0.0702c-0.0375 0-0.0795 0.0159-0.117 0.0234-0.015 0.0075-0.0318 0.0234-0.0468 0.0234-0.0375 0.015-0.0636 0.0243-0.0936 0.0468-0.06735 0.05985-0.09735 0.1535 0 0.28078 0.0075 0.015 0.0318 9e-3 0.0468 0.0234 0.08235 0.05985 0.19188 0.0543 0.30418 0.0468 0.10485 0 0.21246 0.0135 0.25738 0.1404 0.0225 0 0.0477 0.01575 0.0702 0.0234 0.0225-0.0075 0.0318-0.0075 0.0468 0 0.10485 0.31448 0.12825 0.45861 0.0234 0.79556l-0.0234 0.0936c-0.03 0.0973-0.04965 0.18345-0.117 0.28079-0.05985 0.0823-0.18999 0.12075-0.25738 0.2106l-0.0468 0.0468c-0.0075 0.015 0 0.0243 0 0.0468-0.0075 0.0448-0.0075 0.0881 0 0.1404 0.04485 0.16473 0.19094 0.32571 0.28078 0.46797 0.11235 0.17221 0.19188 0.46705 0.30418 0.63177l0.0468 0.0468c-0.03-7e-3 -0.0402-0.0159-0.0702-0.0234-0.0375-8e-3 -0.087-9e-3 -0.117-0.0234-0.05985-0.0225-0.11145-0.0561-0.16378-0.0936-0.0375-0.015-0.0636-0.0243-0.0936-0.0468-0.35193-0.25458-0.44178-0.67482-0.56158-1.1465-0.22462-0.0974-0.14595-0.27237-0.28078-0.44459l-0.0702-0.0702-0.0234-0.0468c-0.0375-0.03-0.1029-0.0477-0.1404-0.0702-0.08235-0.0375-0.17595-0.0636-0.28078-0.0936-0.1422-0.0375-0.263-0.0486-0.39778-0.0936-0.04485-0.015-0.08805-0.0243-0.1404-0.0468 0 0-0.0234-0.0157-0.0234-0.0234-0.0225-0.015-0.0477-0.0168-0.0702-0.0468-0.015-0.0075-9e-3 -0.0318-0.0234-0.0468-0.0225-0.03-0.0477-0.04785-0.0702-0.0702-0.015-0.015-0.0318-0.0393-0.0468-0.0468-0.07485-0.04485-0.1769-0.04305-0.30418 0.0468-0.21039 0.1422-0.22725 0.48951-0.0468 0.63177 0.1497 0.11235 0.26114 0.0561 0.35098 0.0936l0.0468 0.0234c0.03 0.03 0.0561 0.058 0.0936 0.1404 0.1422 0.26957 0.2705 0.74034 0.2106 1.0998-0.015 0.0749-0.0477 0.12735-0.0702 0.18718-0.15724 0.015-0.30232 0.0402-0.44458 0.0702-0.1497 0.03-0.29482 0.0795-0.44458 0.117-0.08985 0.03-0.17595 0.0478-0.28078 0.0702-0.05235 8e-3 -0.1029 0.0318-0.1404 0.0468s-0.0636 0.0243-0.0936 0.0468c-0.0375 0.0225-0.0711 0.0402-0.0936 0.0702-0.015 0.0225-0.0318 0.0636-0.0468 0.0936-0.015 0.0448-0.0234 0.10395-0.0234 0.1638-0.0075 0.0748-7.5e-4 0.15255-0.0234 0.25739-0.0075 0.0449-0.0243 0.10395-0.0468 0.16378-0.07485 0-0.16004 8e-3 -0.25738 0h-0.1404c-0.0225 0-0.0552-7e-3 -0.0702 0-0.10485 8e-3 -0.18999 0.0252-0.25738 0.0702-0.03 0.015-0.0552 0.0402-0.0702 0.0702-0.1872 0.29951 0.1011 0.6168 0.28078 0.81897 0.0225 0.015 0.0552 0.0318 0.0702 0.0468 0.37438 0.4268 0.41182 0.96872 0.37438 1.5678-0.0075 0.0973-0.0075 0.18251-0.0234 0.25739-0.0075 0.0748-0.0243 0.14325-0.0468 0.21058-0.045 0.11985-0.11415 0.24803-0.23398 0.39779-0.0375 0.045-0.0795 0.087-0.117 0.117-0.03 0.0375-0.0636 0.0478-0.0936 0.0702-0.03 0.0225-0.0402 0.0552-0.0702 0.0702s-0.07965 0.0159-0.117 0.0234c-0.08235 0.0225-0.20124 0.0234-0.35098 0.0234-0.31448 1e-5 -0.66734-5e-3 -0.95936 0.0702-0.2995 0.0748-0.44739 0.22557-0.70197 0.39778-0.27704 0.19467-0.3126 0.25646-0.70197 0.23399-0.21714-0.32946-0.52881-0.25083-0.86576-0.28079-0.40432-0.03-0.4998-0.33132-0.88916-0.42118-0.08985-0.0225-0.18345-0.0393-0.28078-0.0468-0.23961-0.015-0.49324-1e-3 -0.72537-0.0468-0.61398-0.10485-1.0988-0.2499-1.638-0.63177-0.89103-0.62897-1.5668-1.5612-2.4802-2.1526-0.48669-0.32198-0.94156-0.32384-1.2635-0.79556-0.26206-0.41182-0.46518-0.85921-0.77216-1.2635-0.29952-0.40434-0.69356-0.92566-1.053-1.2402-0.55408-0.47172-0.87138-0.13755-1.0062 0.49138-0.614 0.03-1.1194-0.1236-1.5912 0.28079-0.44176 0.37438-0.8199 0.74782-1.4039 0.91255-0.89852 0.23961-1.856 1.7043-1.4741 2.7376 0.19468 0.48669 0.6065 0.32945 0.93596 0.56157 0.1347 0.0898 0.18532 0.19842 0.32758 0.28079 0.0225 8e-3 0.0477 0.0393 0.0702 0.0468 0.045 0.0225 0.0954 0.0318 0.1404 0.0468 0.045 0.0225 0.08805 0.0318 0.1404 0.0468 0.11235 0.03 0.22276 0.0542 0.32758 0.0468 0.0375-0.20217 6e-3 -0.3566-0.0702-0.49139-0.05235-0.10485-0.1422-0.20778-0.18718-0.32758-0.0075-0.0225-0.0159-0.0402-0.0234-0.0702l-0.0468-0.0936c-0.10485-0.19467-0.27237-0.47358-0.25738-0.60837 0.24708-0.0449 0.44644 0.0786 0.67856 0.0936 0.25458 0.03 0.36783-0.1329 0.58498-0.1404 0.38936-0.015 0.88728 0.73095 0.84236-0.0702h0.21058c0.22464 7e-3 0.44178 0.015 0.56158-0.18719 0.10485-0.1797-0.11235-0.57936 0.18718-0.63177 0.32198-0.0524 0.23025 0.44364 0.32758 0.60837 0.07485 0.11985 0.61866 0.4764 0.117 0.49137-0.18718 0.29202-0.25738 0.30606-0.25738 0.72537 0 0.41183 0.08985 0.68138-0.37438 0.74877h-0.0702c-0.12735 0.0225-0.32384 0.03-0.42118 0-0.1422-0.0524-0.27048-0.32853-0.39777-0.35098-0.1422-0.0225-0.21996 0.0272-0.2574 0.117-0.0075 0.015-0.0234 0.0243-0.0234 0.0468-0.0075 0.015-0.0234 0.0477-0.0234 0.0702-0.0225 0.1347-0.0168 0.28546-0.0468 0.39778-0.25458 0.015-0.51758 8e-3 -0.77216 0.0234-0.015 0.20966 0.16566 0.14505 0.21058 0.25739 0.015 0.03 0.0234 0.0636 0.0234 0.0936 0.0075 0.0225 0.0234 0.0477 0.0234 0.0702 0.0075 0.0523 0.0075 0.10395 0 0.16378v0.117c0 8e-3 0.0075 0.0159 0 0.0234 0.0075 0.0375-0.01575 0.0636-0.0234 0.0936-0.0225 0.23961-0.0711 0.45395-0.0936 0.67857-0.0375 0.5466 0.39966 1.0314 0.63177 1.4507 0.21714 0.39684 0.34443 0.58029 0.37438 1.0296 0.03 0.32196 0.117 0.58309 0.117 0.91255 0 0.26955 0.0162 0.54098 0.0234 0.79556 0.0075 0.35941 0.0234 0.69261 0.0234 1.0296 0 0.20966 0.0972 0.76374 0 0.93596-0.11235 0.19468-0.55408 0.26767-0.74877 0.32758-0.08235 0.0225-0.18344 0.0477-0.28078 0.0702-0.06735 0.015-0.11985 9e-3 -0.18718 0.0234-0.09735 0.0225-0.21434 0.0402-0.30418 0.0702-0.12735 0.0448-0.24522 0.11235-0.32758 0.18719-0.11235 0.11235-0.16098 0.27517-0.0936 0.51478 0.05985 0.23211 0.25458 0.47172 0.18718 0.74876 0 0.015 0.0075 0.0159 0 0.0234 0 0.03-0.0075 0.0477-0.0234 0.0702-0.0225 0.0448-0.07215 0.0954-0.117 0.1404-0.03 0.0225-0.0636 0.0552-0.0936 0.0702-0.0375 0.0225-0.072 0.0477-0.117 0.0702-0.06735 0.0448-0.12735 0.0795-0.18718 0.117-0.03 0.0225-0.0711 0.0477-0.0936 0.0702-0.29202 0.23212-0.33507 0.23961-0.70197 0.1872-0.08235-7e-3 -0.26206-9e-3 -0.37438-0.0234-0.0225 0-0.0318 7e-3 -0.0468 0-0.015-2e-5 -0.0318-0.0157-0.0468-0.0234-0.03-0.015-0.0552-0.0168-0.0702-0.0468-0.0075 7e-3 0-0.0157 0-0.0234-0.05985-0.0599-0.06555-0.11985-0.1404-0.1872-0.20216-0.18719-0.36128-0.27891-0.60837-0.23399-0.04485 8e-3 -0.08805 0.0318-0.1404 0.0468-0.0375 0.0973-0.09645 0.18158-0.16378 0.23399-0.0225 0.0225-0.0402 0.0318-0.0702 0.0468-0.12735 0.0898-0.28827 0.0918-0.46798 0.0468-0.08235-0.015-0.17502-0.0243-0.25738-0.0468-0.0225 0-0.0318-0.0162-0.0468-0.0234-0.08235-0.0225-0.17502-0.0552-0.25738-0.0702h-0.0234c-0.1422-0.0225-0.2939-0.0135-0.42118 0.0234-0.0375 0.015-0.0561 0.0318-0.0936 0.0468-0.0375 0.0225-0.0636 0.0168-0.0936 0.0468-0.04485 0.0375-0.1029 0.0879-0.1404 0.1404-0.15723 0.21715-0.14505 0.33882-0.0702 0.42118 0.05235 0.0524 0.14415 0.1029 0.234 0.1404 0.08985 0.03 0.19094 0.0561 0.28078 0.0936 0.24708 0.11235 0.59994 0.50636 0.77216 0.67857 0.0375 0.015 0.0795 0.0168 0.117 0.0468 0.045 0.03 0.0954 0.072 0.1404 0.117 0.26956 0.23961 0.5438 0.68699 0.67857 0.88916 0.05235 0.0748 0.0636 0.10395 0.0936 0.1638 0.015 0.015 0.0318 0.0402 0.0468 0.0702 0.0225 0.0599 9e-3 0.22836 0.0468 0.28078 0.03 0.03 0.0486 0.0627 0.0936 0.0702 0.04485 0.015 0.11145 0.0159 0.1638 0.0234h0.0234c0.04485 8e-3 0.0954 9e-3 0.1404 0.0234 0.03 7e-3 0.0477 0.0159 0.0702 0.0234 0.0225 7e-3 0.0318 0.0318 0.0468 0.0468 0.10485 0.0973 0.17408 0.23211 0.23398 0.37437 0.0375 0.0898 0.0636 0.20685 0.0936 0.3042 0.045 0.1422 0.08895 0.27704 0.16378 0.37437 0.05985 0.0824 0.16848 0.13485 0.28078 0.1872 0.11985 0.0448 0.23212 0.087 0.37438 0.117 0.13485 0.03 0.28641 0.0552 0.42118 0.0702 0.12735 0.015 0.26114 0.0318 0.35098 0.0468 0.03 0.12735 0.09735 0.23772 0.18718 0.32759 0.07485 8e-3 0.12735 0 0.1872 0 0.06735 0 0.1422 9e-3 0.18718 0.0234 0.0375 8e-3 0.0636-6e-3 0.0936 0.0234 0.05235 0.0375 0.0954 0.10485 0.1404 0.18718 0.0225 0.0448 0.0477 0.088 0.0702 0.1404 0.045 0.10485 0.0795 0.22277 0.117 0.32759 0.015 0.0524 0.0477 0.0954 0.0702 0.1404 0.05235 7e-3 0.087 0.0486 0.117 0.0936 0.09735 0.11985 0.16098 0.34723 0.28078 0.44458 0.25458 0.2396 0.2939 0.1694 0.60837 0.117 0.32946-0.0448 0.86109-0.20122 1.1232 0.0234 0.0225 0.015 0.0552 0.0402 0.0702 0.0702 0.0375 0.0524 0.0552 0.11235 0.0702 0.18719 0.15723 0.11985 0.43054 0.19749 0.65517 0.25738 0.03 0.015 0.0402 0.0159 0.0702 0.0234 0.03 7e-3 0.0711 0.0234 0.0936 0.0234 0.1347 0.03 0.2293 0.03 0.30418 0 0.015 0 0.0393-8e-3 0.0468-0.0234 0.0225-8e-3 0.0318-0.0243 0.0468-0.0468 0.05235-0.0674 0.0795-0.17782 0.117-0.32758 0.0375-0.015 0.0954-0.0234 0.1404-0.0234 0.10485-0.0225 0.19935-0.0309 0.30418-0.0234 0.10485 0 0.20684-7.5e-4 0.30418-0.0234 0.0225 0 0.0477 7e-3 0.0702 0 0.03-8e-3 0.0477-0.0161 0.0702-0.0234 0.0375-0.015 0.0795-0.0477 0.117-0.0702s0.0711-0.0402 0.0936-0.0702c0.20217-0.20216 0.26768-0.51758 0.32758-0.77216 0.15723-0.6664 0.14415-1.0436 0.60837-1.5678 0.39684-0.45675 0.52881-1.096 0.86576-1.5678 0.1497-0.20965 0.23118-0.4839 0.35098-0.67857 0.0375-0.0524 0.0795-0.0954 0.117-0.1404 0.08235-0.0824 0.1591-0.15163 0.23398-0.234 0.04485-0.0375 0.087-0.088 0.117-0.1404 0.0225-0.015 9e-3 -0.0477 0.0234-0.0702 0.1872-0.45673-0.0318-0.7029 0.51478-0.91255 0.23211-0.0974 0.30324-0.1161 0.46797-0.28079 0.43428-0.44176 0.58592-0.64113 1.1699-0.86575 0.32198-0.12735 0.5569-0.31167 0.81897-0.49139 0.17222-0.1347 0.35847-0.23772 0.53817-0.32758 0.35192-0.18719 0.73378-0.34161 1.1232-0.49137 0.61398-0.23961 1.082-0.4764 1.7782-0.49137 0.68138 0 1.3534-0.0748 2.0122-0.1872 0.63645-0.11235 1.183-0.23399 1.8718-0.23399 0.16473 0 0.31072 9e-3 0.46797 0.0234 0.1497 8e-3 0.31822 0.0168 0.46798 0.0468 0.07485 0.015 0.1347 0.0477 0.18718 0.0702 0.17222 0.0598 0.26582 0.13665 0.46798 0.23399 0.32944 0.1497 0.50634 0.1086 0.67856 0.46798 0.09735 0.1797 0.12825 0.41369 0.2106 0.60837 0.03 0.0598 0.0486 0.11145 0.0936 0.16379 0.04485 0.0523 0.10395 0.0795 0.16378 0.117 0.19468 0.0974 0.453 0.1179 0.65517 0.1404 0.15724 0.0225 0.34162-4e-3 0.49138 0.0468 0.1497 0.0598 0.2396 0.20497 0.37437 0.2574 0.15724 0.0523 0.32666 7.3e-4 0.49138 0.0234 0.03 0 0.0636 0.0159 0.0936 0.0234 0.0375 0.015 0.0636 0.0243 0.0936 0.0468 0.06735 0.0448 0.11985 0.0956 0.18718 0.1404 0.03 0.0225 0.0561 0.0552 0.0936 0.0702 0.15724 0.0898 0.31917 0.0824 0.49138 0.18718 0.1497 0.0824 0.20122 0.19749 0.35098 0.25739h0.0234l0.0234 0.1404c0.0075 0.0448 0.01605 0.0795 0.0234 0.117 0.015 0.0824 0.04875 0.17502 0.0936 0.25738 0.11985 0.23961 0.24522 0.36878 0.32758 0.60837 0.11235 0.28454 0.18063 0.52602 0.21058 0.79557 0.0075 0.0448 0.0234 0.0954 0.0234 0.1404 0.015 0.0898 0.0075 0.17595 0 0.28079-0.57656 0.20217-1.8064-0.30699-1.7316 0.56157 0.49419 0.0225 0.97246-0.0459 1.4741-0.0234 0.05985 0.41931-1.0333 0.20685-1.3103 0.30418-0.05235 0.20217 0.1245 0.28266 0.30418 0.32759 0.045 0.1347 0.0702 0.30231 0.0702 0.44458 0.30699-0.0375 0.57374-0.24241 0.86576-0.25738 0.26206-0.015 0.58965 0.1077 0.88916 0.0702 0.55334-0.0524 0.37083-0.1422 0.49138-0.56159 0.11985-0.42679 0.41276-0.29763 0.77216-0.32758 0.60651-0.0448 0.81054-0.70383 1.3571-0.93596 0.29202-0.11985 0.68325-0.0411 0.98276-0.0936 0.05985-8e-3 0.13485-0.0477 0.18718-0.0702 0.1497-0.0749 0.24054-0.19935 0.2106-0.49137-0.0225-0.20965-0.06555-0.30138-0.1404-0.42118-0.03-0.0448-0.0402-0.0647-0.0702-0.117l-0.0234-0.0234c-0.0225-0.0375-0.0318-0.0636-0.0468-0.0936-0.10485-0.16473-0.11235-0.18533 0-0.32759 0.015-0.0225 0.0243-0.0636 0.0468-0.0936 0.03-0.0449 0.0879-0.0954 0.1404-0.1404 0.2396-0.24709 0.61586-0.48201 0.79556-0.0702 0.33694 0.0973 0.57 0.15537 0.95936 0.1404 0.20966-0.24709 0.57375-0.61678 0.49138-1.0062-0.1497-0.0898-0.27986-0.20498-0.44458-0.25739-0.05235-0.12735-0.0375-0.27798 0-0.39778-0.16473-0.12735-0.53444-0.31355-0.63177-0.53817-0.08235-0.19467 7.5e-4 -0.64862 0.0234-0.86576 0.08985-0.74128 0.6636-0.80211 1.2401-0.58497-0.0225 0.22463 0.49138 0.27143 0.67857 0.23399 0.40434-0.0974 0.2527-0.40434 0.32758-0.74877 0.05985-0.25458 0.18158-0.48669 0.23398-0.74876 0.0075-0.03 0-0.0636 0-0.0936 0.0075-0.0748 0.0318-0.15912 0.0468-0.234 0.0075-0.03 9e-3 -0.0636 0.0234-0.0936 0.0075-0.015 0.0159-9e-3 0.0234-0.0234 0.05985-0.0898 0.2106-0.21432 0.2106-0.30418 0-0.45674-1.0923-0.1254-1.4741-0.51477-0.03-0.03-0.0786-0.072-0.0936-0.117-0.09735-0.2471 0.1125-0.54192 0-0.81896-0.09735-0.25458-0.41649-0.4165-0.49137-0.67857-0.1497-0.50916-0.05235-1.4732 0-2.0122 0.045-0.43428 0.28452-1.534 0.74876-1.6614 0.10485-0.23211 0.43522-0.34068 0.39778-0.65517-0.0075-0.10485-0.13005-0.24615-0.25738-0.35097-0.05235-0.0375-0.08805-0.0711-0.1404-0.0936-0.0225-8e-3 -0.0711-0.0159-0.0936-0.0234-0.05985-0.015-0.10395-0.0234-0.16378-0.0234-0.05985 0-0.11145 7e-3 -0.1638 0.0234-0.0225 8e-3 -0.0477 8e-3 -0.0702 0.0234-0.0225 0-0.0477 0.0159-0.0702 0.0234-0.05235 0.0225-0.1188 0.0477-0.16378 0.0702-0.1497 0.0748-0.263 0.1404-0.39778 0.1404-0.11985 0-0.25552-0.0459-0.39778-0.2106-0.06735-0.0824-0.12735-0.16659-0.18718-0.23398-0.05985-0.0824-0.1188-0.15911-0.1638-0.23399-0.05985-0.10485-0.1263-0.21528-0.16378-0.32758-0.03-0.10485-0.0318-0.2237-0.0468-0.35099-0.015-0.10485-0.03075-0.20029-0.0234-0.32758 0.03-0.614 0.25364-1.3272-0.39778-1.5444-0.05235-0.015-0.0954-0.0477-0.1404-0.0702-0.08235-0.0375-0.1422-0.0645-0.18718-0.117-0.20966-0.1872-0.19376-0.46611-0.1638-0.79557l0.0234-0.16379v-0.1872c0.0075-0.20216-0.0075-0.453 0.0234-0.65517 0.0075-0.06735 7.5e-4 -0.10395 0.0234-0.16378 0.11235-0.2995 0.3566-0.3828 0.30418-0.77217-0.05235-0.0075-0.1188-0.0159-0.16378-0.0234-0.0225 0-0.0318-0.0234-0.0468-0.0234-0.26956-0.015-0.51759 0.01785-0.77217 0.0702-0.16473 0.0375-0.31822 0.08055-0.46798 0.1404-0.03 0.015-0.0636 0.0393-0.0936 0.0468-0.05985 0.0225-0.12735 0.0402-0.18718 0.0702l-0.0702 0.0468c-0.11985 0.07485-9e-3 0.23306-0.23398 0.2106-0.1797-0.0075-0.36034-0.39591-0.39778-0.53817-0.03-0.0375-0.0327-0.0411-0.0702-0.0936-0.12735-0.0075-0.26206-0.0159-0.37438-0.0234-0.23211 0-0.43521-0.0135-0.58497-0.1404-0.08235-0.06735-0.1347-0.15351-0.18718-0.2808-0.04485-0.11985-0.0627-0.24708-0.0702-0.37437 0-0.06735 0.0075-0.12735 0-0.1872-0.015-0.06735-0.0318-0.12735-0.0468-0.18718-0.08985-0.28454-0.20498-0.497-0.2574-0.81897-0.0375-0.1797-0.1188-0.3828-0.16378-0.58497-0.015-0.05235-0.0159-0.11145-0.0234-0.16378-0.0075-0.07485-0.0075-0.15912 0-0.234v-0.1404c0.0075-0.11985 0.02265-0.26206 0-0.37437-0.0075-0.04485-0.01605-0.07215-0.0234-0.117-0.0375-0.1347-0.11415-0.26674-0.23398-0.30418-0.03-0.0075-0.072-0.015-0.117 0-0.015-0.0075-0.0318 0.0159-0.0468 0.0234l-0.0702 0.0234c-0.13485 0.08235-0.16473 0.30512-0.37438 0.32758-0.06735-0.16473-0.0243-0.35098-0.0468-0.53818-0.38187-0.1797-1.257 0.09825-1.6614 0.2106h-0.0234c-0.05985 0.0225-0.1029 0.0393-0.1404 0.0468h-0.0234c-0.16473 0.0375-0.24802 0.01785-0.39778-0.117-0.0375-0.03-0.072-0.0645-0.117-0.117h-0.0234c-0.16473-0.1497-0.36876-0.42962-0.60837-0.44458z",
+                Matsu:"m47.89 49.587c-0.5391 0.81864-0.3307 2.5646-0.0312 3.463-0.75874 0.08984-1.3228 0.52164-1.8719 1.0607 0.87854 1.6672-0.22714 1.5961-0.68638 2.9638-0.56906 1.6672 0.4917 2.5258 1.5599 3.2446 0.40934 0.27954 0.76624 0.68512 1.1856 0.90476 1.0383 0.46922 0.98962 0.07608 1.7783-0.09354 0.7288-0.18968 0.60276-0.31948 1.5911-0.24958 0.62896 0.02994 1.2292 0.46298 2.028 0.34318 0.39934-0.75874 1.4738-2.1078 2.4022-2.028 0.51914 1.6772 2.6594-0.27828 3.3382-0.71756 1.4876-0.98836 2.26-1.5712 2.0904-3.5878-1.797 0.08986-3.4904-0.45424-5.3974-0.37438-1.1381 0.04992-1.7571-0.1273-2.2464 0.81116-0.1198 0.22962-0.1572 0.47672-0.1872 0.68636l-0.0312 0.28078c0 0.03994-0.0212 0.08486-0.0312 0.1248-0.01 0.08986-0.012 0.1797-0.0312 0.24958-0.01 0.03994-0.012 0.09484-0.0312 0.1248-0.03 0.0599-0.065 0.10608-0.1248 0.156-0.1798 0.12978-0.52538 0.19468-1.1543 0.1248-0.1398-1.6972-0.2683-4.0908-2.7142-3.6814 0.32944-0.609 0.76498-1.0795 1.4039-1.2791 0.1598-0.16972 0.40708-0.72506 0.46798-0.90476 0.1598-0.32946-2.9376-1.4726-3.307-1.6223zm23.56-17.784c-0.38328 0.04264-0.8218 0.14792-1.2479 0.24958-0.21306 0.05082-0.42916 0.11702-0.62396 0.156-0.1948 0.03894-0.37314 0.05302-0.53038 0.0624-0.34942 0.02-0.85984-0.07238-1.2791-0.0624h-0.0312c-0.1698 0-0.31698 2e-3 -0.43678 0.0624-0.70882 0.26956-0.46922 0.52664-0.99836 0.93596-0.34442 0.24958-0.7213 0.5831-1.1231 0.87356s-0.82864 0.53786-1.2479 0.59278c-1.228 0.13978-1.807-0.80616-2.7454 0.31198-1.0882 1.2679 0.1548 1.9006 0.37438 3.0886 0.1198 0.6689-0.0212 0.95716-0.2808 1.2167-0.0698 0.0599-0.1386 0.12728-0.21838 0.18718-0.31948 0.24958-0.74252 0.54536-1.092 1.1543-0.1398 0.25958-0.2421 0.56532-0.31198 0.90476-0.02 0.1198-0.0524 0.25458-0.0624 0.37438-0.0598 0.58902 8e-3 1.2068 0.1872 1.7159 0.1598 0.04992 0.1872-0.04492 0.1872 0.1248 0.20966-0.02996 0.52914 0.09234 0.74876 0.0624-0.1572 0.84736 0.41046 1.3996 1.1232 1.2167 0.1018-0.02616 0.2059-0.06738 0.31198-0.1248-0.0486-0.1872-0.091-0.41458-0.1248-0.65516-0.23696-1.6842-0.0236-4.4052 1.8719-4.4926-0.0224-0.5441 0.0872-0.94332 0.28078-1.2479 0.0968-0.1523 0.20398-0.30146 0.34318-0.40558 0.69598-0.5206 1.8782-0.47422 3.0574-0.37438-0.0798 0.49918 0.1884 0.94468 0.21838 1.4039 1.797-0.7887 2.9938-1.7147 5.2102-0.93596 0.1872 0.38936-0.093 2.9332 0.49918 3.5254 0.0494 0.04932 0.125 0.07348 0.1872 0.09354s0.1106 0.0138 0.1872 0c0.153-0.02786 0.34192-0.1198 0.56156-0.31198 0.0674-0.0587 0.1122-0.13966 0.156-0.2184 0.0438-0.07876 0.1006-0.1542 0.1248-0.2496 0.1936-0.76316-0.191-2.0002-0.1248-2.839 8e-3 -0.10486 8e-3 -0.22142 0.0312-0.31198 0.024-0.09056 0.0812-0.14556 0.1248-0.2184 0.0436-0.07288 0.089-0.13552 0.156-0.1872 0.20096-0.15502 0.5154-0.22214 0.99836-0.1248 0.0798-0.45924 0.0798-1.1107 0-1.5599-0.76874-0.04992-3.01 0.68512-2.8702-0.34318 0.1598-0.99836 1.6186-0.7238 1.2791-2.371-1.1381 0.24958-1.1656-0.99836-2.184-1.2479-0.1798-0.04742-0.43086-0.0596-0.68636-0.03114z"
+                };
+            var i = {};
+            for (var s in r) {
+                i = {};
+                if (this.options.stateSpecificStyles[s]) {
+                    e.extend(i, t, this.options.stateSpecificStyles[s])
+                } else {
+                    i = t
+                }
+                this.stateShapes[s] = n.path(r[s]).attr(i);
+                this.topShape = this.stateShapes[s];
+                this.stateHitAreas[s] = n.path(r[s]).attr({
+                    fill: "#000",
+                    "stroke-width": 0,
+                    opacity: 0,
+                    cursor: "pointer"
+                });
+                this.stateHitAreas[s].node.dataState = s
+            }
+            this._onClickProxy = e.proxy(this, "_onClick");
+            this._onMouseOverProxy = e.proxy(this, "_onMouseOver"),
+            this._onMouseOutProxy = e.proxy(this, "_onMouseOut");
+            for (var s in this.stateHitAreas) {
+                this.stateHitAreas[s].toFront();
+                e(this.stateHitAreas[s].node).bind("mouseout", this._onMouseOutProxy);
+                e(this.stateHitAreas[s].node).bind("click", this._onClickProxy);
+                e(this.stateHitAreas[s].node).bind("mouseover", this._onMouseOverProxy)
+            }
+        },
+        _initCreateLabels: function() {
+            var t = this.paper;
+            var n = [];
+            var r = 860;
+            var i = 220;
+            var s = this.options.labelWidth;
+            var o = this.options.labelHeight;
+            var u = this.options.labelGap;
+            var a = this.options.labelRadius;
+            var f = s / this.scale;
+            var l = o / this.scale;
+            var c = (s + u) / this.scale;
+            var h = (o + u) / this.scale * .5;
+            var p = a / this.scale;
+            var d = this.options.labelBackingStyles;
+            var v = this.options.labelTextStyles;
+            var m = {};
+            for (var g = 0, y, b, w; g < n.length; ++g) {
+                w = n[g];
+                y = (g + 1) % 2 * c + r;
+                b = g * h + i;
+                m = {};
+                if (this.options.stateSpecificLabelBackingStyles[w]) {
+                    e.extend(m, d, this.options.stateSpecificLabelBackingStyles[w])
+                } else {
+                    m = d
+                }
+                this.labelShapes[w] = t.rect(y, b, f, l, p).attr(m);
+                m = {};
+                if (this.options.stateSpecificLabelTextStyles[w]) {
+                    e.extend(m, v, this.options.stateSpecificLabelTextStyles[w])
+                } else {
+                    e.extend(m, v)
+                }
+                if (m["font-size"]) {
+                    m["font-size"] = parseInt(m["font-size"]) / this.scale + "px"
+                }
+                this.labelTexts[w] = t.text(y + f / 2, b + l / 2, w).attr(m);
+                this.labelHitAreas[w] = t.rect(y, b, f, l, p).attr({
+                    fill: "#000",
+                    "stroke-width": 0,
+                    opacity: 0,
+                    cursor: "pointer"
+                });
+                this.labelHitAreas[w].node.dataState = w
+            }
+            for (var w in this.labelHitAreas) {
+                this.labelHitAreas[w].toFront();
+                e(this.labelHitAreas[w].node).bind("mouseout", this._onMouseOutProxy);
+                e(this.labelHitAreas[w].node).bind("click", this._onClickProxy);
+                e(this.labelHitAreas[w].node).bind("mouseover", this._onMouseOverProxy)
+            }
+        },
+        _getStateFromEvent: function(e) {
+            var t = e.target && e.target.dataState || e.dataState;
+            return this._getState(t)
+        },
+        _getState: function(e) {
+            var t = this.stateShapes[e];
+            var n = this.stateHitAreas[e];
+            var r = this.labelShapes[e];
+            var i = this.labelTexts[e];
+            var s = this.labelHitAreas[e];
+            return {
+                shape: t,
+                hitArea: n,
+                name: e,
+                labelBacking: r,
+                labelText: i,
+                labelHitArea: s
+            }
+        },
+        _onMouseOut: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("mouseout", e, t)
+        },
+        _defaultMouseOutAction: function(t) {
+            var n = {};
+            if (this.options.stateSpecificStyles[t.name]) {
+                e.extend(n, this.options.stateStyles, this.options.stateSpecificStyles[t.name])
+            } else {
+                n = this.options.stateStyles
+            }
+            t.shape.animate(n, this.options.stateHoverAnimation);
+            if (t.labelBacking) {
+                var n = {};
+                if (this.options.stateSpecificLabelBackingStyles[t.name]) {
+                    e.extend(n, this.options.labelBackingStyles, this.options.stateSpecificLabelBackingStyles[t.name])
+                } else {
+                    n = this.options.labelBackingStyles
+                }
+                t.labelBacking.animate(n, this.options.stateHoverAnimation)
+            }
+        },
+        _onClick: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("click", e, t)
+        },
+        _onMouseOver: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("mouseover", e, t)
+        },
+        _defaultMouseOverAction: function(t) {
+            this.bringShapeToFront(t.shape);
+            this.paper.safari();
+            var n = {};
+            if (this.options.stateSpecificHoverStyles[t.name]) {
+                e.extend(n, this.options.stateHoverStyles, this.options.stateSpecificHoverStyles[t.name])
+            } else {
+                n = this.options.stateHoverStyles
+            }
+            t.shape.animate(n, this.options.stateHoverAnimation);
+            if (t.labelBacking) {
+                var n = {};
+                if (this.options.stateSpecificLabelBackingHoverStyles[t.name]) {
+                    e.extend(n, this.options.labelBackingHoverStyles, this.options.stateSpecificLabelBackingHoverStyles[t.name])
+                } else {
+                    n = this.options.labelBackingHoverStyles
+                }
+                t.labelBacking.animate(n, this.options.stateHoverAnimation)
+            }
+        },
+        _triggerEvent: function(t, n, r) {
+            var i = r.name;
+            var s = false;
+            var o = e.Event("usmap" + t + i);
+            o.originalEvent = n;
+            if (this.options[t + "State"][i]) {
+                s = this.options[t + "State"][i](o, r) === false
+            }
+            if (o.isPropagationStopped()) {
+                this.element.trigger(o, [r]);
+                s = s || o.isDefaultPrevented()
+            }
+            if (!o.isPropagationStopped()) {
+                var u = e.Event("usmap" + t);
+                u.originalEvent = n;
+                if (this.options[t]) {
+                    s = this.options[t](u, r) === false || s
+                }
+                if (!u.isPropagationStopped()) {
+                    this.element.trigger(u, [r]);
+                    s = s || u.isDefaultPrevented()
+                }
+            }
+            if (!s) {
+                switch (t) {
+                case "mouseover":
+                    this._defaultMouseOverAction(r);
+                    break;
+                case "mouseout":
+                    this._defaultMouseOutAction(r);
+                    break
+                }
+            }
+            return !s
+        },
+        trigger: function(e, t, n) {
+            t = t.replace("usmap", "");
+            e = e.toUpperCase();
+            var r = this._getState(e);
+            this._triggerEvent(t, n, r)
+        },
+        bringShapeToFront: function(e) {
+            if (this.topShape) {
+                e.insertAfter(this.topShape)
+            }
+            this.topShape = e
+        }
+    };
+    var c = [];
+    s(e, "usmap", l, c)
+})(jQuery, document, window, Raphael)
+
+
+
+endingPicker = (out, totv, aa, quickstats) => {
+    
+    //out = "win", "loss", or "tie" for your candidate
+    //totv = total votes in entire election
+    //aa = all final overall results data
+    //quickstat = relevant data on candidate performance (format: your candidate's electoral vote count, your candidate's popular vote share, your candidate's raw vote total)
+  
+    /*
+    e.header = "<h2></h2>"
+    e.pages = ["<p></p>",
+               "<p></p>"]
+    */
+  
+    // NORMAL ENDINGS
+  e.final_overall_results.sort((a, b) => b.popular_votes - a.popular_votes);
+  map = document.getElementById("map_container");
+
+  //不帮助果冻，果冻失败
+  
+  if (aa[0].candidate === 2001557 && e.player_answers.includes(1950399)) {
+  used=false
+  if (used != true) {
+              setInterval(function () {
+                  used = true;
+                  imgg = document.getElementsByClassName("person_image")[0];
+                  if (imgg != null) {
+                      imgg.src =  "https://cc.tvbs.com.tw/img/upload/2023/05/11/20230511101843-4fbdaa77.jpg";
+                  }
+              }, 100);
+          }
+  return "<div style='overflow-y:scroll;height:250px;'><h3>KMT's Landslide Failure, DPP Re-elected</h3><p>Since the nomination of Terry Gou on May 17, 2023, the Kuomintang (KMT) has made a significant mistake. Gou's campaign encountered numerous issues over the months, ultimately leading to the current outcome. Firstly, Gou's involvement in past scandals resurfaced, severely impacting his and the KMT's image. Many within the KMT were also dissatisfied with the influence he had on the party in 2019, including a considerable number of Han Kuo-yu's supporters, as he competed against Han in 2019 and played a role in his significant defeat.</p><p>Mayor Hou You-yi focused on municipal governance and did not actively support Gou's campaign, lacking the backing of the initially popular presidential candidate Hou You-yi. Gou's campaign suffered from a lack of enthusiasm and support.</p><p>Things took a turn for the worse when Ko Wen-je refused to form a KMT-TPP ticket with Gou. Ko was wary of Gou's extensive business background and unclear ties with Beijing, as Gou had substantial business interests in mainland China. Gou insisted on running for president instead of vice president, refused to let the outcome be decided by polls, and even made statements like 'Let the Older brother go first for four years.' By November 23, Ko Wen-je still refused to communicate with Gou. At this point, Gou's approval ratings had fallen to the level of Eric Chu in 2016, and he still had not found a vice president. Ultimately, on November 24, Hung Hsiu-chu, who had been nominated in 2016 before being abolished, became Gou's vice president in an attempt to salvage his candidacy and keep the KMT in the election. Unfortunately, these efforts were in vain, and Gou's defeat was a reality.</p><p>With Gou's defeat, you have one less opponent to deal with in the next four years. Despite achieving high satisfaction ratings in polls for excellent municipal governance, earning the title of 'Five-Star Mayor,' it came at the cost of the KMT's survival and development. After this election, the KMT's electoral capabilities have once again been undermined. How many years will it take for this party to emerge from the shadow of 2016? Perhaps it will never happen.</p></div>"  
+  
+    } 
+    //帮助果冻，果冻失败
+
+    if (aa[0].candidate === 2001557 && e.player_answers.includes(1950400)) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://image.cache.storm.mg/styles/smg-800x533-fp-wm/s3/media/image/2019/11/23/20191123-114039_U4040_M570673_9ed1.jpg?itok=or7yughm";
+                        }
+                    }, 100);
+                }
+        return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Sets Historic Record, KMT Faces Third Defeat</h3><p>Since the Drafted of Terry Gou, his approval ratings have been consistently unstable, ultimately resulting in the current consequences. Lai Ching-te and the Democratic Progressive Party (DPP) have once again emerged victorious, setting a historical record in Taiwan by securing a third term. Meanwhile, you have also set a historical record of failure, a responsibility that Terry Gou must bear. If it weren't for his mishandling of the KMT-TPP Ticket in the later stages of the election, the KMT might have won by tens of thousands or even hundreds of thousands of votes against the DPP. However, his disdainful remarks towards Ko Wen-je and his supporters led Ko's supporters to refuse to transfer their votes to him, even when he was leading in the polls. He publicly stated that Ko Wen-je would absolutely not win and requested Ko's supporters to vote for him to defeat the DPP. His insistence on Ko Wen-je being the vice president further angered the TPP and its supporters. On registration day, Terry Gou, an outsider in politics, appointed actress Lai Pei-hsia as vice president, who had starred in the Taiwanese TV series Wave Makers, a show that exposed sexual harassment issues within the DPP. Despite her good and excellent image as well as eloquence, she lacked political experience and was questioned for the KMT's governing capabilities. Although Hou You-yi consistently supported Terry Gou, he ultimately faced defeat.</p> <p>With Terry Gou's defeat, you have one less opponent to deal with in the next four years. Despite achieving high satisfaction ratings in polls for excellent municipal governance, earning the title of 'Five-Star Mayor,' and establishing numerous connections and enhancing your strength and network in the local community, this success comes at the cost of the KMT's survival and development. After this election, the KMT's electoral capabilities have once again been undermined, and people are losing confidence in the party. However, due to the relatively small gap in this election, they are now looking towards you as the wise rising star. Can you secure victory in 2028? How many years will it take for the KMT to emerge from the shadow of 2016? Perhaps it will never happen. Perhaps it will be in the next four years.</p></div>"  
+        
+          } 
+
+    //不帮助果冻，果冻获胜
+
+    if (aa[0].candidate === 2001591 && e.player_answers.includes(1950399) ) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/800/20240113/2000x1333_wmky_495863372336_0.jpg";
+                        }
+                    }, 100);
+                }
+        return "You fool! I told you not to support him, to make sure he loses, and then let him give up in four years! Now he's the president, and in 2028, Terry Gou will definitely choose to run for re-election. What are you going to do then? After 2026, you can just go home and sleep. Goodbye, Mayor Hou!"  
+        
+          } 
+
+    //帮助果冻，果冻获胜
+    if (aa[0].candidate === 2001591 && e.player_answers.includes(1950400) ) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://news-data.pts.org.tw/media/149657/cover.jpg";
+                        }
+                    }, 100);
+                }
+        return "<div style='overflow-y:scroll;height:250px;'><h3>Terry Gou and Kuomintang Secure Victory! Political Alternation Achieved</h3><p>Since Terry Gou was drafted on May 17, avoiding the internal primary conflicts, his approval ratings have been neck-and-neck with Lai Ching-te until he was officially confirmed as the candidate in July. Gou gradually gained a stable lead over Lai. However, the rise of Ko Wen-je and the TPP caused a decline in Gou's approval ratings. Gou had to consider the KMT-TPP Tickets, and after sporadic negotiations over several months, a decision was made on November 15 to determine the outcome through polls. However, Ko Wen-je regretted the agreement after signing, leading to a loss of confidence in him. Voters looking to oust the Democratic Progressive Party (DPP) ultimately rallied towards Terry Gou. Gou nominated political outsider Lai Pei-hsia as vice president, bringing a positive media image. In the vice presidential debate, her unique eloquence, speaking skills, and sincere words resonated with many voters. According to polls, a staggering 62% considered Lai Pei-hsia the best in the debate. Ultimately, on January 13, Terry Gou emerged victorious and assumed the presidency.</p> <p>With Terry Gou's victory, your support for him will not go unnoticed. He has promised you a position in the cabinet, and the position of Premier is highly likely to be yours! Additionally, your high satisfaction ratings in municipal governance, earning the title of 'Five-Star Mayor,' and building numerous connections and enhancing strength and relationships in the local community have contributed to the survival and development of the Kuomintang. After this election, the electoral capabilities of the Kuomintang seem to have returned, and people's confidence in the party has been proven at the ballot box. Media and the public are speculating on who the DPP will field in the 2028 or even 2032 elections, while in the Kuomintang camp, attention is now turning to you, the rising star. If Terry Gou is willing to serve only one term, can you secure victory in 2028? Or do you plan to compete in the primaries against the incumbent president at that time? Regardless, you have considerable strength to contend with, and I wish you the best of luck, Mayor Hou!</p></div>"  
+        
+          } 
+          ///侯侯本体结局
+          if (aa[0].candidate === 2001591 && quickstats[1] > 40 && quickstats[1] < 46.0) {
+            used=false
+            if (used != true) {
+                        setInterval(function () {
+                            used = true;
+                            imgg = document.getElementsByClassName("person_image")[0];
+                            if (imgg != null) {
+                                imgg.src =  "https://i.imgur.com/hT2wDhP.jpeg";
+                            }
+                        }, 100);
+                    }
+            return "<div style='overflow-y:scroll;height:250px;'><h3>Fourth Party Alternation! KMT Victory, DPP Rule Ends</h3><p>I believe Ko Wen-je must be regretting now, why he didn't accept the offer to be the Vice President on November 18. Because if he did, he would have gained many administrative resources for free, the second-highest position in the country, and the expansion of TPP's strength. But he chose to give up. In November, when the opposition alliances parted ways, many predicted that DPP would unprecedentedly enter its third term. However, when Zhao Shao-kang appeared as the Vice President, the enthusiasm of the blue camp voters was fully ignited. Faced with the untrustworthy Ko Wen-je and the political prodigy who rose to fame 30 years ago, they immediately flocked to the latter. This led to a sharp increase in KMT's poll numbers after November, and Zhao Shao-kang brought at least 500,000 to 1 million blue votes for you, helping you secure victory. Zhao Shao-kang promised not to take a salary if elected and to turn his Vice Presidential residence into social housing.</p><p>In terms of this legislative yuan, you witnessed a complete victory. With 57+2 seats in the National Assembly, you will ensure your majority without having to consider DPP and TPP. You can pass any bills you want, ensuring the smooth operation of the Hou You-yi government in the parliament. However, to push for the cabinet system and other reforms you have promised, cooperation between the three parties must be promoted.</p><p>On May 20 this year, you will become the President of the Republic of China, a son of a pork vendor from rural Chiayi, who has been serving the country since entering the police academy, facing countless gunshots, confrontations, and battles against criminals. But if it weren't for Eric Chu promoting you to Deputy Mayor of New Taipei in 2010, you probably wouldn't have entered politics. In just over a decade, you have become the president. Perhaps your Mandarin is not good, perhaps your appearance is not as impressive as others, perhaps you don't even have much personal charm, but you are steadfast and down-to-earth, which has won the favor of the majority of Taiwanese voters. The first thing you will face after taking office is the mayoral by-election in New Taipei, as well as the major elections for mayors across the country in 2026. You must firmly grasp the local base of the blue camp, and in 2028, your prospects for re-election will be very promising! Good luck, President Hou You-yi!</p></div>"  
+            
+          } 
+          else if (aa[0].candidate === 2001591 && quickstats[1] < 40 && quickstats[1] > 35.0 ) {
+            used=false
+            if (used != true) {
+                        setInterval(function () {
+                            used = true;
+                            imgg = document.getElementsByClassName("person_image")[0];
+                            if (imgg != null) {
+                                imgg.src =  "https://i.imgur.com/FiVAzjB.jpeg";
+                            }
+                        }, 100);
+                    }
+            return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Loses Third Term, 8-Year Curse Continues, Underdog Emerges Victorious</h3> <p>In an intense duel, the one who fights to the end is the true winner. With the possibility of Joint Tickets completely lost, Hou You-yi could only find Zhao Shao-kang as the vice presidential candidate. To put it positively, he is a deep-blue anti-communist candidate who can strengthen your base. To put it negatively, there is simply no other KMT member willing to be your vice president because polls show you lagging behind Lai Ching-te. No one is willing to waste time and sacrifice their political future to help you. They are all wrong because the deep-blue return led by Zhao Shao-kang and a large voter base will ensure that you are on par with the DPP and defeat Lai Ching-te in the final stage of the election. It's truly a thrilling and exciting battle! Ko Wen-je must be regretting now; he could have become vice president, but now he can only be elected as Taipei City citizen. Haha.</p> <p>In terms of this legislative session, you have just obtained a majority, but it's very fragile. The 55+2 seats in the National Assembly will ensure your absolute majority without having to consider the faces of DPP and TPP. You can pass any bills you want, ensuring the smooth operation of the Hou You-yi government in the parliament. However, to push for the cabinet system and other promised reforms, cooperation between the three parties must be promoted. Additionally, if someone in the National Assembly does not vote for you, even one or two people whose party lines are inconsistent, it may lead to you losing the majority. So, you must uphold party discipline. After all, you are now the president, and you might also serve as the party chairman.</p><p>On May 20 next year, you will become the President of the Republic of China, a son of a pork vendor from rural Chiayi, who has been serving the country since entering the police academy, facing countless gunshots, confrontations, and battles against criminals. But if it weren't for Eric Chu promoting you to Deputy Mayor of New Taipei in 2010, you probably wouldn't have entered politics. In just over a decade, you have become the president. Perhaps your Mandarin is not good, perhaps your appearance is not as impressive as others, perhaps you don't even have much personal charm, but you are steadfast and down-to-earth, which has won the favor of the majority of Taiwanese voters. The first thing you will face after taking office is the mayoral by-election in New Taipei, as well as the major elections for mayors across the country in 2026. You must firmly grasp the local base of the blue camp, and in 2028, your prospects for re-election will be very promising! Good luck, President Hou You-yi!</p></div>    "
+          }
+            else if (aa[0].candidate === 2001557 && quickstats[1] <40 && quickstats[1] > 35.0 ) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/1024/20231231/1200x814_wmky_053032638365_202312030108000000.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Unprecedentedly Enters Third Term: KMT Fails to Achieve Party Alternation</h3><p>As predicted, the miracle did not happen. Lai Ching-te maintained his high approval ratings until the last day of the election. Everyone knew that the lack of cooperation between the blue and white camps would benefit Lai Ching-te. As expected, both you and Ko Wen-je lost in the election. However, Lai Ching-te's vote share is not as high as expected, staying below 40%, which means he didn't even secure full support from the DPP base. Zhao Shao-kang's entry brought a strong boost to the blue camp, but the Triumph Apartments incident and the influence of Ma Ying-jeou may have affected your base and votes. You may have also performed poorly in the early stages of the campaign, leading to a drag, but since this was a result that everyone could foresee, it might not be as bad as it seems.</p> <p>Fortunately, we have maintained a relative majority in the Legislative Yuan. The 53+2 seats will ensure that we are the largest party in the legislature. While we didn't achieve an absolute majority, meaning we have to cooperate with the TPP to pass bills, they will become a crucial minority in the parliament.</p> <p>After the election, you must return to the position of Mayor of New Taipei City. Your deputy mayor has been acting on your behalf for the past few months. Your term will continue until 2026. Although some extremists talk about replicating the outcome of Han Kuo-yu in 2020 and attempting to recall you as mayor, their chances of success are unlikely, and you are not particularly disliked. They are not likely to succeed. In 2026, you must step down, and at that time, you will be a free person, able to enjoy retirement and the remaining years of your life. However, if you still have ambitions for 2028, this election is just a stepping stone. Failure is the mother of success. Since the DPP can be re-elected, what reason do you have not to strive for the nomination in 2028?</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Zhao Shao-kang for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>    "
+            }
+            else if (aa[0].candidate === 2001557 && quickstats[1] > 40.0 && quickstats[1] < 46.0) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://d1j71ui15yt4f9.cloudfront.net/wp-content/uploads/2023/12/03223725/20231203000125.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>Narrow Defeat with High Votes: KMT Loses to DPP with Over 40%</h3><p>Once, people believed that getting 40% of the votes in a three-way race would guarantee victory. Unfortunately, luck wasn't on your side, and the DPP secured a victory with just a slightly higher vote count. You garnered nearly the same number of votes, yet you have to return to your position as the mayor of New Taipei City. Is there a flaw in our electoral system? Despite securing a substantial 40% of the votes, achieving a party alternation proved elusive. Your supporters blame Ko Wen-je for siphoning off many of your votes, but despite our best efforts, party alternation couldn't be realized.</p><p>For you, the consolation is that Ko Wen-je secured third place. Before the election, he had significant momentum with substantial support from young people, and TPP supporters made their voices heard online. However, these were ultimately futile dreams. Even if Ko Wen-je had said he would let you run alone, you wouldn't have won. You proved that the KMT, with a solid base, wouldn't easily lose to the TPP, which has only been around for a few years. Among the opposition voters, there's a saying: whoever is in third place is the culprit for the opposition's failure. Judging by the voting pattern, he is indeed the third, and he lost by a significant margin. After the election, his Facebook was turned upside down by angry opposition voters.</p><p>Although Lai Ching-te becomes president, his governance won't be smooth. The high satisfaction with the Tsai administration won't be fully inherited by him. He is destined to face a minority government and a parliament where the opposition party is in power. Currently, the KMT has 56+2 seats, making it the largest party in the Legislative Yuan and securing an absolute majority. This means that, barring any surprises, Han Kuo-yu, who supports you, will become the president of the Legislative Yuan. This is a significant payback for him. Zhao Shao-kang can go back to hosting his show, and you can go back to being the mayor of New Taipei City. You can try running again in 2028, as your performance has at least matched that of Han Kuo-yu in 2020, and this was in a three-way race. If you enter the race in 2028, the presidency could very well be yours. Good luck, Mayor Hou!</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Zhao Shao-kang for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>"
+            }
+          else if (aa[0].candidate === 2001557 && quickstats[1] < 35.0 && quickstats[1] > 30.0) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://images.ctee.com.tw/newsphoto/2024-01-13/1024/20240113700644_20240113212416.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Triumphs Again, KMT Faces Another Defeat: When Will the Chapter of 2016 End?</h3> <p>On the night of your defeat, you had a nightmare: perhaps the KMT will never govern again? It's a frightening thought, but since 2016, the KMT has lost the presidential election three times in a row. The last time they won was 12 years ago, a cycle ago, but it feels as distant as a century ago. The DPP has achieved an unprecedented third term, even though their government is a minority one without the support of the majority of the people. The KMT's failure was anticipated, as the DPP had a few percentage points of a lead, and every step forward for you was challenging, ultimately leading to the KMT's defeat.</p><p>For you, the consolation is that Ko Wen-je came in third. Before the election, he had significant momentum, with substantial support from young people and a large voice among internet users, especially TPP supporters. However, these were ultimately futile dreams. Even if Ko Wen-je said he would let you run alone, you wouldn't have won. You proved that the KMT, with a solid base, wouldn't easily lose to the TPP, which has only been around for a few years. Among the opposition voters, there's a saying: whoever is in third place is the culprit for the opposition's failure. Judging by the voting pattern, he is indeed the third, so he might be the culprit?</p> <p>Although Lai Ching-te becomes president, his governance won't be smooth. The high satisfaction with the Tsai administration won't be fully inherited by him. He is destined to face a minority government and a parliament where the opposition party is in power. Currently, the KMT has 52+2 seats, making it the largest party in the Legislative Yuan. This means that, barring any surprises, Han Kuo-yu, who supports you, will become the president of the Legislative Yuan. This is a significant payback for him. Zhao Shao-kang can go back to hosting his show, and you can go back to being the mayor of New Taipei City. The world seems unchanged, just like before! You can try running again in 2028... if the ROC can survive until then.</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Zhao Shao-kang for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>"
+              map.style.backgroundImage = "url(https://i.imgur.com/VjbWx3Q.jpeg)"; 
+            }
+          else if (aa[0].candidate === 2001591 && quickstats[1] > 46.0 ) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://s.newtalk.tw/album/news/843/636fa5b4b0eaf.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>Hou's Crushing Comeback: KMT Triumphs Over DPP in 2024, Regaining Power!</h3><p>As the lights lit up at the KMT campaign headquarters, the audience below had anticipation and anxiety in their eyes. For most of the past year, Lai Ching-te had been leading in the polls, only recently trading victories with Hou You-yi in the last couple of months. In the audience, there were infants in cradles, elderly individuals in their seventies and eighties, and middle-aged people in their forties and fifties, all hoping for a KMT victory to bring them a better future. When the vote counting began, Hou You-yi and Lai Ching-te were neck and neck. However, people noticed that Hou You-yi had a significantly high vote share in deep-blue regions. In battleground areas like Changhua and Taichung, he also performed admirably, gradually widening the gap. In the end, Hou You-yi secured victory in the presidential election with over 46% of the votes, becoming the 16th president.</p><p>Zhao Shao-kang immediately shouted 'Long live the Republic of China' three times at the scene. You and your campaign team quickly conducted a simulated inauguration ceremony, preparing for the formal inauguration on May 20. Zhao Shao-kang was delighted to become the vice president and pledged to donate all his salary, converting the vice president's residence into social housing for young people through a lottery system. The DPP suffered a major defeat in this election, prompting them to reflect on whether their governance over the past eight years had left the people extremely dissatisfied, leading them to choose the strongest candidate even in the face of opposition division, ultimately ousting the DPP. Lai Ching-te's days as vice president were also coming to an end.</p><p>As the president who led the KMT back to power and won a challenging battle, the rewards for you are substantial. The KMT holds 59+2 seats in the Legislative Yuan, becoming the largest party and securing an absolute majority in the legislature. Han Kuo-yu, who supports you, is destined to become the president of the Legislative Yuan, and party chairman Eric Chu can become the premier. According to tradition, the party chairman should be the president, a significant reward for You. Zhao Shao-kang, as vice president, can handle diplomatic affairs and even represent you on foreign visits. Due to the enormous victory you achieved this year, it's almost certain that you will be nominated for re-election by the KMT in 2028. However, the upcoming New Taipei City mayoral by-election and the 2026 county and city mayoral elections will test your governing abilities. If you can navigate them successfully, then you have a great chance of winning re-election in 2028. Good luck, President Hou You-yi!</p></div>"
+            }
+            else if (aa[0].candidate === 2001622 ) {
+            used=false
+            if (used != true) {
+                        setInterval(function () {
+                            used = true;
+                            imgg = document.getElementsByClassName("person_image")[0];
+                            if (imgg != null) {
+                                imgg.src =  "https://d1b8dyiuti31bx.cloudfront.net/NewsPhotos/20231231/109_025527539611.jpg";
+                            }
+                        }, 100);
+                    }
+            return "<div style='overflow-y:scroll;height:250px;'><h3>Taiwan's Political Earthquake: Blue and Green Parties Overturned, Ko Wen-je Emerges Victorious</h3> <p>A year ago, nobody would have believed that Ko Wen-je and his TPP could secure the presidency of the ROC. However, it happened. Ko Wen-je and his People Party (TPP) claimed the presidency, leaving both the blue and green camps and their supporters in shock. Ko Wen-je's young fanbase erupted in joy, filling the internet with their celebrations, contrasting with the disappointment among blue and green supporters.</p><p>The world's attention turned to Ko Wen-je and the TPP. Media outlets from major countries, including China, the United States, South Korea, Japan, Russia, the United Kingdom, and France, featured front-page coverage on the process and outcome of Ko Wen-je and the TPP securing the presidency in Taiwan. However, Ko Wen-je is destined to be a crippled president as the TPP is the smallest party in the parliament. The solid foundations of the KMT and DPP in the legislature cannot be easily shaken. Can you imagine a president from the third-largest party dealing with a parliament full of opponents? It's almost unimaginable, but it happened. Ko Wen-je can choose to collaborate with either the blue or green camp, but he will never have dominance.</p> <p>With Ko Wen-je's election, your campaign turned into a joke. The KMT lost to a small party that had only been established for five years, and the defeat was embarrassing. The only consolation is that the DPP also suffered a severe setback, so you're not alone in this. As for the future, who knows? Ko Wen-je is an unpredictable figure, and the stance of his government remains uncertain. We know nothing at this point.</p></div>"
+               }
+               else if (aa[0].candidate === 2001557 && quickstats[1] > 46.0 ) {
+                  used=false
+                  if (used != true) {
+                              setInterval(function () {
+                                  used = true;
+                                  imgg = document.getElementsByClassName("person_image")[0];
+                                  if (imgg != null) {
+                                      imgg.src =  "https://cdn.hk01.com/di/media/images/dw/20240112/822423439976435712294650.jpeg/DZO8aeGaT0u6zDkTim6YltXgdsj2Ey8DbXl0JW15dCU?v=w1280r16_9";
+                                  }
+                              }, 100);
+                          }
+                  return "<div style='overflow-y:scroll;height:250px;'><h3>Head-to-Head Showdown Upended: DPP Defeats KMT-TPP Alliance</h3><p>In the November polls, most surveys indicated that the KMT-TPP joint ticket, whether led by Ko Wen-je or Hou You-yi, could defeat Lai Ching-te by at least several hundred thousand votes. However, on January 13th, how did things take such a turn? Lai Ching-te has emerged victorious over you, reminiscent of 2004 when the KMT's poll numbers remained high but were caught up and surpassed in the final stages. It was a painful night, with the supporters of the KMT and TPP left speechless, while not far away, the cheers of DPP supporters echoed through the skies.</p><p>In the Legislative Yuan, the KMT only leads the DPP by one seat, and the 51+2 seats will mean that you only need one person to abstain from voting to lose the relative majority. This is not good news for the KMT, and the TPP might consider choosing to cooperate with the DPP because your failure has brought about bitter political consequences. However, at least in the Legislative Yuan, there is some room for cooperation and contention among the three parties, and the election for the Legislative Yuan President on February 1st will be intense.</p><p>Given your lackluster performance in what was considered a sure-win game, you are being blamed as the main culprit for the failure. Your lack of proficiency in Mandarin, running for office while holding another position, and the image of a charmless rural figure have all weighed you down – issues of your own making. More importantly, your failure to handle some crucial issues properly undoubtedly impacted your votes and the likelihood of ultimate victory. You may not even be able to retain the position of New Taipei City Mayor, as some angry and extreme TPP and KMT supporters are planning to recall you as a failed leader. The saying goes,'a drowning man will clutch at a straw', and now you must find a way to return to city governance and regain the favor of the citizens. Good luck, Mayor Hou.</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Ko Wen-je for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>"
+                }
+                else if (aa[0].candidate === 2001591 && quickstats[1] < 35.0 ) {
+                  used=false
+                  if (used != true) {
+                              setInterval(function () {
+                                  used = true;
+                                  imgg = document.getElementsByClassName("person_image")[0];
+                                  if (imgg != null) {
+                                      imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/800/20230628/1152x768_wmky_0_C20230628000018.jpg";
+                                  }
+                              }, 100);
+                          }
+                  return "<div style='overflow-y:scroll;height:250px;'> <h3>Narrow Victory in the Presidential Race: Hou You-yi Wins Presidency with Less Than 35% of Votes</h3> <p>In this intense multi-candidate competition, the DPP evidently lost its political stronghold, while the KMT's support base remained robust. Although several camps believed they could secure the presidency, the actual results were astonishing. Hou You-yi won the presidency with less than 35% of the vote, with the remaining 65% distributed among other candidates. This marks the lowest presidential vote percentage since the direct election of presidents. Nevertheless, you have secured the presidency, which may be challenging, but you did achieve it. After all, in a multi-candidate election, the support base is the most crucial factor.</p><p>In the Legislative Yuan, you maintain the status of the largest party but only lead the DPP by two seats. The upcoming parliament will undoubtedly involve party cooperation, and Han Kuo-yu is likely to become the next President of the Legislative Yuan without unexpected events. The TPP will inevitably become a crucial third force, and may your dealings with them be smooth! During your presidential term, challenges and opportunities will coexist. The difficulties presented by the challenging parliament and the diplomatic and domestic issues left by the DPP may be bothersome, but a reformed KMT government may gain more support and assistance from the people. The by-election for the mayor of New Taipei City and the 2026 county and city mayor elections will be your test. If you perform well, you may secure the nomination for reelection in 2028. However, if your performance is subpar, the KMT may prefer to nominate a new figure to replace you. Best of luck, President Hou You-yi!</p></div>"
+                }
+                //隐藏结局：2004重演。蓝白合输给民进党
+                else if (aa[0].candidate === 2001557 && aa[1].candidate === 2001591 && quickstats[1] <= 50.12 && quickstats[1] >= 49.87 ) {
+                  used=false
+                  if (used != true) {
+                              setInterval(function () {
+                                  used = true;
+                                  imgg = document.getElementsByClassName("person_image")[0];
+                                  if (imgg != null) {
+                                      imgg.src =  "https://rwnews.tw/upload/newstemp_13273/wide_j861buk_FotoJet-(72).jpg";
+                                  }
+                              }, 100);
+                          }
+                  return "<div style='overflow-y:scroll;height:250px;'><h3>Taiwan Election Deadlocked!</h3><p>Chairman Lai, something big has happened!</p><p>Your campaign office director, Yao Li-ming, hurriedly entered the hallway, finding you enjoying Taiwan's signature hand-shaken milk tea with extra sugar, evidently influenced by the locals in Tainan.</p><p>'Yao Director, what's the urgency?'</p><p>'Haven't you been watching? The vote count is at 95%, and there's still no winner declared!'</p><p>'I'm concerned about my health; high blood pressure, you know. What's going on?'</p><p>Yao quickly turned on the TV in your office, switching to SETN. Hou You-yi's and Lai Ching-te's images were swapping positions every half-minute, and their rankings kept changing. Each channel showed a different story, with Hou leading more on CTI, while Formosa TV and SETN favored Lai.</p><p>'Isn't there still 5% left? Let's wait until all votes are counted; I believe we'll win.'</p><p>One hour later, at the joint campaign headquarters of Hou You-yi and Ko Wen-je, the roar of car horns shattered the sky and everyone's hearts and ears.</p><p>'Everyone, please be quiet; President Hou can't speak in this noise.'</p><p>Hou You-yi stood silent on the stage.</p><p>'Chairman Ko, you go first.'</p><p>Ko Wen-je stepped forward, took the microphone, revealing an unprecedented solemnity in his expression.</p><p>'This is evidence of the DPP rigging the election. Their election staff used various methods, including disabling cameras, not singing the ballots, and much more. Our TPP and KMT supervisors have discovered many flaws in the electoral process, suspected of cheating... Please, everyone, look at the big screen.'</p><p>Hou You-yi added, 'The gap in our defeat is... very, very marginal. This slight difference is clouded in suspicion, raising many doubts. It gives the impression that this is an unfair election. We are preparing to file a lawsuit for the invalidation of the election.'</p><p>Supporters: 'Invalid! Invalid! Invalid!'</p><p>As the chants subsided, Hou You-yi continued, 'The second request is for the CEC to immediately seal all ballot boxes as a basis for future verification.'</p><p>Supporters: 'Verify! Verify! Verify!'</p><p>'If Taiwan really cannot lose, it's here. Everyone, right?'</p><p>Supporters: 'Yes!'</p><p>'Taiwanese people, democracy is our most effective weapon against the CCP. When we destroy this weapon, what other defenses do we have? Unfair elections not only make us hear about the doubts just mentioned but also clearly witness manipulative actions throughout the election. Everyone knows this, and we are using the most rational and gentle method to expose the deception carried out by Lai Ching-te and the DPP throughout this election. Let the whole world understand, shall we?'</p><p>Supporters: 'Go Hou-Ko! Go Hou-Ko!'</p><p>What happened in the world was unclear, but it was certain that Taiwan would once again enter bitter days of election violence and confrontation.</p></div>"
+                }
+                //白莲教赢过侯，侯大于23%
+                else if (aa[1].candidate === 2001622 && aa[2].candidate === 2001591 && quickstats[1] >= 23.1 && quickstats[1] < 30.0) {
+                    used=false
+                    if (used != true) {
+                                setInterval(function () {
+                                    used = true;
+                                    imgg = document.getElementsByClassName("person_image")[0];
+                                    if (imgg != null) {
+                                        imgg.src =  "https://imgcdn.cna.com.tw/www/webphotos/WebCover/800/20231223/1200x900_118527508580.jpg";
+                                    }
+                                }, 100);
+                            }
+                    return "<div style='overflow-y:scroll;height:250px;'> Is this the result of your self-sabotage? Well, I must say you succeeded because you managed to make a century-old political party lose to a third-party newcomer that has only been around for 5 years. It's quite a failure, and everyone on the internet is mocking you. </div>"
+                  }
+                  else if (aa[1].candidate === 2001622 && aa[2].candidate === 2001591 && quickstats[1] < 23.1 && quickstats[1] < 30.0) {
+                    used=false
+                    if (used != true) {
+                                setInterval(function () {
+                                    used = true;
+                                    imgg = document.getElementsByClassName("person_image")[0];
+                                    if (imgg != null) {
+                                        imgg.src =  "https://img.ltn.com.tw/Upload/news/600/2015/10/21/php4Ic3tg.jpg";
+                                    }
+                                }, 100);
+                            }
+                    return "<div style='overflow-y:scroll;height:250px;'>Your votes is even lower than Lien Chan's in 2000. I'm speechless. Now, Ko Wen-je and his supporters can openly mock the Kuomintang and you!</div>"
+                  }
+}
+
+
+setInterval(endingPicker, 250);
+
+//注释代码
+function getTooltips(str) {
+    let matches = [];
+
+    tooltipList.forEach((tooltip, index) => {
+        // Adjust the regex to match searchString potentially surrounded by “ and followed by optional punctuation
+       let regex = new RegExp(`(?<=\\b|\\s|^|“)${tooltip.searchString}(?=[.,;!?]?\\b|\\s|”|$)`, 'g');
+
+
+        let match;
+        while ((match = regex.exec(str)) !== null) {
+            matches.push({
+                start: match.index + (match[0].startsWith('“') ? 1 : 0), // Adjust for potential starting “
+                end: match.index + match[0].length - (match[0].endsWith('”') ? 1 : 0) - (match[2] ? 1 : 0), 
+                tooltipIndex: index
+            });
+        }
+    });
+
+    // Sort by starting position; if two start at the same position, longer match comes first
+    matches.sort((a, b) => a.start - b.start || b.end - b.start - (a.end - a.start));
+
+    // Filter out overlaps
+    for (let i = 0; i < matches.length - 1; ) {
+        if (matches[i + 1].start < matches[i].end) {
+            matches.splice(i + 1, 1); // Remove the next match since it overlaps
+        } else {
+            i++; // Move to next match
+        }
+    }
+
+    return matches;
+}
+function applyTooltips(str) {
+    const matches = getTooltips(str);
+    let result = '';
+    let lastIndex = 0;
+
+    matches.forEach(match => {
+        const tooltip = tooltipList[match.tooltipIndex];
+        result += str.slice(lastIndex, match.start);
+        result += `<span class='mytooltip'>${tooltip.searchString}<span class='mytooltiptext'>${tooltip.explanationText}</span></span>`;
+        lastIndex = match.end;
+    });
+
+    result += str.slice(lastIndex); // Add the remainder of the original string
+    return result;
+}
+
+function applyTooltipsToObject(obj) {
+    for (let key in obj) {
+        if (typeof obj[key] === 'string') {
+            obj[key] = applyTooltips(obj[key]);
+        } else if (typeof obj[key] === 'object') {
+            applyTooltipsToObject(obj[key]); // Recursive call
+        }
+    }
+}
+
+applyTooltipsToObject(campaignTrail_temp.questions_json);
+applyTooltipsToObject(campaignTrail_temp.answers_json);
+applyTooltipsToObject(campaignTrail_temp.answer_feedback_json);

--- a/static/mods/2024ROC_Hou-Zhao.json
+++ b/static/mods/2024ROC_Hou-Zhao.json
@@ -1,0 +1,9117 @@
+e=campaignTrail_temp // this is redundant, but Decstar uses this because it looks nicer in the code.
+campaignTrail_temp.multiple_endings=true
+campaignTrail_temp.cyoa = true
+campaignTrail_temp.questions_json = [
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950011,
+        "fields": {
+            "priority": 0,
+            "description": "it's January 2023, congratulations on successfully securing re-election as the Mayor of New Taipei a month ago, with an impressive 62% of the votes. It appears that there is a high likelihood of your candidacy in the 2024 presidential election. According to Formosa's polls, you lead with a support rate of 39.9%, surpassing Lai Ching-te's 34.1%. Do you wish to participate in the 2024 election and potentially lead the KMT to regain the lost governance after 8 years?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950015,
+        "fields": {
+            "priority": 0,
+            "description": "More than a month after the Chinese New Year, on March 22nd, the KMT Central Standing Committee passed a resolution authorizing the party chairman, Eric Chu, to Drafting the party's presidential candidate. However, a primary election is scheduled before that. Your opponent in the primary is Terry Gou. Do you have any specific campaign strategies for the upcoming primary?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950016,
+        "fields": {
+            "priority": 0,
+            "description": "Currently, the primary have begun, and as the most popular candidate, your poll numbers are ahead of Terry Gou. What specific areas do you plan to focus on during the preliminary election competition?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950017,
+        "fields": {
+            "priority": 0,
+            "description": "Congratulations! In today's Central Standing Committee meeting, Chairman Eric Chu announced that you will be the Kuomintang (KMT) presidential candidate for 2024. Terry Gou also congratulated you on Facebook for receiving the party's draft. You will represent the KMT in the 2024 election, aiming to take down the incompetent DPP government!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950018,
+        "fields": {
+            "priority": 0,
+            "description": "On the same day you were drafted, Taiwan People's Party Chairman Ko Wen-je was also selected as the party's presidential candidate. This means that the opposition camp is divided into two parts for the election, which could potentially impact the overall prospects of the pan-blue votes. What is your overall strategy about the TPP?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950019,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, it seems we've encountered trouble! A private kindergarten has been exposed for alleged child abuse by teachers, including the shocking revelation of feeding children Class III controlled substances like barbital and Class IV controlled substances like phenobarbital! Some parents have reported this to the police, and this issue has just come to our attention. We need to take immediate action, or the DPP will use this incident to launch a major attack against you!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950020,
+        "fields": {
+            "priority": 0,
+            "description": "In the midst of the kindergarten incident's escalation, your approval ratings have sharply declined, akin to falling off a cliff into the water. After addressing this matter, you engage in face-to-face discussions with students at National Chengchi University and Taiwan University. When students inquire about your stance on the One China Policy and the differences between you and Han Kuo-yu, how will you respond?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950021,
+        "fields": {
+            "priority": 0,
+            "description": "With a significant decline in your polls, your campaign is facing a major crisis. In many polls, your support is trailing behind Ko Wen-je. According to Formosa and TVBS polls in June, you had support rates of 23% and 17.1%, respectively, while Ko Wen-je had 33% and 28.6%. Even legislator Cheng Li-wen suggested replacing you with Han Kuo-yu due to your lower poll numbers. Additionally, there is uncertainty about Terry Gou's support. Some polls suggest that Gou might reconsider running. What measures do you plan to take to prevent further decline?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950022,
+        "fields": {
+            "priority": 0,
+            "description": "Finally, an hot fire in the snow! Former key strategist for Ma Ying-jeou's campaigns and former ROC representative to the U.S., King Pu-tsung, has agreed to serve as the campaign office chairman under your personal visit. He will assist in orchestrating your campaign!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950023,
+        "fields": {
+            "priority": 0,
+            "description": "On July 1st, you were invited to attend a gathering organized by the Kuomintang's 'Huang Fuxing' branch, where you are expected to meet with Han Kuo-yu. Han's supporters have consistently expressed dissatisfaction with your candidacy, believing that Han Kuo-yu is a more suitable candidate. During the gathering, what do you plan to do to win them over and dispel the sentiment of 'Replacing Hou with Han'?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950024,
+        "fields": {
+            "priority": 0,
+            "description": "On July 3rd, you participated in an interview with Zhao Shao-kang, discussing the election strategy and campaign situation after being Drafted by the KMT. The aim was to gain more media exposure. Zhao mentioned that Han's supporters feel you were not actively supportive in 2020, and many of his fans do not favor you. the promised support from Terry Gou seems to be elusive, and there are rumors of him considering an independent run. What message would you like to convey during this interview?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950025,
+        "fields": {
+            "priority": 0,
+            "description": "On July 23rd, the KMT held a National Party Convention, officially nominating you as the candidate. This signifies that any rumors of replacement are baseless. During the event, Han Kuo-yu expressed his formal support, stating one of his three wishes for this year is for the KMT, under your leadership, to oust the corrupt and incompetent DPP.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950026,
+        "fields": {
+            "priority": 0,
+            "description": "Since the official commencement of your campaign, you have the first opportunity to visit various locations and boost support in specific areas. Where do you intend to concentrate your efforts primarily?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950027,
+        "fields": {
+            "priority": 0,
+            "description": "After 7 years of rule, DPP has left many vulnerable points for you to attack. From restricting freedom of speech to tense relations with the mainland, the widening wealth gap, rising prices, and numerous scandals highlighting incompetence and corruption. How do you plan to launch your strongest attacks against your main opponent?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950028,
+        "fields": {
+            "priority": 0,
+            "description": "As the election has passed its midpoint, you need to present more and better specific policies to attract KMT voters. Currently, your performance in opinion polls is still not favorable, and many are concerned that you might end up as the third in this election. How do you plan to consolidate your support base?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950029,
+        "fields": {
+            "priority": 0,
+            "description": "Some very bad news just came in... Business tycoon Terry Gou, who has been hesitant to support you since you officially entered the race, announced today that he is running for president as an independent candidate! He made this announcement during a press conference for the \"Mainstream Opinion Alliance.\" It seems like the pan-blue's voter base is being further divided. What should we do?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950030,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, it seems that the People's Party has proactively proposed a united plan: they hope to select the sole opposition candidate through comparative candidate polling, and whoever loses will withdraw from the election. What is your opinion on this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950031,
+        "fields": {
+            "priority": 0,
+            "description": "Among the voters, there is a significant portion who lack trust in your abilities and qualifications, with many expressing doubts about your diplomatic skills. A considerable number believe that you lack experience in handling international relations. To address this concern, the KMT Central Committee has decided to send you on an official visit to the United States. In This Trip,What key messages would you like to emphasize?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950032,
+        "fields": {
+            "priority": 0,
+            "description": "Since entering October, legislators nationwide have gradually intensified their activities, and your campaign may be entering its most critical period! At this juncture, Han Kuo-yu is putting aside all previous reservations and actively supporting your candidacy. Now, let's pass the microphone to Mayor Han. What are your thoughts on Mayor Hou?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950033,
+        "fields": {
+            "priority": 0,
+            "description": "Entering November, the joint ticket decision between the KMT and TPP remains undecided. Despite polls indicating that the opposition alliance consistently outperforms Lai Ching-te, both the KMT and the TPP are reluctant to take on a mere preparatory role as vice president, as they both aspire to wield the executive power of the presidency. As time gradually slips away, former President Ma Ying-jeou and Han Kuo-yu propose settling the matter through a nationwide poll, with the loser becoming the vice president. What are your thoughts on this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950034,
+        "fields": {
+            "priority": 0,
+            "description": "On November 15th, waking up in the morning, Taiwan's media and political circles were shocked by a piece of news: KMT-TPP has confirmed the formation of a joint ticket, endorsing a single presidential candidate. This is expected to severely impact Lai Ching-te's support. Chairman Zhu, Mayor Hou, former President Ma, and Chairman Ko have reached an agreement to introduce a set of candidates using the cumulative results of previous polls. This is considered a very intense competition... but due to the selection of fixed-time polls, your current efforts may not be of much use...The final results will be announced on the 18th.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950035,
+        "fields": {
+            "priority": 0,
+            "description": "Damn it... With Ko Wen-je's backtracking, there are only a few days left until the deadline for presidential candidate registration! We must complete the integration within these few days... or find our own vice presidential candidate! Terry Gou and Ko Wen-je invite you to the Taipei Grand Hyatt to discuss the last hope for Joint Tickets... We must rise to the challenge!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950036,
+        "fields": {
+            "priority": 0,
+            "description": "With the breakdown of Joint Tickets, you must now find a vice presidential candidate! Otherwise, the KMT cannot continue participating in this election! Lai Ching-te has already chosen Hsiao Bi-Khim as the vice president, and Ko Wen-je is still undecided about his choice. You must now find a vice presidential candidate willing to sacrifice themselves to join you in this challenging battle!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950037,
+        "fields": {
+            "priority": 0,
+            "description": "After Hou You-yi chose Zhao Shao-kang as his VP, the entire pan-blue camp was shocked. They were disappointed with Ko Wen-je's reversal and the failure to reach a Joint Tickets agreement. In response, they decided to align themselves with the KMT. This has given you a boost in the polls, with an estimated 500,000 to 1 million additional votes expected for the KMT. However, the DPP is attempting to sow discord between you and Zhao Shao-kang, suggesting that you are merely a puppet and that the more charismatic Zhao Shao-kang is the true president. How do we counter this narrative?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950038,
+        "fields": {
+            "priority": 0,
+            "description": "As the presidential election enters its final stage, it has been discovered that Lai Ching-te's ancestral home is found to have violated building regulations. Although this issue has been known for quite some time, it has only recently been sensationalized. This could be our only opportunity to undermine Lai Ching-te before the election. Do you want to pursue this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950039,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, we have our own troubles. The Democratic Progressive Party (DPP) is attacking the Triumph Apartments owned by your wife, highlighting the high rent and claiming it exploits young people for your personal gain. They argue that you, appearing as a landlord, are unfit to discuss housing justice and social housing. How do you respond?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950040,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou, at the final stretch of the election, we might need some advertisements or policies to boost our polling numbers. What policies or advertisements would you most like us to release?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950041,
+        "fields": {
+            "priority": 0,
+            "description": "As 2023 enters its final days, the presidential debates have commenced. Facing Lai Ching-te and Ko Wen-je in this intense battle, what is the most important message you want to convey to the people of Taiwan?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950042,
+        "fields": {
+            "priority": 0,
+            "description": "It seems there is discord within our camp. Former President Ma Ying-jeou, in an interview with Deutsche Welle, mentioned that in the context of cross-strait relations, it is necessary to trust Xi Jinping. The media has widely circulated this, which may be a significant blow to the Kuomintang's electoral prospects. How do you respond to this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950851,
+        "fields": {
+            "priority": 0,
+            "description": "Today is the last day of the election. In which specific area of Taiwan do you plan to campaign to make a final push in these last stages?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950411,
+        "fields": {
+            "priority": 0,
+            "description": "Today is the last day before the election, and your polls have been consistently declining since your nomination. The deadlock with Ko Wen-je and the lead by Lai Ching-te have not been broken, and the situation persists until the registration of presidential candidates in November. There are hardly any individuals willing to be your vice president, until Hung Hsiu-chu, whose nomination was abolished in 2016, volunteered. It is only then that you have a vice presidential candidate to appear on the ballot. On the final day before the election, where do you plan to conduct your campaign activities?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950424,
+        "fields": {
+            "priority": 0,
+            "description": "Today is the last day before the election, On the final day before the election, According to the latest polls conducted 10 days before the election, your and Lai Ching-te's polls are within the margin of error. In other words, the presidential position hinges on a difference of just 500,000 votes.where do you plan to conduct your campaign activities?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950687,
+        "fields": {
+            "priority": 0,
+            "description": "On November 15th, waking up in the morning, Taiwan's media and political circles were shocked by a piece of news: KMT-TPP has confirmed the formation of a joint ticket, endorsing a single presidential candidate. This is expected to severely impact Lai Ching-te's support. Chairman Zhu, Mayor Hou, former President Ma, and Chairman Ko have reached an agreement to introduce a set of candidates using the cumulative results of previous polls. The terms include a provision that, if the polls fall within the margin of error, it will be considered a victory for Hou You-yi. This is widely seen as a sign that Hou You-yi is likely to win. The final results will be announced on the 18th.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950890,
+        "fields": {
+            "priority": 0,
+            "description": "With the formation of the Joint Tickets, Ko Wen-je has officially become your vice president, marking a political tornado in Taiwan. It's highly likely that Lai Ching-te will lose the presidential position. On the day of the presidential candidate registration, what capabilities of Ko Wen-je would you like to highlight?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950900,
+        "fields": {
+            "priority": 0,
+            "description": "In order to achieve cooperation between the blue and white camps, the cost you have to pay is to accept some reform demands and positions of the TPP. Among these proposals, which ones do you favor more and consider most likely to reach an agreement?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950911,
+        "fields": {
+            "priority": 0,
+            "description": "In this presidential election, facing a one-on-one debate with Lai Ching-te, although you are widely regarded as not the most eloquent, and even your proficiency in Mandarin is limited, your grassroots image in stark contrast to Lai Ching-te's elite image creates a strong juxtaposition. In the debate, what content do you want to emphasize?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950398,
+        "fields": {
+            "priority": 0,
+            "description": "Since you have withdrawn from the primary and essentially paved the way for Terry Gou to secure the presidential candidate position, how do you plan to support him in the upcoming electoral campaign?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950927,
+        "fields": {
+            "priority": 0,
+            "description": "Now, you are in a one-on-one battle with Lai Ching-te in the later stages of the election. Polls indicate that you currently have a lead by several percentage points, but this could be lost due to inappropriate campaign strategies or visiting mistakes. We must stabilize our current position!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 1950933,
+        "fields": {
+            "priority": 0,
+            "description": "This year's presidential debate has an unprecedented presence of four presidential candidates: yourself, Lai Ching-te, Ko Wen-je, and the former Chairman of Hon Hai Precision Industry, Terry Gou, who does not support you. In this year's presidential debate, what main points do you want to convey?",
+            "likelihood": 1
+        }
+    }
+]
+
+campaignTrail_temp.answers_json = [
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950012,
+        "fields": {
+            "question": 1950011,
+            "description": "I will steadfastly continue my course and move forward. Currently, my mission is to serve the citizens of New Taipei City, as they are my top priority and the ones I am most concerned about at the moment."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950013,
+        "fields": {
+            "question": 1950011,
+            "description": "Regardless of any challenges we may face, we will approach them earnestly. If in the future, the party central has any tasks to assign to me, I am more than willing to accept. However, at the moment, my primary focus is on doing things well in New Taipei City."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950014,
+        "fields": {
+            "question": 1950011,
+            "description": "At present, my sole intention is to diligently fulfill my role as the mayor and strive towards constructing a beautiful hometown. To make New Taipei City a great city, we must undertake significant initiatives. By connecting the development of Northern Taiwan through New Taipei, we can contribute to the betterment of Taiwan. A better Taiwan leads to shared prosperity, ensuring peace and stability for the Republic of China."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950388,
+        "fields": {
+            "question": 1950015,
+            "description": "In fact, I do not wish to participate in the primary election. Firstly, I've observed the outcome for Han Kuo-yu, and I believe it's not appropriate for me to run for president while holding my current position . Secondly, I believe Mr.Gou is a more suitable candidate than me. He is a devoted supporter of the Republic of China and can take good care of the country."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950389,
+        "fields": {
+            "question": 1950015,
+            "description": "Chairman Terry Gou is a steadfast supporter of the Republic of China and a patriot. I am pleased to compete alongside him, and if he emerges as the candidate, I will gracefully accept the outcome."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950390,
+        "fields": {
+            "question": 1950015,
+            "description": "I am deeply grateful to Chairman Eric Chu and the party central for giving me this opportunity. In the primary election, I will enhance myself and showcase a broader perspective on international affairs. I recognize the need to develop a more presidential demeanor as I progress."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950399,
+        "fields": {
+            "question": 1950398,
+            "description": "No. My intention in withdrawing from the primary was to focus on effectively managing the city. I didn't want to run for president before completing my term. Therefore, I plan to assist Chairman Terry Gou in his campaign during the later intense stages of the election."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950400,
+        "fields": {
+            "question": 1950398,
+            "description": "Absolutely! I will support him in the campaign, including rallying support for him in New Taipei City and endorsing him for legislative candidates nationwide after his official nomination. I hope he can bring down the Democratic Progressive Party!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950412,
+        "fields": {
+            "question": 1950411,
+            "description": "We have no choice but to stay in Taipei. We cannot afford to let Taipei, this stronghold of the blue camp, be lost!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950413,
+        "fields": {
+            "question": 1950411,
+            "description": "I don't want to lose my hometown. Please allow me to campaign in New Taipei City, and I hope Mayor Hou You-yi can come forward to assist us!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950414,
+        "fields": {
+            "question": 1950411,
+            "description": "We must secure Taoyuan, the stronghold and vote bank of the Hakka people and the Kuomintang!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950415,
+        "fields": {
+            "question": 1950411,
+            "description": "On the final day, I must drive around the entire Taiwan! Let more people see us!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950425,
+        "fields": {
+            "question": 1950424,
+            "description": "We aim to secure victory in my hometown, New Taipei! Let's conduct the final day of the campaign activities in New Taipei City!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950426,
+        "fields": {
+            "question": 1950424,
+            "description": "Of course, it's in Taipei City. We will declare to all Taipei citizens that tomorrow, we are marching towards the Presidential Office!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950430,
+        "fields": {
+            "question": 1950424,
+            "description": "We plan to hold our last campaign event in Kaohsiung to counter Lai Ching-te and appeal to his support base!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950432,
+        "fields": {
+            "question": 1950424,
+            "description": "The swing state of Taichung is crucial for us, and we aim to secure victory in Taichung."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950441,
+        "fields": {
+            "question": 1950016,
+            "description": "I will visit various counties and cities across Taiwan and establish good relationships with local mayors. I hope to garner more support from these mayors."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950442,
+        "fields": {
+            "question": 1950016,
+            "description": "Let's make some friends in the Legislative Yuan! I will meet with current legislators and discuss campaign matters with them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950443,
+        "fields": {
+            "question": 1950016,
+            "description": "I should appear in the media to share my insights and future prospects in the mayoral election. This can bring me positive media exposure!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950444,
+        "fields": {
+            "question": 1950016,
+            "description": "Anyway, votes come from the voters, and I plan to participate in more offline events to increase my visibility among the electorate. Voters tend to prefer someone familiar and present in their communities!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950454,
+        "fields": {
+            "question": 1950017,
+            "description": "I appreciate Chairman Eric Chu's favor and the support of all the voters. I also want to thank Chairman Terry Gou for his full support. In 2024, we will return to governance, and I am honored to have the opportunity to run for the Kuomintang!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950460,
+        "fields": {
+            "question": 1950018,
+            "description": "Chairman Ko Wen-je has the authority to run for election on his own, and I just need to follow my own path. It's like two brothers climbing a mountain – each making their own effort. Currently, there is no need to discuss coalition votes to avoid affecting the unity and loyalty within our party."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950461,
+        "fields": {
+            "question": 1950018,
+            "description": "I must criticize Ko Wen-je and the TPP. It's widely known that the division within the opposition alliance will only pave the way for the DPP to secure the next term. Chairman Ko Wen-je should seriously consider whether he should indeed continue to run for the presidency!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950462,
+        "fields": {
+            "question": 1950018,
+            "description": "Everyone knows that 60% of the voters want a party alternation. We cannot afford to be divided into two camps. I will extend an olive branch to Chairman Ko . We should work together to bring down the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950463,
+        "fields": {
+            "question": 1950018,
+            "description": "Rather than concerning with Ko, let's focus on targeting Lai Ching-te! Over the past eight years, the DPP government has numerous vulnerabilities we can exploit. Let's concentrate our efforts on the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950477,
+        "fields": {
+            "question": 1950019,
+            "description": "The immediate priority is to investigate and determine what happened. We will promptly send the police to the kindergarten to inspect surveillance footage and search the teachers' personal computers for evidence."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950478,
+        "fields": {
+            "question": 1950019,
+            "description": "The safety and health of the children are our top priorities. We will immediately arrange for them to undergo medical examinations to check if their health has been compromised in any way."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950479,
+        "fields": {
+            "question": 1950019,
+            "description": "The key priority is to calm the parents' emotions. I must hold private meetings with the parents, exchange views and information, and discuss the latest developments and concerns regarding their children."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950487,
+        "fields": {
+            "question": 1950020,
+            "description": "I hope I can handle things well. Let me explain to you why doing things properly is important; it's a matter of attitude because..."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950488,
+        "fields": {
+            "question": 1950020,
+            "description": "When I was a child, I used to hide under the desk and read comic books. My mom would ask, 'What are you doing?' and I would say, 'Studying knowledge by reading comic books.'....."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950489,
+        "fields": {
+            "question": 1950020,
+            "description": "When I was a criminal investigator in the past, combating crime involved collaborating with Interpol, but I always hoped for the exchange of intelligence....."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950490,
+        "fields": {
+            "question": 1950020,
+            "description": "The cross-strait relationship, regardless of the consensus, is entirely based on the Cross-Strait Act. and Only the Constitution of the ROC can bring stability to both sides. I am against Taiwan independence and the One Country, Two Systems!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950502,
+        "fields": {
+            "question": 1950021,
+            "description": "I must seek the recognition of party bosses.and arrange a meeting with the Lien Chan family to request their support. This would be a symbolic move."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950503,
+        "fields": {
+            "question": 1950021,
+            "description": "Allow me to seek the assistance of former party chairman Wu Poh-hsiung of Hakka descent, I need to strengthen my support in Hakka-dominant areas. I hope to gain his recognition!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950504,
+        "fields": {
+            "question": 1950021,
+            "description": "I will invite former President Ma Ying-jeou to serve as the Honorary Chairman of my campaign headquarters and request his endorsement and favorable statements for my candidacy."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950513,
+        "fields": {
+            "question": 1950021,
+            "description": "I am heading south to Kaohsiung to visit former Legislative Yuan Speaker Wang Jin-ping. I will seek his advice on campaign strategies and solutions to the current situation. I must secure his assistance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950521,
+        "fields": {
+            "question": 1950022,
+            "description": "I am delighted to have King Pu-tsung as a valuable aide in my campaign. He has a strong track record in dealing with the Democratic Progressive Party and will assist me in handling negotiations!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950523,
+        "fields": {
+            "question": 1950023,
+            "description": "I will formally apologize to Han during the gathering and appeal to his supporters to rally behind me. I will acknowledge my mistake in not accepting the position of campaign chairman for New Taipei City in 2020, as I was too focused on municipal affairs and neglected to assist him. I sincerely apologize."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950524,
+        "fields": {
+            "question": 1950023,
+            "description": "I do not need to apologize. Han Kuo-yu's popularity is not at a level where I must pull him back. Furthermore, getting too close to him might harm my image among moderate voters. There is no need to lower my own standing at this point."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950525,
+        "fields": {
+            "question": 1950023,
+            "description": "I don't need a formal apology, but let me build a rapport with Han Kuo-yu, present a very familiar and friendly appearance. We don't harbor any dislike for each other; we are good brothers. Let's move past this matter!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950535,
+        "fields": {
+            "question": 1950024,
+            "description": "I support the 1992 Consensus that aligns with the Constitution of the Republic of China. I have made my stance clear! I am against the \"One Country, Two Systems\" and Taiwan independence. I also oppose the Democratic Progressive Party's attempt to stigmatize the 1992 Consensus. It's that simple!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950536,
+        "fields": {
+            "question": 1950024,
+            "description": "I am not against nuclear power, but rather, I support having nuclear power with proper nuclear safety measures. I assure you that I will ensure the end of the DPP's anti-nuclear policy, and I will restart nuclear power plants to guarantee stable electricity supply and lower electricity prices in Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950537,
+        "fields": {
+            "question": 1950024,
+            "description": "I hope Chairman Terry Gou, being the son of a police officer and a devout follower of Guan Gong, values loyalty and keeps his promises. I believe he will definitely assist me!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950550,
+        "fields": {
+            "question": 1950025,
+            "description": "I sincerely appreciate Mayor Han Kuo-yu's affirmation. I apologize for any previous actions towards him. Now, let's collaborate and work together to win the 2024 election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950558,
+        "fields": {
+            "question": 1950026,
+            "description": "Certainly, I will focus on strengthening my stronghold, Taipei, New Taipei, and Keelung. The northern region is the KMT's most solid base and a crucial vote bank for us!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950559,
+        "fields": {
+            "question": 1950026,
+            "description": "I hope to make efforts in the central region, particularly in Changhua, Taichung, and Nantou. These three areas are crucial in every election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950560,
+        "fields": {
+            "question": 1950026,
+            "description": "I must pay special attention to my hometown, Chiayi County and City. As a southerner, I aim to achieve victory in this deep-green states!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950561,
+        "fields": {
+            "question": 1950026,
+            "description": "Being a southerner myself and proficient in Taiwanese, even though I am from the Kuomintang, I hope to achieve significant results in Tainan, Kaohsiung, and Pingtung. Perhaps, I can turn the tide in these areas!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950579,
+        "fields": {
+            "question": 1950027,
+            "description": "The DPP government has proven incapable of addressing the issue of fraud. Taiwan, once known for its hospitality, is now dubbed the \"Fraud Island.\" I am committed to taking strong measures to tackle the problem of fraud head-on."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950580,
+        "fields": {
+            "question": 1950027,
+            "description": "Under the rule of the Tsai government, we have witnessed increased pressure from the CCP on Taiwan. The median line in the Taiwan Strait has disappeared, and despite the DPP government claiming to resist China and protect Taiwan.we say no to war and yes to dialogue, no to warplanes and yes to business opportunities, no to crises and yes to diplomatic solutions!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950581,
+        "fields": {
+            "question": 1950027,
+            "description": "DPP government is corrupt and plagued by graft. Their digital development sector has squandered 20 billion NT dollars, achieving nothing substantial. In the end, all they managed to do was order takeout!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950582,
+        "fields": {
+            "question": 1950027,
+            "description": "Under the DPP's rule, dissenting voices are suppressed, and even after a court ruled in favor of CTiTV, the NCC continues to deny them the right to resume broadcasting on television. This is the authoritarian oppression of the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950593,
+        "fields": {
+            "question": 1950028,
+            "description": "We must restore law and order. there has been a rampant increase in firearms, drugs, and violent incidents on the streets. Only two death row inmates were executed in the past eight years. The DPP leans towards abolishing the death penalty, but due to public opinion, they refrain from doing so. This is not beneficial for Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950597,
+        "fields": {
+            "question": 1950028,
+            "description": "I will revive the Special Investigation Division. The DPP abolished this institution, responsible for investigating political corruption and official misconduct, as soon as they took office. Was it for their own convenience? I will revive the SPD, and regardless of political affiliation, if any official dares to engage in corruption, we will apprehend them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950599,
+        "fields": {
+            "question": 1950028,
+            "description": "I support housing justice and propose the implementation of a property hoarding tax targeting those with a significant number of properties. This is to ensure that more young people can afford homes. I also commit to continuing the construction of more public housing!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950600,
+        "fields": {
+            "question": 1950028,
+            "description": "My energy policy is clear: Green Sustainability, Reduce Coal with Nuclear, Move towards Coal-free, Transition with Gas. I never been against nuclear power and will include nuclear energy in carbon reduction efforts. If elected, I will complete the inspection and maintenance work for nuclear plants, ensuring safety and extending their operation."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950609,
+        "fields": {
+            "question": 1950029,
+            "description": "This damn Terry Gou! In 2019, he harmed Han Kuo-yu, and now he's doing the same to me this year! We must aggressively attack this untrustworthy guy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950610,
+        "fields": {
+            "question": 1950029,
+            "description": "I hope Chairman Gou can return to the blue camp. We can't afford more division. Persisting in this way will only pave the way for Lai Ching-te to become president!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950611,
+        "fields": {
+            "question": 1950029,
+            "description": "Let's not speak. Just release a campaign video featuring Hou Youyi and Guan Gong, emphasizing the loyalty, benevolence, and integrity of Guan Yu. This will naturally contrast with the untrustworthy behavior of Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950615,
+        "fields": {
+            "question": 1950030,
+            "description": "Polls are only based on phone inquiries and may not accurately reflect actual voting preferences. Let's propose a method for a democratic primary, allowing people across Taiwan to cast their votes to determine the opposition candidate with the highest support!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950616,
+        "fields": {
+            "question": 1950030,
+            "description": "The TPP should not make excessive demands. The KMT is a party with 14+1 county/city mayors and is the second-largest party in the legislature. Our party strength should be taken into account rather than solely relying on individual candidate polls. More people are consider giving their party vote to the KMT!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950617,
+        "fields": {
+            "question": 1950030,
+            "description": "Our current performance in various polls is not very good, but we cannot outright reject the proposal. Refusing it would shift the responsibility for the opposition's inability to integrate onto us. Let's not deny it for now, But we will delay the actual implementation!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950647,
+        "fields": {
+            "question": 1950031,
+            "description": "Everyone knows that the Three Principles of the People, particularly the democratic ideals of government by the people, for the people, and of the people, are closely related. Let's work together to advance these great principles and ensure that the system of liberal democracy continues to thrive in Taiwan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950648,
+        "fields": {
+            "question": 1950031,
+            "description": "Are you... Little Chuck? I didn't expect you to have grown so much. I'm happy to see you again! When I rescued you from the kidnappers all those years ago, you were just a baby. Now, I can hardly recognize you!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950649,
+        "fields": {
+            "question": 1950031,
+            "description": "I would say is my encounters with Mayor Adams of New York City. I even met with legislators from both the Democratic and Republican parties in Washington. AIT Chairman Rosenberger also had a meeting with me. This highlights the strength of the KMT and me in international relations!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950658,
+        "fields": {
+            "question": 1950032,
+            "description": "People have misunderstood Mayor Hou deeply. He genuinely cares about me! Please stop spreading rumors about our supposed discord. After my removal, he was the first to call and offer his comfort, asking if I needed any assistance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950659,
+        "fields": {
+            "question": 1950032,
+            "description": "Mayor Hou is a real man, someone who helped maintain public order in the midst of gunfire and chaos. Such individuals are what Taiwan needs the most—no flashy rhetoric, just someone dedicated to doing good things. I recommend him wholeheartedly!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950660,
+        "fields": {
+            "question": 1950032,
+            "description": "I want everyone to recognize that the DPP is corrupt, not only engaging in financial malfeasance but also steering Taiwan towards the deadly path of war. Only the Kuomintang and Mayor Hou can help Taiwan emerge from the shadows of conflict and restore normal relations with the mainland!\""
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950670,
+        "fields": {
+            "question": 1950033,
+            "description": "We have no choice but to accept the challenge, as time is running out. Even if our poll numbers are not high, we must face the battle. Otherwise, it may be perceived as a display of timidity."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950671,
+        "fields": {
+            "question": 1950033,
+            "description": "We must accept the challenge, and we believe we can surpass Ko Wen-je. We have to outperform him to ensure the Kuomintang's dominant position in the joint ticket alliance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950688,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950691,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950692,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950693,
+        "fields": {
+            "question": 1950687,
+            "description": "I believe we will surely win and secure victory in the entire election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950721,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950722,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950723,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950724,
+        "fields": {
+            "question": 1950034,
+            "description": "Even though we may not perform well in the polls, I believe we can beat Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950737,
+        "fields": {
+            "question": 1950035,
+            "description": "After receiving a text from Chairman Ko, he mentioned that he believes Terry Gou should find a reason to withdraw from the election, to avoid further disrupting the pan-blue camp. Can I read into this, Chairman Ko?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950738,
+        "fields": {
+            "question": 1950035,
+            "description": "I also brought Chairman Eric Chu and former President Ma Ying-jeou to witness this moment. There is no demand for the TPP to concede a 6% margin in the polls; instead, we will determine the outcome based on the respective margins of error in each poll, alright?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950739,
+        "fields": {
+            "question": 1950035,
+            "description": "Today is a crucial day that determines the future destiny of Taiwan and its people. I hope Chairman Terry Gou and President Ko can prioritize the overall situation. We must unite forces to bring down the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950740,
+        "fields": {
+            "question": 1950035,
+            "description": "Today is a crucial day that determines the future destiny of Taiwan and its people. I hope Chairman Terry Gou and President Ko can prioritize the overall situation. We must unite forces to bring down the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950751,
+        "fields": {
+            "question": 1950036,
+            "description": "I have no other choice; Han Kuo-yu and Ko Chih-en have been included in the party list as they aim to become legislators. I must now approach the prominent media figure Zhao Shao-kang to be my vice president. He will surely come to our rescue!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950755,
+        "fields": {
+            "question": 1950036,
+            "description": "I will personally visit Zhao Shao-kang and request him to be my vice president. I must leverage his powerful debating skills, high recognition, and positive reputation among the blue voters to strengthen my support base!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950764,
+        "fields": {
+            "question": 1950037,
+            "description": "(Zhao speaking to the media) The DPP likened Mayor Hou to Adou, but I disagree! I just like Zhao Zilong, loyal to Liu Bei. How could he be compared to a Adou? Just Like Zhao yun'ssteadfast and patriotic, with courage running through my veins."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950765,
+        "fields": {
+            "question": 1950037,
+            "description": "I feel that the DPP lacks professionalism, resorting to divisive tactics to win elections. This kind of maneuver seems quite low-level. If I am elected, Mayor Hou You-yi is the leader, the president, and I am the vice president - merely in a preparatory role!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950766,
+        "fields": {
+            "question": 1950037,
+            "description": "I won't give any attention to such tags. DPP has been in power for a considerable time, yet their election strategies seem to rely on questionable tactics. Can the people of Taiwan still believe in a party that governs without progress but resorts to such tactics during elections?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950781,
+        "fields": {
+            "question": 1950038,
+            "description": "Let's aggressively pursue this issue! Lai Ching-te is truly a candidate who disregards the law, even ignoring illegal construction on his own property. Can someone who disregards the law in such a manner be fit for the presidency?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950782,
+        "fields": {
+            "question": 1950038,
+            "description": "Launching a series of ads attacking Lai Ching-te would be an effective strategy to convey that he is an untrustworthy and arrogant candidate. Emphasize how he has tolerated illegal activities even within his own home, highlighting his lack of integrity. Portray him as someone not deserving of trust and as the people's greatest concern."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950783,
+        "fields": {
+            "question": 1950038,
+            "description": "Hold on, let's not get too carried away! Lai Ching-te's unauthorized construction has been years ago, and according to legal provisions, there is no requirement for demolition. It only needs to be documented and registered through photographs. Let's issue a statement acknowledging that Lai Ching-te's illegal actions technically violate the law, but we have chosen to show leniency and not pursue further action against him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950784,
+        "fields": {
+            "question": 1950038,
+            "description": "An excavator? Yes, right in the Zhongfu neighborhood of Wanli District. Go ahead and demolish his ancestral home for me!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950796,
+        "fields": {
+            "question": 1950039,
+            "description": "Firstly, this property is a legitimate part of my family's assets, and you have no right to interfere. Secondly, I have the right to set the rent at whatever amount I deem appropriate; it's determined by the free market!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950797,
+        "fields": {
+            "question": 1950039,
+            "description": "You're right. I'll discuss it with my wife immediately. I will reduce the rent by half, and after the contract expires, I will convert it into social housing. Is that satisfactory for you?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950798,
+        "fields": {
+            "question": 1950039,
+            "description": "you guys like to attack? Well, then I'll respond with an attack. Lai Ching-te, when will you tear down the unauthorized construction? You dare criticize me; have I committed any crimes? And attacking my wife? That property belongs to her, not me. Please refrain from involving my family in this matter."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950799,
+        "fields": {
+            "question": 1950039,
+            "description": "I won't give this fire any more oxygen. Don't respond to these issues, as it's all legal business operations. Voters will see through it naturally."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950814,
+        "fields": {
+            "question": 1950040,
+            "description": "We want to revisit President Ma Ying-jeou's classic campaign ad from 2008. Our formidable team of county and city mayors is making a comeback to support my campaign, symbolizing unity among ROC's local leaders from across the country. This ad aims to bring hope to the people!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950815,
+        "fields": {
+            "question": 1950040,
+            "description": "We must attack, attack, and attack again. Lai Ching-te and his DPP are highly corrupt, even morally corrupt. It's unknown how many are involved in extramarital affairs, adultery, or even cases of sexual harassment and crimes. This party, often associated with romantic and virtuous imagery, is full of hypocrisy and scandals!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950816,
+        "fields": {
+            "question": 1950040,
+            "description": "I will propose policies that appeal to young people. Many can't afford homes, so we will offer low-interest loans of up to 15 million, waiving the down payment. As long as young people are willing to borrow, we can provide them with this policy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950817,
+        "fields": {
+            "question": 1950040,
+            "description": "I will emphasize our various policies. If you dislike the NCC restricting free speech, despise opaque governance, and are against the DPP's one-party dominance, then join us because we aim to dismantle all of them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950818,
+        "fields": {
+            "question": 1950031,
+            "description": "I will deliver a speech in Washington, emphasizing the importance of the 3D strategy. Which 3Ds? Deterrence, Dialogue, and De-escalation. This can construct peace and stability across the Taiwan Strait while upholding our sovereignty."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950838,
+        "fields": {
+            "question": 1950041,
+            "description": "I understand that scams cause you concern, and the threat of war makes you worry. However, let's not be afraid. You deserve a better future! In the future, I will definitely stand with you!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950839,
+        "fields": {
+            "question": 1950041,
+            "description": "I declare to the people of Taiwan that I am committed to initiating a new era of democratic political reform. Advocating for a cabinet system is not something that can be achieved by one person or one party alone, but it is a task we must accomplish. Our shared goal is peace, integrity, fairness, and justice in governance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950840,
+        "fields": {
+            "question": 1950041,
+            "description": "Candidates, do you truly oppose or support the abolition of the death penalty? All I hear are ambiguous answers, but let me be clear—I am against the abolition of the death penalty. It is a significant harm to the families of the victims. Candidates, please make your stance clear!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950841,
+        "fields": {
+            "question": 1950041,
+            "description": "January 13th marks the day of Mr. Chiang Ching-kuo's passing. Fellow patriots, on this day, it is crucial to come out and vote, exercising your democratic rights. Mr. Chiang Ching-kuo once said, \"What you don't do today, you'll regret tomorrow!\" I am committed to safeguarding Taiwan's democratic system with my life!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950852,
+        "fields": {
+            "question": 1950042,
+            "description": "We must distance ourselves from him. I have a different perspective, and our views do not align with those of President Ma Ying-jeou. To penalize him and minimize the impact, we must reject his attendance at our pre-election night event!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950853,
+        "fields": {
+            "question": 1950042,
+            "description": "I will strongly criticize President Ma Ying-jeou's remarks, as they diverge from the mainstream thoughts of the Taiwanese people! Under the leadership of Mayor Hou You-yi, the Kuomintang will establish new relations with the mainland, and we don't need to blindly trust anyone."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950858,
+        "fields": {
+            "question": 1950042,
+            "description": "Don't pay attention to him. In the critical situation of this election, addressing this issue will only bring about greater division among us!We cannot afford to take risks at this time!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950863,
+        "fields": {
+            "question": 1950851,
+            "description": "I will conduct campaign activities in my home turf, New Taipei and Taipei. At the New Taipei Sports Stadium, we will gather a crowd and defeat the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950864,
+        "fields": {
+            "question": 1950851,
+            "description": "I want to conduct activities in the deeply green cities of Tainan and Kaohsiung, engage in a battle in Lai Ching-te's stronghold, and show him that people in the southern region won't blindly support the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950865,
+        "fields": {
+            "question": 1950851,
+            "description": "We will drive through the Hakka region and finally organize our pre-election night event in Taoyuan City!The Hakka and youth votes have been taken away by Ko Wen-je, and we must retain them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950866,
+        "fields": {
+            "question": 1950851,
+            "description": "We must focus on areas with fewer voters and less competition. Hualien, Taitung, Yilan, and Pingtung are our key areas of concern. We must secure the entire east coast!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950891,
+        "fields": {
+            "question": 1950890,
+            "description": "Ko Wen-je is very popular among the youth, and we must emphasize this. Our alliance lacks support from the younger generation the most. Let Ko Wen-je campaign for our alliance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950892,
+        "fields": {
+            "question": 1950890,
+            "description": "The alliance between the KMT and TPP is a shared aspiration of the Taiwanese people, as evidenced by the polls. We are confident in defeating Lai Ching-te. Let's strengthen the unity and cooperation between the two parties and jointly overcome the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950893,
+        "fields": {
+            "question": 1950890,
+            "description": "Certainly, Chairman Ko's eloquence and formidable abilities will provide excellent support for me. In the vice presidential debate, I hope he can defeat Hsiao Bi-khim, while I will confront Lai Ching-te. Together, let's advance progress in Taiwan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950901,
+        "fields": {
+            "question": 1950900,
+            "description": "We will create goals for the third wave of democratic reforms in Taiwan. We will promote a Parliamentary system instead of a presidential system where power is concentrated in one party's hands. This change will benefit the future of Taiwan, as democracy requires a system of checks and balances!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950902,
+        "fields": {
+            "question": 1950900,
+            "description": "In the future coalition government, KMT will take the lead in economic and developmental responsibilities, while the TPP will be responsible for oversight and checks and balances. This is much better than the authoritarian rule of the DPP. Our future government will be free from corruption, and anyone who dares to engage in corruption will be held accountable!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950903,
+        "fields": {
+            "question": 1950900,
+            "description": "Now, we represent the greatest consensus of the Taiwanese people. Let's unite and launch a full-scale attack on the DPP! The opposition alliance will surge and break through the DPP's base!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950912,
+        "fields": {
+            "question": 1950911,
+            "description": "Lai Ching-te has claimed to be a pragmatic advocate for Taiwan independence. Now he says Taiwan is already an independent country. This is just the opportunistic behavior of a politician without integrity.I has been loyal to the Republic of China  throughout his life, and I will sacrifice my life to protect it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950913,
+        "fields": {
+            "question": 1950911,
+            "description": "Taiwan cannot afford to be ruled by the DPP anymore. The past 8 years of their governance have exposed the rapid pace of corruption and moral decay within your political regime, making it impossible for the people to trust you any longer. Please believe in the Taiwan United Government under the KMT-TPP alliance; we will do better!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950914,
+        "fields": {
+            "question": 1950911,
+            "description": "What I insist on is the democratic freedom of the 23 million people in Taiwan. We must strengthen national defense, deter war, and hold the key to peace, security, and stability in the Taiwan Strait. The DPP's approach cannot help Taiwan achieve true peace!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950915,
+        "fields": {
+            "question": 1950911,
+            "description": "My father is a veteran, and I am the son of a pork vendor from the rural areas of Chiayi. I understand the hardships of life and have climbed up from being the lowest-ranking police officer to my current position. I am grateful for the support and assistance from each and every one of you!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950928,
+        "fields": {
+            "question": 1950927,
+            "description": "Now it's a one-on-one battle between me and Lai Ching-te! We must rally our base to come back!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950934,
+        "fields": {
+            "question": 1950933,
+            "description": "Lai Ching-te has claimed to be a pragmatic advocate for Taiwan independence. Now he says Taiwan is already an independent country. This is just the opportunistic behavior of a politician without integrity.I has been loyal to the Republic of China throughout his life, and I will sacrifice my life to protect it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950935,
+        "fields": {
+            "question": 1950933,
+            "description": "Chairman Ko had once promised to pursue a blue-white coalition, but now he has backtracked. This proves that Chairman Ko is someone who prioritizes political interests over integrity. He changed his decision to personally sign the agreement due to opposition from his staff and family, which is truly embarrassing."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950936,
+        "fields": {
+            "question": 1950933,
+            "description": "Chairman Guo had once promised to support me, but the subsequent results are well known. Now the opposition is divided into three parts. Where is the benefit in that? I am the strongest candidate. On election day, we should abandon Guo and support Hou!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950946,
+        "fields": {
+            "question": 1950933,
+            "description": "I and Mr. Guo both advocate for the ROC, and we both love this country. However, he is not a viable winner. Please concentrate your votes on me; I am the only one with the potential to defeat the Democratic Progressive Party."
+        }
+    }
+
+]
+
+
+campaignTrail_temp.states_json = [
+    {
+        "model": "campaign_trail.state",
+        "pk": 251,
+        "fields": {
+            "name": "Tainan City",
+            "abbr": "Tainancity",
+            "electoral_votes": 1,
+            "popular_votes": 1120238,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 252,
+        "fields": {
+            "name": "Kaohsiung City",
+            "abbr": "Kaohsiungcity",
+            "electoral_votes": 1,
+            "popular_votes": 1636962,
+            "poll_closing_time": 180,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 253,
+        "fields": {
+            "name": "Pingtung County",
+            "abbr": "Pingtung",
+            "electoral_votes": 1,
+            "popular_votes": 475927,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 254,
+        "fields": {
+            "name": "Taidong County",
+            "abbr": "Taidong",
+            "electoral_votes": 1,
+            "popular_votes": 109941,
+            "poll_closing_time": 75,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 255,
+        "fields": {
+            "name": "Hualien County",
+            "abbr": "Hualien",
+            "electoral_votes": 1,
+            "popular_votes": 174157,
+            "poll_closing_time": 90,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 256,
+        "fields": {
+            "name": "Chiayi County",
+            "abbr": "ChiayiCounty",
+            "electoral_votes": 1,
+            "popular_votes": 292534,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 257,
+        "fields": {
+            "name": "Chiayi City",
+            "abbr": "ChiayiCity",
+            "electoral_votes": 1,
+            "popular_votes": 157656,
+            "poll_closing_time": 80,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 258,
+        "fields": {
+            "name": "Nantou County",
+            "abbr": "Nantou",
+            "electoral_votes": 1,
+            "popular_votes": 287296,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 259,
+        "fields": {
+            "name": "Yunlin County",
+            "abbr": "Yunlin",
+            "electoral_votes": 1,
+            "popular_votes": 380619,
+            "poll_closing_time": 130,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 260,
+        "fields": {
+            "name": "Changhua County",
+            "abbr": "Changhua",
+            "electoral_votes": 1,
+            "popular_votes": 741368,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 261,
+        "fields": {
+            "name": "Penghu County",
+            "abbr": "Penghu",
+            "electoral_votes": 1,
+            "popular_votes": 49277,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 262,
+        "fields": {
+            "name": "Taichung City",
+            "abbr": "Taichung",
+            "electoral_votes": 1,
+            "popular_votes": 1707203,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 263,
+        "fields": {
+            "name": "Yilan County",
+            "abbr": "Yilan",
+            "electoral_votes": 1,
+            "popular_votes": 267129,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 264,
+        "fields": {
+            "name": "Hsinchu County",
+            "abbr": "HsinchuCounty",
+            "electoral_votes": 1,
+            "popular_votes": 340310,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 265,
+        "fields": {
+            "name": "Hsinchu City",
+            "abbr": "HsinchuCity",
+            "electoral_votes": 1,
+            "popular_votes": 266389,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 266,
+        "fields": {
+            "name": "Miaoli County",
+            "abbr": "Miaoli",
+            "electoral_votes": 1,
+            "popular_votes": 318665,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 267,
+        "fields": {
+            "name": "New Taipei City",
+            "abbr": "Newtaipei",
+            "electoral_votes": 1,
+            "popular_votes": 2458480,
+            "poll_closing_time": 225,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 268,
+        "fields": {
+            "name": "Taipei City",
+            "abbr": "Taipei",
+            "electoral_votes": 1,
+            "popular_votes": 1542009,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 269,
+        "fields": {
+            "name": "Taoyuan City",
+            "abbr": "Taoyuan",
+            "electoral_votes": 1,
+            "popular_votes": 1350792,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 270,
+        "fields": {
+            "name": "Keelung City",
+            "abbr": "Keelung",
+            "electoral_votes": 1,
+            "popular_votes": 218781,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 271,
+        "fields": {
+            "name": "Kinmen County",
+            "abbr": "Kinmen",
+            "electoral_votes": 1,
+            "popular_votes": 45612,
+            "poll_closing_time": 70,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 272,
+        "fields": {
+            "name": "Lienchiang County",
+            "abbr": "Matsu",
+            "electoral_votes": 1,
+            "popular_votes": 6159,
+            "poll_closing_time": 50,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.issues_json = [
+    {
+        "model": "campaign_trail.issue",
+        "pk": 32,
+        "fields": {
+            "name": "Party coalition",
+            "description": 0,
+            "stance_1": "Deep Green",
+            "stance_desc_1": 0,
+            "stance_2": "Green",
+            "stance_desc_2": 0,
+            "stance_3": "Light Green",
+            "stance_desc_3": 0,
+            "stance_4": "Neutral",
+            "stance_desc_4": 0,
+            "stance_5": "Light Blue",
+            "stance_desc_5": 0,
+            "stance_6": "Blue",
+            "stance_desc_6": 0,
+            "stance_7": "Deep Blue",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 33,
+        "fields": {
+            "name": "Provincial differences",
+            "description": 0,
+            "stance_1": "Mostly Taiwanese",
+            "stance_desc_1": 0,
+            "stance_2": "Taiwanese and Hakka mixed",
+            "stance_desc_2": 0,
+            "stance_3": "Taiwanese,Hakka,Mainlanders mixed",
+            "stance_desc_3": 0,
+            "stance_4": "mixing of ethnic groups",
+            "stance_desc_4": 0,
+            "stance_5": "Aboriginal",
+            "stance_desc_5": 0,
+            "stance_6": "Taiwanese Hakka(Northern)",
+            "stance_desc_6": 0,
+            "stance_7": "Mostly Mainlanders",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 34,
+        "fields": {
+            "name": "Urban/rural differences",
+            "description": 0,
+            "stance_1": "Townships Rural",
+            "stance_desc_1": 0,
+            "stance_2": "Small towns and large towns",
+            "stance_desc_2": 0,
+            "stance_3": "Small cities and towns",
+            "stance_desc_3": 0,
+            "stance_4": "Medium-sized city",
+            "stance_desc_4": 0,
+            "stance_5": "Groups of Small Cities",
+            "stance_desc_5": 0,
+            "stance_6": "Large Cities",
+            "stance_desc_6": 0,
+            "stance_7": "Capitals",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 35,
+        "fields": {
+            "name": "Young population",
+            "description": 0,
+            "stance_1": "Very little",
+            "stance_desc_1": 0,
+            "stance_2": "Little",
+            "stance_desc_2": 0,
+            "stance_3": "Less",
+            "stance_desc_3": 0,
+            "stance_4": "Normal level",
+            "stance_desc_4": 0,
+            "stance_5": "Relatively much more",
+            "stance_desc_5": 0,
+            "stance_6": "Large young population",
+            "stance_desc_6": 0,
+            "stance_7": "Younger society",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 36,
+        "fields": {
+            "name": "Feelings about DPP Government",
+            "description": 0,
+            "stance_1": "DPP is the best!",
+            "stance_desc_1": 0,
+            "stance_2": "That's what we like!",
+            "stance_desc_2": 0,
+            "stance_3": "Pro-DPP",
+            "stance_desc_3": 0,
+            "stance_4": "no feelings for the DPP",
+            "stance_desc_4": 0,
+            "stance_5": "Hate green governance",
+            "stance_desc_5": 0,
+            "stance_6": "Mosquitoes, cockroaches, and the DPP",
+            "stance_desc_6": 0,
+            "stance_7": "Never support the Taiwan Independence Party!!",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.state_issue_score_json = [
+    //台北市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191111,
+        "fields": {
+            "state": 268,
+            "issue": 32,
+            "state_issue_score": 0.22,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191112,
+        "fields": {
+            "state": 268,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191113,
+        "fields": {
+            "state": 268,
+            "issue": 34,
+            "state_issue_score": 1,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191114,
+        "fields": {
+            "state": 268,
+            "issue": 35,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191115,
+        "fields": {
+            "state": 268,
+            "issue": 36,
+            "state_issue_score": 0.1,
+            "weight": 0.5
+        }
+    },
+    //新北市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191116,
+        "fields": {
+            "state": 267,
+            "issue": 32,
+            "state_issue_score": 0.15,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191117,
+        "fields": {
+            "state": 267,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191118,
+        "fields": {
+            "state": 267,
+            "issue": 34,
+            "state_issue_score": 0.65,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191119,
+        "fields": {
+            "state": 267,
+            "issue": 35,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191120,
+        "fields": {
+            "state": 267,
+            "issue": 36,
+            "state_issue_score": 0.0,
+            "weight": 0.5
+        }
+    },
+    //桃园市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191121,
+        "fields": {
+            "state": 269,
+            "issue": 32,
+            "state_issue_score": 0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191122,
+        "fields": {
+            "state": 269,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191122,
+        "fields": {
+            "state": 269,
+            "issue": 34,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191123,
+        "fields": {
+            "state": 269,
+            "issue": 35,
+            "state_issue_score": 0.75,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191124,
+        "fields": {
+            "state": 269,
+            "issue": 36,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    //新竹市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191125,
+        "fields": {
+            "state": 265,
+            "issue": 32,
+            "state_issue_score": 0.4,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191126,
+        "fields": {
+            "state": 265,
+            "issue": 33,
+            "state_issue_score": -0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191127,
+        "fields": {
+            "state": 265,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191128,
+        "fields": {
+            "state": 265,
+            "issue": 35,
+            "state_issue_score": 0.65,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191129,
+        "fields": {
+            "state": 265,
+            "issue": 36,
+            "state_issue_score": 0.35,
+            "weight": 0.5
+        }
+    },
+    //基隆市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191130,
+        "fields": {
+            "state": 270,
+            "issue": 32,
+            "state_issue_score": 0.5,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191131,
+        "fields": {
+            "state": 270,
+            "issue": 33,
+            "state_issue_score": 0.1,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191132,
+        "fields": {
+            "state": 270,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191133,
+        "fields": {
+            "state": 270,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191134,
+        "fields": {
+            "state": 270,
+            "issue": 36,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    //新竹县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191135,
+        "fields": {
+            "state": 264,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191136,
+        "fields": {
+            "state": 264,
+            "issue": 33,
+            "state_issue_score": 0.45,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191137,
+        "fields": {
+            "state": 264,
+            "issue": 34,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191138,
+        "fields": {
+            "state": 264,
+            "issue": 35,
+            "state_issue_score": 0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191139,
+        "fields": {
+            "state": 264,
+            "issue": 36,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    //苗栗縣
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191140,
+        "fields": {
+            "state": 266,
+            "issue": 32,
+            "state_issue_score": 0.85,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191141,
+        "fields": {
+            "state": 266,
+            "issue": 33,
+            "state_issue_score": 0.55,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191142,
+        "fields": {
+            "state": 266,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191143,
+        "fields": {
+            "state": 266,
+            "issue": 35,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191144,
+        "fields": {
+            "state": 266,
+            "issue": 36,
+            "state_issue_score": 0.85,
+            "weight": 0.5
+        }
+    },
+    //宜兰县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191145,
+        "fields": {
+            "state": 263,
+            "issue": 32,
+            "state_issue_score": -0.45,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191146,
+        "fields": {
+            "state": 263,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191147,
+        "fields": {
+            "state": 263,
+            "issue": 34,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191148,
+        "fields": {
+            "state": 263,
+            "issue": 35,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191149,
+        "fields": {
+            "state": 263,
+            "issue": 36,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    //台中市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191150,
+        "fields": {
+            "state": 262,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191151,
+        "fields": {
+            "state": 262,
+            "issue": 33,
+            "state_issue_score": 0,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191152,
+        "fields": {
+            "state": 262,
+            "issue": 34,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191154,
+        "fields": {
+            "state": 262,
+            "issue": 35,
+            "state_issue_score": 0.35,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191155,
+        "fields": {
+            "state": 262,
+            "issue": 36,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    //南投县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191156,
+        "fields": {
+            "state": 258,
+            "issue": 32,
+            "state_issue_score": 0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191157,
+        "fields": {
+            "state": 258,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191158,
+        "fields": {
+            "state": 258,
+            "issue": 34,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191159,
+        "fields": {
+            "state": 258,
+            "issue": 35,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191160,
+        "fields": {
+            "state": 258,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //花莲县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191161,
+        "fields": {
+            "state": 255,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191162,
+        "fields": {
+            "state": 255,
+            "issue": 33,
+            "state_issue_score": 0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191163,
+        "fields": {
+            "state": 255,
+            "issue": 34,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191164,
+        "fields": {
+            "state": 255,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191165,
+        "fields": {
+            "state": 255,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //台东县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191166,
+        "fields": {
+            "state": 254,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191167,
+        "fields": {
+            "state": 254,
+            "issue": 33,
+            "state_issue_score": 0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191168,
+        "fields": {
+            "state": 254,
+            "issue": 34,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191169,
+        "fields": {
+            "state": 254,
+            "issue": 35,
+            "state_issue_score": -0.33,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191170,
+        "fields": {
+            "state": 254,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //彰化县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191171,
+        "fields": {
+            "state": 260,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191172,
+        "fields": {
+            "state": 260,
+            "issue": 33,
+            "state_issue_score": -0.85,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191173,
+        "fields": {
+            "state": 260,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191174,
+        "fields": {
+            "state": 260,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191175,
+        "fields": {
+            "state": 260,
+            "issue": 36,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    //云林县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191176,
+        "fields": {
+            "state": 259,
+            "issue": 32,
+            "state_issue_score": -0.4,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191177,
+        "fields": {
+            "state": 259,
+            "issue": 33,
+            "state_issue_score": -0.85,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191178,
+        "fields": {
+            "state": 259,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191179,
+        "fields": {
+            "state": 259,
+            "issue": 35,
+            "state_issue_score": -0.85,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191180,
+        "fields": {
+            "state": 259,
+            "issue": 36,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    //澎湖
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191181,
+        "fields": {
+            "state": 261,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191182,
+        "fields": {
+            "state": 261,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191183,
+        "fields": {
+            "state": 261,
+            "issue": 34,
+            "state_issue_score": -0.9,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191184,
+        "fields": {
+            "state": 261,
+            "issue": 35,
+            "state_issue_score": -0.75,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191185,
+        "fields": {
+            "state": 261,
+            "issue": 36,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    //嘉义县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191186,
+        "fields": {
+            "state": 256,
+            "issue": 32,
+            "state_issue_score": -0.75,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191187,
+        "fields": {
+            "state": 256,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191188,
+        "fields": {
+            "state": 256,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191189,
+        "fields": {
+            "state": 256,
+            "issue": 35,
+            "state_issue_score": -0.9,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191190,
+        "fields": {
+            "state": 256,
+            "issue": 36,
+            "state_issue_score": -0.75,
+            "weight": 0.5
+        }
+    },
+    //嘉义市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191191,
+        "fields": {
+            "state": 257,
+            "issue": 32,
+            "state_issue_score": -0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191192,
+        "fields": {
+            "state": 257,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191193,
+        "fields": {
+            "state": 257,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191194,
+        "fields": {
+            "state": 257,
+            "issue": 35,
+            "state_issue_score": -0.6,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191195,
+        "fields": {
+            "state": 257,
+            "issue": 36,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+     //台南市
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191196,
+            "fields": {
+                "state": 251,
+                "issue": 32,
+                "state_issue_score": -0.85,
+                "weight": 1
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191197,
+            "fields": {
+                "state": 251,
+                "issue": 33,
+                "state_issue_score": -0.15,
+                "weight": 2
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191198,
+            "fields": {
+                "state": 251,
+                "issue": 34,
+                "state_issue_score": 0.55,
+                "weight": 0.5
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191199,
+            "fields": {
+                "state": 251,
+                "issue": 35,
+                "state_issue_score": 0.15,
+                "weight": 0.5
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191200,
+            "fields": {
+                "state": 251,
+                "issue": 36,
+                "state_issue_score": -0.75,
+                "weight": 0.5
+            }
+        },
+         //高雄市
+             {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191201,
+                "fields": {
+                    "state": 252,
+                    "issue": 32,
+                    "state_issue_score": -0.55,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191202,
+                "fields": {
+                    "state": 252,
+                    "issue": 33,
+                    "state_issue_score": -0.15,
+                    "weight": 2
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191203,
+                "fields": {
+                    "state": 252,
+                    "issue": 34,
+                    "state_issue_score": 0.65,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191204,
+                "fields": {
+                    "state": 252,
+                    "issue": 35,
+                    "state_issue_score": 0.15,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191205,
+                "fields": {
+                    "state": 252,
+                    "issue": 36,
+                    "state_issue_score": -0.75,
+                    "weight": 0.5
+                }
+            },
+            //屏东县
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191206,
+                "fields": {
+                    "state": 253,
+                    "issue": 32,
+                    "state_issue_score": -0.5,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191207,
+                "fields": {
+                    "state": 253,
+                    "issue": 33,
+                    "state_issue_score": -0.25,
+                    "weight": 2
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191208,
+                "fields": {
+                    "state": 253,
+                    "issue": 34,
+                    "state_issue_score": 0.25,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191209,
+                "fields": {
+                    "state": 253,
+                    "issue": 35,
+                    "state_issue_score": 0,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191210,
+                "fields": {
+                    "state": 253,
+                    "issue": 36,
+                    "state_issue_score": -0.55,
+                    "weight": 0.5
+                }
+            },
+              //金门县
+              {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191211,
+                "fields": {
+                    "state": 271,
+                    "issue": 32,
+                    "state_issue_score": 1,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191212,
+                "fields": {
+                    "state": 271,
+                    "issue": 33,
+                    "state_issue_score": 1,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191213,
+                "fields": {
+                    "state": 271,
+                    "issue": 34,
+                    "state_issue_score": -0.75,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191214,
+                "fields": {
+                    "state": 271,
+                    "issue": 35,
+                    "state_issue_score": -0.25,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191215,
+                "fields": {
+                    "state": 271,
+                    "issue": 36,
+                    "state_issue_score": 1,
+                    "weight": 0.5
+                }
+            },
+                //连江县
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191216,
+                    "fields": {
+                        "state": 272,
+                        "issue": 32,
+                        "state_issue_score": 1,
+                        "weight": 1
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191217,
+                    "fields": {
+                        "state": 272,
+                        "issue": 33,
+                        "state_issue_score": 1,
+                        "weight": 1
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191218,
+                    "fields": {
+                        "state": 272,
+                        "issue": 34,
+                        "state_issue_score": -1,
+                        "weight": 0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191219,
+                    "fields": {
+                        "state": 272,
+                        "issue": 35,
+                        "state_issue_score": 0.25,
+                        "weight": 0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191220,
+                    "fields": {
+                        "state": 272,
+                        "issue": 36,
+                        "state_issue_score": 1,
+                        "weight": 0.5
+                    }
+                },
+]
+campaignTrail_temp.candidate_issue_score_json = [
+    //赖清德
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 328,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 32,
+            "issue_score": -0.85 //深绿
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 329,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 33,
+            "issue_score": -0.75 //台湾本省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 330,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 34,
+            "issue_score": -0.35 //矿工之子
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 331,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 35,
+            "issue_score": 0.25 //年轻人支持度还行
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 332,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 36,
+            "issue_score": -1 //我就是现任副总统啊
+        }
+    },
+    //侯友谊
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 333,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 32,
+            "issue_score": 0.15 //浅蓝，甚至蓝皮绿谷
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 334,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 33,
+            "issue_score": -0.9 //比赖清德更本省
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 335,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 34,
+            "issue_score": -0.5 //嘉义乡下卖猪肉的
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 336,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 35,
+            "issue_score": -0.25 //年轻人不喜欢的老蓝男
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 337,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 36,
+            "issue_score": 0.25 //攻击性不强
+        }
+    },
+    //柯文哲
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 338,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 32,
+            "issue_score": -0.5 //我内心本质还是深绿的
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 339,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 33,
+            "issue_score": -0.75 //本省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 340,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 34,
+            "issue_score": 0.15 //家庭条件还可以
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 341,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 35,
+            "issue_score": 0.8 //阿北阿北我爱你
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 342,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 36,
+            "issue_score": 0.5 //攻击性很强，但并不把下架民进党当第一目标
+        }
+    },
+     //郭台铭
+     {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 343,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 32,
+            "issue_score": 0.7 //深蓝
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 344,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 33,
+            "issue_score": 0.75 //外省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 345,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 34,
+            "issue_score": 0.75 //城里人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 346,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 35,
+            "issue_score": -0.25 //老蓝男
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 347,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 36,
+            "issue_score": 0.4 //攻击性一般，下架民进党是说说听得口号
+        }
+    },
+]
+campaignTrail_temp.running_mate_issue_score_json = [
+  //萧美琴
+  {
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9343,
+    "fields": {
+        "candidate": 1002,
+        "issue": 32,
+        "issue_score": -0.7
+    }
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9344,
+    "fields": {
+        "candidate": 1002,
+        "issue": 33,
+        "issue_score": -0
+    }
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9345,
+    "fields": {
+        "candidate": 1002,
+        "issue": 34,
+        "issue_score": -0.25
+},
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9346,
+    "fields": {
+        "candidate": 1002,
+        "issue": 35,
+        "issue_score": 0.25 
+    }
+},
+    {
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9347,
+    "fields": {
+        "candidate": 1002,
+        "issue": 36,
+        "issue_score": -0.5
+    }
+    },
+    //蓝白联票
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9348,
+        "fields": {
+            "candidate": 50001,
+            "issue": 32,
+            "issue_score": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9349,
+        "fields": {
+            "candidate": 50001,
+            "issue": 33,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9350,
+        "fields": {
+            "candidate": 50001,
+            "issue": 34,
+            "issue_score": 0
+    },
+},
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9351,
+        "fields": {
+            "candidate": 50001,
+            "issue": 35,
+            "issue_score": 0.15 
+        }
+    },
+        {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9352,
+        "fields": {
+            "candidate": 50001,
+            "issue": 36,
+            "issue_score": 0.4
+        }
+        },
+        //赵少康
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93481,
+            "fields": {
+                "candidate": 50000,
+                "issue": 32,
+                "issue_score": 0.95
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93491,
+            "fields": {
+                "candidate": 50000,
+                "issue": 33,
+                "issue_score": 0.95
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93501,
+            "fields": {
+                "candidate": 50000,
+                "issue": 34,
+                "issue_score": 0.55
+        },
+    },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93511,
+            "fields": {
+                "candidate": 50000,
+                "issue": 35,
+                "issue_score": 0.1
+            }
+        },
+            {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93521,
+            "fields": {
+                "candidate": 50000,
+                "issue": 36,
+                "issue_score": 0.5
+            }
+            },
+            //韩国瑜
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 934812,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 32,
+                    "issue_score": 0.95
+                }
+            },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 934912,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 33,
+                    "issue_score": 0.95
+                }
+            },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935013,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 34,
+                    "issue_score": -0.25
+            },
+        },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935114,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 35,
+                    "issue_score": 0
+                }
+            },
+                {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935215,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 36,
+                    "issue_score": 0.65
+                }
+                },
+                //柯志恩
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9348121,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 32,
+                        "issue_score": 0.15
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9349121,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 33,
+                        "issue_score": -0.75
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9350131,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 34,
+                        "issue_score": -0.15
+                },
+            },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9351141,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 35,
+                        "issue_score": 0.5
+                    }
+                },
+                    {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9352151,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 36,
+                        "issue_score": 0.42
+                    }
+                    },
+                    //赖佩霞
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93481211,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 32,
+                            "issue_score": 0.1
+                        }
+                    },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93491211,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 33,
+                            "issue_score": 0
+                        }
+                    },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93501311,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 34,
+                            "issue_score": 0.25
+                    },
+                },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93511411,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 35,
+                            "issue_score": 0.15
+                        }
+                    },
+                        {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93521511,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 36,
+                            "issue_score": 0.15
+                        }
+                        },
+                        //白蓝联票
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410110,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 32,
+                                "issue_score": -0.1
+                            }
+                        },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410111,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 33,
+                                "issue_score": 0
+                            }
+                        },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410112,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 34,
+                                "issue_score": 0
+                        },
+                    },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410113,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 35,
+                                "issue_score": 0.75
+                            }
+                        },
+                            {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410114,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 36,
+                                "issue_score": 0.25
+                            }
+                            },
+                            //吴欣盈
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241000,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 32,
+                                    "issue_score": 0
+                                }
+                            },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241001,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 33,
+                                    "issue_score": 0
+                                }
+                            },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241002,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 34,
+                                    "issue_score": 0
+                            },
+                           },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241003,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 35,
+                                    "issue_score": 0.75
+                                }
+                            },
+                                {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241004,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 36,
+                                    "issue_score": 0.25
+                                }
+                        }
+    ]
+
+campaignTrail_temp.candidate_state_multiplier_json = [
+       //台南市
+       {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25191,
+        "fields": {
+            "candidate": 2001557,
+            "state": 251,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25192,
+        "fields": {
+            "candidate": 2001591,
+            "state": 251,
+            "state_multiplier": 0.265
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25693,
+        "fields": {
+            "candidate": 2001622,
+            "state": 251,
+            "state_multiplier": 0.17
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25694,
+        "fields": {
+            "candidate": 2001653,
+            "state": 251,
+            "state_multiplier": 0.07
+        }
+    },
+    //嘉义县
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25691,
+        "fields": {
+            "candidate": 2001557,
+            "state": 256,
+            "state_multiplier": 0.28
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25692,
+        "fields": {
+            "candidate": 2001591,
+            "state": 256,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25693,
+        "fields": {
+            "candidate": 2001622,
+            "state": 256,
+            "state_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25694,
+        "fields": {
+            "candidate": 2001653,
+            "state": 256,
+            "state_multiplier": 0.07
+        }
+    },
+      //花莲县
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25591,
+        "fields": {
+            "candidate": 2001557,
+            "state": 255,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25592,
+        "fields": {
+            "candidate": 2001591,
+            "state": 255,
+            "state_multiplier": 0.366
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25593,
+        "fields": {
+            "candidate": 2001622,
+            "state": 255,
+            "state_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25594,
+        "fields": {
+            "candidate": 2001653,
+            "state": 255,
+            "state_multiplier": 0.1
+        }
+    },
+      //屏东
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25391,
+        "fields": {
+            "candidate": 2001557,
+            "state": 253,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25392,
+        "fields": {
+            "candidate": 2001591,
+            "state": 253,
+            "state_multiplier": 0.23
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25393,
+        "fields": {
+            "candidate": 2001622,
+            "state": 253,
+            "state_multiplier": 0.14
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25294,
+        "fields": {
+            "candidate": 2001653,
+            "state": 253,
+            "state_multiplier": 0.07
+        }
+    },
+    //高雄
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25291,
+        "fields": {
+            "candidate": 2001557,
+            "state": 252,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25292,
+        "fields": {
+            "candidate": 2001591,
+            "state": 252,
+            "state_multiplier": 0.23
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25293,
+        "fields": {
+            "candidate": 2001622,
+            "state": 252,
+            "state_multiplier": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25294,
+        "fields": {
+            "candidate": 2001653,
+            "state": 252,
+            "state_multiplier": 0.07
+        }
+    },
+    //台东
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252912,
+        "fields": {
+            "candidate": 2001557,
+            "state": 254,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252922,
+        "fields": {
+            "candidate": 2001591,
+            "state": 254,
+            "state_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252932,
+        "fields": {
+            "candidate": 2001622,
+            "state": 254,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252942,
+        "fields": {
+            "candidate": 2001653,
+            "state": 254,
+            "state_multiplier": 0.1
+        }
+    },
+        //嘉义市
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114514,
+            "fields": {
+                "candidate": 2001557,
+                "state": 257,
+                "state_multiplier": 0.28
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114515,
+            "fields": {
+                "candidate": 2001591,
+                "state": 257,
+                "state_multiplier": 0.23
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114516,
+            "fields": {
+                "candidate": 2001622,
+                "state": 257,
+                "state_multiplier": 0.15
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114517,
+            "fields": {
+                "candidate": 2001653,
+                "state": 257,
+                "state_multiplier": 0.05
+            }
+        },
+        //南投
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 566666,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 258,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 666666,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 258,
+                        "state_multiplier": 0.31
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 6666666,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 258,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 66666666,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 258,
+                        "state_multiplier": 0.08
+                    }
+                },
+                //彰化
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 114514123,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 260,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1145141234,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 260,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 11451414,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 260,
+                        "state_multiplier": 0.19
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 21412412,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 260,
+                        "state_multiplier": 0.06
+                    }
+                },
+                //云林
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1111,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 259,
+                        "state_multiplier": 0.32
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2222,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 259,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 3333,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 259,
+                        "state_multiplier": 0.19
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 4444,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 259,
+                        "state_multiplier": 0.04
+                    }
+                },
+                //澎湖
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 5555,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 261,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 6666,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 261,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 7777,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 261,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 8888,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 261,
+                        "state_multiplier": 0.05
+                    }
+                },
+                //台中
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412241,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 262,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412411,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 262,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412412,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 262,
+                        "state_multiplier": 0.22
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412511,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 262,
+                        "state_multiplier": 0.05
+                    }
+                },
+                //新竹县
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101001,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 264,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101002,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 264,
+                        "state_multiplier": 0.29
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101003,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 264,
+                        "state_multiplier": 0.26
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101004,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 264,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //新竹市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010012,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 265,
+                        "state_multiplier": 0.285
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010022,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 265,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010032,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 265,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010042,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 265,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //苗栗
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2194,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 266,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2195,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 266,
+                        "state_multiplier": 0.35
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2196,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 266,
+                        "state_multiplier": 0.22
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2197,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 266,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //新北市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12194,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 267,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12195,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 267,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12196,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 267,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12197,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 267,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //台北市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 268,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 268,
+                        "state_multiplier": 0.34
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 268,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 268,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //桃园
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 269,
+                        "state_multiplier": 0.26
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 269,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 269,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 269,
+                        "state_multiplier": 0.13
+                    }
+                },
+                //基隆
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 270,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 270,
+                        "state_multiplier": 0.33
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 270,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 270,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //金门
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19581,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 271,
+                        "state_multiplier": 0.05
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19582,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 271,
+                        "state_multiplier": 0.55
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19583,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 271,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19584,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 271,
+                        "state_multiplier": 0.15
+                    }
+                },         
+                 //宜兰
+                 {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195813,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 263,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195823,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 263,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195833,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 263,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195843,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 263,
+                        "state_multiplier": 0.08
+                    }
+                },       
+                  //连江
+                  {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195812,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 272,
+                        "state_multiplier": 0.05
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195822,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 272,
+                        "state_multiplier": 0.55
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195832,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 272,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195842,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 272,
+                        "state_multiplier": 0.15
+                    }
+                },      
+]
+
+
+campaignTrail_temp.answer_score_global_json = [
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13413,
+        "fields": {
+            "answer": 13408,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13415,
+        "fields": {
+            "answer": 13409,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950382,
+        "fields": {
+            "answer": 1950012,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950384,
+        "fields": {
+            "answer": 1950013,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950387,
+        "fields": {
+            "answer": 1950014,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950393,
+        "fields": {
+            "answer": 1950388,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950395,
+        "fields": {
+            "answer": 1950389,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950397,
+        "fields": {
+            "answer": 1950390,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950403,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950404,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950405,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950406,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950407,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.45
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950408,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950409,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.23
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950410,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950423,
+        "fields": {
+            "answer": 1950415,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950437,
+        "fields": {
+            "answer": 1950425,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950438,
+        "fields": {
+            "answer": 1950426,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950439,
+        "fields": {
+            "answer": 1950430,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950440,
+        "fields": {
+            "answer": 1950432,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950451,
+        "fields": {
+            "answer": 1950443,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.021
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950459,
+        "fields": {
+            "answer": 1950454,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950465,
+        "fields": {
+            "answer": 1950463,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950466,
+        "fields": {
+            "answer": 1950463,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950469,
+        "fields": {
+            "answer": 1950462,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950470,
+        "fields": {
+            "answer": 1950462,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950472,
+        "fields": {
+            "answer": 1950461,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950473,
+        "fields": {
+            "answer": 1950461,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950475,
+        "fields": {
+            "answer": 1950460,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950480,
+        "fields": {
+            "answer": 1950454,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950482,
+        "fields": {
+            "answer": 1950477,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.37
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950484,
+        "fields": {
+            "answer": 1950478,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.37
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950486,
+        "fields": {
+            "answer": 1950479,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.37
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950492,
+        "fields": {
+            "answer": 1950487,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950495,
+        "fields": {
+            "answer": 1950488,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950498,
+        "fields": {
+            "answer": 1950489,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950500,
+        "fields": {
+            "answer": 1950490,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950506,
+        "fields": {
+            "answer": 1950502,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.0354
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950508,
+        "fields": {
+            "answer": 1950503,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.005
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950516,
+        "fields": {
+            "answer": 1950504,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.0354
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950528,
+        "fields": {
+            "answer": 1950525,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950531,
+        "fields": {
+            "answer": 1950524,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950533,
+        "fields": {
+            "answer": 1950523,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950539,
+        "fields": {
+            "answer": 1950535,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950541,
+        "fields": {
+            "answer": 1950521,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950542,
+        "fields": {
+            "answer": 1950521,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": 5.3
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950545,
+        "fields": {
+            "answer": 1950536,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950547,
+        "fields": {
+            "answer": 1950537,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950548,
+        "fields": {
+            "answer": 1950537,
+            "candidate": 2001591,
+            "affected_candidate": 1950365,
+            "global_multiplier": 0.018
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950552,
+        "fields": {
+            "answer": 1950550,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950595,
+        "fields": {
+            "answer": 1950593,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950601,
+        "fields": {
+            "answer": 1950597,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950606,
+        "fields": {
+            "answer": 1950600,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950622,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950623,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950624,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950626,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950627,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950629,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950635,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950636,
+        "fields": {
+            "answer": 1950615,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950637,
+        "fields": {
+            "answer": 1950615,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950638,
+        "fields": {
+            "answer": 1950579,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950639,
+        "fields": {
+            "answer": 1950580,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950640,
+        "fields": {
+            "answer": 1950581,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950641,
+        "fields": {
+            "answer": 1950582,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950642,
+        "fields": {
+            "answer": 1950616,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950644,
+        "fields": {
+            "answer": 1950617,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950654,
+        "fields": {
+            "answer": 1950647,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950655,
+        "fields": {
+            "answer": 1950648,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950656,
+        "fields": {
+            "answer": 1950649,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950663,
+        "fields": {
+            "answer": 1950658,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950665,
+        "fields": {
+            "answer": 1950659,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950668,
+        "fields": {
+            "answer": 1950660,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950674,
+        "fields": {
+            "answer": 1950658,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950675,
+        "fields": {
+            "answer": 1950659,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950676,
+        "fields": {
+            "answer": 1950660,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950677,
+        "fields": {
+            "answer": 1950670,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950678,
+        "fields": {
+            "answer": 1950671,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950681,
+        "fields": {
+            "answer": 1950600,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950682,
+        "fields": {
+            "answer": 1950599,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950684,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950685,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950686,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950698,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950699,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950700,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950701,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950702,
+        "fields": {
+            "answer": 1950692,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950703,
+        "fields": {
+            "answer": 1950692,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950704,
+        "fields": {
+            "answer": 1950693,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950705,
+        "fields": {
+            "answer": 1950693,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950729,
+        "fields": {
+            "answer": 1950721,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950730,
+        "fields": {
+            "answer": 1950721,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950731,
+        "fields": {
+            "answer": 1950722,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950732,
+        "fields": {
+            "answer": 1950722,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950733,
+        "fields": {
+            "answer": 1950723,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950734,
+        "fields": {
+            "answer": 1950723,
+            "candidate": 2001591,
+            "affected_candidate": 0,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950735,
+        "fields": {
+            "answer": 1950724,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950736,
+        "fields": {
+            "answer": 1950724,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950742,
+        "fields": {
+            "answer": 1950737,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950744,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950745,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950748,
+        "fields": {
+            "answer": 1950739,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -100
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950749,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950750,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950758,
+        "fields": {
+            "answer": 1950751,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950759,
+        "fields": {
+            "answer": 1950755,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950760,
+        "fields": {
+            "answer": 1950751,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950761,
+        "fields": {
+            "answer": 1950755,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950768,
+        "fields": {
+            "answer": 1950766,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950769,
+        "fields": {
+            "answer": 1950766,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950772,
+        "fields": {
+            "answer": 1950765,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950773,
+        "fields": {
+            "answer": 1950765,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950775,
+        "fields": {
+            "answer": 1950764,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.034
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950776,
+        "fields": {
+            "answer": 1950764,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950777,
+        "fields": {
+            "answer": 1950737,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950778,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950779,
+        "fields": {
+            "answer": 1950739,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950780,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950786,
+        "fields": {
+            "answer": 1950784,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950787,
+        "fields": {
+            "answer": 1950784,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950791,
+        "fields": {
+            "answer": 1950782,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950792,
+        "fields": {
+            "answer": 1950782,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950793,
+        "fields": {
+            "answer": 1950783,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950794,
+        "fields": {
+            "answer": 1950781,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950795,
+        "fields": {
+            "answer": 1950781,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950801,
+        "fields": {
+            "answer": 1950796,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950802,
+        "fields": {
+            "answer": 1950796,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950806,
+        "fields": {
+            "answer": 1950797,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950810,
+        "fields": {
+            "answer": 1950799,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950811,
+        "fields": {
+            "answer": 1950798,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950812,
+        "fields": {
+            "answer": 1950798,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950820,
+        "fields": {
+            "answer": 1950818,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950823,
+        "fields": {
+            "answer": 1950814,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950826,
+        "fields": {
+            "answer": 1950815,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950827,
+        "fields": {
+            "answer": 1950815,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.034
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950830,
+        "fields": {
+            "answer": 1950816,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950831,
+        "fields": {
+            "answer": 1950816,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950835,
+        "fields": {
+            "answer": 1950817,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950836,
+        "fields": {
+            "answer": 1950814,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950844,
+        "fields": {
+            "answer": 1950838,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950848,
+        "fields": {
+            "answer": 1950840,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.021
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950855,
+        "fields": {
+            "answer": 1950852,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950860,
+        "fields": {
+            "answer": 1950858,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950861,
+        "fields": {
+            "answer": 1950853,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950883,
+        "fields": {
+            "answer": 1950863,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950884,
+        "fields": {
+            "answer": 1950864,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950885,
+        "fields": {
+            "answer": 1950865,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950886,
+        "fields": {
+            "answer": 1950866,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950887,
+        "fields": {
+            "answer": 1950863,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950888,
+        "fields": {
+            "answer": 1950864,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950906,
+        "fields": {
+            "answer": 1950903,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950909,
+        "fields": {
+            "answer": 1950901,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950925,
+        "fields": {
+            "answer": 1950914,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950930,
+        "fields": {
+            "answer": 1950928,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950931,
+        "fields": {
+            "answer": 1950928,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950938,
+        "fields": {
+            "answer": 1950936,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950939,
+        "fields": {
+            "answer": 1950936,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.059
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950941,
+        "fields": {
+            "answer": 1950935,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950942,
+        "fields": {
+            "answer": 1950935,
+            "candidate": 2001591,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950944,
+        "fields": {
+            "answer": 1950934,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950945,
+        "fields": {
+            "answer": 1950934,
+            "candidate": 2001591,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950949,
+        "fields": {
+            "answer": 1950946,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950950,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1950951,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.02
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_issue_json = [
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950385,
+        "fields": {
+            "answer": 1950013,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950446,
+        "fields": {
+            "answer": 1950441,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.155
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950448,
+        "fields": {
+            "answer": 1950442,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950467,
+        "fields": {
+            "answer": 1950463,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950476,
+        "fields": {
+            "answer": 1950460,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950493,
+        "fields": {
+            "answer": 1950487,
+            "issue": 35,
+            "issue_score": -0.15,
+            "issue_importance": 0.3
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950496,
+        "fields": {
+            "answer": 1950488,
+            "issue": 35,
+            "issue_score": -0.15,
+            "issue_importance": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950499,
+        "fields": {
+            "answer": 1950489,
+            "issue": 35,
+            "issue_score": -0.15,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950501,
+        "fields": {
+            "answer": 1950490,
+            "issue": 35,
+            "issue_score": -0.1,
+            "issue_importance": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950527,
+        "fields": {
+            "answer": 1950525,
+            "issue": 32,
+            "issue_score": -0.04,
+            "issue_importance": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950532,
+        "fields": {
+            "answer": 1950524,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950534,
+        "fields": {
+            "answer": 1950523,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950540,
+        "fields": {
+            "answer": 1950535,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950546,
+        "fields": {
+            "answer": 1950536,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950549,
+        "fields": {
+            "answer": 1950537,
+            "issue": 32,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950553,
+        "fields": {
+            "answer": 1950550,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950555,
+        "fields": {
+            "answer": 1950550,
+            "issue": 36,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950584,
+        "fields": {
+            "answer": 1950579,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950587,
+        "fields": {
+            "answer": 1950580,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950588,
+        "fields": {
+            "answer": 1950580,
+            "issue": 36,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950589,
+        "fields": {
+            "answer": 1950581,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950591,
+        "fields": {
+            "answer": 1950582,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950592,
+        "fields": {
+            "answer": 1950582,
+            "issue": 36,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950596,
+        "fields": {
+            "answer": 1950593,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950602,
+        "fields": {
+            "answer": 1950597,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950604,
+        "fields": {
+            "answer": 1950599,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950607,
+        "fields": {
+            "answer": 1950600,
+            "issue": 34,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950608,
+        "fields": {
+            "answer": 1950600,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950625,
+        "fields": {
+            "answer": 1950609,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950628,
+        "fields": {
+            "answer": 1950610,
+            "issue": 32,
+            "issue_score": 0.02,
+            "issue_importance": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950630,
+        "fields": {
+            "answer": 1950611,
+            "issue": 32,
+            "issue_score": 0.03,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950631,
+        "fields": {
+            "answer": 1950559,
+            "issue": 33,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950632,
+        "fields": {
+            "answer": 1950560,
+            "issue": 33,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950633,
+        "fields": {
+            "answer": 1950561,
+            "issue": 33,
+            "issue_score": -0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950634,
+        "fields": {
+            "answer": 1950513,
+            "issue": 33,
+            "issue_score": -0.03,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950643,
+        "fields": {
+            "answer": 1950616,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950645,
+        "fields": {
+            "answer": 1950617,
+            "issue": 32,
+            "issue_score": 0.02,
+            "issue_importance": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950653,
+        "fields": {
+            "answer": 1950647,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950657,
+        "fields": {
+            "answer": 1950649,
+            "issue": 32,
+            "issue_score": 0.15,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950662,
+        "fields": {
+            "answer": 1950658,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950666,
+        "fields": {
+            "answer": 1950659,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950669,
+        "fields": {
+            "answer": 1950660,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950679,
+        "fields": {
+            "answer": 1950671,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950680,
+        "fields": {
+            "answer": 1950670,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950762,
+        "fields": {
+            "answer": 1950751,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950763,
+        "fields": {
+            "answer": 1950755,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950770,
+        "fields": {
+            "answer": 1950766,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950804,
+        "fields": {
+            "answer": 1950796,
+            "issue": 35,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950805,
+        "fields": {
+            "answer": 1950797,
+            "issue": 35,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950809,
+        "fields": {
+            "answer": 1950799,
+            "issue": 35,
+            "issue_score": -0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950813,
+        "fields": {
+            "answer": 1950798,
+            "issue": 35,
+            "issue_score": -0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950821,
+        "fields": {
+            "answer": 1950818,
+            "issue": 32,
+            "issue_score": 0.015,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950824,
+        "fields": {
+            "answer": 1950814,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950829,
+        "fields": {
+            "answer": 1950816,
+            "issue": 35,
+            "issue_score": 0.02,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950833,
+        "fields": {
+            "answer": 1950817,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950834,
+        "fields": {
+            "answer": 1950817,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950846,
+        "fields": {
+            "answer": 1950839,
+            "issue": 32,
+            "issue_score": 0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950850,
+        "fields": {
+            "answer": 1950841,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950857,
+        "fields": {
+            "answer": 1950852,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950862,
+        "fields": {
+            "answer": 1950853,
+            "issue": 32,
+            "issue_score": -0.12,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950897,
+        "fields": {
+            "answer": 1950891,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950898,
+        "fields": {
+            "answer": 1950892,
+            "issue": 32,
+            "issue_score": 0.07,
+            "issue_importance": 0.11
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950899,
+        "fields": {
+            "answer": 1950893,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950910,
+        "fields": {
+            "answer": 1950902,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950917,
+        "fields": {
+            "answer": 1950912,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950919,
+        "fields": {
+            "answer": 1950913,
+            "issue": 35,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950921,
+        "fields": {
+            "answer": 1950913,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950924,
+        "fields": {
+            "answer": 1950915,
+            "issue": 33,
+            "issue_score": -0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950926,
+        "fields": {
+            "answer": 1950914,
+            "issue": 32,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950932,
+        "fields": {
+            "answer": 1950928,
+            "issue": 32,
+            "issue_score": 0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 1950948,
+        "fields": {
+            "answer": 1950946,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_state_json = [
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950420,
+        "fields": {
+            "answer": 1950412,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950421,
+        "fields": {
+            "answer": 1950413,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950422,
+        "fields": {
+            "answer": 1950414,
+            "state": 269,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950428,
+        "fields": {
+            "answer": 1950425,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.0355
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950434,
+        "fields": {
+            "answer": 1950426,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950435,
+        "fields": {
+            "answer": 1950430,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950436,
+        "fields": {
+            "answer": 1950432,
+            "state": 262,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950452,
+        "fields": {
+            "answer": 1950444,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950453,
+        "fields": {
+            "answer": 1950444,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950509,
+        "fields": {
+            "answer": 1950503,
+            "state": 264,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950510,
+        "fields": {
+            "answer": 1950503,
+            "state": 266,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950511,
+        "fields": {
+            "answer": 1950503,
+            "state": 269,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950512,
+        "fields": {
+            "answer": 1950503,
+            "state": 265,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950517,
+        "fields": {
+            "answer": 1950513,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950518,
+        "fields": {
+            "answer": 1950513,
+            "state": 260,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950519,
+        "fields": {
+            "answer": 1950513,
+            "state": 259,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950520,
+        "fields": {
+            "answer": 1950513,
+            "state": 255,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950563,
+        "fields": {
+            "answer": 1950558,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950564,
+        "fields": {
+            "answer": 1950558,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950565,
+        "fields": {
+            "answer": 1950558,
+            "state": 270,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950568,
+        "fields": {
+            "answer": 1950559,
+            "state": 262,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950569,
+        "fields": {
+            "answer": 1950559,
+            "state": 258,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950570,
+        "fields": {
+            "answer": 1950559,
+            "state": 260,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950572,
+        "fields": {
+            "answer": 1950560,
+            "state": 256,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950573,
+        "fields": {
+            "answer": 1950560,
+            "state": 257,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950575,
+        "fields": {
+            "answer": 1950561,
+            "state": 253,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950576,
+        "fields": {
+            "answer": 1950561,
+            "state": 251,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950577,
+        "fields": {
+            "answer": 1950561,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950871,
+        "fields": {
+            "answer": 1950863,
+            "state": 267,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950872,
+        "fields": {
+            "answer": 1950863,
+            "state": 268,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950873,
+        "fields": {
+            "answer": 1950864,
+            "state": 251,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950874,
+        "fields": {
+            "answer": 1950864,
+            "state": 252,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950875,
+        "fields": {
+            "answer": 1950865,
+            "state": 264,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950876,
+        "fields": {
+            "answer": 1950865,
+            "state": 265,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950877,
+        "fields": {
+            "answer": 1950865,
+            "state": 269,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950878,
+        "fields": {
+            "answer": 1950865,
+            "state": 266,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950879,
+        "fields": {
+            "answer": 1950866,
+            "state": 254,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950880,
+        "fields": {
+            "answer": 1950866,
+            "state": 263,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950881,
+        "fields": {
+            "answer": 1950866,
+            "state": 255,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950882,
+        "fields": {
+            "answer": 1950866,
+            "state": 253,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 1950889,
+        "fields": {
+            "answer": 1950560,
+            "state": 259,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "state_multiplier": 0.04
+        }
+    },
+
+]
+
+campaignTrail_temp.answer_feedback_json = [
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950381,
+        "fields": {
+            "answer": 1950012,
+            "candidate": 2001591,
+            "answer_feedback": "Over the past few months, you have consistently employed vague municipal rhetoric when addressing the media. Whether it's to manage troublesome press interactions or conceal your true intentions, you should start preparing for the presidential election sooner rather than later."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950383,
+        "fields": {
+            "answer": 1950013,
+            "candidate": 2001591,
+            "answer_feedback": "Even though you claim to be focusing on municipal affairs at the moment, your statement 'Regardless of any challenges' has been interpreted by the media as a precursor hinting at your intention to run for president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950386,
+        "fields": {
+            "answer": 1950014,
+            "candidate": 2001591,
+            "answer_feedback": "While you consistently emphasize your current focus on municipal affairs, a presidential election demands a significant amount of time and energy. Do you believe you can effectively balance your responsibilities in local governance while engaging in a campaign?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950392,
+        "fields": {
+            "answer": 1950388,
+            "candidate": 2001591,
+            "answer_feedback": "On May 17th, Terry Gou was drafted as the KMT's presidential candidate, and your qualification for the primary elections came to an end. In the time ahead, you can now focus exclusively on handling municipal affairs in New Taipei City."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950394,
+        "fields": {
+            "answer": 1950389,
+            "candidate": 2001591,
+            "answer_feedback": "While polite words may suggest otherwise, it's worth noting that you currently enjoy a leading advantage in the polls, and Terry Gou has yet to fully regain his Kuomintang membership."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950396,
+        "fields": {
+            "answer": 1950390,
+            "candidate": 2001591,
+            "answer_feedback": "The media spotlight has now turned towards you, with headlines from China Times and United Daily News: 'Mayor Hou Youyi Officially Announces Presidential Bid?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950401,
+        "fields": {
+            "answer": 1950399,
+            "candidate": 2001591,
+            "answer_feedback": "Understood. It seems you have chosen to continue focusing on municipal affairs, but I hope you won't acquire a reputation for being indifferent to party matters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950402,
+        "fields": {
+            "answer": 1950400,
+            "candidate": 2001591,
+            "answer_feedback": "Terry Gou is very grateful for your assistance and promises that he will bring down the Democratic Progressive Party. He assures you a position in the cabinet once elected."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950416,
+        "fields": {
+            "answer": 1950415,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950417,
+        "fields": {
+            "answer": 1950414,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950418,
+        "fields": {
+            "answer": 1950413,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950419,
+        "fields": {
+            "answer": 1950412,
+            "candidate": 2001591,
+            "answer_feedback": "Good luck to you, Chairman Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950427,
+        "fields": {
+            "answer": 1950425,
+            "candidate": 2001591,
+            "answer_feedback": "You spent the final day in your hometown. Wishing you good luck and hoping that you will be elected as the president tomorrow!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950429,
+        "fields": {
+            "answer": 1950426,
+            "candidate": 2001591,
+            "answer_feedback": "On Ketagalan Boulevard, amidst the bustling crowd of voters hoping for a political change, best of luck tomorrow!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950431,
+        "fields": {
+            "answer": 1950430,
+            "candidate": 2001591,
+            "answer_feedback": "You held the final event near the military dependents' village next to Kaohsiung Harbor, hoping that this would impact Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950433,
+        "fields": {
+            "answer": 1950432,
+            "candidate": 2001591,
+            "answer_feedback": "Absolutely, Taichung City serves as the dividing line between northern and southern Taiwan, making it a crucial region. Wishing you good luck!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950445,
+        "fields": {
+            "answer": 1950441,
+            "candidate": 2001591,
+            "answer_feedback": "You are rallying support from mayors across the country, and with the impressive lineup of 14+1 KMT-supported mayors this year, it will be a significant boost to your campaign."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950447,
+        "fields": {
+            "answer": 1950442,
+            "candidate": 2001591,
+            "answer_feedback": "Building good relationships with legislators is also a wise choice. If elected, you will rely on their support in the Legislative Yuan. Regional legislators can also positively influence your campaign in different areas."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950449,
+        "fields": {
+            "answer": 1950443,
+            "candidate": 2001591,
+            "answer_feedback": "In your interview on TVBS's Situation Room with Zhao Shao-kang, you spoke confidently and it brought you some media exposure. You also appeared on this program before the 2018 mayoral election."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950450,
+        "fields": {
+            "answer": 1950444,
+            "candidate": 2001591,
+            "answer_feedback": "Your participation in the completion events of various construction projects and local festivals in New Taipei City and Taipei City has increased your exposure and familiarity among the voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950458,
+        "fields": {
+            "answer": 1950454,
+            "candidate": 2001591,
+            "answer_feedback": "Terry Gou stated on Facebook: 'Mayor Hou is the most solid popular support within the Kuomintang. It is only natural and the best choice for him to take on greater responsibilities. He will keep his promises and exert utmost effort to support Mayor Hou's victory'."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950464,
+        "fields": {
+            "answer": 1950463,
+            "candidate": 2001591,
+            "answer_feedback": "Focusing your energy primarily on the DPP can shape a blue-green confrontation atmosphere, but be cautious. Balance your critiques, as the public is weary of excessive attacks rather than positive campaigning."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950468,
+        "fields": {
+            "answer": 1950462,
+            "candidate": 2001591,
+            "answer_feedback": "As now, Ko Wen-je has not supported your request. He mentioned that it is difficult to cooperate due to differences in policy and ideology between him and the Kuomintang."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950471,
+        "fields": {
+            "answer": 1950461,
+            "candidate": 2001591,
+            "answer_feedback": "Initiating infighting within the opposition camp this early is not good news. It will only benefit the DPP and create a negative impression of the KMT, portraying it as solely focused on attacks without a clear vision."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950474,
+        "fields": {
+            "answer": 1950460,
+            "candidate": 2001591,
+            "answer_feedback": "Currently, this strategy ensures the independence of your party. However, there will come a day when you need to discuss collaboration against the DPP, so please be prepared."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950481,
+        "fields": {
+            "answer": 1950477,
+            "candidate": 2001591,
+            "answer_feedback": "Unfortunately, parents cannot wait until the slow administrative and police investigations conclude. Taking advantage of the situation, DPP legislators, along with some parents, held a press conference attacking the efficiency of Mayor Hou's government in handling the case. Your Polls have plummeted as if falling from a skyscraper."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950483,
+        "fields": {
+            "answer": 1950478,
+            "candidate": 2001591,
+            "answer_feedback": "With children claiming they were fed 'colorful potions,' and some showing signs of barbital, awaiting confirmation through hair tests, the credibility of the city government has been damaged. It is essential to conduct a thorough investigation into other kindergartens to prevent any potential issues. This incident has left parents across Taiwan concerned."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950485,
+        "fields": {
+            "answer": 1950479,
+            "candidate": 2001591,
+            "answer_feedback": "You and your city government are facing severe criticism for this incident. Parents are questioning why they reported the case in mid-May and attempted to contact through the mayor's mailbox, but did not receive a response from the government at that time."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950491,
+        "fields": {
+            "answer": 1950487,
+            "candidate": 2001591,
+            "answer_feedback": "Your response at National Chengchi University was disliked by young people; they feel you didn't directly answer the questions. Your standard-style responses are derogatorily referred to as HOHOGPT."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950494,
+        "fields": {
+            "answer": 1950488,
+            "candidate": 2001591,
+            "answer_feedback": "The video of your evasive answers at National Chengchi University has been widely circulated on various news media platforms, drawing a lot of mockery from young people. Even legislator Ko Chih-en believes that this has caused significant damage to your image."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950497,
+        "fields": {
+            "answer": 1950490,
+            "candidate": 2001591,
+            "answer_feedback": "Before to this, you spoke about housing prices for ten minutes, and even your more normal responses were drowned out by online ridicule and the attacks from opponents on the kindergarten incident."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950505,
+        "fields": {
+            "answer": 1950502,
+            "candidate": 2001591,
+            "answer_feedback": "Lien Chan, despite his 87-year-old frame, has released an open letter in his own name, urging all members of the Kuomintang to support Hou You-yi."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950507,
+        "fields": {
+            "answer": 1950503,
+            "candidate": 2001591,
+            "answer_feedback": "Wu Poh-hsiung, leaning on his cane, strongly supports Hou You-yi, referring to him as \"brothers in adversity.\" He mentioned that the more people get to know him, the more they like him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950514,
+        "fields": {
+            "answer": 1950504,
+            "candidate": 2001591,
+            "answer_feedback": "Ma Ying-jeou has agreed to assist you, and he will recruit a highly valuable individual to support your campaign. As for the specific person, it cannot be disclosed at this moment."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950515,
+        "fields": {
+            "answer": 1950513,
+            "candidate": 2001591,
+            "answer_feedback": "Speaker Wang Jin-ping has successfully organized a legislative support group for you. At the very least, you have the support of the party organization and legislative members, and they have decided to fully support Hou You-yi in the upcoming campaign."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950522,
+        "fields": {
+            "answer": 1950521,
+            "candidate": 2001591,
+            "answer_feedback": "With this news, the media has begun discussing the impact and assistance that 'Little Knife King' (金小刀) might bring to your campaign. After all, he played a crucial role in helping Ma defeat Tsai in 2012, and at that time, Tsai was already a formidable opponent who would become the president in 2016."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950526,
+        "fields": {
+            "answer": 1950525,
+            "candidate": 2001591,
+            "answer_feedback": "You might think it's a clever move, but in reality, the keen-eyed media has caught onto your subtle actions. They interpret your move of pulling a chair next to Han Kuo-yu as a deliberate attempt to cozy up to him, and this has been met with mockery."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950529,
+        "fields": {
+            "answer": 1950523,
+            "candidate": 2001591,
+            "answer_feedback": "While your apology to Han Kuo-yu is accepted, his supporters remain unconvinced and continue to harbor resentment towards you. To win them over, it may require direct intervention and efforts from Han himself."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950530,
+        "fields": {
+            "answer": 1950524,
+            "candidate": 2001591,
+            "answer_feedback": "you serious? Not offering an apology to Han Kuo-yu in this situation might make it challenging to win back his supporters. The swing voters may not necessarily lean towards you, and as for Han's fans, if presented with other options, you know where they might turn."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950538,
+        "fields": {
+            "answer": 1950535,
+            "candidate": 2001591,
+            "answer_feedback": "It seems like your campaign has finally returned to the right track. Many people find it difficult to accept KMT candidates who do not adhere to the 1992 Consensus, while others simply do not accept the consensus at all."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950543,
+        "fields": {
+            "answer": 1950537,
+            "candidate": 2001591,
+            "answer_feedback": "Businessmen worship Guan Gong just to seek his blessings for them to earn more money."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950544,
+        "fields": {
+            "answer": 1950536,
+            "candidate": 2001591,
+            "answer_feedback": "There are several nuclear power plants in New Taipei, However, due to concerns about safety, you have not allowed them to insert nuclear fuel rods, and there is no particularly specific and feasible plan for nuclear waste."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950551,
+        "fields": {
+            "answer": 1950550,
+            "candidate": 2001591,
+            "answer_feedback": "After this , a portion of Han's supporters has shifted their support towards you, solidifying unity within the party!This marks the beginning of your resurgence in the polls!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950562,
+        "fields": {
+            "answer": 1950558,
+            "candidate": 2001591,
+            "answer_feedback": "Strengthening our base is always essential, but we must be cautious as Ko Wen-je and Terry Gou may divert crucial pan-blue votes!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950566,
+        "fields": {
+            "answer": 1950559,
+            "candidate": 2001591,
+            "answer_feedback": "Capturing the crucial central region is indeed a priority, especially focusing on Changhua, where a significant number of Minnan people reside. You might have a good chance to perform well there!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950571,
+        "fields": {
+            "answer": 1950560,
+            "candidate": 2001591,
+            "answer_feedback": "It seems like you must secure victory in your hometown; otherwise, it might not look good. At least ensure that Puzi City stays blue, alright?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950574,
+        "fields": {
+            "answer": 1950561,
+            "candidate": 2001591,
+            "answer_feedback": "Although holding a KMT membership in the south often means not winning, your southern identity and local Taiwanese flavor could work in your favor."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950578,
+        "fields": {
+            "answer": 1950489,
+            "candidate": 2001591,
+            "answer_feedback": "Angry students demand direct answers from you... Shifting topics here is not a good move."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950583,
+        "fields": {
+            "answer": 1950579,
+            "candidate": 2001591,
+            "answer_feedback": "The DPP government indeed lacks effective measures against fraud, and their anti-fraud task force is seen as a waste of time and money. However, it remains questionable how many votes you can sway on this issue."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950585,
+        "fields": {
+            "answer": 1950580,
+            "candidate": 2001591,
+            "answer_feedback": "Since 2022, the military threat from the mainland towards Taiwan has intensified. The DPP government, however, has yet to proactively ease the situation. Nevertheless, this can stir up the green base and anti-China sentiments."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950586,
+        "fields": {
+            "answer": 1950581,
+            "candidate": 2001591,
+            "answer_feedback": "While the digital development department, led by Tang Feng, is widely seen as a failure, the current government is reluctant to replace him. Moreover, this issue is not a top concern for the voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950590,
+        "fields": {
+            "answer": 1950582,
+            "candidate": 2001591,
+            "answer_feedback": "This strategy aims to strengthen your deep blue support base. However, many green supporters in Taiwan see CTiTV as pro-China media that could undermine Taiwan's free and democratic system."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950594,
+        "fields": {
+            "answer": 1950593,
+            "candidate": 2001591,
+            "answer_feedback": "death penalty is a sensitive point for the DPP. They have to moderate their stance on this issue. They might argue that Taiwan has not abolished the death penalty, but the number of executions during the DPP's term is significantly lower than during Ma Ying-jeou's presidency."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950598,
+        "fields": {
+            "answer": 1950597,
+            "candidate": 2001591,
+            "answer_feedback": "DPP criticizes your approach, claiming that it aims to return to the era of one-party rule, and they argue that there would be no oversight for the SPD. However, this is undoubtedly well-received among supporters of the blue camp!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950603,
+        "fields": {
+            "answer": 1950599,
+            "candidate": 2001591,
+            "answer_feedback": "This is your attempt to attract young people, but it doesn't seem to be effective. All candidates support the construction of public housing and a property hoarding tax, so it may not have a unique appeal."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950605,
+        "fields": {
+            "answer": 1950600,
+            "candidate": 2001591,
+            "answer_feedback": "on this issue, the KMT and DPP have completely opposite policies, with significant differences. Nuclear power also offers the advantage of generating electricity at a lower cost."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950612,
+        "fields": {
+            "answer": 1950609,
+            "candidate": 2001591,
+            "answer_feedback": "Hey, isn't your attack a bit too much? You might be angry with him, but opposition voters don't want to see more attacks and divisions. This will only help Ko Wen-je gain more support."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950613,
+        "fields": {
+            "answer": 1950610,
+            "candidate": 2001591,
+            "answer_feedback": "These are empty words and useless statements; Terry Gou has already announced his independent candidacy, and he won't stop now."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950614,
+        "fields": {
+            "answer": 1950611,
+            "candidate": 2001591,
+            "answer_feedback": "This is a very interesting advertisement that has caught the media's attention. Many believe that you released this video to satirize Terry Gou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950618,
+        "fields": {
+            "answer": 1950615,
+            "candidate": 2001591,
+            "answer_feedback": "This is a favorable proposal for you, but it's evident that TPP won't accept it as their party members and support base are lower than yours. Anyway, you've tossed the ball back to them."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950620,
+        "fields": {
+            "answer": 1950616,
+            "candidate": 2001591,
+            "answer_feedback": "While what you say is true, it might create an image of you overpowering a smaller party, and TPP supporters may perceive you as timid, hiding behind the strength of the KMT."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950621,
+        "fields": {
+            "answer": 1950617,
+            "candidate": 2001591,
+            "answer_feedback": "Certainly, negotiations will continue, but you must reach an agreement before November 24th; otherwise, this election will turn into a three-way competition!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950650,
+        "fields": {
+            "answer": 1950649,
+            "candidate": 2001591,
+            "answer_feedback": "Compared to Vice President Lai Ching-te, you have indeed met with more important figures. This will be helpful for you and add more points to your international diplomatic efforts."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950651,
+        "fields": {
+            "answer": 1950647,
+            "candidate": 2001591,
+            "answer_feedback": "Three Principles of the People encompass nationalism, democracy, and people's livelihood. However, it also has a complex historical relationship with by the people, for the people.and of the people.Unfortunately, in modern times, few Taiwanese can comprehend your political discourse."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950652,
+        "fields": {
+            "answer": 1950648,
+            "candidate": 2001591,
+            "answer_feedback": "In November 1997, when criminals broke into the home of a South African military attaché and kidnapped his entire family, you helped rescue the baby. The infant, who was in your arms back then, has grown up, touching the hearts of many."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950661,
+        "fields": {
+            "answer": 1950658,
+            "candidate": 2001591,
+            "answer_feedback": "This will significantly alleviate the differences between Hou and Han, bringing back the majority of Han's supporters into the Kuomintang camp!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950664,
+        "fields": {
+            "answer": 1950659,
+            "candidate": 2001591,
+            "answer_feedback": "This can enhance Mayor Hou's image in terms of law and order, helping boost his scores in public safety. It will contribute to an improvement in Mayor Hou You-yi's standings in the polls."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950667,
+        "fields": {
+            "answer": 1950660,
+            "candidate": 2001591,
+            "answer_feedback": "Stirring up hatred against the DPP and instilling fear of war is a common tactic. However, here, you mentioned that Mayor Hou You-yi will unite more people who believe in these ideas around him!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950672,
+        "fields": {
+            "answer": 1950670,
+            "candidate": 2001591,
+            "answer_feedback": "From now on, polls will begin to assess your specific data. This will determine the fate of Taiwan. Good luck, Mayor Hou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950673,
+        "fields": {
+            "answer": 1950671,
+            "candidate": 2001591,
+            "answer_feedback": "From now on, polls will begin to assess your specific data. This will determine the fate of Taiwan. Good luck, Mayor Hou."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950694,
+        "fields": {
+            "answer": 1950688,
+            "candidate": 2001591,
+            "answer_feedback": "Unfortunately, Ko Wen-je seems unwilling to form an alliance, as his core supporters and aides strongly oppose cooperation with the KMT. Additionally, he is considering excluding indoor telephone polls, as this would benefit Hou..."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950695,
+        "fields": {
+            "answer": 1950691,
+            "candidate": 2001591,
+            "answer_feedback": "Damn... Ko Wen-je's family is exerting significant pressure on him, especially his mother and wife. His mother only wants her son to run for the presidency, while his wife is ignoring calls from Hou You-yi..."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950696,
+        "fields": {
+            "answer": 1950692,
+            "candidate": 2001591,
+            "answer_feedback": "Damn... Under the interference of Ko Wen-je, his staff, and family, on the 18th, TPP's polling experts suggested excluding all indoor phone polls, and the margin of error in other polls became a contentious issue... "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950697,
+        "fields": {
+            "answer": 1950693,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je's supporters and TPP immediately started spreading online that the margin of error the KMT needs to concede is not the commonly perceived 3% but rather a range of plus or minus 3%. This implies that the KMT is asking Ko Wen-je to concede a margin of error of 6%."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950725,
+        "fields": {
+            "answer": 1950721,
+            "candidate": 2001591,
+            "answer_feedback": "It seems there's a big problem... Both sides are in constant dispute over the margin of error and which poll each side won. No decision was made on the 18th... Is this reaching a breaking point?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950726,
+        "fields": {
+            "answer": 1950722,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je's supporters and TPP immediately started spreading online that the margin of error the KMT needs to concede is not the commonly perceived 3% but rather a range of plus or minus 3%. This implies that the KMT is asking Ko Wen-je to concede a margin of error of 6%."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950727,
+        "fields": {
+            "answer": 1950723,
+            "candidate": 2001591,
+            "answer_feedback": "It seems there's a big problem... Both sides are in constant dispute over the margin of error and which poll each side won. No decision was made on the 18th... Is this reaching a breaking point?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950728,
+        "fields": {
+            "answer": 1950724,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je's supporters and TPP immediately started spreading online that the margin of error the KMT needs to concede is not the commonly perceived 3% but rather a range of plus or minus 3%. This implies that the KMT is asking Ko Wen-je to concede a margin of error of 6%."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950741,
+        "fields": {
+            "answer": 1950737,
+            "candidate": 2001591,
+            "answer_feedback": "Ko agrees but immediately counterattacks, stating that revealing private conversations is something only internet trolls and unscrupulous media outlets would do. Fortunately, this ensures Terry Gou's withdrawal as they announce that he will not register as a presidential candidate."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950743,
+        "fields": {
+            "answer": 1950738,
+            "candidate": 2001591,
+            "answer_feedback": "Regardless of how you explain it, it's too late. Joint tickets have already failed since the time when the polls became controversial."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950746,
+        "fields": {
+            "answer": 1950739,
+            "candidate": 2001591,
+            "answer_feedback": "Ko Wen-je refuses to withdraw from the election, declaring that as long as his supporters don't give up, he won't either. The only consolation is that Terry Gou has withdrawn from the election and stated that he will not continue to participate."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950747,
+        "fields": {
+            "answer": 1950740,
+            "candidate": 2001591,
+            "answer_feedback": "both Ko Wen-je and Gou believe they have the right to independently continue their candidacies. Despite Gou's low polling numbers, he still managed to gather 940,000 citizen signatures. With the situation completely collapsing, you might need to prepare for a concession speech."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950756,
+        "fields": {
+            "answer": 1950751,
+            "candidate": 2001591,
+            "answer_feedback": "After careful consideration, Zhao requests you to make a final call to Ko Wen-je. Upon learning that Ko Wen-je and Cynthia Wu have already registered as presidential candidates, Zhao immediately joins you in heading to the Central Election Commission (CEC) and registers as a candidate alongside you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950757,
+        "fields": {
+            "answer": 1950755,
+            "candidate": 2001591,
+            "answer_feedback": "After careful consideration, Zhao requests you to make a final call to Ko Wen-je. Upon learning that Ko Wen-je and Cynthia Wu have already registered as presidential candidates, Zhao immediately joins you in heading to the Central Election Commission (CEC) and registers as a candidate alongside you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950767,
+        "fields": {
+            "answer": 1950766,
+            "candidate": 2001591,
+            "answer_feedback": "This is a direct criticism of the DPP. Considering that the Kuomintang might be perceived as too focused on attacks, you must offer the people a new hope to have a chance at winning."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950771,
+        "fields": {
+            "answer": 1950765,
+            "candidate": 2001591,
+            "answer_feedback": "Unfortunately, during the policy statement event, you mistakenly referred to \"Hou You-yi\" as \"Lai Ching-te,\" turning it into a big joke. Damn it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950774,
+        "fields": {
+            "answer": 1950764,
+            "candidate": 2001591,
+            "answer_feedback": "We understand that the story of the Three Kingdoms is popular and interesting, but the DPP continues to question the relationship between you and Hou. They still portray Hou as your puppet..."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950785,
+        "fields": {
+            "answer": 1950784,
+            "candidate": 2001591,
+            "answer_feedback": "You might think it's cool, but the news of violent demolition of Lai Ching-te's ancestral home has triggered a backlash among swing voters and the green base. The public is showing even more sympathy towards him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950788,
+        "fields": {
+            "answer": 1950783,
+            "candidate": 2001591,
+            "answer_feedback": "That's the correct choice. Lai Ching-te's unauthorized construction was built a long time ago and hasn't posed any safety hazards. Most people aren't very concerned about this issue, so it's best not to overreact."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950789,
+        "fields": {
+            "answer": 1950782,
+            "candidate": 2001591,
+            "answer_feedback": "Perhaps Lai Ching-te hasn't handled this issue well, but regardless, many local residents support him. Your ads have inadvertently backfired, generating a negative impact with excessive aggression. It might be more beneficial to reconsider the tone and approach to avoid alienating potential supporters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950790,
+        "fields": {
+            "answer": 1950781,
+            "candidate": 2001591,
+            "answer_feedback": "Lai may indeed lack transparency in this matter, and his teary performance may not garner much sympathy. However, pursuing an attack specifically targeting personal and family matters may not be the best choice, as such tactics are generally unpopular. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950800,
+        "fields": {
+            "answer": 1950796,
+            "candidate": 2001591,
+            "answer_feedback": "This response is indeed very good. it further enhance the negative image among young people and the DPP. While these are facts, it seems that the Taiwanese public might not be receptive to such a stance.nice try."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950803,
+        "fields": {
+            "answer": 1950797,
+            "candidate": 2001591,
+            "answer_feedback": "This helps to immediately stop the bleeding. However, your image as a landlord has already become disliked by some young people, and they won't easily change their minds because of this."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950807,
+        "fields": {
+            "answer": 1950798,
+            "candidate": 2001591,
+            "answer_feedback": "Mutual attacks will only make things worse and strengthen the support bases on both sides. If that's what you prefer, then let it be."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950808,
+        "fields": {
+            "answer": 1950799,
+            "candidate": 2001591,
+            "answer_feedback": "While your image among young people may have further deteriorated, fortunately, most pan-blue and swing voters seem to understand. They recognize that this issue doesn't involve personal character but rather legal business operations."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950819,
+        "fields": {
+            "answer": 1950818,
+            "candidate": 2001591,
+            "answer_feedback": "This will strengthen the Kuomintang's image in national defense and help alleviate concerns among Americans about KMT's pro-China stance."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950822,
+        "fields": {
+            "answer": 1950814,
+            "candidate": 2001591,
+            "answer_feedback": "The effectiveness of this advertisement may not match the one from 2008, but it still resonates and is quite impactful. Well done!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950825,
+        "fields": {
+            "answer": 1950815,
+            "candidate": 2001591,
+            "answer_feedback": "Choosing to engage in close combat with the DPP has its benefits as you can inflict damage, but the downside is that people have less hope for you, only seeing more of your attacks."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950828,
+        "fields": {
+            "answer": 1950816,
+            "candidate": 2001591,
+            "answer_feedback": "This policy is not considered very favorable. While the loan amount is flexible, the substantial monthly repayments pose a heavy burden for young people. Failing to repay could potentially ruin their lives."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950832,
+        "fields": {
+            "answer": 1950817,
+            "candidate": 2001591,
+            "answer_feedback": "This will solidify your base, as most of the opposition voters are reluctant to vote for the DPP. However, winning will still depend on the preferences of swing voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950843,
+        "fields": {
+            "answer": 1950838,
+            "candidate": 2001591,
+            "answer_feedback": "Mayor Hou, you and your supporters sincerely hope for your victory.They hope you can address Taiwan's public safety and fraud issues!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950845,
+        "fields": {
+            "answer": 1950839,
+            "candidate": 2001591,
+            "answer_feedback": "This is a very ambitious goal, and if it involves amending the constitution, it will require bipartisan cooperation. But at least you have set a clear objective."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950847,
+        "fields": {
+            "answer": 1950840,
+            "candidate": 2001591,
+            "answer_feedback": "Over 80% of Taiwanese people support the death penalty, while the DPP has been ambiguous on this issue, reducing the number of executions. Ko believes that if the death penalty is to be abolished, life imprisonment must be maintained."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950849,
+        "fields": {
+            "answer": 1950841,
+            "candidate": 2001591,
+            "answer_feedback": "This will rally your deep-blue supporters and boost their voter turnout. Hopefully, on the anniversary of Mr. Chiang Ching-kuo's passing, you can achieve victory!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950854,
+        "fields": {
+            "answer": 1950852,
+            "candidate": 2001591,
+            "answer_feedback": "Whether it's good or bad, this highlights internal divisions and ideological issues within the Kuomintang. Hopefully, this won't cause you too much harm."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950856,
+        "fields": {
+            "answer": 1950853,
+            "candidate": 2001591,
+            "answer_feedback": "As a light-blue presidential candidate, attacking our only former president is a very serious matter. You may risk losing some core support base votes. Is it really worth it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950859,
+        "fields": {
+            "answer": 1950858,
+            "candidate": 2001591,
+            "answer_feedback": "While this avoids the emergence of internal party disputes, it may lead to disapproval from the moderate voters. Hopefully, your base is solid enough."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950867,
+        "fields": {
+            "answer": 1950866,
+            "candidate": 2001591,
+            "answer_feedback": "After the final campaign event with our native friends, you had a good night's sleep and am ready to cast you vote tomorrow."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950868,
+        "fields": {
+            "answer": 1950865,
+            "candidate": 2001591,
+            "answer_feedback": "In Taoyuan, you have connected well with the Hakka community, strengthening your support base. Best of luck to you in tomorrow's election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950869,
+        "fields": {
+            "answer": 1950864,
+            "candidate": 2001591,
+            "answer_feedback": "If Lai Ching-te were to fall from grace over one thing, it would be the loss of his stronghold. You and Zhao Shao-kang have delivered speeches in Tainan and Kaohsiung using Taiwanese, snatching away votes!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950870,
+        "fields": {
+            "answer": 1950863,
+            "candidate": 2001591,
+            "answer_feedback": "Strengthening your own stronghold is always a good move. New Taipei City is an enormously important vote bank, equivalent to four Changhua Counties. Any presidential candidate cannot afford to lose here."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950894,
+        "fields": {
+            "answer": 1950891,
+            "candidate": 2001591,
+            "answer_feedback": "He can attract many young votes for you; however, since he formed an alliance with the KMT, some of the lightly green-leaning young people have distanced themselves from him. He cannot transfer all of his votes to you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950895,
+        "fields": {
+            "answer": 1950892,
+            "candidate": 2001591,
+            "answer_feedback": "At present, you are leading in the polls, but you must be cautious about unforeseen events. It's best not to make significant moves at this time!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950896,
+        "fields": {
+            "answer": 1950893,
+            "candidate": 2001591,
+            "answer_feedback": "To achieve this alliance, you must accept some of the TPP's political positions and reform demands. If this is the collective will of the Taiwanese people, then you will be elected on January 13 next year."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950905,
+        "fields": {
+            "answer": 1950903,
+            "candidate": 2001591,
+            "answer_feedback": "In the last presidential election, the Democratic Progressive Party (DPP) secured 8.17 million votes. Can you, with the consensus of the majority of the Taiwanese people, surpass this historical record?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950907,
+        "fields": {
+            "answer": 1950902,
+            "candidate": 2001591,
+            "answer_feedback": "The checks and balances between political parties could be the optimal way to ensure a democratic system, but the downside is that your governance may face constraints."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950908,
+        "fields": {
+            "answer": 1950901,
+            "candidate": 2001591,
+            "answer_feedback": "The Parliamentary system is indeed a challenging goal. Even if you win, amending the constitution or pushing through extensive reforms will require cooperation from the DPP. Gaining more seats in the parliament becomes crucial in this context."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950916,
+        "fields": {
+            "answer": 1950912,
+            "candidate": 2001591,
+            "answer_feedback": "Lai Ching-te may be a flip-flopper, but you have to understand that his base will tolerate him no matter what. The room for maneuvering among the swing voters in the center has diminished considerably."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950918,
+        "fields": {
+            "answer": 1950913,
+            "candidate": 2001591,
+            "answer_feedback": "This is a direct confrontation between the blue and green camps, and we hope you can emerge victorious here!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950922,
+        "fields": {
+            "answer": 1950914,
+            "candidate": 2001591,
+            "answer_feedback": "This will weaken the DPP's red-baiting tactics against you and help restore the KMT's anti-communist image. Moreover, being a true local, your Taiwan-centric image is even stronger than that of Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950923,
+        "fields": {
+            "answer": 1950915,
+            "candidate": 2001591,
+            "answer_feedback": "Lai Ching-te also comes from a humble background; however, his current image carries more of an elite vibe, while you appear similar to an ordinary uncle on the street."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950929,
+        "fields": {
+            "answer": 1950928,
+            "candidate": 2001591,
+            "answer_feedback": "The current lead you have in the polls may easily disappear due to scandals or failed strategies; public opinion is fluid, so proceed with caution!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950937,
+        "fields": {
+            "answer": 1950936,
+            "candidate": 2001591,
+            "answer_feedback": "Guo is definitely trailing in this election, and your appeal to his voters will not be ignored!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950940,
+        "fields": {
+            "answer": 1950935,
+            "candidate": 2001591,
+            "answer_feedback": "Although some in the TPP doubt whether you are only aiming to defeat Ko Wen-je and secure the second position, rather than focusing on attacking Lai Ching-te, the votes are likely to flow significantly between opposition parties."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950943,
+        "fields": {
+            "answer": 1950934,
+            "candidate": 2001591,
+            "answer_feedback": "Lai Ching-te may be a flip-flopper, but you have to understand that his base will tolerate him no matter what. The room for maneuvering among the swing voters in the center has diminished considerably."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950947,
+        "fields": {
+            "answer": 1950946,
+            "candidate": 2001591,
+            "answer_feedback": "He indeed cannot win this election, so the hope for the Pan-Blue Coalition's victory lies here: whoever can secure the support of Terry Gou's voters will be able to win!"
+        }
+    }
+]
+
+cyoAdventure = function (a) {
+    ans = campaignTrail_temp.player_answers[campaignTrail_temp.player_answers.length-1];
+    if (ans == 13019 || 13020 || 13021 ){
+        campaignTrail_temp.election_json[0]["fields"].advisor_url = "https://i.imgur.com/BZlgvel.jpeg";
+    }
+    if (ans == 1950388 ){
+        campaignTrail_temp.questions_json[2] = {
+            "model": "campaign_trail.question",
+            "pk": 1950398,
+            "fields": {
+              "priority": 1,
+              "description": "Since you have withdrawn from the primary and essentially paved the way for Terry Gou to secure the presidential candidate position, how do you plan to support him in the upcoming electoral campaign?",
+              "likelihood": 1
+            }
+          }
+        }
+        if (ans == 1950399 ){
+            campaignTrail_temp.candidate_json[2]["fields"].first_name = "";
+            campaignTrail_temp.candidate_json[2]["fields"].last_name = "Terry Gou";
+            campaignTrail_temp.candidate_json[6]["fields"].last_name = "None";
+            campaignTrail_temp.candidate_last_name = 'Terry Gou';
+            campaignTrail_temp.candidate_image_url = 'https://www.foxconn.com/img/about/group-profile/founder-m.png?5f65a';
+            campaignTrail_temp.running_mate_image_url = 'https://img.ltn.com.tw/Upload/news/600/2015/10/07/phpbfQCOW.jpg';
+            campaignTrail_temp.running_mate_last_name = 'Hong Xiuzhu';
+            campaignTrail_temp.question_number = 28;
+            campaignTrail_temp.questions_json[29] = {
+                "model": "campaign_trail.question",
+                "pk": 1950411,
+                "fields": {
+                  "priority": 1,
+                  "description": "Today is the last day before the election, and your polls have been consistently declining since your nomination. The deadlock with Ko Wen-je and the lead by Lai Ching-te have not been broken, and the situation persists until the registration of presidential candidates in November. There are hardly any person willing to be your vice president, until Hong Xiu-Zhu, whose nomination was abolished in 2016, volunteered. It is only then that you have a vice presidential candidate to appear on the ballot. On the final day before the election, where do you plan to conduct your campaign activities?",
+                  "likelihood": 1
+                }
+              }
+        }
+        if (ans == 1950400 ){
+            campaignTrail_temp.candidate_json[2]["fields"].first_name = "";
+            campaignTrail_temp.candidate_json[2]["fields"].last_name = "Terry Gou";
+            campaignTrail_temp.candidate_json[6]["fields"].last_name = "None";
+            campaignTrail_temp.candidate_last_name = 'Terry Gou';
+            campaignTrail_temp.candidate_image_url = 'https://www.foxconn.com/img/about/group-profile/founder-m.png?5f65a';
+            campaignTrail_temp.running_mate_image_url = 'https://i.imgur.com/ZmWU9KE.png';
+            campaignTrail_temp.running_mate_last_name = 'Lai Pei-hsia';
+            campaignTrail_temp.question_number = 28;
+            campaignTrail_temp.questions_json[29] = {
+                "model": "campaign_trail.question",
+                "pk": 1950424,
+                "fields": {
+                  "priority": 1,
+                  "description": "Today is the last day before the election, On the final day before the election,  According to the latest polls conducted 10 days before the election, your and Lai Ching-te's approval ratings are within the margin of error. In other words, the presidential position hinges on a difference of just 500,000 votes.where do you plan to conduct your campaign activities?",
+                  "likelihood": 1
+                }
+              }
+        }      
+        if (ans == 1950740 ){
+            campaignTrail_temp.questions_json[27] = {
+                "model": "campaign_trail.question",
+                "pk": 1950933,
+                "fields": {
+                  "priority": 1,
+                  "description": "This year's presidential debate has an unprecedented presence of four presidential candidates: yourself, Lai Ching-te, Ko Wen-je, and the former Chairman of Hon Hai Precision Industry, Terry Gou, who does not support you. In this year's presidential debate, what main points do you want to convey?                  ",
+                  "likelihood": 1
+                }
+              }
+        }
+        
+        if (ans == 1950751 || ans == 1950755 ){
+            campaignTrail_temp.running_mate_image_url = 'https://i.imgur.com/W8ycwUr.png';
+            campaignTrail_temp.running_mate_last_name = 'Zhao';
+        }
+        //蓝白合 直接选侯赵将消失   
+
+                //赵子龙
+                getResults = function (out, totv, aa, quickstats) {
+                    if( aa[0].candidate === 2001591 && aa[2].candidate === 2001622 && aa[1].candidate === 2001557 && e.player_answers.includes(1950537) && e.player_answers.includes(1950611) && e.player_answers.includes(1950764)) {
+                        unlockAchievement("Three Kingdom Romance");
+                          }
+                         }
+                    //三民主义
+                        getResults = function (out, totv, aa, quickstats) {
+                       if( aa[0].candidate === 2001591 && e.player_answers.includes(1950647) && e.player_answers.includes(1950740) ) {
+                           unlockAchievement("Three Principles of People");
+                             }
+                            }
+                       //果冻获胜
+                        getResults = function (out, totv, aa, quickstats) {
+                       if( aa[0].candidate === 2001591 && e.player_answers.includes(1950388) && e.player_answers.includes(1950400)){
+                           unlockAchievement("New Taipei Has A Mayor");
+                             }
+                            }
+                        //嘉义之子
+                        getResults = function (out, totv, aa, quickstats) {
+                            let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 256);
+                            let stateResulttwo = campaignTrail_temp.final_state_results.find((x) => x.state == 257);
+                            let stateResultthree = campaignTrail_temp.final_state_results.find((x) => x.state == 267);
+                        if( aa[0].candidate === 2001591 && stateResult.result[0].candidate == 2001591 && stateResulttwo.result[0].candidate == 2001591 && stateResultthree.result[0].candidate == 2001591) {
+                            unlockAchievement("Chiayi favorite son");
+                        }
+                    }
+                 //主流民意获胜
+                 getResults = function (out, totv, aa, quickstats) {
+                                if( aa[0].candidate === 2001591 && quickstats[1] > 59.9) {
+                                    unlockAchievement("Main Stream Opinion Wins");
+                                }
+                            }
+                 //南部孩子回家了
+                 getResults = function (out, totv, aa, quickstats) {
+                    let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 256);
+                    let stateResulttwo = campaignTrail_temp.final_state_results.find((x) => x.state == 257);
+                    let stateResultthree = campaignTrail_temp.final_state_results.find((x) => x.state == 259);
+                    let stateResultfour = campaignTrail_temp.final_state_results.find((x) => x.state == 260);
+                    let stateResultfive = campaignTrail_temp.final_state_results.find((x) => x.state == 263);
+                    let stateResultsix = campaignTrail_temp.final_state_results.find((x) => x.state == 253);
+                    
+                    if( aa[0].candidate === 2001591 && stateResult.result[0].candidate == 2001591 && stateResulttwo.result[0].candidate == 2001591 && stateResultthree.result[0].candidate == 2001591 && stateResultfour.result[0].candidate == 2001591 && stateResultfive.result[0].candidate == 2001591 && stateResultsix.result[0].candidate == 2001591) {
+                        unlockAchievement("Southern Boys Returning Home");
+                    }
+                }
+            
+                getResults = function (out, totv, aa, quickstats) {
+                    if( aa[1].candidate === 2001591 && quickstats[1] < 31.04) {
+                        unlockAchievement("Challenge the Bottom Line");
+                    }
+                }
+            //各党标题
+    if ( ans == 1950012 || ans == 1950013 || ans == 1950014 ){    
+        nct_stuff.themes[nct_stuff.selectedTheme].coloring_window = "#f4f4ee" 
+        nct_stuff.themes[nct_stuff.selectedTheme].coloring_title = "#13366e" 
+        $(".container")[0].style.backgroundColor = "#6848ff" 
+        $("#game_window")[0].style.borderColor = "#99A0A8" 
+        $(".container")[0].style.backgroundColor = "#F4F4EE" 
+        $("#game_window")[0].style.borderColor = "#f4f4ee" 
+        $("#game_window")[0].style.backgroundImage = "url(https://imgur.com/3praAwi.jpg)" 
+        document.getElementById("header").src = "https://i.imgur.com/I7YpjTe.jpeg" 
+        document.body.background = "https://i.imgur.com/cknN16g.jpg"
+    }
+    }
+
+campaignTrail_temp.jet_data = [{}
+]
+
+campaignTrail_temp.candidate_image_url = "https://i.imgur.com/GCeTdoX.png";
+campaignTrail_temp.running_mate_image_url = "https://i.imgur.com/KLN8hlP.jpeg";
+campaignTrail_temp.candidate_last_name = "Hou";
+campaignTrail_temp.running_mate_last_name = "For KMT 2024";
+campaignTrail_temp.running_mate_state_id = '265';
+campaignTrail_temp.player_answers = [];
+campaignTrail_temp.player_visits = [];
+campaignTrail_temp.answer_feedback_flg = 1;
+campaignTrail_temp.game_start_logging_id = '3660822';
+
+const style_overwrite = document.createElement("style");
+style_overwrite.innerHTML = 
+`#campaign_sign {
+    background-color: #13366e;
+    border-color: #b22525;
+}
+#menu_container {
+  background-color: #c3c3c3;
+}
+#overall_result_container {
+  background-color: #c3c3c3;
+}
+#state_info h3 {
+  background-color: #ffffff;
+}
+#overall_result h3 {
+  background-color: #ffffff;
+}`
+;
+document.head.appendChild(style_overwrite);
+
+
+let style = document.createElement('style');
+style.type = 'text/css';
+style.id = 'dynamic-style';
+
+style.innerHTML = `
+  .inner_window_question h3 {
+    background-color: #e1e1e1;
+  }
+  .overlay_window h3 {
+    background-color: #b4b4b4;
+  }
+`;
+
+document.head.appendChild(style);
+
+
+function checkIfCanAddMap() {
+    map = document.getElementById("map_container");
+    
+    if(map) {
+        map.style.backgroundImage = "url('https://images.rawpixel.com/image_800/czNmcy1wcml2YXRlL3Jhd3BpeGVsX2ltYWdlcy93ZWJzaXRlX2NvbnRlbnQvbHIvdjk5Ni0wMDlfMS1rcm9pcjRkay5qcGc.jpg')"; 
+    }
+}
+
+setInterval(checkIfCanAddMap, 250);
+
+(function(e, t, n, r, i) {
+    function s(e, t, n, r) {
+        r = r instanceof Array ? r : [];
+        var i = {};
+        for (var s = 0; s < r.length; s++) {
+            i[r[s]] = true
+        }
+        var o = function(e) {
+            this.element = e
+        };
+        o.prototype = n;
+        e.fn[t] = function() {
+            var n = arguments;
+            var r = this;
+            this.each(function() {
+                var s = e(this);
+                var u = s.data("plugin-" + t);
+                if (!u) {
+                    u = new o(s);
+                    s.data("plugin-" + t, u);
+                    if (u._init) {
+                        u._init.apply(u, n)
+                    }
+                } else if (typeof n[0] == "string" && n[0].charAt(0) != "_" && typeof u[n[0]] == "function") {
+                    var a = Array.prototype.slice.call(n, 1);
+                    var f = u[n[0]].apply(u, a);
+                    if (n[0] in i) {
+                        r = f
+                    }
+                }
+            });
+            return r
+        }
+    }
+    var o = 1010,
+        u = 500,
+        a = 50;
+    var f = {
+        stateStyles: {
+            fill: "#333",
+            stroke: "#666",
+            "stroke-width": 1,
+            "stroke-linejoin": "round",
+            scale: [1, 1]
+        },
+        stateHoverStyles: {
+            fill: "#33c",
+            stroke: "#000",
+            scale: [1.1, 1.1]
+        },
+        stateHoverAnimation: 500,
+        stateSpecificStyles: {},
+        stateSpecificHoverStyles: {},
+        click: null,
+        mouseover: null,
+        mouseout: null,
+        clickState: {},
+        mouseoverState: {},
+        mouseoutState: {},
+        showLabels: true,
+        labelWidth: 20,
+        labelHeight: 15,
+        labelGap: 6,
+        labelRadius: 3,
+        labelBackingStyles: {
+            fill: "#333",
+            stroke: "#666",
+            "stroke-width": 1,
+            "stroke-linejoin": "round",
+            scale: [1, 1]
+        },
+        labelBackingHoverStyles: {
+            fill: "#33c",
+            stroke: "#000"
+        },
+        stateSpecificLabelBackingStyles: {},
+        stateSpecificLabelBackingHoverStyles: {},
+        labelTextStyles: {
+            fill: "#fff",
+            stroke: "none",
+            "font-weight": 300,
+            "stroke-width": 0,
+            "font-size": "10px"
+        },
+        labelTextHoverStyles: {},
+        stateSpecificLabelTextStyles: {},
+        stateSpecificLabelTextHoverStyles: {}
+    };
+    var l = {
+        _init: function(t) {
+            this.options = {};
+            e.extend(this.options, f, t);
+            var n = this.element.width();
+            var i = this.element.height();
+            var s = this.element.width() / o;
+            var l = this.element.height() / u;
+            this.scale = Math.min(s, l);
+            this.labelAreaWidth = Math.ceil(a / this.scale);
+            var c = o + Math.max(0, this.labelAreaWidth - a);
+            this.paper = r(this.element.get(0), c, u);
+            this.paper.setSize(n, i);
+            this.paper.setViewBox(-500, 0, c, u, false);
+            this.stateHitAreas = {};
+            this.stateShapes = {};
+            this.topShape = null;
+            this._initCreateStates();
+            this.labelShapes = {};
+            this.labelTexts = {};
+            this.labelHitAreas = {};
+            if (this.options.showLabels) {
+                this._initCreateLabels()
+            }
+        },
+        _initCreateStates: function() {
+            var t = this.options.stateStyles;
+            var n = this.paper;
+            var r = {
+                Tainancity:"m178.94 309.54c1.821 0.85976 1.9013 1.8004 3.9722 1.3601 0.52002 1.6719-1.5712 1.0502-1.4009 2.6113 0.8704 0.21983 2.3913 0.20091 2.5009 1.2003 2.4514 1.3001-0.0196 1.501 0.46065 3.6413 2.191-0.12068 3.2917 1.4299 5.2733 1.8898 0.13963 1.4005-0.8306 1.1807-1.6207 1.8011-1.0903 0.85976-1.1105 1.2309-1.181 2.6706-0.0698 1.411-0.89063 5.8318 0.97023 6.032 0.0496 0.85128 0.0496 1.7515 0 2.6008-0.82081 0.37966-1.1705 1.4814-1.1105 2.3405 0.5807 0.0202 1.2006 0.03 1.7806 0.06 0.17029 0.33986 0.2897 0.71103 0.39083 1.0607 1.7114-0.20939 1.8902 1.5512 3.2813 1.8904 0.16051-0.81019 1.3415-1.1305 1.7219-0.3503 0.0692 0 0.55983-0.0104 0.61072 0 0.84039-1.4103 2.5114-1.3803 2.8611-3.2414 0.73077 1.1709 1.2312 1.6308 2.6314 1.7411 1.4909 0.10959 2.4716-0.39988 3.8418-0.0998 0.76079 1.1598 1.6618 0.69994 1.8817-0.36074 0.39931 0.31051 0.63942 0.76061 0.63029 1.3007-0.15986 0.0398-0.30014 0-0.45021 0.06-0.12984 1.3803-0.89063 1.4599-1.6501 2.4606-0.97023 1.2694-0.14094 1.9498-0.3804 3.1696-0.3308 1.6608-3.2924 3.1214-4.3331 4.6817-1.5007 2.2616-2.7815 3.6608-3.7217 6.3217-0.85083 2.4208-1.6612 4.5519-3.9122 5.5415-2.3711 1.0496-3.1919 3.0013-4.8727 4.8018-0.71055 0.74886-1.9209 1.7593-2.8317 2.1696-1.4204 0.63993-2.4814 0.69081-3.1815 2.3412-0.21009 0.50098-0.16051 1.4899-0.4502 1.8611-0.53047 0.68038-0.94022 0.39009-1.581 0.75996-1.0707 0.62036-1.4707 1.6112-2.281 2.6217-1.0505 1.291-1.0603 2.12-1.6906 3.5917-0.52068 1.2303-1.5509 2.2799-2.2915 3.3706-0.74056 1.0711-1.4707 2.1814-2.0312 3.1312-0.46065 0.77953 0.15007 1.1905-0.97088 1.3197-0.79015 0.0998-1.1705-0.12916-1.0603-0.96936-0.64008-0.0307-1.3108-0.0307-1.9509 0-1.2006 1.4703-2.7515 1.5004-4.0323 2.7711-1.0707 1.0705-0.46065 1.2303-2.0011 1.5695-0.89062 0.21005-2.3809 0.51991-2.1812-0.84019-1.8008-0.15982-3.432-0.77039-5.4827-0.69081-1.3604 0.0502-3.862-0.33008-4.8531 0.43053-1.3708-0.99153-4.3024-0.48011-4.8524-2.9113-1.641 0.95044-6.023-1.3503-7.784 0.42923-0.26034-1.9707-0.0803-4.4417-0.65052-5.7913-0.99045-2.3803-1.2103-4.501-3.1619-6.2114-2.0612-1.8102-4.8929-2.9609-6.513-5.122-1.4009-1.8806-2.9916-3.0216-5.3731-3.8415-5.5428-1.9009-6.4536-7.8024-2.5009-11.954 1.1608-1.2198 1.4811-1.2603 1.5007-3.2107 0.01-1.4606-0.20031-3.1207 0.15985-4.501 0.63029-2.3901 3.1521-3.9714 4.0225-6.3817 0.98067-2.7208-0.42019-5.6817 0.86062-8.4522 0.65051-1.4005 0.52002-2.7606 0.97022-4.1612 0.35038-1.1305 0.68053-0.7306 1.331-1.6308 0.52002-0.72016 0.39018-0.96087 0.49001-1.8813 0.21009-1.9198 0.97022-2.3601 1.7806-3.7815 1.4609 0.61123 2.4911 1.8709 4.0323 2.3008 0.1703 0.8702 0.81037 1.561 1.0603 2.4508 0.51024-0.0404 1.0903 0.09 1.611 0.0502 0.15007 1.9707 3.6819 4.7417 3.5618 1.1598 0.2499 0.3503 0.49001 0.45989 0.6603 0.96935 0.77057 0.0802 1.6012 1.1814 2.3111 1.0202 0.50045-0.11025 0.80059-1.1814 1.1608-1.6713 0.86062-1.1807 2.1108-1.7711 2.3613-3.4704 1.4211-1.5701 4.8028 0.42988 4.2822-2.8311-1.121-0.58122-0.30014-1.8513 0.65052-1.9113 0.98066-0.06 1.271 1.1403 2.6914 0.55121-0.30993-1.3614-1.2808-2.4221 0.31058-3.5512 1.4811-1.0405 2.8513 0.25897 2.7417-2.261 0.84038 0.0404 1.731 0.27006 2.6412 0.14025 1.5405-0.21984 0.94022-0.34965 1.9907-1.3001 1.3806-1.261 3.1521-1.0907 5.013-1.3705 1.611-0.24005 2.9316-1.0007 4.6626-1.0007 1.4707 0 3.9618 1.1102 5.0025-0.34965 0.97936 0.81476 2.5198 1.3144 3.6708 1.8546z",
+                Kaohsiungcity:"m156.17 440.89c0.0502 0.35029 0.20031 0.66993 0.12984 1.0502-0.0803-0.0111-0.15985 0-0.23032-0.0111-0.27991-0.50033-0.60027-0.33986-1.0309-0.58905-0.39996-0.24006-0.4502-0.63014-0.67009-0.96152-0.44042-0.67973-1.1105-1.3301-1.6312-1.9498-1.0707-1.291-2.0612-2.6908-3.0516-4.002-0.20031-0.27006-0.29035-0.8004-0.56047-0.93021-0.0202-0.06 0.01-0.12003-0.0202-0.17026-0.2499-0.34964-0.93043-0.3803-1.2404-0.63993 0.48022-0.15916 1.1608-0.0691 1.6808-0.0489-0.0202 0.17874 0.0803 0.30007 0.0803 0.47881 0.73077-0.0998 0.16051 0.93086 0.85083 0.96152 0.0202 0.0489-0.0104 0.12916 0.0202 0.17026 0.16964 0.14938 0.42998 0.17873 0.57026 0.30007 0.13963 0.12981 0.2897 0.47032 0.42998 0.63014 0.4502 0.49055 0.67009 0.78018 0.93043 1.3307 0.10961 0.2394 0.18986 0.5199 0.39017 0.72995 0.23033 0.24984 0.45021 0.2805 0.66031 0.47033 0.39018 0.36986 0.55068 0.78996 1.0603 1.06 0.12984 0.51012 0.52002 1.1103 0.78035 1.5408 0.0503 0.01 0.0998 0.01 0.15986 0.0196 0.0515 0.37052 0.29166 0.62036 0.69162 0.56035zm102.79-136.88c-0.15007 0-0.25968 0.0104-0.27012 0.0496-0.24011 0.69082-0.0502 1.1409 0.77057 1.3307 0.30992 1.6406 0.55982 2.8402 0.33994 4.6113-1.5203 0.24984-4.1014-0.3503-4.3226 1.5395-0.03 0.28116 0.51023 0.45011 0.51023 0.82063 0 0.77952-0.28969 0.71038-0.47043 1.2101-0.35038 0.93934-0.79014 1.5401-0.67009 2.6002 1.8015-0.20092 1.0309 0.68037 2.0109 1.3307 0.79015 0.53947 1.8413 0.33986 2.7717 0.39009-0.0692 0.3503 0.20096 0.81019 0.19052 1.0705 1.4609-0.61057 3.342 2.9113 3.1417 4.0412-1.0205 0.36987-1.1705 1.0705-0.95065 1.7704-0.8704 0.52056-2.052 0.29029-2.9818 0.6308-1.2006 0.42988-2.0409 1.3803-3.2115 1.9302-1.331 0.61122-2.4716 0.88129-3.832 1.2009-1.731 0.41031-2.2615 1.1507-3.3315 2.3412-0.7497 0.8291-1.4511 2.291-2.3411 2.9609-0.82929 0.61906-2.7012 0.25897-3.3113 1.2303-0.57026 0.92043 0.14028 3.2114-0.0202 4.3106-0.0698 0.54012-0.45021 0.92043-0.5011 1.4906-0.06 0.75996 0.29035 1.4514 0.17095 2.1703-0.28056 1.6204-1.6716 1.2616-2.3515 2.6608-0.30014 0.63014 0.21009 1.1807-0.35038 1.8011-0.39018 0.42075-1.4211 0.53034-1.9411 0.57013-0.27012 1.03 0.81037 1.291 1.611 1.5004 0.14028 2.6504 0.4104 5.9629-0.0998 8.5135-0.1703 0.91912-0.77057 2.0294-1.3604 2.8311-0.47043 0.63928-0.88997 0.75996-1.0498 1.5904-0.2101 1.0907 0.21988 0.88128 0.54025 1.5316 0.33015 0.66929 1.7604 2.621 0.96044 3.4808-0.89063 0.96087-2.9414-0.47098-3.462 1.1898-0.44108 1.4103 1.3108 2.0711 0.30013 3.6308-0.6205 0.95044-2.2419 1.6406-3.0118 2.4208-1.9809 2.0105-3.1514 6.702-1.6005 9.2728 0.24011-0.0189 0.55982 0.0802 0.79014 0.0502 0.53046 1.3999-0.06 3.1312 0.18009 4.6322 0.27012 1.6608 2.1212 2.0796 2.0305 3.651 1.9711-0.24005 1.7408 0.76061 1.8315 2.3308 2.0305 0.0189 1.3911 1.0705 0.28056 1.6497-0.0502-0.12916-0.11027-0.2394-0.18008-0.3503-0.74056-1.0796-3.5012-2.3901-4.7924-2.2799-1.4609 0.12916-2.3215 1.1298-3.5116 1.6797-1.2103 0.56035-2.1714 0.19048-2.0214 2.1409-2.251 0.10959-4.1125-0.60079-4.5021-3.1214-1.641-1.0705-2.9218-2.3105-4.8126-3.0209-1.1307-0.4201-1.7206-0.54012-2.9916-0.33007-1.2404 0.20091-1.5007 0.60013-2.4716 1.0202-0.30014 0.8702-1.4909 1.7293-2.071 2.5408-2.0011-2.0907-2.8122-4.2303-5.9936-3.561-1.38 0.28963-2.4409 1.2205-3.8013 1.7-1.1307 0.39074-2.9224 0.27006-3.8431 1.0802-0.90042 0.79062-1.0309 1.9707-1.8308 2.7104-0.71055 0.64972-1.791 1.9204-2.6314 2.3803-2.0312 1.1005-5.9232 0.28898-7.724-0.50098-1.0505-0.46054-2.3913-0.88064-3.6519-0.55056-1.5712 0.4214-1.4309 1.1703-1.3408 2.8409 0.0502 0.91064 0.73012 3.1996 0.33994 4.0014-0.45999 0.93021-1.1705 0.17874-1.6808 0.77887-0.35038 0.41097-0.15986 1.4814-0.15986 2.0516 0.01 2.7815 0 5.5617 0 8.3321 0 1.2101 0.2499 2.9309-0.36995 3.972-0.84038 1.4097-1.4707 1.079-1.4609 3.1996v4.3327c0 1.5604-0.39996 2.3706-0.68053 3.6602-0.58005 2.7815 0.28057 5.4221 0.64008 8.0118 0.18008 1.2407 0.39018 2.7411 0.2101 4.0014-0.32037 2.1514-1.2606 1.0007-2.3411 2.1709-1.3604 1.4814-0.50045 6.3817-0.50045 8.3321v0.21005c-0.92064-0.63993-1.301-0.42141-2.6614-0.54013-2.4213-0.23092-3.0118-2.5806-5.043-3.6308-1.4211-0.72995-2.1316-0.82911-3.2519-1.9107-0.96044-0.93086-2.4416-2.2009-3.2617-3.1918-0.2499-0.52055-0.8704-1.291-1.4309-1.5206 0.11027-0.53034 0.39018-0.50034 0.93043-0.47033 0.01 0.06 0 0.11024 0.0202 0.15982 0.03 0.0104 0.0698 0.0196 0.0998 0.03 0.0502 0.18982 0.15986 0.2805 0.2101 0.47032 0.2499 0.11024 0.69032 0.21005 0.86061 0.3914 0.24011 0.2394 0.2101 0.69994 0.50045 0.85911 0.28056 0.15982 0.91085-0.0189 1.1908-0.0496 0.46065-0.0404 0.72034 0.0404 1.181 0.14025 0.0104 0.69929 0.90041 0.25049 1.2508 0.7306 0.15007-0.97066-1.2208-1.2407-1.8713-1.7006-0.33994-0.24005-0.82016-0.45988-1.1105-0.74038-0.39997-0.39075-0.36995-0.78997-0.57026-1.2401-0.40976-0.8702-1.7108-0.54012-2.3809-1.3105-0.38039-0.42988-0.24011-0.88064-0.5807-1.3001-0.25968-0.33008-0.71054-0.60014-0.99045-0.93935-0.30993-0.36986-0.75035-0.66993-1.1307-1.0111-0.42019-0.39074-0.7001-0.91064-1.0303-1.3797-0.61071-0.83041-1.2006-1.6504-2.0116-2.231 0.42019-0.0307 1.331-0.17091 1.6912 0.03 0.40975 0.23027 0.36995 0.93086 0.55982 1.3803 0.38039 0.17026 1.4106 0.63015 1.3708 1.06 0.81037 0-0.35038-1.1011-0.56048-1.1898-0.19052-0.42075-0.23032-0.82975-0.49-1.1703-0.25969-0.33072-0.61007-0.48011-0.82995-0.86041-0.2499-0.44945-0.23032-0.57992-0.80058-0.84998-0.46-0.22048-0.86062-0.16047-1.3408-0.29028-0.81037-0.24006-1.5307-1.15-2.1714-1.6993-0.94021-0.81018-0.88084-1.3999-0.88084-2.6217v-2.1807c0-0.33073-0.0698-0.71038 0.1305-0.94 0.15985-0.19048 0.6603-0.23092 0.89062-0.42075 0.36017-0.31964 0.81037-1.06 0.91086-1.5206 0.15985-0.80105-0.29036-1-0.63029-1.6106-0.06-0.0307-0.12985-0.0496-0.18009-0.0698 0.39997-0.24984 0.70011 0.12981 0.96044 0.36073 0.40976 0.34965 0.47044 0.40966 1.1007 0.37965 0.0502-0.88976-0.0502-1.8891-0.38039-2.6706-0.97023-0.0907-0.88084 0.31051-1.1203 1.0405-0.50045 0.06-0.59049-1.3196-0.69032-1.73-0.16051-0.68103-0.74056-1.261-0.8704-1.9413-0.0698-0.39987 0.0698-0.77039-0.12984-1.1207-0.1703-0.30007-0.61072-0.45989-0.79015-0.75996-0.35037-0.61123 0.11027-1.2701-0.48022-1.8206 0.23033-1.4103-1.5307-2.2505-2.1616-3.1612-0.57026-0.82128-0.7001-1.6915-0.82995-2.6608-0.29035-2.0405-0.54024-1.5904-1.8713-2.9713-0.88084-0.91064-0.64008-1.3301-0.8306-2.6713-0.32036-2.2505-1.4811-4.1716-1.5105-6.4919-0.0202-2-0.53046-3.8911-1.3604-5.6517-1.1405-0.27006-1.581-1.4508-1.7806-2.9002 1.761-1.7802 6.1437 0.52055 7.784-0.42988 0.55003 2.4312 3.4816 1.9198 4.8524 2.9113 0.99046-0.76061 3.492-0.38031 4.8531-0.43054 2.0514-0.0796 3.6819 0.53034 5.4827 0.69147-0.20031 1.3601 1.2906 1.0496 2.1812 0.84019 1.5405-0.33986 0.93043-0.50098 2.0011-1.5701 1.2808-1.2707 2.8317-1.3007 4.0323-2.7711 0.64008-0.03 1.3108-0.03 1.9509 0-0.10962 0.84019 0.27012 1.0705 1.0603 0.97 1.121-0.12981 0.51023-0.54012 0.97088-1.3203 0.55982-0.94978 1.2906-2.06 2.0312-3.1312 0.74055-1.09 1.7708-2.1403 2.2915-3.3706 0.63029-1.471 0.64008-2.3008 1.6906-3.591 0.81037-1.0111 1.2103-2.0007 2.281-2.6223 0.64008-0.36922 1.0505-0.0796 1.5809-0.75996 0.29035-0.36922 0.24011-1.3601 0.45021-1.8611 0.7001-1.6504 1.761-1.7 3.1815-2.3405 0.91085-0.41031 2.1212-1.4214 2.8317-2.1703 1.6808-1.8011 2.5009-3.7515 4.8727-4.8018 2.251-0.99023 3.0614-3.1207 3.9122-5.5415 0.94021-2.6608 2.221-4.0614 3.7217-6.321 1.0407-1.561 4.0023-3.0216 4.3324-4.6824 0.24011-1.2198-0.58984-1.9002 0.38104-3.1696 0.76013-1.0007 1.5203-1.0802 1.6501-2.4606 0.15007-0.06 0.29035-0.0202 0.4502-0.06 0.0104-0.54012-0.23097-0.99088-0.63028-1.3007 0.01-0.0496 0.0189-0.10959 0.03-0.17026 0.12919-1.0496-0.43063-2.4306-0.71054-3.3308-0.65052-2.0509-1.3911-4.9316-0.64008-7.1521 0.8704-0.14025 2.8115-0.12916 3.6519 0.14025 1.5209 0.51012 0.67009 1.8513 1.9809 2.5114 2.8715 1.4508 2.482-2.7013 4.0121-3.8409 1.1405-0.85128 1.9809-0.11089 3.171-0.66145 0.35038-0.15982 1.9509-1.8402 2.1714-2.1305 0.65052-0.85063 0.5011-2.1207 1.4909-2.7515 0.98066-0.61971 2.6516-0.25963 3.8124-0.31964 0.28056-1.4306 0.39996-2.5506 1.821-3.1918 0.96109-0.42075 3.3315 0.25049 4.0519-0.39922 0.36995-0.33986 0.77122-2.8918 1.1105-3.6015 0.53046-1.1103 0.86061-2 1.2103-3.1514 0.38039-1.3105 0.82081-2.2805 2.1714-2.7593 1.2006-0.43053 3.0908 0.23941 4.0114-0.70059 0.21009-0.21983 0.36995-1.3601 0.6205-1.7202 0.27991-0.41031 0.93043-1.0802 1.3206-1.3418 1.0302-0.66928 2.4011-0.8004 3.5514-0.94978 1.1816-0.14025 1.9914-0.2094 2.6914-1.1298 0.79015 0.0802 1.821-0.27984 2.4018-0.88977 0.24989-0.0691 0.50044-0.12981 0.74055-0.18004 1.2208-0.24984 1.0903-0.11024 2.1714 0.36987 1.5509 0.69081 2.9316 0.59035 4.8022 0.69994 0.0104 0.33008 0.25055 0.55056 0.2101 0.93087 0.35037-0.0104 0.74055 0.27985 1.1307 0.23027 0.14942 0.98109-0.26033 1.7104-0.29035 2.6217 0.14028-0.0104 0.32037 0.0104 0.46065 0.0404 0.0176 0.12981-0.0124 0.30986-0.0124 0.45924z",
+                Pingtung:"m166.08 473.61c0.38039 0.47033 0.52002 0.84019 0.50045 1.4403-0.0398 0-2.1408 2.4514-2.3515 2.681-0.8704 0.88912-2.5212 1.7104-2.9016-0.16047 1.2808-0.74952 0.64008-2.0405 1.3206-3.1116 0.71054-1.1279 2.2615-0.91913 3.432-0.84933zm69.867-77.268c0.47044 1.2205-0.3693 2.9909 0.65052 4.0907 0.52002 0.57013 2.9218 1.4305 3.7119 1.7906 1.121 0.51012 1.121-0.18982 1.5007 1.1598 0.19052 0.6608 0.10961 1.9198 0.12984 2.5414 0.0692 1.8611-0.53046 2.5806-2.1016 3.4912 0.61137 1.8317 1.1307 5.6928-0.85017 7.1521-1.0107 0.75017-2.7613-0.18983-4.0121 0.32029-0.88997 0.36074-1.6605 1.4814-2.5414 2.1207-1.4106 1.0411-1.9607 1.03-3.802 1.2205-1.0603 0.10959-2.822-0.19047-3.5318 0.78997-0.73077 0.99153 0.25968 2.6413-0.1305 3.8722-0.39018 1.2205-1.6312 2.06-2.0005 3.3412-0.35038 1.2094-0.2499 1.8806-1.0002 2.9498-0.73077 1.0405-1.2906 1.76-1.701 2.8807-0.77057 2.0907-1.0303 4.201-1.1601 6.4828-3.0314 0.03 0.39932 5.3817 0.74056 6.1919 0.7001 1.6797 1.1608 5.4508 0.63029 7.0425-0.32037 0.96935-1.2006 2.1507-0.51024 3.4612 0.76079 1.4299 1.8015 0.21004 2.9616 1.0404 1.2704 0.90021 1.9013 5.1312 1.6808 6.6022-1.6612 0.0698-4.0114 0.74039-4.472 2.3601-0.25055 0.87085-0.0411 2.1011-0.18008 3.0013-0.10962 0.77105-0.46 1.6915-0.30014 2.471 0.48022-0.0802 0.8704 0.21983 1.2808 0.21983 0.45021 2.0516 2.0011 1.5401 3.5318 2.6419 1.671 1.1807 1.581 2.4808 1.4707 4.6406-2.2412 0.03-2.3711 1.6902-2.2817 3.5004 0.86061-0.0685 2.9414 0.40053 3.6421 0.82063 1.9711 1.1703-0.77058 1.8017-0.47044 3.1807 0.90042-0.12003 1.1908 0.50163 1.0002 1.3418 1.8511 0.0992 2.1212 0.57013 3.4712 1.1807 1.1908 0.53947 3.2421-0.0307 3.5318 1.6412 1.8008-0.23092 1.5907 1.9498 3.4418 0.99936 0.73077-0.38031 1.9711-1.7208 2.681-2.4508 0.33081 1.1598 0.67009 2.3608 0.39997 3.3608-0.2101 0.82062-0.6205 1.0907-0.71055 2.1207-0.09 0.91977-0.12984 1.7208-0.30013 2.5506-0.56048 2.7398 0.29035 6.411 0.0998 9.5931-0.98066 0.4201-1.2612 1.8206-0.97022 2.8611 0.38039 1.3601 0.94021 1.4292 2.4716 1.3601 0.09 0.48011 0.09 1.1403 0 1.6106-0.73077 0.6608-1.4511 0.59035-1.8113 1.531-0.33015 0.8702 0.0111 2.5617 0.0111 3.501 0 0.98044-0.27012 2.4103-0.0111 3.3406 0.32036 1.1011 1.2508 1.2101 0.98067 2.6308-0.61985 0.12981-1.2006 0.24006-1.7806 0.39988-0.0411 0.55056-0.21989 1.0404-0.21989 1.6002-1.5509 0.40966-0.93042 0.77104-1.4707 1.8702-0.70076 1.3908-0.68053 0.85976-2.3013 1.2003-2.5212 0.53034-2.0409 2.4814-2.0409 4.8011 0 1.8506-0.60028 4.9218 0.72033 6.2923 0.67988 0.69994 1.151 0.45989 1.6207 1.3712 0.29035 0.58971 0.38039 2.4808 0.30014 3.1507-1.7708 0.45989-1.8106-1.2309-2.7606-2.1905-0.51024-0.51991-0.95066-0.4899-1.3911-1.1207-0.34972-0.5199-0.4104-1.2198-0.82994-1.8004-1.0603-1.4703-1.8811-0.78018-3.5018-1.3608-0.71054-0.25962-1.2906-0.91977-1.9907-1.1814-0.59048-0.21983-1.3506-0.18982-1.9711-0.36008-0.79014-1.5003-4.5021-2.561-5.3327-0.44032-0.49001 1.2401 0.79014 1.6008 0.63029 2.8011-0.16965 1.3203-1.6606 1.3705-2.6712 1.8206-0.53046-0.78018-1.6605-1.4606-2.0011-2.1507-0.47956-0.97001-0.1592-2.7208-0.1592-3.8311 0-1.3007 0.1703-2.7208 0-4.0014-0.23097-1.7606-0.99111-1.5401-1.962-2.711-0.83973-1-0.69945-1.8891-1.0798-3.0809-0.20096-0.63079-0.65052-0.79061-0.63029-1.5506 0.03-0.82976 0.50958-0.75996 0.66944-1.501 0.12071-0.55056-0.25903-1.5095 0-2 0.51023-0.96087 0.56047-0.12068 1.331-0.66081 0.81038-0.55056 1.8511-2.1311 0.53046-2.8611-0.24011-0.39987-0.43063-0.99088-0.50109-1.4508 0.44041 0.0802 1.0107-0.12982 1.4518-0.0496 0.20944-1.2505 0.42933-2.4814 0.36016-3.8115-0.0998-1.8806-0.36995-1.8206-1.4707-3.0411-1.6906-1.8904-0.35038-4.8911-1.0309-7.2923-0.35038-1.2309-1.4909-1.8402-1.8008-3.1709-0.30013-1.291-0.13962-2.4599-0.54024-3.6608-0.8704-2.5695-3.1521-3.0007-4.3722-5.3014-0.60027-1.1292-0.46064-2.471-0.46064-3.8715 0-1.6112-0.46065-2.3608-1.0009-3.6713-0.84038-2.0405-2.0409-3.6817-3.7217-5.291-0.85082-0.82063-1.7304-1.2805-2.1108-2.381-0.54025-1.5395-0.65051-1.79-1.7108-3.1612-1.6508-2.1403-3.1019-2.7208-5.4632-4.0105-1.0714-0.5897-2.7117-0.83954-3.5018-1.8311-1.3904-0.17939-3.3518-0.50034-4.3722-1.2903-0.89063-0.7006-1.3108-1.8409-2.131-2.6719-1.7708-1.7906-4.8531-2.3797-6.0034-4.3706-0.72033-1.2401-0.95065-1.8617-2.1212-2.8709-0.2101-0.17026-0.39018-0.31051-0.55004-0.42075v-0.2094c0-1.9504-0.86061-6.852 0.50045-8.3321 1.0805-1.1703 2.0214-0.0202 2.3411-2.1709 0.18008-1.2603-0.03-2.7593-0.2101-4.0014-0.36017-2.591-1.2208-5.2316-0.64008-8.0118 0.28057-1.291 0.68053-2.1011 0.68053-3.6602v-4.3327c-0.0104-2.1207 0.62051-1.79 1.4609-3.1996 0.6205-1.0411 0.36995-2.7606 0.36995-3.972 0-2.7711 0.01-5.5519 0-8.3321 0-0.57013-0.19052-1.6412 0.15986-2.0516 0.51023-0.60014 1.2208 0.15003 1.6808-0.77888 0.39018-0.8017-0.2897-3.0907-0.33994-4.002-0.09-1.6712-0.23032-2.4208 1.3408-2.8402 1.2606-0.33007 2.6014 0.09 3.6519 0.55056 1.8008 0.78997 5.6935 1.6002 7.724 0.50099 0.84039-0.45989 1.9209-1.7306 2.6314-2.3803 0.80123-0.74039 0.93042-1.9198 1.8308-2.7111 0.92064-0.80953 2.7117-0.69016 3.8431-1.0796 1.3604-0.47946 2.4213-1.4103 3.802-1.7 3.1815-0.66994 3.9912 1.4703 5.993 3.561 0.58071-0.81019 1.7708-1.6706 2.071-2.5408 0.97022-0.4214 1.2306-0.82127 2.4716-1.0202 1.271-0.21005 1.8615-0.09 2.9916 0.33008 1.8909 0.71038 3.1717 1.9504 4.8126 3.0209 0.39083 2.5206 2.251 3.231 4.5021 3.1214-0.15007-1.9504 0.81037-1.5806 2.0214-2.1409 1.1908-0.54991 2.052-1.5506 3.5116-1.6797 1.2912-0.1109 4.0519 1.2003 4.7931 2.2799 0.0672 0.10763 0.12789 0.21787 0.17747 0.34703z",
+                Taidong:"m327.47 304.02c-0.32036 0.81019-0.64007 1.6302-0.96044 2.5004-0.7001 1.9204-0.23097 3.9309-0.55068 5.9518-0.27013 1.7417-1.1601 3.3412-1.4407 5.0627-0.25055 1.5904-0.0196 4.8415-1.181 6.0614-1.0903 1.1598-3.1417 1.2309-4.3122 2.6908-1.3108 1.6412-1.6508 2.9713-1.761 5.2519-0.0803 1.5708 0.36995 4.6217-0.50045 5.8116-0.76079 1.0607-2.852 0.77105-3.5723 2.3712-0.63095 1.4208-0.0698 3.651 0.0692 5.0712 0.29035 2.8611-0.1703 8.1527 3.7322 7.8129-1.0798 0.39009-1.35 1.6002-2.2308 2.1403-0.63029 0.39922-1.3004-0.0496-2.0116 0.50033-0.47956 0.36073-0.58983 1.1403-0.93042 1.3608-1.8211 1.1598-5.4827 0.12981-4.8126 3.9413 0.0502 1.7104-0.68053 3.561-1.331 4.8311-0.61072 1.1703-0.32037 2.4599-0.71055 3.621-0.42998 1.2805-1.4909 2.441-1.9607 3.732-0.44042 1.1807-0.36995 2.2199-1.0407 3.3216-1.301 2.1305-4.1621 2.5108-4.9229 4.8716-0.4502 1.3803-0.0907 2.3405-0.88084 3.591-0.59048 0.93021-1.0498 1.9504-1.7003 2.8611-0.42085 0.60013-0.98067 0.85063-1.2912 1.4814-0.25968 0.51991-0.10048 1.319-0.3693 1.8304-0.70075 1.2707-2.1114 0.97001-1.992 2.8409-2.2204 0.12003-6.4138-0.59035-7.4441 2.0607-1.0798 2.7698 0.82082 4.9603 1.6312 7.1319 0.71054 1.8898-0.31971 2.0411-1.5007 2.7111-1.5607 0.88063-1.1301 1.1403-1.331 2.9609-0.24989 2.2799-3.1619 3.1696-4.5223 5.1605-0.03 0.0502 0.01 0.39139-0.0104 0.48011-0.97023 0.75995-2.3913 1.1298-3.312 1.8904-0.93042 0.75996-1.2006 2.321-2.3313 2.9707-1.0107 0.59035-2.5212 0.14938-3.7021 0.6308-1.2208 0.50098-1.6312 1.5199-2.5009 2.5004-1.6012 1.8102-4.4022 2.1109-5.9232 3.9218-0.64008 0.74104-0.90041 2.3803-1.2103 3.2916-0.39931 1.2003-0.57026 2.4006-0.63029 3.7013-0.12005 2.5004-0.17029 4.3712-2.2014 5.8116-1.1203 0.78996-1.9202 0.91064-2.6308 1.9909-0.66095 0.99023-1.1908 2.1605-1.6716 3.3301-0.52003 1.2609-0.4202 2.5206-0.8704 3.8011-0.44042 1.2401-1.181 2.2805-1.5105 3.5408-0.63942 2.4821-0.44042 5.0327-1.181 7.4724-1.8308 0.47098-1.5607 4.6824-2.2713 6.203-0.88997 1.9002-1.2997 3.651-1.9111 5.5904-0.57026 1.8108-1.2208 4.4123-2.8017 5.5722-0.85017 0.6308-0.43977 2.3405-0.8293 3.6608-0.28121 0.91978 0.33016 7.2023 0.33016 8.1723 0 0.69016 0.24011 1.5004 0.47956 2.351-0.71054 0.72995-1.9502 2.0705-2.681 2.4508-1.8511 0.95043-1.6416-1.2303-3.4418-0.99936-0.28969-1.6719-2.3411-1.1011-3.5318-1.6412-1.35-0.61058-1.6201-1.0802-3.4712-1.1807 0.19052-0.84019-0.0998-1.4606-1.0002-1.3418-0.30013-1.379 2.4409-2.0105 0.47044-3.1807-0.70076-0.42009-2.7815-0.88911-3.6421-0.82062-0.09-1.8096 0.0411-3.4704 2.2817-3.5004 0.10962-2.1612 0.20031-3.4612-1.4707-4.6406-1.5307-1.1011-3.0816-0.59035-3.5318-2.6419-0.41041 0-0.80059-0.30007-1.2808-0.21983-0.15985-0.77953 0.19052-1.7 0.30014-2.471 0.14028-0.90021-0.0698-2.1305 0.18008-3.0014 0.46-1.6197 2.8115-2.2903 4.472-2.3601 0.21989-1.471-0.4104-5.702-1.6808-6.6022-1.1601-0.8291-2.2014 0.39074-2.9616-1.0405-0.69032-1.3105 0.18987-2.4906 0.51023-3.4612 0.53046-1.5904 0.0698-5.3628-0.63029-7.0425-0.33994-0.81019-3.772-6.1618-0.74056-6.1919 0.12919-2.2805 0.39018-4.3908 1.1601-6.4828 0.41041-1.1207 0.97023-1.8396 1.701-2.8807 0.75034-1.0705 0.65052-1.7404 1.0002-2.9498 0.3693-1.2805 1.611-2.1207 2.0005-3.3412 0.39083-1.2309-0.60028-2.8807 0.13049-3.8722 0.70989-0.98044 2.4716-0.68037 3.5318-0.78996 1.8406-0.19048 2.3913-0.17939 3.802-1.2205 0.88084-0.63927 1.6508-1.76 2.5414-2.1207 1.2508-0.50947 3.0027 0.42988 4.012-0.31964 1.9809-1.4599 1.4609-5.321 0.85018-7.1527 1.5712-0.91064 2.1714-1.6302 2.101-3.4912-0.0196-0.62036 0.0607-1.8806-0.12919-2.5414-0.38039-1.3497-0.38039-0.64971-1.5007-1.1598-0.79079-0.36008-3.1926-1.2205-3.7119-1.7906-1.0205-1.1011-0.18008-2.8702-0.65051-4.0907 1.1105-0.58057 1.7512-1.6308-0.28057-1.6497-0.0907-1.5701 0.14028-2.5708-1.8315-2.3308 0.0907-1.5701-1.7604-1.9902-2.0305-3.6511-0.24011-1.501 0.35038-3.231-0.18008-4.6322-0.23032 0.03-0.55069-0.0691-0.79015-0.0502-1.5509-2.5695-0.38039-7.2623 1.6005-9.2728 0.77057-0.77952 2.3913-1.4703 3.0118-2.4208 1.0107-1.561-0.74121-2.2205-0.30014-3.6302 0.52002-1.6615 2.5708-0.23092 3.462-1.1905 0.80059-0.85976-0.63028-2.8115-0.96044-3.4808-0.32036-0.65037-0.75034-0.44097-0.54024-1.5317 0.15985-0.8291 0.58004-0.94978 1.0498-1.5904 0.59048-0.80171 1.1908-1.9113 1.3604-2.8311 0.51024-2.5506 0.24011-5.8618 0.0998-8.5135-0.80058-0.2094-1.8811-0.47033-1.611-1.5004 0.52003-0.0404 1.5509-0.14938 1.9411-0.57013 0.55982-0.62036 0.0502-1.1709 0.35038-1.8011 0.67988-1.3999 2.071-1.0405 2.3515-2.6608 0.12005-0.72017-0.23098-1.4103-0.17095-2.1703 0.0502-0.57013 0.43063-0.95044 0.5011-1.4899 0.16051-1.1011-0.55004-3.3908 0.0202-4.3112 0.61072-0.97 2.4814-0.61122 3.3113-1.2303 0.89062-0.66993 1.5907-2.1318 2.3411-2.9609 1.0714-1.1905 1.6012-1.9309 3.3315-2.3405 1.3604-0.32029 2.5009-0.59036 3.832-1.2016 1.1705-0.54991 2.0109-1.5004 3.2115-1.9302 0.93043-0.33986 2.1114-0.11024 2.9818-0.6308 0.17943 0.65037 0.66031 1.3105 1.0309 1.7208 0.99046 1.1103 2.1401 2.0516 2.4905 3.7111 0.36082 1.7404 0.0111 2.8311 1.2508 4.2114 0.97023 1.0705 3.2617 0.81018 3.4118 2.09 1.4002 0.0907 4.1217-0.14938 5.133 0.69081 1.5209 1.2609 0.36016 3.1918 3.0014 3.3412 1.5509 0.09 3.3022-1.4508 4.8531-0.33986 1.3108 0.94979 1.4302 3.1996 1.5098 4.8115 0.81038 0.0489 1.6508 0.01 2.4514 0.06 0.06 1.03-0.03 2.1305 0.19052 3.1312 0.30014 1.3503 2.1414 2.1807 3.4816 2.03-0.33994 1.5095 0.63029 1.561 1.8315 1.501 0.21988 0.94 1.2208 1.4703 1.7408 2.2603 0.52002 0.79061 0.58918 1.9707 1.611 2.3908 2.131 0.89043 4.7226-0.91064 6.6533-1.03 0.11027-1.2694-0.28057-2.3712-0.14094-3.6413 0.0998-0.93934 0.9611-2.0105 0.9611-2.8696 0.0104-1.3203-1.2704-1.7606-1.2912-2.972-0.0196-1.2101 1.0603-2.2407 2.3013-2.0209 0.88084-2.3405 1.671-4.7117 2.8317-7.0118 0.63029-1.2505 0.03-2.6008 0.53046-3.8115 0.47044-1.1605 1.9914-1.3908 2.6308-2.4906 0.70011-1.2094 0.42998-2.6308 0.54025-4.0014 0.12071-1.4703 0.70989-2.2205 1.1705-3.501 0.15007-0.4201 0.0411-1.3503 0.48022-1.6406 0.50045-0.33007 1.5607 0.57013 2.2014-0.06 0.69031-0.69994 0.28969-2.6217 1.1503-3.471 1.0009-0.99153 2.5316-0.66993 1.5007-2.1709-0.30014-0.42988-2.1708-1.8304-2.6412-2.0202-0.10961-1.8709 0.12985-3.3914 0.84039-4.9414 1.2306-0.71038 0.7001-3.6308 2.2713-3.4012 0.68053-0.97001 2.4605-0.45011 2.2308-2.2707 1.0909-0.64972 2.9113-0.31964 3.9722 0.14025 0.41041 0.18004 1.1405 0.85128 1.5307 0.96087 0.62572 0.18004 1.1164-0.10894 1.7564-0.1396zm-3.9279 119.23-0.0202-0.18004c0.23097-0.12003 4.063-0.30985 4.3722-0.0189 1.5209-0.91064 2.4018-0.82975 2.6614 0.99088 0.15986 0.0404 0.29035 0.0196 0.45021 0.06-0.48022 0.80105-0.81037 1.7704-1.0002 2.7815-0.79015 0.12916-0.75035 0.21984-0.95066 0.82911 0.27013-0.0496 0.66031 0.0802 0.94022 0.0502-0.0607 0.78018 0.09 1.6302 0.33994 2.2694-1.5412 0.83041-3.4522-1.6706-5.1128-1.9902-0.21988-0.40053-0.29035-0.98044-0.17029-1.441 1.7003-0.91978-1.5509-2.3301-2.052-3.0307 0.1318-0.3105 0.29231-0.30007 0.5422-0.32029zm19.79 101.38c0.68053 1.6706 0.32037 2.231 0.33994 3.9518-1.301 0.17939-2.3222-0.39922-3.6121-0.33986-1.3611-2.1709-2.5616-3.0307-5.0025-3.171-0.60028-1.2609-2.6112-2.2407-3.573-3.4312-0.70989-0.88064-0.47043-2.1905-0.79014-3.201-0.27013-0.84019-1.7408-2.1005-1.3108-2.8109 0.8704-0.0802 1.5712 0.20026 2.4513 0.15982 0.0405 0.15916 0 0.30006 0.0502 0.44945 1.8106 0.0907 5.5428 0.55969 6.9834-0.41031 0.23098 0.81018 0.11027 0.33007 0.64008 0.8004 0.0104 0.58122 0.03 1.1905 0.0405 1.7802 0.15986 0.0404 0.30014 0.0104 0.46065 0.0502 0.2101 1.09-0.47043 1.1807-0.65052 1.6706-0.21988 0.61122-0.36995 1.1102-0.30014 1.9504 1.0903-0.18005 1.1105 0.85063 1.1608 1.6608 0.82994 0.03 0.68052 0.0496 1.0009 0.66994 0.70076-0.0398 1.4615 0.0307 2.1114 0.22048z",
+                Hualien:"m262.01 324.77c-0.21989-0.69994-0.0698-1.3999 0.95065-1.7704 0.20031-1.1298-1.6808-4.6517-3.1417-4.0411 0.0104-0.25897-0.25903-0.72017-0.19052-1.0705-0.93043-0.0496-1.9809 0.14938-2.7717-0.39009-0.98001-0.65037-0.20944-1.5317-2.0109-1.3307-0.12006-1.06 0.32036-1.6602 0.67009-2.6002 0.18008-0.50098 0.47043-0.43053 0.47043-1.2101 0-0.36921-0.54025-0.53947-0.50958-0.82062 0.21988-1.8898 2.8017-1.291 4.3226-1.5395 0.21988-1.7717-0.0307-2.972-0.33994-4.6113-0.82081-0.18983-1.0107-0.63993-0.77057-1.3307 0.0104-0.0404 0.12005-0.0496 0.27012-0.0496 0.2897-0.0196 0.72033-0.0104 0.84039-0.12981 0.20031-0.2094 0.15985-0.61057 0.47956-0.88977 0.8704-0.74104 0.48022-0.69081 1.7108-0.94978 0.72033-0.15004 1.4707-0.15004 2.1414-0.36987 0.14941-2.4906-2.191-1.9504-1.3108-4.3112 0.61985-1.6497 1.3304-3.3301 2.3802-4.8004 1.8713-2.6413 7.6137-2.561 10.085-0.72016 0.49001-0.7704 1.331-0.90021 2.0116-1.3405 0.10961-1.8311-0.2101-3.5715-0.0998-5.4417 1.6312-0.48011 1.4106-0.72017 1.7806-2.1709-0.27012 0.06-0.68053-0.0998-0.95065-0.0496-0.13963-0.78018-0.24011-1.6308 0.61136-1.8409 0.03-0.12003-0.0307-0.34899 0.06-0.43966 1.1601-0.5597 2.0514 0.60013 2.972 0.31963 0.48022-0.14025 1.4309-1.9002 1.5209-2.321 1.0198-0.71104 1.1908 0.20939 1.9411 0.20026 0.57026-0.0104 1.1014-0.32029 1.6716-0.42988 0.50045-0.71038 0.10961-1.3503 0.3693-2.1311 0.33994-1.0502 0.72033-0.5897 1.1712-1.3803 0.55982-1.0007-0.16051-2.3608 0.2499-3.441 0.39017-1 1.7003-1.7404 1.9111-3.0209 0.16051-0.9002-0.59049-1.5003-0.51023-2.3308 0.0907-0.8291 0.73011-1.2505 0.84038-2.3308 0.09-0.88064 0.0998-1.9707 0.01-2.8402-0.23946-2.1207-1.81-2.2805-2.0109-4.1612-0.2897-2.8213-0.2897-2.651-2.972-3.201-0.27991-1.4808 1.331-3.6113 2.7822-3.8311-0.17095-1.4103-0.24011-2.9211 0.21988-4.2812 0.53046 0 0.77971-0.2805 1.2808-0.39074 0.69031-1.3405 0.51023-3.06 1.1503-4.471 0.23097-0.5199 0.69031-0.65037 0.88083-1.1703 0.14094-0.3803 0.0411-0.93087 0.16051-1.3307 0.27013-0.84019 0.70011-1.2609 1.0303-1.9804 0.21988 0.0404 0.55003-0.0202 0.78036-0.0502 0.0698-1.3803-0.80059-5.8018 1.331-5.6615 0.1703-3.3816 0.51024-6.7822 0.33994-10.124-0.69945-0.0404-1.4204-0.01-2.1205-0.0502-0.12005-2.4808 0.64008-3.4312 1.3206-5.4717 0.42998-1.2903 0.75034-2.0607 1.3708-3.291 0.73011-1.4508 0.47108-2.4006 0.6205-3.8813 0.21988-2.2505 0.96109-1.0196 2.4611-1.8709 0.85996-0.47945 1.5405-1.6706 2.2112-2.4306 1.2912-1.4703 2.1812-4.9414 0.45999-6.1716-0.82994-0.59035-2.3313-0.90021-3.2513-1.5708-1.181-0.8702-1.0707-1.2903-2.8513-1.3105-0.23098-0.72017-0.3308-1.6902-0.0698-2.351 0.30013-0.72995 0.97022-0.77039 1.2208-1.2505 0.3804-0.70973 0.03-1.5304 0.32037-2.2199 0.42019-0.97979 0.4104-0.5199 1.3708-0.95043 1.6012-0.71038 2.4213-1.1814 3.6023-2.2205 1.2201-1.06 1.9411-0.93022 3.6721-1.0196 0.17943-0.80105 0.14028-1.6712-0.78036-1.8408-0.0998-1.1605 0.1305-1.5904 0.55069-2.1612 0.16964-0.21983 0.36995-0.47033 0.60028-0.8004 0.47108-0.67972 0.82994-2.3706 1.5209-2.9707 0.94087-0.82063 2.7326-0.0802 3.312-1.0307 0.59048-0.97979-0.35038-3.0607-0.01-4.1723 0.44042-1.4103 1.7304-1.4201 2.5205-2.4899 0.53046-0.74104-0.01-0.95043 0.82082-1.5108 0.49-0.33986 1.151-0.20026 1.7108-0.66994 0.78036-0.63014 1.7519-1.5095 2.1218-2.3301 0.50045-1.1403-0.30079-2.8317 0.20031-3.972 0.24011-0.54991 1.4504-1.7098 2.2412-2.1807 0.0411 0.0907 0.0907 0.18004 0.15007 0.27006 0.4104 0.60014 0.93956 0.39074 1.5712 0.59035 0.74056 0.23027 1.1705 0.87999 1.8811 1.2003 0.46064 0.21005 1.0009 0.27006 1.4302 0.54012 0.44107 0.27006 0.72033 0.59035 1.0805 0.93022 0.15986 0.15003 0.32037 0.25962 0.5011 0.39074 0.2897 0.18982 0.19052 0.21983 0.41041 0.0992 0.3693-0.19048 0.48022-0.66015 1.0407-0.50033 0.24011 0.0691 0.27013 0.21983 0.58005 0.24984 0.25055 0.0202 0.38039-0.0502 0.59049-0.0802 0.45021-0.0698 0.93043-0.06 1.3715 0.0411 0.61006 0.12916 1.1503 0.30985 1.7904 0.36921 0.41106 0.0404 0.84038 0 1.2508 0.0502 0.98067 0.0998 1.151 1.1905 1.761 1.8206 0.62051 0.63928 0.8306 1.3301 1.8106 1.4606 0.81037 0.10959 1.5809 0.01 2.3613 0.2094 0.39018 0.0998 0.82016 0.26027 1.2397 0.22048 0.26034-0.0307 0.47108-0.12981 0.74121-0.0907 0.23946 0.03 0.42019 0.15003 0.66944 0.12068-0.0998-0.25049-0.0398-0.53034-0.0803-0.82062-0.0502-0.47946-0.23032-0.45924-0.60027-0.80954-0.17943-0.17091-0.33015-0.28963-0.27013-0.55969 0.06-0.29029 0.03-0.14938 0.21989-0.14025 0.12984 0.0202 0.15006 0.18004 0.32036 0.17026 0.18987-0.0104 0.30014-0.19048 0.42998-0.31051 0.20031-0.20092 0.41041-0.65037 0.70076-0.72995 0.28904-0.0802 0.39018 0.21983 0.6205 0.10959 0.23946-0.10959 0.21988-0.63015 0.28904-0.84998 0.0901-0.27006 0.30014-0.53034 0.54025-0.66993 0.0502 0.24005 0.23098 0.48011 0.46065 0.53033 0.42019 0.11025 0.40975-0.1409 0.71054 0.23027 0.15986 0.20027 0.2897 0.78018 0.59049 0.58057 0.16964-0.11024 0.16964-0.61057 0.18987-0.80953 0.03-0.27006 0.0803-0.69994 0.0104-0.96087-0.11027-0.42989-0.44955-0.33986-0.74056-0.66016-0.19052-0.21004-0.19052-0.45988-0.33994-0.67972-0.2003-0.27984-0.55982-0.39009-0.6603-0.77039-0.20031-0.75017 0.49001-1.6308 1.2404-1.1305 0.32037 0.21984 0.68053 0.68038 0.95066 0.96022 0.33015 0.3503 0.63942 0.69995 0.98066 1.0411 1.1503 1.1507 0.0803-1.1011 1.2006-0.76061 0.24011 0.0802 0.36016 0.44032 0.55003 0.63015 0.38039 0.3803 0.90041 0.51011 1.2612 0.92043 0.36017 0.41031 0.66031 0.84997 1.1099 1.1598 0.35038 0.25049 0.66095 0.19048 1.0805 0.25049 0.46064 0.0691 0.53046 0.3105 0.90041 0.50033 0.39996 0.21005 0.96109-0.0404 1.3904 0.12003 0.29035 0.11024 0.59049 0.36073 0.8704 0.5199 0.53046 0.29028 0.99111 0.61123 1.5816 0.79062 0.46 0.14938 0.93043 0.12002 1.4204 0.12002 0.53046-0.01 0.92064 0.12982 1.4106 0.29029 0.61985 0.19048 1.4713 0.0196 2.0514 0.33986 0.33994 0.18983 0.60093 0.54012 0.93108 0.72995 0.2897 0.17026 0.58136 0.23027 0.90042 0.31051 0.49066 0.12981 1.5405 0.7606 2.022 0.3803 0.0196-0.01 0.0405-0.03 0.0405-0.0496 0.0796 0.42988 0.18987 0.96022 0.0411 1.3405-0.15007 0.43053-0.76078 0.27006-0.87105 0.88064-2.0905 1.3112-2.9414 2.9218-3.2219 5.4019-0.18987 1.7104-0.15985 2.2805-1.8811 2.8807-1.3708 0.48011-2.1904 0.8702-3.3518 1.6406 0.06 1.1305-1.0107 2.3908-1.9313 2.8311-0.57027 0.2805-1.2802 0.44032-1.8406 0.68037-0.95065 0.39009-1.0707 0.74952-1.7512 1.4508-0.99111 1.0196-1.4217 1.7606-1.5105 3.4006-0.0404 0.92043-0.33993 3.8011 0.61007 4.1416 0.57091 1.9615 0.39083 4.5115-1.2606 5.702-0.63943 0.4501-1.4707 0.72016-2.0612 1.1514-0.61071 0.44945-1.4511 1.3705-1.9411 1.9707-1.8504 2.2812-1.9307 8.5428-0.0698 10.763 0.39997 0.47032 1.0414 0.91064 1.5809 1.0502 0.97023 1.4508 1.7715 3.5506 0.62051 5.2016-0.36017-0.03-0.62051 0.16047-0.95066 0.17026-0.0496 0.1709-0.12919 0.29028-0.17029 0.46054-0.39997 0.0998-0.81037 0.19047-1.2097 0.29028-0.0998 0.23027-0.18987 0.21983-0.2897 0.45989-3.002 0.20026-1.7512 9.1221-1.8615 11.283-0.0907 1.8304-0.86062 3.8611-1.3611 5.5219-0.60028 1.9602-0.44042 3.8813-0.76079 5.972-0.17943 1.2303-1.0603 2.3706-1.8811 3.351-1.1601 1.4005-1.2397 2.1409-1.2397 4.0314 0 1.7508 0.68053 3.9818 0.12006 5.6322-0.53046 1.5806-1.9711 2.5004-2.4912 4.2512-1.0407 3.5708 0.0698 8.1723-1.5607 11.684-0.91085 1.9707-2.0807 2.2107-2.4513 4.5617-0.32037 2.0405 0.23032 4.2114 0.01 6.2623-0.21009 1.8611-1.4002 3.2805-1.761 4.9909-0.41041 1.9609-0.0796 3.9211-0.74056 5.762-0.59049 1.6706-2.1316 4.0907-0.12006 5.4913-0.57026 2.7411-1.4818 5.0418-2.4416 7.4926-0.64008 0.03-1.1307 0.31898-1.7519 0.13959-0.39018-0.10959-1.1203-0.77952-1.5307-0.96087-1.0603-0.45924-2.8813-0.78996-3.9723-0.14025 0.23097 1.8206-1.5503 1.3007-2.2308 2.2707-1.5712-0.23092-1.0407 2.6908-2.2713 3.4012-0.71054 1.5499-0.95065 3.0705-0.83973 4.9414 0.47043 0.18982 2.3411 1.5904 2.6412 2.0202 1.0309 1.501-0.5011 1.1814-1.5007 2.1709-0.86061 0.85063-0.45999 2.7711-1.151 3.471-0.63943 0.63015-1.7004-0.27006-2.2014 0.06-0.44042 0.28964-0.33015 1.2205-0.47957 1.6406-0.46064 1.2805-1.0505 2.0307-1.1705 3.501-0.11092 1.3712 0.1592 2.7906-0.54025 4.0014-0.64008 1.1011-2.1616 1.3301-2.6314 2.4906-0.5011 1.2094 0.0998 2.561-0.53046 3.8115-1.1601 2.3001-1.9502 4.6713-2.8317 7.0118-1.2397-0.21983-2.3215 0.81019-2.3006 2.0216 0.0196 1.2101 1.3004 1.6497 1.2906 2.9713 0 0.85977-0.86061 1.9302-0.96044 2.8702-0.13963 1.2694 0.25055 2.3712 0.14028 3.6406-1.9307 0.12068-4.5223 1.9204-6.6533 1.03-1.0198-0.4201-1.0903-1.6002-1.611-2.3908-0.52067-0.78996-1.5209-1.319-1.7408-2.2603-1.2006 0.06-2.1714 0.0104-1.8308-1.501-1.3415 0.14938-3.1821-0.67972-3.4822-2.03-0.21988-1.0007-0.12919-2.1011-0.19052-3.1312-0.80059-0.0502-1.641-0.0104-2.4513-0.06-0.0803-1.6112-0.20031-3.8618-1.5098-4.8115-1.5509-1.1102-3.3028 0.42988-4.8531 0.33986-2.6412-0.14938-1.4811-2.0803-3.0014-3.3412-1.0107-0.83954-3.7322-0.60014-5.133-0.69081-0.15007-1.2799-2.4416-1.0196-3.4118-2.09-1.2404-1.3803-0.89063-2.471-1.2508-4.2114-0.35037-1.6608-1.5013-2.6008-2.4911-3.7104-0.37778-0.41814-0.858-1.0783-1.0381-1.7287z",
+                ChiayiCity:"m184.85 297.29c0.06 1.2094-0.28056 1.4703-1.301 1.9994-0.12984 0.89042-0.33994 2.5317-1.6005 1.8017-0.42019-0.24005-0.55069-0.76061-1.0805-0.89042-0.39017-0.10959-1.2808-0.14938-1.671-0.09-0.75034 0.12003-1.4707 1.1005-1.9907 1.6706-0.51023 0.57013-1.4113 1.5506-2.3313 1.4005-0.48022-0.50164-0.2499-1.1709-0.67988-1.711-0.52002-0.64972-0.99046-0.55056-0.93043-1.5904-0.71054-0.0404-1.4309 0.0104-2.1414-0.03-0.0698-1.1011-1.1803-0.61057-1.8308-0.55056-0.98001 0.0992-1.4106-0.69994-0.27012-1.0404 0.0998-0.63993 0.76078-1.5904-0.39997-1.501-0.42019-0.53034-0.53046-1.4899-0.6205-2.1403-0.12984-0.97001-0.01-0.91978 0.94022-1.261 0.4502-0.17025 0.91085-0.42988 1.181-0.82062 0.0998-0.0104 0.21989 0.0104 0.30993 0 0.0502 0.33986 0.12005 0.66081 0.19052 0.98044 0.77057-0.0404 0.99045-0.63014 1.6605-0.82062 0.62051-0.17939 1.3911-0.0698 2.0612-0.0998-0.18009-1.3601 1.2606-0.94979 2.1714-1 0.0196-0.34899 0.17029-0.63014 0.42998-0.8291 0.33994 0.21983 0.26034 0.50033 0.48022 0.78018 0.20031 0.27985 0.63029 0.4488 0.79014 0.70973 0.49001 0.77952 0.03 1.2701 1.3004 1.1709 0.0998-0.29029 0.1703-0.57013 0.19053-0.89042 0.38039 0.03 1.5105 0.24005 1.7512 0.49054 0.32036 0.33008 0.24989 1.2101 0.33993 1.6497 0.93108 0.17026 1.3004 0.84019 2.3013 0.85976 0.03 0.4899 0.0398 0.93087 0.10961 1.3914 0.22967 0.17026 0.33994 0.2805 0.64008 0.36073z",
+                ChiayiCounty:"m205.81 336.38c-0.21988 1.0607-1.1216 1.5206-1.8817 0.36073-1.3708-0.30007-2.3515 0.2094-3.8418 0.0998-1.4002-0.11024-1.9013-0.57013-2.6314-1.741-0.35038 1.8611-2.0207 1.8311-2.8611 3.2414-0.0502-0.0104-0.54025 0-0.61071 0-0.38039-0.78018-1.5614-0.45988-1.7219 0.3503-1.3904-0.33986-1.5705-2.1011-3.2813-1.8904-0.0998-0.34965-0.22053-0.72017-0.39083-1.0607-0.5807-0.03-1.2006-0.0398-1.7806-0.06-0.0607-0.85912 0.2897-1.9609 1.1105-2.3405 0.0496-0.85063 0.0496-1.7508 0-2.6008-1.8615-0.20026-1.0414-4.6211-0.97023-6.032 0.0692-1.4397 0.09-1.8096 1.181-2.6706 0.79014-0.62036 1.761-0.39922 1.6207-1.8011-1.9816-0.45989-3.0816-2.0105-5.2733-1.8898-0.48022-2.1403 1.9914-2.3412-0.46064-3.6413-0.10962-0.99936-1.6312-0.98045-2.5009-1.2003-0.1703-1.561 1.9209-0.93935 1.4009-2.6112-2.071 0.44032-2.1512-0.50033-3.9723-1.3601-1.1503-0.54012-2.6915-1.0404-3.6721-1.8506-1.0407 1.4599-3.5318 0.34965-5.0025 0.34965-1.731 0-3.0516 0.76061-4.6626 1.0007-1.8609 0.27985-3.6317 0.10959-5.013 1.3705-1.0505 0.95044-0.45021 1.0802-1.9907 1.3001-0.91085 0.12982-1.8008-0.0998-2.6412-0.14025 0.10961 2.5206-1.2606 1.2205-2.7417 2.261-1.5907 1.1298-0.6205 2.1905-0.31057 3.5512-1.4204 0.58905-1.7108-0.61123-2.6915-0.55056-0.95065 0.06-1.7708 1.3294-0.65051 1.9106 0.52002 3.261-2.8618 1.2609-4.2822 2.8311-0.24989 1.7-1.5007 2.291-2.3613 3.471-0.36016 0.4899-0.6603 1.5604-1.1608 1.6706-0.71054 0.15982-1.5405-0.93934-2.3111-1.0196-0.17029-0.51012-0.40975-0.61971-0.6603-0.97 0.12005 3.5812-3.4118 0.81018-3.5618-1.1598-0.52003 0.0405-1.1007-0.0907-1.611-0.0502-0.2499-0.88912-0.89063-1.5806-1.0603-2.4508-1.5405-0.42989-2.5714-1.6908-4.0323-2.3001 0.03-0.0607 0.0698-0.12068 0.0998-0.17939 0.74056-1.3607-0.0404-3.7313 1.4811-4.471 0.21988-0.1109 0.48022-0.15982 0.7001-0.24006 0.30014-0.12133 0.42019-0.25962 0.67074-0.39074 0.10962-0.0607 0.76014-0.16047 0.82016-0.23092 0.67988-0.80106-2.3815-1.4201-2.6712-1.5199 1.8909-0.17025 6.6232-0.12068 4.6521-3.1814-0.36995-0.0411-0.55003 0.31051-0.80058 0.55969-0.53046-0.42074-1.2103-1.5506-0.93043-2.1011 0.20031-0.39987 0.58005-0.45989 0.56047-0.96935-0.0202-0.45011-0.33993-0.42988-0.0698-0.93087-0.48022-0.0104-0.86061-0.54012-0.81037-1.0104 0.06-0.62036 0.78036-0.88064 1.0505-1.3196 0.49001-0.79127 0.06-2.4019-1.0505-1.9309-0.44042 0.18983-0.44042 0.85977-1.1203 0.69081-0.53046-0.12981-0.70076-0.76061-0.44042-1.2309 0.35038-0.63993 0.78036-0.34965 1.3108-0.5199 0.7001-0.22114 0.38039-0.82128 0.38039-1.441 0-1.2401 0.88084-1.441 1.5607-2.2499 0.72033-0.86042 0.38039-2.0516-0.99046-1.5506-0.18987 0.0796-0.36995 0.31898-0.57026 0.37965-0.25968 0.0907-0.55003-0.0196-0.82016 0.0496-0.27012 0.0607-0.39996 0.33073-0.60027 0.39075-0.36995 0.11024-0.42019-0.0907-0.70076-0.15982-0.21988-0.06-0.63029 0.0104-0.82016-0.0998-0.42998-0.25049-0.17029-0.39922-0.30992-0.75996-0.20031-0.50098-0.73077-0.54012-0.94087-0.99087-0.27991-0.58971 0.21988-1.1905 0.36995-1.7104 0.0803-0.25962 0.0803-0.55969 0.20031-0.79061 0.13963-0.31051 0.36996-0.40966 0.50045-0.69081 0.47043-0.11025 0.58005 0.20091 0.96044 0.33072 0.33994 0.11025 0.80059 0.0405 1.1608 0.0405 0.58005 0 1.8909 0.25962 1.611-0.62036-0.12006-0.36008-0.66031-0.4201-0.55004-0.87999 0.06-0.27006 0.33994-0.35029 0.48022-0.59035 0.70011 0.45989 1.2006 0.95044 1.0505 2.0607 0.32036-0.0502 0.79014 0.12981 1.1105 0.06 0.42019 0.75996 2.9714 0.95044 3.862 1.1403 1.6508 0.35029 3.2317 0.85063 4.8224 1.1605 2.0312 0.39922 3.8724 0.40966 3.522-2.1709-0.0998-0.66994-0.89063-1.3601-0.98067-1.8617-0.14028-0.78997 0.38039-1.5304 0.50045-2.2805 0.33015-0.01 1.5607-0.21983 1.8113-0.03 0.63029 0.47098 0 1.0913 0.36996 1.6412 0.92064 1.3712 2.221 0.69081 1.9907-0.93021 1.9209-0.63993 1.1705-1.1403 2.101-2.7404 0.85082-1.441 1.6207-0.68038 3.342-0.82063-0.10049-0.63993-0.59049-1.1102-0.61072-1.7802 1.0407-0.09 2.161 0.18983 3.1214 0.4501 0.0405-2.2707 0.15007-2.651 2.3515-2.8122 1.4106-0.0998 3.0314-1.0405 2.7019-2.8004 0.88019-0.36008 1.9809-0.17939 2.9414-0.23027-0.2101-1.6615 1.9013-3.0516 3.3615-2.972 1.5007 0.0698 2.3515 2.9511 4.5125 1.6804 0.77057-0.4501 0.54025-1.3203 1.5307-1.6804 0.76013-0.27006 2.1512 0 2.9616 0 0.90041 0 1.9411 0.14025 2.8017-0.0398 0.96044-0.19048 1.38-0.86041 2.5114-0.60013 0.2499 1.3105 1.6207 1.8806 1.7206 3.1109 0.23098-0.0189 0.55004 0.0802 0.78036 0.06 0.80059 4.1514 4.6123 2.6112 7.694 3.3014 1.7114 0.39074 2.8115 1.291 4.8531 1.1703 1.7519-0.10959 3.1514-0.85976 4.9627-0.81019 0.35038 2.1514 0.06 3.1012 2.6614 2.4514 0.24011-0.49055 0.46064-0.47946 0.82994-0.79062 0.20096 2.0516 2.452 0.69994 3.5423 0.65037 1.4811-0.0692 3.6121 1.4103 5.0025 1 1.1007-0.33008 0.80059-0.71038 0.79015-1.8311 0-0.53034 0.09-2.0209-0.12071-2.5114-0.25903-0.62036-1.2306-0.4899-1.3604-1.3405-0.06-0.42988 0.64007-1.2003 1.1405-1.4305 0.2101 0.12068 0.5011 0.21983 0.89062 0.27006 1.2006 0.17026 2.5714-0.20026 3.9723-0.14025 0.0104 0.32029 0.19053 0.4899 0.2101 0.78018 0.75034 0.0502 1.5307 0.0202 2.2817 0.06 0.92064 0.68038 0.52002 1.4005 1.6906 1.8213 0.79014 0.27006 2.3111 0 3.1521-0.0404 0.0502-0.15004 0.01-0.29029 0.0502-0.45011 0 0 0.47957-0.0202 0.44955 0.0104 0.36995 0.66081 1.0903 1.3908 1.2012 2.1403 0.0692 0.55056-0.31123 1.9204-0.33994 2.6608-0.0502 0.98045-0.12985 1.6908-0.70011 2.4606-0.53046 0.7293-1.5007 0.77953-1.4511 1.8506 0.15986 0.0489 0.30014 0.0104 0.46065 0.0489 0.06 1.5904 0.70989 2.9811 1.01 4.4815 0.25055 1.2309 0.16051 3.7711 1.6508 4.1918 0.06 2.2499 0.52003 2.2805 2.6915 2.3001 1.6201 0.0196 3.0516 0.45011 4.6417 0.31116 0.39997-2.242 7.5844-0.54012 9.1849-0.44097 0 0-0.06 0.30007-0.0802 0.30007 0.0698 0.22049 0.28056 0.36074 0.29035 0.63993 0.45999-0.0698 0.94021-0.21005 1.4002-0.33008-0.58071 0.61058-1.6116 0.97001-2.4018 0.88977-0.7001 0.91978-1.5098 0.99088-2.6914 1.1298-1.151 0.14938-2.5212 0.27985-3.5514 0.94978-0.39084 0.26028-1.0414 0.93087-1.3206 1.3412-0.2499 0.36073-0.41041 1.501-0.6205 1.7208-0.92064 0.93934-2.8115 0.27006-4.0114 0.69994-1.3506 0.47946-1.791 1.4508-2.1714 2.76-0.35038 1.1507-0.67988 2.0411-1.2103 3.1514-0.33994 0.71038-0.74056 3.261-1.1105 3.6015-0.72033 0.64971-3.0908-0.0196-4.0519 0.39987-1.4204 0.63993-1.5398 1.76-1.821 3.1918-1.1601 0.06-2.8317-0.30007-3.8124 0.31899-0.99046 0.63145-0.84039 1.9009-1.4909 2.7522-0.21988 0.28898-1.821 1.9707-2.1714 2.1305-1.1901 0.55056-2.0305-0.18982-3.171 0.66081-1.5307 1.1403-1.1412 5.291-4.0121 3.8415-1.3108-0.6608-0.45999-2-1.9809-2.5114-0.84038-0.27006-2.7815-0.2805-3.6519-0.14025-0.75035 2.2205-0.01 5.1012 0.64008 7.1521 0.27991 0.90086 0.83973 2.2812 0.71054 3.3308-9e-3 0.0626-0.0189 0.12264-0.0287 0.17222zm-22.262-37.091c1.0198-0.53033 1.3604-0.78996 1.301-1.9994-0.30014-0.0802-0.41106-0.19048-0.64008-0.36008-0.0698-0.46054-0.0803-0.90151-0.10961-1.3914-1.0009-0.0196-1.3708-0.69081-2.3013-0.85976-0.09-0.43967-0.0202-1.3196-0.33993-1.6497-0.24012-0.25049-1.3708-0.46054-1.7512-0.49054-0.0202 0.32029-0.09 0.60013-0.19053 0.89042-1.2704 0.0992-0.81037-0.3914-1.3004-1.1709-0.1605-0.25963-0.59048-0.42988-0.79014-0.70973-0.21988-0.28115-0.14028-0.56035-0.48022-0.78018-0.25969 0.20026-0.41041 0.47946-0.42998 0.8291-0.91085 0.0502-2.3515-0.36008-2.1714 1-0.67009 0.03-1.4407-0.0796-2.0612 0.0998-0.67009 0.19048-0.89062 0.77953-1.6605 0.82062-0.0698-0.31963-0.14028-0.63992-0.19052-0.98044-0.09 0.0104-0.2101-0.0104-0.30993 0-0.27012 0.39074-0.73077 0.65037-1.181 0.82063-0.95066 0.33986-1.0707 0.28963-0.94022 1.2603 0.09 0.65037 0.20031 1.6112 0.6205 2.1409 1.1608-0.0907 0.50045 0.85976 0.39997 1.5004-1.1405 0.33986-0.70989 1.1403 0.27012 1.0411 0.65052-0.0607 1.761-0.55121 1.8308 0.55057 0.71055 0.0398 1.4309-0.0104 2.1414 0.03-0.06 1.0405 0.41041 0.94 0.93043 1.5904 0.42998 0.53947 0.20031 1.2094 0.67988 1.7104 0.92064 0.14938 1.821-0.82976 2.3313-1.3999 0.52002-0.57013 1.2404-1.5506 1.9907-1.6706 0.39018-0.0607 1.2808-0.0196 1.671 0.09 0.53047 0.12982 0.66031 0.65037 1.0805 0.89042 1.2606 0.7293 1.4707-0.91194 1.6005-1.8024z",
+                Nantou:"m217.09 275.91c-0.88997-0.5199-0.50958-1.5506-1.671-2.351-1.581-1.0907-0.96044 0.88977-1.7806 1.79-0.74056 0.81019-2.9805-0.4899-3.0314 0.98109-1.4818 0.0692-2.7515-0.20091-4.1125-0.33986-0.39084-0.82975-0.2101-1.8206-0.57027-2.6106-1.121 0.36009-1.7806 2.1905-2.9316 1.9504-0.39997-2.0307-0.12071-3.3308 0.25968-5.1918 0.36082-1.7515 1.4909-2.7906 1.9118-4.4214 0.36017-1.3307-0.35038-1.3001-0.7001-2.2009-0.36017-0.91065-0.27991-1.6504-0.32037-2.6706-0.0404-0.66993-0.58005-2.351-0.18008-3.0013 0.47109-0.77952 1.5209-0.47032 2.4716-0.52055 0.10962-2.0607-0.15986-3.7913-0.63942-5.6406-0.26034-1.0202-0.54025-1.2505-1.0903-1.9805 0.18987 0 0.39997-0.03 0.57027-0.0502-0.0698-0.8004 0.51023-1.2003 0.88997-1.7802 1.7519-0.41031 2.972-0.95043 4.9425-1.0496-0.01-0.0698-0.01-0.39074 0-0.4501-0.49 0-0.82994-0.31051-1.2808-0.39009-0.03-0.4899-0.27991-0.90021-0.21988-1.4403-0.33994-0.33008-0.86062-0.59035-1.2808-0.66994 0.03 1.7515-3.8118 0.54013-4.0519-0.50033-1.6605-0.42988-1.4609-2.9107-2.7815-3.0509 0.50958-1.2707-0.21989-6.3021 1.2697-6.8422 0.0698-1.1403-0.09-2.3308 0.32036-3.351 0.21989-0.55056 0.71055-0.6608 0.8815-1.291 0.12005-0.47032 0-1.1605-0.0307-1.6406-0.23032 0.03-0.55004-0.0802-0.77971-0.0502-0.0907-1.561-0.55003-3.2708-0.33015-4.7815 3.1208 0.12003 3.2806-4.201 1.9411-6.002-0.47043 0.09-0.85017-0.19048-1.2704-0.21983-0.3693-4.1012 4.553-0.39009 5.8931-2.6706 0.28057 0.15982 0.58071 0.29029 0.91086 0.36922 1.2006 0.3105 2.9218-0.0104 4.1726-0.0104 1.8106 0 2.3913 0.31116 3.8424 0.80105 3.342 1.1396 4.6221-0.93086 6.4543-3.1814 0.66944-0.81997 1.5007-1.7704 1.8902-2.7704 0.42085-1.1011 0.62051-2.8813 1.6912-3.6413 0.82081-0.58057 1.9711-0.3503 2.942-0.39987 0.12005-2.4808-0.21989-5.0516 0.65051-7.3119 0.47957-1.2101 1.2906-1.9602 2.7019-1.3203 0.58005 0.25962 0.75034 0.97 1.3004 1.2003 0.73077 0.29029 0.82015-0.03 1.6808-0.17938 0.44955 1.1102-0.33081 2.9211 0.23032 3.9302 0.88084 1.5904 2.4011 0.48011 2.6314-0.96023 0.19052-1.1605-1.1105-3.321 0.84038-3.0007 1.3408 0.20939 1.121 1.8898 2.9616 1.4703 0.54025-1.1814 1.7708-1.1814 2.8409-1.6602 2.3613-1.09 4.4825-0.32029 7.234 0.0196 0.33994-1.0196 0.79015-1.8402 2.052-1.73 0.09-2.291 1.151-4.0111 3.631-4.1012 2.6014-0.09 3.6023-0.40053 5.6635-1.6712 1.8308-1.1298 2.3711-2.8702 3.9618-4.1612 1.5614-1.2799 4.4434-0.58905 6.4738-0.69929 0.12919-1.4814 0.0496-2.7411 1.3604-3.1409 1.0198-0.3105 2.9414-0.63014 4.0023-0.50033 0.55982 0.0802 1.0498 0.60992 1.6312 0.47033 0.42998-0.0998 0.81037-0.95044 1.5398-1.1305 0.70076-0.17939 1.4217-0.12916 2.1714-0.33986 0.66096-0.19048 0.84039-1.2205 1.3604-0.19048 0.72033 0.0404 1.5509 0.10046 2.2713 0.06 1.1405-0.0691 0.48022 0.48011 1.2006-0.69994 0.82016-1.3497 0.99111-2.6406 3.1417-2.3105-0.33994 2.1507 1.6201 1.0411 2.2204 2.1103 0.7001 0.12002 1.4818 0.0502 2.1108-0.15982 0.24011-2.0105 6.0934-0.0202 6.7936 1.0202-0.0802 0.19048-0.0502 0.28963-0.0698 0.47946 0.0196 0 0.03 0.0104 0.0502 0-0.42019 0.57013-0.65052 1-0.55069 2.1612 0.92064 0.17025 0.96044 1.0404 0.78036 1.8402-1.731 0.0907-2.452-0.0404-3.6728 1.0202-1.181 1.0404-2.0005 1.5101-3.6023 2.2205-0.96044 0.42988-0.95065-0.03-1.3708 0.95043-0.29035 0.69016 0.06 1.5101-0.32036 2.2199-0.2499 0.48011-0.92064 0.5199-1.2208 1.2505-0.26033 0.66081-0.16051 1.6308 0.0692 2.351 1.7806 0.0202 1.6716 0.44032 2.852 1.3105 0.92064 0.66993 2.4213 0.98044 3.2513 1.5708 1.7212 1.2303 0.82995 4.7013-0.45999 6.1716-0.67009 0.76061-1.3506 1.9504-2.2112 2.4306-1.5007 0.85128-2.2419-0.38031-2.4611 1.8709-0.14942 1.4814 0.10961 2.4312-0.62051 3.8813-0.61985 1.2303-0.94021 2.0007-1.3708 3.291-0.67988 2.0405-1.4407 2.9909-1.3206 5.4717 0.7001 0.0411 1.4211 0.0104 2.1205 0.0502 0.17095 3.3412-0.16964 6.7418-0.33994 10.124-2.1323-0.14025-1.2612 4.2812-1.331 5.6615-0.23097 0.03-0.56047 0.09-0.78035 0.0502-0.33016 0.72016-0.76079 1.1403-1.0303 1.9804-0.12005 0.39988-0.0202 0.95044-0.16051 1.3307-0.19052 0.5199-0.65051 0.65037-0.88084 1.1703-0.64007 1.4103-0.45999 3.1305-1.1503 4.471-0.5011 0.10959-0.75034 0.39074-1.2815 0.39074-0.45999 1.3608-0.39017 2.8702-0.21988 4.2812-1.4511 0.21983-3.0608 2.351-2.7815 3.8311 2.6817 0.54991 2.6817 0.3803 2.972 3.201 0.20097 1.8806 1.7715 2.0405 2.0109 4.1612 0.0907 0.8702 0.0802 1.9602-0.01 2.8402-0.11027 1.0802-0.75034 1.501-0.84039 2.3308-0.0802 0.83041 0.67009 1.4306 0.51024 2.3308-0.2101 1.2805-1.5209 2.0209-1.9111 3.0209-0.4104 1.0802 0.31058 2.441-0.25055 3.441-0.44955 0.78997-0.82994 0.33008-1.1705 1.3803-0.25904 0.77953 0.13049 1.4208-0.3693 2.1311-0.57092 0.10959-1.1014 0.42075-1.6716 0.42988-0.74969 0.0104-0.92064-0.91064-1.9411-0.20026-0.09 0.42075-1.0407 2.1807-1.5209 2.321-0.92064 0.2805-1.8113-0.88064-2.972-0.31964-0.0907 0.0907-0.03 0.31964-0.0607 0.43966-0.85017 0.21005-0.74969 1.0607-0.61072 1.8409 0.27013-0.0502 0.68053 0.10959 0.95066 0.0496-0.36995 1.4508-0.15007 1.6908-1.7806 2.1709-0.11027 1.8702 0.21009 3.6106 0.0998 5.4417-0.68053 0.44032-1.5209 0.57014-2.0116 1.3405-2.4716-1.8396-8.214-1.9198-10.085 0.72017-1.0498 1.4703-1.761 3.1507-2.3802 4.8004-0.8815 2.3608 1.4602 1.8206 1.3108 4.3112-0.67009 0.21984-1.4217 0.21984-2.1414 0.36987-1.2306 0.25897-0.84039 0.20874-1.7108 0.94978-0.32036 0.2805-0.28056 0.68038-0.48022 0.88977-0.12005 0.12068-0.55003 0.11025-0.84038 0.12981 0-0.14938 0.0307-0.33007 0.0111-0.45988-0.14028-0.03-0.32037-0.0502-0.46065-0.0405 0.03-0.91064 0.44042-1.6412 0.29035-2.6217-0.39083 0.0496-0.78036-0.24005-1.1307-0.23027 0.0411-0.3803-0.20031-0.60079-0.2101-0.93086-1.8713-0.10959-3.2513-0.0104-4.8022-0.69995-1.0805-0.48011-0.95065-0.6197-2.1714-0.36986-0.24011 0.0502-0.49 0.11024-0.74055 0.18004-0.46 0.12003-0.94022 0.25897-1.4002 0.33007-0.0104-0.2805-0.21989-0.42074-0.29035-0.63993 0.0202 0 0.0802-0.30006 0.0802-0.30006-1.6012-0.0992-8.7849-1.8011-9.1849 0.44097-1.5907 0.14025-3.0216-0.29029-4.6417-0.31116-2.1714-0.0196-2.6314-0.0502-2.6915-2.3001-1.4909-0.42074-1.4002-2.9609-1.6508-4.1918-0.30014-1.5003-0.95066-2.8911-1.01-4.4815-0.16051-0.0398-0.30014 0-0.46065-0.0489-0.0502-1.0711 0.92064-1.1213 1.4511-1.8506 0.57026-0.77104 0.65052-1.4814 0.70011-2.4606 0.03-0.74039 0.4104-2.1103 0.33994-2.6608-0.11027-0.74952-0.82995-1.4808-1.2006-2.1403 0.03-0.03-0.44955-0.0104-0.44955-0.0104-0.0411 0.16047 0 0.30007-0.0502 0.4501-0.84039 0.0405-2.3613 0.31051-3.1521 0.0405-1.1705-0.42075-0.77057-1.1409-1.6906-1.8213-0.75034-0.0398-1.5314-0.01-2.2817-0.06-0.0196-0.29028-0.20031-0.46054-0.21009-0.78017-1.4002-0.06-2.7717 0.31115-3.9723 0.14024-0.39083-0.0489-0.68053-0.14873-0.89063-0.26875z",
+                Yunlin:"m204.7 249.7c0.55004 0.72995 0.82929 0.96022 1.0903 1.9805 0.47957 1.8506 0.7497 3.5806 0.63943 5.6406-0.95066 0.0502-2.0005-0.25897-2.4716 0.52055-0.39932 0.65037 0.14028 2.3308 0.18008 3.0014 0.0411 1.0196-0.0405 1.7606 0.32037 2.6706 0.35037 0.90021 1.0603 0.8702 0.7001 2.2009-0.42085 1.6308-1.5503 2.6706-1.9118 4.4214-0.38039 1.8611-0.6603 3.1612-0.25968 5.1918 1.151 0.24006 1.8106-1.5904 2.9316-1.9504 0.36017 0.78997 0.17943 1.7802 0.57026 2.6106 1.3604 0.14025 2.6308 0.41032 4.1125 0.33986 0.0502-1.471 2.2908-0.17025 3.0314-0.98109 0.82147-0.90021 0.20097-2.88 1.7806-1.79 1.1608 0.8004 0.78036 1.8304 1.671 2.351-0.50045 0.23092-1.2006 1.0007-1.1405 1.4305 0.12984 0.84998 1.1014 0.72017 1.3604 1.3405 0.2101 0.49055 0.12071 1.9804 0.12071 2.5114 0.01 1.1207 0.30992 1.501-0.79015 1.8311-1.3904 0.41031-3.522-1.0705-5.0025-1-1.0903 0.0496-3.342 1.3999-3.5416-0.65037-0.36996 0.31116-0.59049 0.30007-0.8306 0.79062-2.6014 0.64971-2.3111-0.30007-2.6614-2.4514-1.8113-0.0496-3.2115 0.7006-4.9627 0.81019-2.0409 0.12068-3.141-0.77953-4.8531-1.1703-3.0816-0.69016-6.8934 0.85063-7.694-3.3008-0.23032 0.0196-0.55003-0.0802-0.78036-0.0607-0.0992-1.2303-1.4707-1.8004-1.7206-3.1109-1.1307-0.25962-1.5509 0.41032-2.5114 0.60014-0.86061 0.17939-1.902 0.0398-2.8017 0.0398-0.81037 0-2.2014-0.27006-2.9616 0-0.9911 0.36009-0.76078 1.2303-1.5307 1.6804-2.1616 1.2707-3.0118-1.6106-4.5125-1.6804-1.4609-0.0802-3.5723 1.3105-3.3615 2.972-0.96044 0.0502-2.0612-0.13046-2.9414 0.23027 0.33015 1.7606-1.2912 2.7013-2.7019 2.8004-2.2014 0.15982-2.3111 0.54012-2.3515 2.8122-0.96044-0.26027-2.0807-0.54012-3.1214-0.4501 0.0202 0.66994 0.51024 1.1403 0.61072 1.7802-1.7212 0.14025-2.4912-0.62036-3.342 0.82063-0.93043 1.6002-0.18009 2.1005-2.101 2.7404 0.23033 1.6197-1.0707 2.3001-1.9907 0.93021-0.36996-0.54991 0.25968-1.1703-0.36996-1.6412-0.25055-0.18982-1.4811 0.0202-1.8113 0.0307-0.12006 0.74952-0.64008 1.4899-0.50045 2.2799 0.09 0.50164 0.88084 1.1905 0.98067 1.8617 0.35038 2.5806-1.4909 2.5708-3.522 2.1709-1.5907-0.31116-3.1717-0.81019-4.8224-1.1605-0.89063-0.18983-3.4418-0.38031-3.862-1.1403-0.32037 0.0698-0.79015-0.11024-1.1105-0.06 0.15006-1.1102-0.35038-1.6008-1.0505-2.0607 0.0405-0.0496 0.06-0.11024 0.0803-0.18004 0.26033-1.0705-0.55004-0.88912-0.95066-1.5304-0.0502-0.0104-0.11026 0-0.1605-0.0196-0.0503-0.87085-0.06-1.8011-0.01-2.6804 0.0405-0.71038 0.27991-0.36987 0.50045-0.81019 0.21988-0.45988-0.21989-0.63993-0.4202-0.88977-0.57026-0.71038-0.38039-1.6908-0.33015-2.621 0.0202-0.52056 0.30014-0.66994 0.36995-1.0607 0.0803-0.40966-0.24011-0.75017-0.31057-1.1403-0.0803-0.48011 0.0202-1.0405-0.01-1.5304-0.36995-0.13047-1.151-0.74104-1.0505-1.2107 0.0998-0.5199 0.85082-0.27006 1.1105-0.80105 0.18008-0.36922 0.0104-1.2505 0.0104-1.6797 0-0.72017 0.32036-0.94 0.50044-1.5708 0.18009-0.62036 0.4202-1.0098 0.88084-1.5101 0.49001-0.53034 0.6205-0.84019 0.85996-1.5095 0.24011-0.66993 0.39018-1.09 0.45021-1.7906 0.0398-0.56035 0.27012-0.89043 0.64008-1.3007 0.57026-0.62036 2.2112-1.6008 1.7206-2.6308-0.21989-0.45989-0.45021-0.48989-0.48022-1.1403-0.03-0.4201 0.0998-0.97979-0.0803-1.3601-0.21009-0.44945-0.48022-0.3803-0.85082-0.30985-0.32037 0.06-0.20031 0.36008-0.57026 0.10959-0.18009-0.12068-0.27992-0.33986-0.26034-0.56034 0.12005-0.97979 1.8413-0.62036 2.5016-0.70973 0.0398-0.8702-0.15007-1.7404-0.18008-2.6008-0.0398-0.99022 0.20031-1.2505 0.70076-2 0.81037-0.0404 2.681 0.30007 3.1214-0.44032-0.0998-0.52055-0.20031-0.99088-0.20031-1.561 0-0.27985-0.0803-0.69016 0.0802-0.93021 0.18009-0.27007 0.55069-0.27007 0.73077-0.50034-0.6603-0.30007-0.88084 0.2505-1.181 0.66994-0.27991 0.39987-0.81037 0.75996-1.0205 1.1905-0.45021 0.12003-0.72033 0.63993-1.121 0.87999-0.32037 0.19047-0.67988 0.12068-0.99046 0.25049-0.24011 0.0998-0.42019 0.30007-0.67987 0.30007-0.09-0.68038-0.59049-1.2101-1.0205-1.7215-0.51024-0.6197-0.47043-1.0796-0.49001-1.8806 0.21988 0.51011 0.70011 1.0307 1.3004 0.93999 0.52002-0.0907 0.59049-0.54991 0.78036-1.0007 0.38039-0.89042 0.47043-1.8904 0.42019-2.8807-0.68053 0.0698-1.0309 0.24984-1.5105 0.74038-0.46065 0.45989-0.78036 0.58057-1.3506 0.8702-0.09-0.50033 0.74055-1.0307 1.1105-1.2903 0.47043-0.33986 0.68053-0.7306 1.1307-1.0711 0.39018-0.28898 0.89063-0.74952 1.3708-0.9002 0.88084-0.28964 1.3206-0.57013 1.9711-1.2094 0.6205-0.62036 1.2906-1.1703 2.1616-1.4005 0.75034-0.21005 3.3015 0.46054 2.9414-1-0.15007-0.60014-0.88084-0.63928-0.24011-1.3001 0.27991-0.2805 0.67009-0.36987 1.0603-0.39075 0.30014 0.12068 0.74056 0.18005 1.1307 0.11025 0.67009 2.0516 3.5919 0.81997 4.3918 2.2805 2.3411 0.66015 4.3226 0.86042 6.9736 0.86042 1.1908 0 2.681 0.24984 3.8418 0.01 1.4009-0.30007 1.9013-1.2903 3.1319-0.20026 0.97023-2.0516 1.7708-1.8102 4.0323-1.8102 0.92064 0 1.8308-0.06 2.6216 0.21005 1.0407 0.35029 1.241 0.9002 2.5212 0.82062-0.0398 0.27006 0.11027 0.66994 0.06 0.94 0.20031 0.20026 0.20031 0.01 0.33015 0.33986 1.581 0.0907 2.4611 0.06 3.6317 0.69081 0.99045 0.53034 1.7212 1.3307 2.6614 1.6608 2.651 0.90999 5.593 0.20939 8.3543 0.33986 0.4104 0.0202 1.4818-0.0189 1.8413 0.16047 0.47043 0.23092 0.73012 1.06 1.1908 1.3105 0.91085 0.47097 2.7417 0.48011 3.802 0.53034 1.6801 0.0802 3.3818 0.17025 5.0626 0.14938 1.9111-0.0189 2.0214-0.0802 3.141 1.4814 0.0215 0.0157 0.0313 0.0359 0.0418 0.0555z",
+                Penghu:"m30.865 336.76c0.46065 0.0698 0.20031 0.18004-0.06003 0.3503-0.51023 0.33986-0.21988 1.15-0.59049 1.6504-0.15007 0.20026-0.32036 0.4788-0.49001 0.64906-0.23032 0.21005-0.47043 0.0907-0.7001 0.25114-0.28056 0.20027-0.14028 0.50947-0.2499 0.8004-0.09004 0.24006-0.27012 0.39988-0.32036 0.66994-0.04045 0.24006 0.0098 0.50033-0.33015 0.50033-0.1703-0.21983-0.40975-0.47032-0.60028-0.69016-0.15986-0.19047-0.56048-0.33072-0.6603-0.53034-0.10962-0.23027 0.1305-0.58904 0.16051-0.80953 0.02023-0.18982 0.02023-0.52055-0.06981-0.69081-0.21988-0.41031-0.76078-0.48989-1.0009-0.90021-0.03001-0.0698-0.05024-0.19047-0.09983-0.24005-0.09983-0.0998-0.18987-0.0405-0.30014-0.11024-0.1703-0.09-0.25968-0.4488-0.47043-0.45989 0.45021 0 0.90041-0.03 1.3506-0.0405 0.32036 0 0.39018-0.0411 0.61072-0.21983 0.23032-0.19048 0.2897-0.18004 0.64008-0.18004 0.48022 0 0.95065 0.0404 1.3708-0.12003 0.20031-0.0698 0.36016-0.0502 0.56047-0.0998 0.27012-0.0607 0.15986-0.22049 0.33994-0.31116 0.10896 0.4214 0.56961 0.48076 0.90955 0.53099zm9.855-23.999c0.12006 0.36008 0.21988 0.66015 0.06981 1.06-0.15986 0.4214-0.55004 0.48011-0.59049 0.96087-0.02023 0.42075 0.24011 0.69994 0.4104 1.0496-0.73077 0.11024-4.3827 0.0907-4.3925-0.78996 0.33015-0.0202 0.60028-0.19048 0.6603-0.50034 0.80058-0.41031 1.3904-1.1905 1.3108-2.0803-0.09983-0.0104-0.2101-0.0307-0.31058-0.0307-0.55982-0.66015-0.09004-0.97-0.09983-1.6497 0-0.54013-0.64008-1.3412 0.26034-1.6713 0.13963-0.03 0.33994 0.17026 0.48022 0.17939 0.11027 0.78997 0.51023 0.0998 0.85082 0.15982 0.81037 0.12981 0.2499 0.25049 0.58005 0.75017 0.1703 0.25898 0.73077 0.42989 0.82016 0.60014 0.24011 0.4201-0.2101 0.85063-0.24011 1.06-0.06916 0.55186 0.03067 0.38226 0.19052 0.90216zm4.2326 0.90021c0.01957 0.25962 0.06981 0.21005-0.1703 0.34964-0.12006 0.0607-0.29035 0.12134-0.43063 0.18004-0.53046 0.25898-0.40975-0.20091-0.85017-0.24983-0.31058-0.0411-0.20031 0.18982-0.33015 0.33986-0.08025 0.11024-0.11027 0.0998-0.2101 0.17025-0.09983 0.0613-0.24011 0.16047-0.36995 0.24006-0.0098 0.22048 0.08025 0.55056-0.1703 0.65036-0.36995 0.12982-0.40975-0.33007-0.45999-0.55056-0.50045 0.03-0.43063-0.69994-0.43063-1.0404 0.33015 0 0.6603 0.0104 0.99046-0.0111 0.09004-0.25898 0.08025-0.57013 0.06003-0.85911-0.11027-0.0111-0.23032-0.0998-0.24011-0.22049-0.04045-0.3105 0.24011-0.14025 0.38039-0.25962 0.11027-0.0998 0.03001-0.27007 0.11027-0.34965 0.10962-0.0907 0.39997 0 0.49001 0.12981 0.20031 0.31051-0.1703 0.55056 0.33994 0.60014 0.19052 0.0196 0.42019-0.12981 0.5807-0.09 0.14028 0.03 0.15007 0.14938 0.2499 0.20874 0.09983 0.0613 0.2101 0.0111 0.30014 0.10046 0.1703 0.15134 0.15072 0.46185 0.16051 0.66146zm0.24011-20.209c-0.21988 0.4201-0.13963 0.91978-0.16964 1.3901-0.90041 0.0502-1.6012 0.2805-2.4213 0.20027-0.42019-0.0489-0.7399-0.16961-1.1503 0-0.32036 0.13046-0.09983 0.63993-0.73077 0.55121-0.0398-0.18004-0.15986-0.21983-0.20031-0.39074-0.21988 0.0411-0.50045-0.0607-0.72033-0.03-0.06003-0.6308 0.71054-0.60079 0.6603-1.1507 0.73012 0.17874 1.7108-0.22048 2.3913-0.42988 0.77057-0.25049 1.4909-0.2107 2.3411-0.14025zm0.26034-23.275c0.19052 0.0998 0.19052 0.8402 0.09004 1.09-0.6603 1.6112-2.3913 0.72016-3.7419 1.2609-0.02023 0.74952-0.0098 0.82975 0.30014 1.4299 0.30014 0.55056 0.36995 0.75017 0.33015 1.4606-0.04045 0.95044 0.15986 2.7019-1.2103 2.6106-0.14028 0.53034 0.98002 1.8011-0.25055 1.8409-0.01957 0.33986-0.12006 0.90021-0.01957 1.2401 0.09983 0.3105 0.43977 0.45989 0.57026 0.75995 0.44042 1.0705-0.38039 1.1807-1.2208 1.1403 0.02023-0.12068-0.0398-0.2805-0.01957-0.39075-0.76078-0.0404-1.7512-0.53034-2.4018-0.09 0.30014 1.3405-1.6207 0.0496-1.611 1.06-0.69032-0.0802-1.0805 0.32029-1.8008 0.25049-0.39997-0.98044 0.06981-1.1102 0.75034-1.5095 0.58005-0.33986 0.27012-0.3803 0.57026-0.81018 0.2101-0.31116 0.1703-0.52056 0.72033-0.58122 0.30992 0.51012 0.51023 0.61971 1.0505 0.60079 0.26034-0.0111 1.1412-0.27006 1.331-0.42075 0.60028-0.50099 0.67009-2.1507 0.38039-2.9211-1.3911 0-1.4009-1.3412-0.08026-0.86041 0.03001-0.61123-0.03001-0.92043 0.32036-1.3803 0.33015-0.44032 0.76078-0.42075 0.85082-1.09-0.14028 0.03-0.33994-0.0502-0.48022-0.03 0.02023-0.11024-0.0398-0.28115-0.02023-0.39074-0.24011-0.0404-0.47043-0.16047-0.73012-0.11024 0.27012-0.8004-0.2499-1.9198 0.09004-2.6406 0.85017-0.0104 0.70989-0.25049 0.98002-0.85063 0.2101-0.44032 0.61072-0.66015 0.75034-1 0.36995-0.8004-0.18008-0.69016 0.75034-1.0802 0.45021-0.19048 0.86061-0.46054 1.3108-0.65037l0.03001 0.0698c0.1305-0.01 0.27012-0.01 0.40062 0.0104-0.2101 0.36074-0.39018 0.6608-0.63029 1.0111-0.29035 0.39922-0.69032 0.39922-0.51024 1.0496 0.77057-0.0502 1.3708 0.57013 2.2412 0.3503 0.21923-0.0587 0.71902-0.52838 0.90955-0.42858zm8.5742-4.4032c-0.23032 1.3803 1.641 2.2205 1.5007 3.8109-0.36995 0.0202-0.76078 0.0104-1.1405 0.0307-0.26034 0.38031-0.32036 1.2401-0.2499 1.7208 0.84039-0.19048 0.82995 0.8004 0.39018 1.1703-0.63029-0.0404-0.50045 0.63014-0.47043 1.0802 1.5307 0.03 1.2912 1.1005 1.2208 2.4208-0.4104 0.03-0.89063-0.2805-1.2306-0.48989-0.7001-0.45011-0.29035-0.48011-0.59049-1.2505-0.39018-1.0411-1.761-0.57013-1.3206-1.9915 0.54025-0.09 0.33015-1.1096 0.31058-1.5806-0.86061 0.0411-0.49001-0.77953-0.75034-1.2603-0.16051-0.29029-0.53046-0.33986-0.65052-0.66994-0.09983-0.24984 0-0.72016-0.01957-0.99023-0.8704-0.26027-2.191-0.63014-2.0814 0.63928-0.53046-0.0196-0.44042 0.52056-0.74056 0.78018-0.50045-0.3803-0.69032-0.93935-1.331-0.65037 0.09004-0.06 0.01044-0.16047 0.08025-0.27984h0.09004c0.31058-0.76061-0.38039-1.1905-0.32036-1.9009 0.56048 0.10959 0.84039-0.36987 1.4009-0.43054 0.54025-0.0691 1.2306 0.0998 1.8211 0.0698-0.04045-0.15982 0.06003-0.39987 0.03001-0.56035 0.41041-0.03 1.0309 0.17026 1.0805-0.33007 0.7001-0.21005 0.84039 0.41031 1.3408 0.63014 0.52981 0.22179 1.0505-0.058 1.6305 0.032zm1.592-17.163c0.09004 0.40966 0.1703 0.78997 0.16051 1.2205-0.18008-0.0411-0.45021 0.0691-0.64008 0.03-0.04045 0.78996-0.31058 0.85976-0.67009 1.3999-0.23032 0.33986-0.15007 1.4606-0.91085 1.2401 0.02023-0.1396-0.08025-0.18004-0.09983-0.24005-0.0098-0.66016-0.10962-1.3503 0.27012-1.9009 0.30014-0.44031 1.1307-0.55056 1.1405-1.1703-0.32036-0.06-0.52002-0.33987-0.59049-0.66994-0.39018 0.0411-0.65052-0.20026-0.64008-0.57992 0.78036-0.21005 1.1803 0.78018 1.9803 0.67059zm0.75687 4.9772c0.27012 0.19048 1.1405 1.0007 1.0009 1.4208-0.14028 0.42988-1.4811 0.24984-1.8511 0.39988-0.5807 0.24005-1.0603 0.92043-1.2306 1.5708-0.39018-0.31116-0.47043-0.78996-0.42998-1.291-0.24011 0.0411-0.43063-0.10959-0.64008-0.10959-0.19052-0.63014 0.40975-0.54012 0.67009-0.9002 0.25968-0.36009 0.23032-0.60014 0.24011-1.0705 0.45999-0.0907 0.78036-0.80105 0.99046-1.1814 0.25968 0.75147 0.64986 0.75147 1.2501 1.1611zm9.1868 29.42c1.0309 0.25049 1.4211 0.16047 1.3904 1.4097-1.1608 0.0913-2.5812 1.0411-2.5009-0.88912-1.3506-0.0698-2.8415-0.14025-4.1523-0.0907-0.82016 0.0307-1.2704 0.22049-1.5007 0.91064-0.2499 0.72017 0.02023 1.1207-0.82995 1.4208-0.30014 0.11024-0.64008-0.0405-0.92064 0.0998-0.35038 0.17939-0.45021 0.52055-0.73012 0.74952-0.46065 0.39074-1.0009 0.33986-1.3408 0.84019-0.75034 1.1103 0.81037 2.8918-0.08026 3.9818-0.30992 0.37965-0.89063 0.25897-1.4204 0.23027-0.43063-1.561-2.0011 0.12068-3.1019 0.17939-0.61072 0.0404-1.4009-0.14939-1.5907-0.82976-0.14028-0.50033 0.42998-1.2394-0.06003-1.7704-0.49001-0.55056-1.2404 0.0998-1.8308-0.50033-0.47043-0.47032-0.21988-1.1605-0.77057-1.5617-0.44042-0.31899-1.5509 0.0698-1.7708-0.64972-0.18987-0.58056 0.55069-0.82062 0.6205-1.3412 0.43063-0.20027 0.30014-0.66015 0.5807-1 1.2103-0.33007-0.02023 2.3412 1.3108 2.1703 0.27991 0.72016 0.75034 1.0104 0.69032 1.8904 0.52002 0.14938 0.8704-0.0998 0.8306-0.63993 1.6207-0.0796 0.81037 0.53034 1.2508 1.6412 1.0407 0.20026 1.2906-0.66994 1.2508-1.561 0.67988 0.0496 2.9616 1.6204 2.5512 0.0111-0.0398-0.19048-0.45999-0.27007-0.48022-0.52121-0.04045-0.47946 0.30014-0.45924 0.50045-0.66929 0.27012-0.30006 0.49001 0.0496 0.51023-0.59035 0-0.12981-0.28056-0.63014-0.36016-0.74039-1.1007-1.3901-2.101 0.20092-3.1417 0.33073-0.97023 0.12003-2.6216-0.76061-2.4911-1.9009 0.68053-0.0691 1.7108 1.2101 2.2412 0.24006 0.65052-1.2101-1.0407-1.4703-1.7408-1.2401-0.09004 0.48011-0.59049 0.31116-1.0107 0.31964 0.15007-0.88977 0.31058-1.1801 1.151-1.6002 0.12006-0.68038-0.98067-1.6106-0.6603-2.0607 0.2499-0.33986 2.0311-0.01 2.4716 0-0.33994-0.90021 0.33994-0.85911 1.0205-0.82911 0.03001 0.66929-0.18008 1.9994 0.36995 2.471 0.09983 0.09 1.0303 0.30007 1.1405 0.26941 0.67009-0.17939 0.39997-0.36987 0.44042-0.94 0.10962-1.6902 0.96044-0.33986 1.5705-1.15 0.64008-0.84084-0.65052-1.4703-0.85017-1.9009-0.12006-0.03-0.1703-0.06-0.2499-0.0998 0.45021-0.12002 0.82016-0.67972 1.4302-0.50033 0.53046 0.16047 0.35038 0.88977 1.2306 0.4899-0.12006-0.74104 0.91085-1.1403 1.2808-0.4899 0.16051 0.28963-0.36016 0.99023-0.42998 1.3405-0.09004 0.4501-0.09983 1.3001 0 1.7508 0.10962 0.48011 0.58005 1.1514 1.0903 0.50099-0.26034-0.36987-0.18008-1.5506-0.06981-1.9413 0.27991-1.0196 0.88084-0.30007 1.8008-0.41031 0.06982-1.3999-0.16051-2.1709 1.5007-1.8898 0.09983 0.67972 0.33015 1.1292 0.36016 1.8898 0.2499-0.03 0.55069 0.0502 0.81037 0.03 0.06981 0.0802 0.09004 0.0907 0.1703 0.17091-0.04045 0.19048 0.02023 0.45989 0.02023 0.72016 0.76078-0.0802 0.23032-1.1605 0.39997-1.6608 0.24011-0.66016 0.76078-0.51991 1.4909-0.48011 0.02023 0.4501-0.15007 1.2205 0.01044 1.6504 0.23032 0.59035 0.52002 0.57991 0.59049 1.3307 0.09722 1.1285-0.05285 2.2884 0.0072 3.409z",
+                Changhua:"m211.1 246.37c-0.01 0.0607-0.01 0.3803 0 0.4501-1.9711 0.0998-3.1919 0.63928-4.9425 1.0496-0.38039 0.58057-0.96044 0.98044-0.88997 1.7802-0.17095 0.0202-0.38039 0.0502-0.57026 0.0502-0.0111-0.0202-0.0202-0.0411-0.0411-0.06-1.1203-1.561-1.2306-1.501-3.141-1.4814-1.6808 0.0202-3.3824-0.0692-5.0632-0.14938-1.0603-0.0502-2.8918-0.0607-3.8013-0.53034-0.46064-0.24984-0.72033-1.0802-1.1908-1.3105-0.36017-0.18004-1.4309-0.14025-1.8413-0.16047-2.7606-0.12981-5.7033 0.57013-8.3543-0.33986-0.94022-0.33008-1.671-1.1298-2.6614-1.6608-1.1705-0.63014-2.0514-0.60014-3.6317-0.69016-0.12984-0.33007-0.12984-0.13959-0.33015-0.33986 0.0502-0.26941-0.0998-0.66928-0.06-0.93934-1.2802 0.0802-1.4805-0.47033-2.5212-0.82063-0.79015-0.27006-1.7004-0.21004-2.6216-0.21004-2.2608 0-3.0614-0.24006-4.0323 1.8102-1.2306-1.0907-1.731-0.0998-3.1319 0.20027-1.1608 0.24005-2.651-0.01-3.8418-0.01-2.6517 0-4.6326-0.20091-6.9736-0.86041-0.80059-1.4606-3.7217-0.23093-4.3918-2.2805-0.39018 0.0698-0.8306 0.01-1.1307-0.11024 0.18009-0.01 0.36996-0.01 0.54025 0 0.60028 0.03 1.4309 0.27006 1.8909-0.21983 0.48022-0.53034-0.18008-0.72017-0.32036-1.3503-0.20031-0.90021 0.59048-1.6008 1.4309-1.561 0.11027-0.69081 0.0803-0.91065 0.8306-0.93022 0.6205-0.0202 1.5105 0.17026 2.0514-0.12981 0.4502-0.25049 0.84038-1.0502 1.0903-1.4814 0.30014-0.53033 0.20031-1.1102 0.42998-1.6406 0.53046-1.2205 1.4309-2.1103 2.2112-3.1312 0.33015-0.43967 0.60028-1.1011 0.77057-1.6204 0.06-0.21004 0.0202-0.57013 0.12984-0.75017 0.19053-0.30985 0.36996-0.23027 0.50045-0.60992 0.10962-0.31051 0.06-0.94 0.06-1.2603-1.1007-0.29028-2.071-0.40053-1.3506-1.6608 0.54025-0.95043 1.3806-1.7 1.731-2.8506 0.27012-0.89042 0.43063-1.8506 1.0009-2.6713 0.15985-0.23027 0.36016-0.36921 0.52002-0.63927 0.12984-0.23093 0.12005-0.48011 0.35037-0.63015 0.50045-0.32029 1.3911 0.30007 1.8811-0.0698 0.33993-0.25049 0.39017-1.0907 0.48022-1.4703 0.15985-0.66994 0.35037-1.3503 0.78035-1.8898 0.58071-0.72016 1.181-1.1807 1.3206-2.1103 0.14028-0.88064 0.7001-1.3712 1.3604-1.9407 0.48022-0.42074 1.9711-0.97 2.131-1.5101 0.88083-0.15004 2.6014-0.66994 2.4213-1.8709-1.0002-0.0802-2.131 0.11024-3.1717 0.0502-0.80058-0.0404-0.78036-0.21983-0.71054-0.95044 0.0502-0.44031-0.0405-1.09 0.0803-1.5506 0.28057-1.1305 1.761-1.1605 2.7613-1.2505 0.57026-0.0502 1.0707-0.26028 1.611-0.31116 0.56047-0.0496 1.1412 0 1.6912 0 0.61071 0 1.5809 0.21005 1.9209-0.42923 0.27991-0.53034 0.0196-1.3412-0.06-1.8709-0.0998-0.65037 0.12984-1.09 0.26034-1.7006 0.13963-0.5897 0.09-1.3196 0.06-1.9302-0.53046-0.0202-1.0309-0.06-1.5607-0.0691-0.77057-0.0104-0.71054 0.0802-0.75034 0.8004-0.06 0.0202-0.11027 0-0.1703 0.0202-0.0202 0.33986 0 0.70059-0.0202 1.0496-0.64007-0.09-0.28056 1.1011-0.44042 1.4906-0.84038 0.0502-1.9914-0.21984-2.8011 0.0111-0.57026 0.1696-0.40061 0.69929-0.95065 0.99022-0.15007 0.0802-0.45021 0.0404-0.61071 0.09-0.2897 0.0907-0.3804 0.33987-0.73012 0.29029 0.21988-1.1703 1.1608-1.4208 1.8511-2.2407 0.76078-0.91065 1.4407-1.8506 2.251-2.7104 0.7001-0.74039 1.5007-1.5108 2.2713-2.2812 0.33015-0.33008 0.67988-0.72017 0.92064-1.1403 0.29035-0.53034 0.36016-1.0502 0.81037-1.4906 1.0205-1.0007 3.0216-0.43053 4.4322-0.51011 0-0.53947 0.06-0.5199-0.12005-0.99023-0.45021-1.2603 0.92064-1.4403 1.4002-2.3608 0.27012-0.53034 0.2003-1.2701 0.71054-1.7202 0.96109-0.85063 2.7913-0.50033 4.0121-0.31116-0.0405-0.12002-0.0803-0.23027-0.12071-0.31963 0.0803 0.03 0.15986 0.0691 0.24011 0.11024 0.0803 1.3497 0.11027 2.2903 0.54025 3.4612 0.42084 1.15 1.0714 1.8402 1.5007 2.8409 0.49001 1.1703 0.0907 2.9002 0.7001 3.9713 0.72033 1.2505 2.0312 0.78997 3.1019 1.2303 0.09 0.68037 0.67009 0.81018 1.331 0.66015-0.0692 0.32029 0.12984 0.80105 0.06 1.1102 1.1405 0.58122 2.0011 1.0502 3.3028 1.2003 1.4106 0.15982 2.6712-0.0802 3.9723 0.36073-0.09 1.8004 0.58005 1.8102 1.2404 3.1012 0.58984 1.15 0.3804 3.0007 2.2706 2.5604-0.11027 0.46054 0.0202 0.21983-0.28056 0.51012-0.0803 0.96022-0.93043 1.5604-1.0303 2.471-0.11027 0.98044 0.33994 2.1005 0.36017 3.1403 0.64007 0.03 1.3108 0.03 1.9509 0-0.0802-0.38031 0.1305-0.91 0.0502-1.2903 2.1512 0.25962 3.2017 2.6106 5.0626 3.621-1.3408 2.2805-6.2631-1.4306-5.8931 2.6706 0.42084 0.03 0.80123 0.30986 1.2704 0.21983 1.3408 1.8004 1.181 6.1221-1.9418 6.002-0.21988 1.5101 0.24011 3.2212 0.3308 4.7815 0.23033-0.03 0.55004 0.0802 0.77971 0.0502 0.03 0.47945 0.15007 1.1703 0.03 1.6406-0.17029 0.63015-0.6603 0.74039-0.88084 1.291-0.4104 1.0196-0.24989 2.2107-0.32036 3.351-1.4909 0.54012-0.76078 5.5715-1.2697 6.8422 1.32 0.14025 1.1203 2.621 2.7815 3.0509 0.24011 1.0404 4.0825 2.2512 4.0519 0.50033 0.42019 0.0802 0.93956 0.33986 1.2808 0.66994-0.06 0.54012 0.19052 0.95043 0.21988 1.4403 0.45151 0.0776 0.79145 0.38813 1.2821 0.38813z",
+                Taichung:"m182.09 177.11c-0.03-0.84997-0.10962-2.0907 0.38039-2.8004 0.42998-0.63015 1.5209-1.4606 2.3515-1.5206-0.0411-0.8004 0.47957-1.09 0.0496-1.8604-0.27012-0.4899-0.80058-0.80106-1.2097-1.1814 1.2397 0.63993 2.5707 0.71038 2.6712 2.4814 0.33015 0.0398 0.57026-0.20092 0.80124-0.36987 0.11027-0.91065 0.26947-1.0202 1.121-1.0705 0.21988-0.97979-0.93108-0.39988-1.0603-1.291-0.74121-0.12982-1.5209-0.21005-2.2817-0.20027 0.82995 0 1.3108-0.48989 1.8713-1 0.3693-0.33986 0.39932-0.29028 0.47957-0.81018 0.06-0.36009 0.0907-0.74039 0.0502-1.1103-0.0692-0.03-0.11027-0.0502-0.18008-0.0802 0.43063 0.0104 1.1307-0.0802 1.701-0.06 0.96044 0.0411 0.76078 0.11024 1.0009 0.8702 0.40975-0.01 0.81037-0.09 1.1705-0.25897 0.0405-0.33073 0.31058-1.1703 0.12005-1.4103-0.0803-0.0998-0.52002-0.15003-0.6603-0.21004-0.24011-0.10959-0.32036-0.32029-0.75034-0.30986 0.41105-0.44097 1.6207 0.0992 1.9809-0.30007 0.56047-0.63079-0.17943-1.9504 0.0411-2.6719 0.2897-0.96936 1.4909-1.5206 2.0801-2.2701 0.97022-1.2205 0.17094-2.591 0.80123-3.8813 0.39018-0.78018 1.1105-1.15 1.761-1.7306 0.60028-0.54012 1.1803-1.2394 1.5698-1.9504 0.32037-0.57991 0.97088-1.1598 1.1816-1.7704 0.24011-0.65036 0.16051-1.1102 0.63942-1.6908 0.8306-1.0104 2.0716-1.4906 2.7019-2.6106 0.0196-0.03 0.0404-0.0691 0.06-0.0998 1.4106 1.1305 1.5105 2.7815 2.5512 4.2114 1.0707 1.4514 2.8709 1.9707 4.0917 3.6217 1.121 1.5003 2.0612 2.351 3.4627 3.591 0.74969 0.66015 1.0407 1.5506 1.9907 1.9602 1.0909 0.47946 1.7212 0.06 2.8017 0.8702 1.7806 1.3405 3.2017 3.2714 5.163 4.4912 2.1212 1.3203 4.9829 0.7006 6.834 2.1807 0.88084 0.70973 1.4609 1.8702 2.4318 2.5806 1.0798 0.78018 2.0605 0.41031 3.4522 0.20092 2.4514-0.36987 5.4821 0.50946 7.6737-0.33073 3.2017-1.2198 0.0998-4.6211 1.6201-6.882 1.4413-2.1096 4.6423 0.0998 6.3831 0.3803 2.2119 0.36008 5.7333-0.30007 7.174 1.8702 0.35038 0.53034 0.15985 1.2505 0.53046 1.7704 0.2499 0.3503 0.93956 0.48011 1.2508 0.74039 1.2306 1.0307 1.4407 1.5708 3.1919 1.4305 0.14028-0.69994 0.63029-1.1507 0.88084-1.7802 1.5907-0.0307 1.5405-1.3803 2.482-1.7006 1.2306-0.41031 1.5712 0.8402 2.6712 0.68038 0.33994-0.0502 2.0514-1.0104 2.3313-1.1703 1.32-0.78997 0.55917-1.0502 1.3708-2.1409 0.36995-0.50033 1.1014-0.33007 1.4609-0.69016 0.38039-0.3803 0.33015-0.8702 0.63029-1.2101 0.89062-1.03 1.151-0.84019 2.542-1.1292 2.3006-0.47098 3.1514-1.2505 4.2013-3.3021 2.221-0.39922 2.052-1.0705 2.1616-3.1703 0.69032-0.12067 1.4602-0.0202 2.1212 0.15917 0.31058 1.501 0.70011 2.8618 2.5205 1.6804 1.1014-0.72995 1.1412-2.03 2.6419-2.561 0.47044-1.1703-0.0802-2.6106 0.39018-3.7809 0.81038 0.0404 1.4106-0.39988 1.9411-0.87999v0.1396c1.6208 0.0802 3.4627 0.0802 5.043-0.15982 1.32-0.20092 2.4905-0.84019 3.4118-1.7802 0.0411 0.03 0.0803 0.0502 0.12071 0.0698 0.2499 0.15982 0.51023 0.28963 0.7001 0.5199 0.20031 0.25962 0.26948 0.60014 0.42998 0.87998 0.33081 0.60014 0.2101 1.1703 0.2101 1.8506-0.01 0.35029-0.0502 0.65036-0.2101 0.92043-0.14941 0.25962-0.35037 0.48011-0.42998 0.78017-0.0607 0.24984-0.18008 0.74039-0.0698 1.0007 0.11027 0.30007 0.49001 0.45989 0.74056 0.63928 0.28056 0.21004 0.44042 0.52055 0.68053 0.78018 0.29035 0.32029 0.42998 0.29028 0.8704 0.29028 0.83059 0 2.0109-0.20092 2.7019 0.17026 0.31971 0.18004 0.91085 0.29028 1.121 0.57991 0.17029 0.23092 0.0998 0.76061 0.0998 1.0411 0 0.82062-0.0202 1.6908 0.82929 2.0111 0.38039 0.14025 0.90041 0.17939 1.3206 0.12003 0.49-0.0691 0.55003-0.3105 0.85017-0.66015 0.2499-0.29028 0.56047-0.3803 0.89062-0.58122 0.41041-0.2394 0.68053-0.21983 1.1412-0.30985 0.50045-0.0998 1.0107-0.12003 1.5607-0.12003 0.35038 0 0.39996 0 0.65051-0.15982 0.16051-0.11024 0.26034-0.28115 0.46065-0.33986 0.48022-0.12981 1.0505-0.12981 1.5307-0.0992 0.73012 0.03 0.85083 0.2094 1.2808 0.76061 0.24011 0.30986 0.25968 0.17939 0.61071 0.30007 0.5807 0.20027 0.70076 0.61971 0.79015 1.1703 0.03 0.20027 0.0802 0.38031 0.14941 0.5597-0.79014 0.47097-2.0005 1.6308-2.2412 2.1814-0.50045 1.1396 0.30014 2.8311-0.20031 3.9713-0.36995 0.81997-1.3415 1.7-2.1212 2.3301-0.56048 0.47098-1.2208 0.33073-1.7114 0.66994-0.82995 0.56035-0.2897 0.77039-0.82081 1.5108-0.79015 1.0705-2.0801 1.0796-2.5205 2.4899-0.33993 1.1103 0.60028 3.1918 0.01 4.1723-0.58005 0.95044-2.3711 0.2094-3.312 1.0307-0.69032 0.60014-1.0498 2.291-1.5209 2.9707-0.23032 0.33007-0.43063 0.58056-0.60028 0.8004-0.0202 0.0104-0.03 0-0.0502 0 0.0196-0.19048-0.0104-0.28963 0.0698-0.47946-0.70011-1.0411-6.5534-3.0307-6.7936-1.0202-0.63029 0.21005-1.4106 0.27985-2.1108 0.15982-0.60027-1.0705-2.5616 0.0411-2.2204-2.1103-2.1512-0.33008-2.3222 0.96087-3.1417 2.3105-0.72033 1.1807-0.06 0.63079-1.2006 0.69994-0.72033 0.0411-1.5509-0.0202-2.2706-0.06-0.52067-1.03-0.70011 0-1.3611 0.19048-0.74969 0.21004-1.4707 0.16047-2.1708 0.33986-0.73012 0.18004-1.1105 1.0307-1.5405 1.1305-0.5807 0.1396-1.0707-0.39009-1.6312-0.47032-1.0603-0.13047-2.9818 0.18982-4.0023 0.50033-1.3115 0.39987-1.2312 1.6602-1.3604 3.1409-2.0312 0.11024-4.9125-0.58057-6.4732 0.69929-1.5907 1.291-2.1323 3.0307-3.9625 4.1618-2.0612 1.2694-3.0614 1.5806-5.6628 1.6706-2.482 0.09-3.5423 1.8102-3.6317 4.1012-1.2606-0.11024-1.7108 0.70973-2.052 1.7306-2.7515-0.33986-4.8727-1.1103-7.234-0.0202-1.0707 0.47945-2.3006 0.47945-2.8409 1.6602-1.8406 0.4201-1.6207-1.2603-2.9616-1.4703-1.9509-0.32029-0.65052 1.8402-0.84039 3.0007-0.23032 1.4403-1.7512 2.5506-2.6314 0.96087-0.55983-1.0111 0.21988-2.8206-0.23033-3.9309-0.86061 0.14938-0.95065 0.47033-1.6808 0.18004-0.55003-0.23092-0.72033-0.93999-1.3004-1.2009-1.4113-0.63928-2.221 0.10959-2.7019 1.3203-0.8704 2.261-0.53046 4.8318-0.65052 7.3119-0.97023 0.0502-2.1212-0.18004-2.9414 0.39988-1.0714 0.76061-1.271 2.5408-1.6919 3.6413-0.39018 0.99936-1.2201 1.9498-1.8902 2.7711-1.8315 2.2499-3.1123 4.3216-6.4543 3.1807-1.4511-0.48989-2.0305-0.80105-3.8424-0.80105-1.2508 0-2.9714 0.32029-4.1726 0.0111-0.3308-0.0802-0.63094-0.21005-0.91085-0.36987-1.8608-1.0104-2.9113-3.3608-5.0625-3.621 0.0803 0.38031-0.12984 0.91064-0.0502 1.2903-0.63943 0.03-1.3108 0.03-1.9509 0-0.0196-1.0405-0.47043-2.1605-0.36016-3.1403 0.0998-0.91064 0.95065-1.5101 1.0302-2.471 0.30014-0.29029 0.1703-0.0502 0.28057-0.51012-1.8902 0.44032-1.6801-1.4103-2.2706-2.5604-0.66096-1.291-1.331-1.3007-1.2404-3.1012-1.301-0.44097-2.5616-0.20091-3.9723-0.36073-1.301-0.14938-2.1616-0.61971-3.3022-1.2003 0.0692-0.3105-0.12984-0.78996-0.0607-1.1102-0.6603 0.15003-1.2404 0.0202-1.331-0.66015-1.0707-0.43967-2.3809 0.0202-3.1019-1.2303-0.61007-1.0711-0.20945-2.8011-0.69946-3.9714-0.43063-1.0007-1.0805-1.6908-1.5013-2.8409-0.42932-1.1703-0.45999-2.1103-0.54024-3.4612-0.0796-0.0411-0.15921-0.0802-0.23946-0.11024-0.60028-1.2303-2.0612-0.78018-3.0614-1.5206-0.55069-0.40053-0.86061-0.63993-1.5007-0.84019-0.60027-0.18004-0.96044-0.33008-1.4811-0.67059 0.33015-0.12003 0.64008-0.25897 0.92064-0.45989 0.50045-0.3803 0.48022-0.58057 0.6205-1.1005 0.11027-0.4501 0.26034-0.72995 0.46065-1.1305 0.15007-0.30985 0.17029-0.8004 0.48022-0.99022-0.06 0.57013-0.0196 1.3999 0.06 1.9811 0.12005 0.7704 0.67987 0.90021 0.88018 0.12003 0.15007-0.57991-0.20031-1.4606 0.44042-1.6902 0.51024-0.18004 1.4217 0.21983 1.9209 0.30985 0.14029-0.57013 0.0502-1.0404 0.0803-1.6197 0.0202-0.56034 0.16051-1.1213 0.17029-1.6804-0.33994-0.0698-0.53046 0.27006-0.72033 0.51012-0.44042 0.55056-0.32036 0.50033-0.90041 0.44031-0.87562-0.10437-0.94609 0.2655-1.2958 1.0359z",
+                Yilan:"m393.17 81.6c0.64987 0.54012 1.0505 1.2003 1.0002 2.0405-0.0404 0.04044-0.0692 0.0698-0.12005 0.12068-1.1014 0.06915-3.342 0.46054-3.2519-1.1011-0.20031-0.06001-0.4104-0.12981-0.60027-0.21005-0.0104-0.03979-0.0104-0.06915-0.0104-0.10959h0.0196c0.36995 0.06067 0.81037 0.12981 1.2103 0.10959 0.18987-0.39922 0.11027-0.87998 0.53046-1.12 0.4613-0.25962 0.89193 0 1.2221 0.27006zm-72.209 76.407c-0.0692-0.17938-0.12006-0.36008-0.14942-0.55969-0.0907-0.55056-0.21009-0.97-0.79014-1.1709-0.35038-0.12003-0.36995 0.0104-0.61072-0.30007-0.43063-0.55056-0.55068-0.72995-1.2808-0.76061-0.48022-0.03-1.0505-0.03-1.5307 0.0998-0.20096 0.06-0.30013 0.23092-0.46064 0.33986-0.2499 0.15982-0.30014 0.15982-0.65052 0.15982-0.55003 0-1.0603 0.0196-1.5614 0.12002-0.45999 0.09-0.73011 0.0692-1.1412 0.30986-0.33015 0.20091-0.63943 0.29028-0.88998 0.58122-0.30013 0.3503-0.36016 0.5897-0.85082 0.66015-0.42019 0.06-0.93956 0.0202-1.32-0.12003-0.85017-0.32029-0.82994-1.1905-0.82994-2.0111 0-0.2805 0.0698-0.81019-0.0992-1.0411-0.21009-0.28898-0.80123-0.39922-1.1216-0.57992-0.69032-0.36986-1.87-0.17025-2.7012-0.17025-0.44042 0-0.58005 0.03-0.8704-0.29029-0.24011-0.25962-0.39996-0.57013-0.68053-0.78018-0.2499-0.17938-0.63029-0.33986-0.74056-0.63927-0.10961-0.26028 0.0104-0.75018 0.0692-1.0007 0.0803-0.30007 0.28056-0.5199 0.43063-0.78018 0.15986-0.27006 0.20096-0.57078 0.2101-0.92043 0-0.67972 0.12005-1.2505-0.2101-1.8506-0.16051-0.27984-0.23032-0.62036-0.43063-0.87998-0.19053-0.23092-0.44956-0.36008-0.69945-0.5199 0.39017-0.73061 0.31971-1.8311 0.79014-2.5708 0.27012-0.41031 0.77057-0.36922 1.0107-0.66015 0.2101-0.24984 0.24011-0.80106 0.39018-1.1305 0.24011-0.57013 0.73012-1.7404 1.2103-2.06 0.47043-0.32029 0.90041-0.0698 1.3904-0.25114 0.63942-0.23027 0.29035-0.5199 0.74056-0.84998 0.0998-0.71038 0.53046-0.62036 1.0107-0.81997 0.75034-0.31116 0.5807-0.17026 0.75034-1.0007 0.30014-1.4103 1.0107-0.84997 2.1616-1.2603 0.31057-1.1011-0.23033-1.7515 0.93108-2.2505 0.91998-0.40966 1.2508-0.33986 1.0798-1.4906-0.15986-1.1103-1.1301-3.7313-0.34973-4.6915 0.39018-0.47946 1.1705-0.44032 1.6312-0.95044 0.74969-0.85911 0.0692-0.95043-0.35038-1.6902-0.16051-0.28963-0.24011-0.66928-0.24011-1.0705-0.0104-1.06 0.50045-2.3105 1.3708-2.6217 0.71054-0.24984 1.1608-0.01 1.7114-0.72017 0.46-0.60013 0.44042-1.3001 0.65052-2.0105 0.41041-1.4208 1.4609-1.8709 2.5714-2.681 0.21988-0.66928 0.57026-1.9009 0.27991-2.5004-0.30993-0.66015-0.72033-0.46054-0.45999-1.2394 0.12005-0.33008 0.47043-0.77105 0.71054-1.0307 0.67009-0.74039 2.3411-0.88129 3.5618-0.95044 0.2101 0 0.39997-0.0111 0.57026-0.0202 0.88149-0.0404 1.2704-0.06 2.0011-0.43053 0.58005-0.28898 1.0805-0.77953 1.7708-0.92043 0.70989-0.14025 1.5307 0.0607 2.1812-0.20026 0.35038-0.14025 0.63029-0.4201 0.98067-0.54991 0.2897-0.0998 0.67988-0.0802 0.92064-0.23093 0.86061-0.50033 0.54025-1.7802 1.0714-2.5108 0.53959-0.76061 2.4905-0.91064 3.432-0.90021 1.2208 0 1.5907-0.40966 1.5098-1.6602 2.7026 0.12003 2.7326-2.0705 1.9711-4.0712-0.33016-0.87998-0.44042-1.7508 0-2.6908 0.33015-0.69016 1.2097-1.8304-0.0503-2.2603 0-0.12068 0.0405-0.26028 0.0503-0.33986 0.0692-1.4299 2.3613-1.6197 3.3518-1.6497 1.1105-0.04045 0.85017-0.20092 1.0002-1.1709 0.0998-0.60014 0.36017-1.1096 0.85083-1.4808 1.0302-0.76061 2.7913-0.69016 4.0721-0.77039 1.3806-0.08024 2.7515-0.02022 4.1524-0.09067 0.0398-0.69016-0.12071-1.5506 0.33015-2.1005 0.36995-0.44945 1.151-0.63014 1.6012-0.97 0.49-0.36922 0.81037-1 1.1705-1.4299 0.65052-0.78018 2.3006-1.7306 3.312-1.9302 1.3408-0.26028 2.7404 0.21983 3.9416-0.48011 1.1601-0.66015 1.6116-1.6106 2.9009-2.0105 0.29035-0.56035 0.86061-0.66994 0.75034-1.3007-0.0998-0.57992-0.7001-0.62036-0.38039-1.4208 1.4009-0.0098 0.94021-1.7202 1.4106-2.5004 1.2097-0.24984 2.3913-0.3503 3.6525-0.3503 0.53047 0 1.2808 0.0698 1.7004-0.23027 0.3693-0.26028 0.68053-0.72016 1.1405-1.0202 0.58071-0.36987 2.0801-1.2003 2.2315-1.9107 0.21989-1.06-1.0805-1.9805-2.1414-1.9413-0.42998-1.4403 0.26033-2.0796 1.1712-3.0711 1.1014-1.1703 2.2608-0.84019 3.8215-0.91064 0.6603-0.04044 1.4296-0.02022 2.0801-0.15004 0.82081-0.14938 1.0805-0.60014 1.5705-1.12 0.84039-0.91064 2.0912-1.5206 3.2722-1.6504 0.46-0.04958 1.4309-0.01957 1.8517-0.23027 0.56961-0.2805 0.60028-0.88064 1.2312-1.1305 1.2006-0.47033 2.2008 0.42988 3.3916 0.36987-0.11027 0.30007-0.15007 0.66015-0.0998 1.1103-1.4106-0.05023-2.882 0.66015-4.1432 1.2094-0.39931 0.17091-1.181 0.32029-1.3708 0.69081-0.19053 0.39009 0.15985 1.0796-0.44042 1.2394-0.0202 0.03001 0 0.0698-0.0104 0.10959-0.4215 0.28115-0.64008 0.6608-1.0303 0.97066-0.36995 0.31051-0.71054 0.91064-1.2103 0.96022-0.42084 0.4899-0.93108 1.0202-1.6312 1.1605-0.39018 0.08024-0.50045 0.08024-0.82929 0.33008-0.25969 0.20092-0.68053 0.42988-0.8306 0.75017-0.2897 0.63014 0.16051 1.4808 0.16051 2.1311-0.0104 0.6608-0.65052 1.3203-1.1705 1.6602-0.24011 0.17091-0.52067 0.30007-0.72033 0.50098-0.18987 0.19048-0.49001 0.41031-0.68053 0.63014-0.4489 0.53034-0.84039 1.1298-1.3604 1.5701-0.47957 0.41031-1.0107 0.98044-1.4413 1.4403-0.47892 0.53034-0.88932 0.8291-1.0407 1.5604-0.12984 0.63014-0.49 1.1103-0.76013 1.6902-0.31058 0.6608-0.53046 1.4103-0.82081 2.0907-0.60028 1.3901-0.47043 2.9811-0.58984 4.5219-0.0502 0.61058-0.09 1.2805-0.25903 1.8402-0.12984 0.45989-0.2512 0.85063-0.3308 1.3301-0.0796 0.50098-0.18987 0.97066-0.28057 1.4305-0.27012 1.3307-0.0502 2.7906-0.0502 4.1514 0 1.2303 0.2101 2.5702 0.51024 3.7509 0.27012 1.0705 1.1014 2.1703 1.6312 3.0901 0.27991 0.46054 0.40976 0.69081 0.44042 1.2101 0.03 0.44945 0.0796 0.85976 0.1703 1.291 0.12984 0.69081 0.36995 1.3999 0.3308 2.1207-0.03 0.60014-0.0411 1.2205-0.0411 1.8402 0 0.60013 0.0496 1.1814 0.0802 1.7802 0.0196 0.48989 0.26947 0.93021 0.31971 1.4208 0.0405 0.36008-0.0998 0.67972-0.0411 1.0496 0.12136 0.74104 0.72033 1.2909 0.93173 1.9915 0.28904 0.93021 0.17878 1.7 0.79014 2.4899 0.47044 0.61057 0.68053 1.501 1.3708 1.9009 0.65052 0.38031 1.1014 0.5199 1.8413 0.66081 0.20879 0.0404 0.39997 0.14024 0.61985 0.17025-0.0111 0.31051 0.23946 1.2205-0.36995 1.1207-0.2101-0.0404-0.33015-0.35029-0.50045-0.47032-0.2101-0.15004-0.30014-0.15004-0.58135-0.16047-0.49001-0.01-1.0407-0.0998-1.4106 0.24984-0.34973 0.33007-0.28057 0.8702-0.2499 1.3307 0.25969 0.12981 0.45999 0.36986 0.74056 0.47032 0.20944 0.0698 0.44107 0.0698 0.66095 0.17091 0.0992 0.15982 0.21989 0.33986 0.30014 0.50033 0.12006-0.0998 0.21989-0.21004 0.30014-0.33986 0.18987-0.0196 0.39083 0.0196 0.57026 0.0907 0.0104 0.28049-0.17943 1.1403 0.12071 1.2094 0.18987 0.32029-0.14028 0.36987-0.3693 0.43054-0.48022 0.12068-0.51024 0.03-0.56048 0.61057-0.0998 1.09-0.03 2.1898 0.03 3.2805 0.68053-0.17026 0.4502 1.4005 0.4502 1.8011 0 0.68038 0.28057 1.7097-0.50109 1.9602-0.72034 0.21983-1.4511 0.06-2.1212 0.57078-0.28904 0.2094-0.52067 0.40966-0.88084 0.47032-0.54024 0.09-1.0407 0.0196-1.3715 0.57992-0.25055 0.42075-0.22054 1.0307-0.1703 1.5101 0.0411 0.33986 0.0998 0.66994 0.30014 0.93935 0.25968 0.35029 0.68053 0.29028 0.95065 0.55121 0.25969 0.24005 0.1703 0.63014 0.25969 0.96022 0.14028 0.53034 0.39018 0.78018 0.82081 1.1207 0.17943 0.14025 0.82016 0.72995 0.84038 0.92043 0.0398 0.31116-0.73077 0.32029-0.99176 0.33008-1.4707 0.0698-2.3606 1.2407-3.4411 2.1318-0.31971 0.25897-0.88084 0.57992-1.0714 0.95044-0.20031 0.3803-0.1703 1.0104-0.30014 1.4208-0.63942 0.06-1.181 1.1807-1.6305 1.6308-0.35038 0.33986-0.63094 0.66993-0.90107 1.0802-0.20031 0.30986-0.53046 0.60014-0.70989 0.91-0.17029 0.32029-0.25968 0.74038-0.39083 1.0907-0.14028 0.36987-0.2101 0.81997-0.24011 1.2101-0.0796 0.96022-0.06 1.9504-0.25968 2.8702-0.18987 0.8702-0.27013 1.7306-0.31058 2.6308-0.0411 0.75017-0.31971 1.3105-0.73012 1.9204-0.49001 0.71038-0.82081 1.3503-0.8704 2.2505-0.0405 0.8702-0.25055 1.6706-0.25055 2.5512 0 0.63015-0.0411 1.2505-0.0496 1.8696-0.0104 0.36074 0.15986 1.0502-0.0998 1.3307 0 0.0202-0.0196 0.0411-0.0405 0.0502-0.48022 0.38031-1.5314-0.24984-2.0214-0.3803-0.31971-0.0802-0.61137-0.14025-0.90107-0.31051-0.33015-0.18983-0.58983-0.54012-0.93108-0.72995-0.58005-0.32029-1.4302-0.15003-2.0514-0.33986-0.49001-0.16047-0.88084-0.30007-1.4106-0.28963-0.49001 0-0.96109 0.03-1.4204-0.12068-0.59048-0.17939-1.0505-0.50033-1.5816-0.78997-0.27991-0.15982-0.58005-0.40966-0.8704-0.5199-0.42933-0.15982-0.99045 0.09-1.3904-0.12003-0.3693-0.18982-0.44042-0.42988-0.90041-0.50098-0.4202-0.06-0.73012 0-1.0805-0.24984-0.44955-0.31051-0.74969-0.75017-1.1099-1.1605-0.36082-0.41032-0.88084-0.54013-1.2612-0.92043-0.18987-0.19048-0.30992-0.55056-0.55003-0.63015-1.1203-0.33986-0.0502 1.9113-1.2006 0.76061-0.33994-0.33986-0.65052-0.69016-0.98067-1.0404-0.27013-0.27985-0.63029-0.74039-0.95066-0.96022-0.75034-0.50099-1.4407 0.3803-1.2404 1.1298 0.0998 0.3803 0.46065 0.48989 0.6603 0.77105 0.15007 0.21983 0.15007 0.47032 0.33994 0.67972 0.2897 0.31964 0.63029 0.23027 0.74056 0.66015 0.0698 0.25962 0.0196 0.69016-0.0104 0.96022-0.0202 0.20092-0.0202 0.69994-0.18987 0.81019-0.30014 0.20026-0.43063-0.38031-0.59049-0.58057-0.30013-0.36987-0.29035-0.12068-0.71054-0.23093-0.23098-0.0502-0.41041-0.28963-0.46065-0.53033-0.24011 0.13959-0.4502 0.39922-0.54024 0.66928-0.0692 0.21983-0.0503 0.74104-0.2897 0.85063-0.23033 0.11024-0.33015-0.19048-0.61985-0.10959-0.29035 0.0802-0.5011 0.53034-0.70076 0.7293-0.12984 0.12068-0.24011 0.30007-0.42998 0.31116-0.17029 0.01-0.19052-0.15004-0.32036-0.17026-0.19053-0.0104-0.16051-0.15004-0.21989 0.14025-0.06 0.27006 0.0907 0.39009 0.27013 0.55904 0.36995 0.3503 0.55003 0.33008 0.60027 0.81019 0.0411 0.29028-0.0202 0.57013 0.0803 0.81997-0.2499 0.03-0.42998-0.09-0.66944-0.12003-0.27013-0.0404-0.48022 0.06-0.74121 0.09-0.42019 0.0411-0.85017-0.12003-1.2397-0.21983-0.78036-0.20027-1.5509-0.0998-2.3613-0.21005-0.98002-0.12981-1.1908-0.81997-1.8106-1.4599-0.61071-0.6308-0.7797-1.7215-1.761-1.8206-0.41041-0.0502-0.83973-0.0111-1.2508-0.0502-0.63943-0.06-1.181-0.24005-1.7904-0.36986-0.44107-0.0992-0.92064-0.11025-1.3715-0.0405-0.2101 0.03-0.33994 0.0992-0.59049 0.0802-0.30992-0.03-0.33994-0.18004-0.58005-0.25049-0.56047-0.15917-0.67009 0.31115-1.0407 0.50098-0.21988 0.12003-0.12071 0.09-0.41041-0.0998-0.18008-0.13047-0.33994-0.24006-0.5011-0.39009-0.36016-0.33986-0.63942-0.66016-1.0798-0.93022-0.42998-0.27006-0.97023-0.33007-1.4309-0.54012-0.71055-0.32029-1.1405-0.97001-1.8811-1.2003-0.63094-0.20091-1.1608 0.01-1.5712-0.59035-0.0574-0.0855-0.10701-0.17548-0.14746-0.2655z",
+                HsinchuCounty:"m293.48 147.63c0.0196-0.71104-0.09-1.4514-0.0502-2.1514 0.03-0.55969 0.18987-1.1807 0.0698-1.73-0.12005-0.56034-0.58005-0.84019-0.91085-1.2707-0.2897-0.38031-0.67009-0.63015-1.0002-0.96023-0.67988-0.71103-1.2312-1.5812-1.9118-2.2805-0.60027-0.61123-1.2704-1.1102-1.7604-1.8011-0.55982-0.80041 0.47043-1.3705 0.19052-2.1403-0.25968-0.66993-1.0002-1.1703-1.5705-0.70973-0.69097 0.57013-1.5509 0.16961-2.2315 0.69016-0.30014 0.23027-0.52002 0.57079-0.88084 0.66015-0.36017 0.0907-0.88997 0.0111-1.2508 0-0.35038-0.01-0.66944-0.03-1.0002 0-0.39997 0.0411-0.58071 0.24006-0.93108 0.32029-0.47044 0.12003-0.61072-0.12981-0.95066-0.30985-0.34972-0.19048-0.72946-0.12068-1.1203-0.14025-0.69032-0.0307-1.0498-0.93086-1.7108-0.48011-0.25968 0.16961-0.38039 0.62036-0.61072 0.73974-0.18008 0.10045-0.82015 0.0502-1.0205 0-0.39018-0.10959-0.43064-0.51012-0.76079-0.69995-0.30014-0.19048-0.6205-0.06-0.90041 0.11025-0.21988 0.12981-0.3693 0.28963-0.55004 0.48011-0.24011 0.26027-0.47043 0.35029-0.79014 0.53033-0.30014 0.16961-0.44042 0.24984-0.67988 0.4899-0.24011 0.23027-0.33015 0.33986-0.6603 0.3803-0.69097 0.0692-1.3604-0.0607-1.8615-0.39074-0.52067-0.3503-1.1705-0.0691-1.791-0.24984-0.15985-0.2805-0.44955-0.47032-0.58005-0.78996-0.14028-0.3503-0.0802-0.75017-0.13049-1.1207-0.0998-0.66994-0.74056-1.3901-0.2499-2.0516 0.23032-0.32029 0.54025-0.36008 0.91085-0.43967 0.53047-0.0998 0.36996-0.18004 0.60093-0.57013 0.20945-0.3503 0.58984-0.55056 0.66031-1.0104 0.0692-0.42009-0.24011-0.4501-0.5011-0.62036-0.2897-0.20026-0.61072-0.48989-0.84039-0.77039-0.23946-0.2805-0.50958-0.5199-0.80058-0.75996-0.3804-0.32029-0.89063-0.74039-1.3604-0.95043-0.0803-0.47033 0.76078-0.33987 1.0407-0.44032 0.32037-0.12068 0.53046-0.36074 0.58136-0.72017 0.10961-0.78018 0.3693-1.5003 0.85996-2.1305 0.35038-0.46054 0.39083-0.9002 0.70989-1.3307 0.27012-0.36008 0.65051-0.66015 0.55134-1.1703-0.15007-0.78018-1.0414-1.0502-1.2808-1.711-0.17095-0.47033 0.12919-0.69994-0.33994-1.0405-0.39018-0.27006-0.73011-0.25049-0.99045-0.66993-0.23098-0.36009-0.29035-0.74039-0.81037-0.59036-0.30014 0.09-0.99111 0.48011-1.0407 0.76061-0.22053-0.0802-0.39996-0.41031-0.55069-0.58057-0.24011-0.27006-0.52002-0.48989-0.7797-0.74038-0.65052-0.6308-1.3115-1.0104-2.2119-1.3301-0.58983-0.21005-0.81037-0.78996-1.4106-1.0111-0.14942-0.0496-0.3693-0.03-0.50045-0.0802-0.2101-0.0991-0.12984-0.0691-0.25968-0.30007-0.19053-0.31964-0.20031-0.39009-0.57027-0.50033-0.19052-0.41031 0-0.89042-0.09-1.3307-0.10961-0.50033-0.60027-0.3503-1.0805-0.36987-0.80059-0.0496-1.1099-0.69016-1.5607-1.2394-0.23098-0.27985-0.54025-0.47033-0.76078-0.76061-0.30993-0.39009-0.43977-0.88129-0.78036-1.2505-0.21989-0.23092-0.54025-0.3105-0.77971-0.51011-0.25968-0.21984-0.35038-0.54013-0.64007-0.69016-0.54025-0.2805-0.91086-0.0411-0.66031-0.81019 0.12984-0.39987 0.50045-0.62036 0.76013-0.96022 0.33016-0.44097 1.2508-1.4814 0.82995-2.1612-0.27012-0.44945-1.4811-0.43053-1.9111-0.29028-0.64008 0.21005-0.33994 1-1.1705 0.8702-0.78036-0.12003-0.76079-1.0104-1.5907-0.5897-0.2897 0.14025-0.39018 0.3105-0.70011 0.0991-0.18008-0.10959-0.39083-0.47946-0.42084-0.66015-0.0196-0.0202-0.0502-0.0404-0.0803-0.06 1.2612-1.0104 0.11027-3.2212 0.85148-4.5213 0.8293-0.29028 1.8008-0.15003 2.7215-0.20092 0.0496-0.97001-0.15007-2.1207 0.65051-2.8206 0.76079-0.66015 2.1408 0.02022 2.6112-0.91064 0.2499-0.4899 0.13963-0.93021 0.47957-1.4403 0.30014-0.4501 0.41041-0.63014 0.94022-0.7306 0.74055-0.15004 1.9711 0.66015 2.1812 1.3203 0.2897 0.01044 0.60028 0.01957 0.89063 0.03001 0.0398 0.20026 0.18987 0.31964 0.18987 0.54991 0.5807 0.46054 0.28056 1.0307 0.49001 1.6804 0.33015 1.0307 0.63029 0.27985 1.2397 0.08024 0.90106-0.28963 1.1712 0.09915 0.91085-1.1403-0.10962-0.53034-0.15986-1.3601-0.33994-1.9204-0.19052-0.60014-0.64986-0.91064-0.98067-1.4305-0.38039-0.60014-0.33015-1.1096-0.33015-1.8396 0-1.5101-0.65051-1.9909-1.84-2.7508-0.64008-0.41031-1.0603-1.0104-1.7519-1.2401-0.89063-0.30007-1.3708-0.0698-1.8406-0.99023-0.88084-0.06067-1.4602-0.21005-2.2204-0.45989-0.73077-0.23092-1.6207 0.0098-2.2921-0.36987-1.35-0.76061-1.4211-2.651-3.0216-2.8311 0.0404-0.06001 0.0698-0.11024 0.0404-0.19048 0.0992-2.471 1.9202-1.6008 2.9218-3.1709 0.4502-0.71038-0.03-1.9107 0.14028-2.7508 0.26034-1.2401 1.0205-2.3105 1.6312-3.3908 0.5011-0.85976 0.66096-1.9805 1.3115-2.6908 0.4202-0.44945 0.93043-0.78996 1.4407-1.12 0.47956 0.12981 1.1705 0.12981 1.5607 0.03979 0.61006-0.1396 0.82995-0.7293 1.4407-0.90021 0.63029-0.17939 1.1908 0.2805 1.8106 0.3803 0.8704 0.13046 1.35-0.24006 2.0807-0.39922 0.61072-0.12981 1.4707-0.01044 1.9907 0.27006 0.41041 0.21983 1.3806 0.8702 1.6606 1.1703 0.81037 0.88977 0.0202 2.9713 0.27012 4.1416 0.26034 1.2205 2.4716 1.09 3.5925 1.5708 0.66944 0.28898 1.0107 0.54991 1.8308 0.5199 0.69032-0.03001 1.3506-0.11024 2.071-0.0698-0.11027 0.54012-0.06 1.2003-0.23032 1.7404 0.0992-0.33008 1.4511 0.63993 1.4602 0.65037 0.70011 0.24006 1.9509 0.01044 2.7019 0.01044 0.71055 0 2.2204 0.33986 2.4213 1 0.0405 0.14025-0.24011 0.36074-0.17029 0.58057 0.0992 0.36008 0.3693 0.19048 0.47957 0.44032 0.15006 0.33986 0.15985 1.12 0.16964 1.5003 0.0111 0.66994-0.0496 0.84998-0.47957 1.3307-0.36995 0.40966-0.82016 0.42075-0.6603 1.1403 0.30014-0.03001 0.47957 0.0698 0.72033 0.19048 0.20031 0.09981 0.52002 0.67972 0.78036 0.85976 0.28969 0.20026 0.74969 0.39987 1.0798 0.5199 0.55069 0.19048 1.7108 0.14938 1.5907 1.0104 0.86061-0.1396 1.181 0.56035 1.331 1.2505 1.0407 0.33008 1.6808 1.5708 2.8918 1.3307 0-0.18004 0.14028-0.33986 0.11027-0.54991 0.53046-0.08024 1.0413 0.09915 1.5614 0.08024 0.03 0.66928-0.26034 1.6706 0.51023 1.8206 0.63942 0.12003 1.2606-0.72016 1.8308-0.75017 0.91085-0.03979 0.57091 0.92043 1.1705 1.3405 0.39018 0.27006 1.4002 0.43053 1.9013 0.51012-0.03 0.59035 0.01 1.3412 0.3693 1.8206 0.45021 0.60014 0.99111 0.29028 1.6312 0.67972 0.0998 0.06001 0.31058 0.3803 0.5011 0.50098 0.30014 0.20026 0.6205 0.33008 0.85082 0.4899 0.65052 0.44945 0.78036 0.55969 1.581 0.74039 1.3004 0.30007 2.2014 1.6706 1.9209 3.0914-0.12984 0.66015-0.67988 0.93021-0.82995 1.5003-0.15985 0.55969 0.0104 1.3803 0.18008 1.9009 0.21989 0.0502 0.12071 0.0802 0.2499 0.17026 0.11027-0.0202 0.27013 0.0202 0.39083 0.0202 0.41041 1.8004-1.3911 2.9707-0.72033 4.8115 0.12984 0 0.2499 0.03 0.38039 0 0.44042-0.48011 1.5509-0.51012 2.2713-0.39988 0.93957 0.1396 0.80059 0.50034 1.3108 1.1905 0.33994 0.45989 0.88084 0.76061 1.0198 1.3901 0.16051 0.71038 0 1.4703 0.18008 2.1507 0.39018 0.0202 1.6312-0.17939 1.9209 0.0802 0.31906 0.2805 0.17943 1.411 0.14942 1.8506-0.03 0.61123-0.14942 1.0502 0.2499 1.5708 0.45999 0.61057 0.80124 0.66994 0.76013 1.5904 1.4609-0.28898 0.30014 3.2812 0.33994 4.002 0.86061 0.50033 0.74056 1.7508 1.5809 2.2512 0.76079 0.01 1.2508 0.77039 1.8413 0.99023 0.73012 0.27984 1.8902 0.0502 2.6712-0.0502 0 0.39987 0.0802 0.78018 0.24011 1.0711 0.42019 0.74039 1.1007 0.82976 0.35038 1.6902-0.46065 0.50947-1.2404 0.47033-1.6312 0.95044-0.78036 0.96022 0.19052 3.5806 0.35038 4.6909 0.1703 1.1507-0.15986 1.0802-1.0805 1.4906-1.1608 0.50098-0.6205 1.1507-0.93042 2.2505-1.1516 0.41031-1.8622-0.15004-2.1616 1.2603-0.17029 0.8304 0 0.69081-0.74969 1.0007-0.48022 0.20026-0.91085 0.10959-1.0113 0.81997-0.44956 0.33008-0.0992 0.62036-0.74056 0.85063-0.49001 0.17939-0.92064-0.0698-1.3904 0.25049-0.48022 0.32029-0.97088 1.4906-1.2103 2.0607-0.14942 0.33008-0.17943 0.88064-0.39018 1.1298-0.24011 0.29028-0.74056 0.24984-1.0107 0.66015-0.47043 0.74104-0.39997 1.8402-0.79015 2.5708-0.0411-0.0202-0.0802-0.0404-0.1207-0.0698-0.91999 0.94-2.0905 1.5812-3.4118 1.7802-1.5809 0.24005-3.4222 0.24005-5.043 0.15982 6.5e-4 -0.0437 6.5e-4 -0.0939 6.5e-4 -0.14351z",
+                HsinchuCity:"m239.48 98.926c0.2101-0.57078 0.27012-0.55121 0.82995-0.91064 0.30013-0.19048 0.85996-0.51012 1.1209-0.81019 0.25904-0.30007 0.20031-0.63014 0.30993-0.98044 0.0803-0.27006 0.24011-0.77953 0.11027-1.0802-0.14942-0.36008-0.63029-0.4201-0.91086-0.60014-0.24989-0.14025-0.58135-0.4899-0.42084-0.8291 0.0998-0.20092 0.28056-0.12068 0.39083-0.29028 0.09-0.14938 0.03-0.46054 0.03-0.63014 0-0.71038-0.0502-1.4501 0-2.1611 0.0196-0.34965 0.10962-0.5897 0.24011-0.8702 0.12006-0.26941 0.39018-0.4201 0.55069-0.66015 0.18987-0.31051 0.21989-0.7006 0.40976-1.0196 0.21988-0.3803 0.47956-0.4501 0.51023-0.91064 0.0196-0.33986-0.03-0.68037 0.0803-1.0007 0.11027-0.30985 0.3693-0.5199 0.5396-0.78996 0.20096-0.30985 0.41106-0.4899 0.64008-0.74039 0.23032-0.24006 0.42019-0.53034 0.6205-0.84019 0.38039-0.55969 0.42019-1.4103-0.25969-1.7306-0.30013-0.14025-0.63029-0.21983-0.95065-0.24984 0.06-0.4899 2.5616-0.16047 3.0314-0.27985 0.03-0.06001 0.0692-0.0998 0.09-0.14025 1.6005 0.17939 1.6716 2.0705 3.0216 2.8311 0.67009 0.3803 1.5614 0.1396 2.2921 0.36987 0.75948 0.24984 1.3408 0.39922 2.2204 0.45989 0.47109 0.91978 0.95066 0.69016 1.8406 0.99023 0.69032 0.23027 1.1105 0.83041 1.7512 1.2401 1.1908 0.76061 1.8406 1.2401 1.8406 2.7508 0 0.72995-0.0502 1.2394 0.33015 1.8396 0.33015 0.52055 0.79014 0.83041 0.98067 1.4305 0.18008 0.56035 0.23097 1.3908 0.33993 1.9204 0.25969 1.2394-0.0104 0.85063-0.91085 1.1403-0.61006 0.20026-0.9102 0.95044-1.2397-0.08024-0.21009-0.65037 0.09-1.2205-0.49001-1.6804 0-0.23092-0.15006-0.3503-0.18986-0.54991-0.29036-0.01109-0.60028-0.02022-0.89063-0.03001-0.2101-0.6608-1.4407-1.4703-2.1812-1.3203-0.53046 0.0998-0.64008 0.27985-0.94021 0.7306-0.33994 0.51012-0.23033 0.95044-0.48022 1.4403-0.47044 0.93021-1.8511 0.24984-2.6112 0.91064-0.80059 0.69994-0.60028 1.8506-0.65052 2.8206-0.91999 0.05023-1.8902-0.09002-2.7215 0.20092-0.74055 1.3001 0.40976 3.5108-0.85082 4.5212-0.42019-0.29028-1.1608-0.33007-1.7206-0.33007-0.8306 0-1.2912-0.14025-1.2808-1.0411 0-0.63928-0.03-1.1298-0.4104-1.6197-0.14094-0.18004-0.41106-0.36986-0.51024-0.54991-0.12984-0.21983-0.0907-0.50098-0.16964-0.74104-0.69097-0.19048-1.1105 1.4103-1.791 1.5401-0.31123 0.06-1.0903 0.03-1.3715-0.09-0.40062-0.15004-0.44955-0.44032-0.91085-0.46054-0.0111-0.06002-0.0202-0.11024 0-0.15004 0.0189-0.20026 0.20944-0.2805 0.3693-0.4201 0.24272-0.2094 0.27273-0.28963 0.37256-0.54926z",
+                Miaoli:"m246.9 103.34c0.03 0.0202 0.06 0.0404 0.0803 0.06 0.03 0.18004 0.24011 0.54991 0.42019 0.66015 0.31123 0.21005 0.41106 0.0411 0.70076-0.0992 0.82994-0.42075 0.81037 0.47032 1.5907 0.5897 0.82994 0.12981 0.53046-0.66015 1.1705-0.8702 0.42998-0.14025 1.641-0.16047 1.9111 0.29028 0.42084 0.67973-0.50045 1.7202-0.82995 2.1612-0.25968 0.33986-0.63094 0.5597-0.76013 0.96022-0.2512 0.7704 0.12005 0.53034 0.6603 0.81019 0.29035 0.14938 0.38039 0.47032 0.63943 0.69016 0.24011 0.20026 0.56047 0.27984 0.78036 0.51011 0.33993 0.36922 0.47043 0.86042 0.78035 1.2505 0.21989 0.29028 0.53046 0.48011 0.76079 0.76061 0.44955 0.54991 0.76078 1.1905 1.5607 1.2394 0.48022 0.0202 0.97088-0.12916 1.0805 0.36987 0.09 0.44032-0.0998 0.92043 0.09 1.3307 0.36995 0.10959 0.38039 0.18004 0.57026 0.50033 0.12985 0.23093 0.0502 0.20092 0.25969 0.30072 0.13049 0.0496 0.35038 0.03 0.50044 0.0796 0.60028 0.22048 0.82016 0.80105 1.4106 1.0111 0.90042 0.31964 1.5607 0.69929 2.2112 1.3301 0.26034 0.25049 0.54025 0.47032 0.78036 0.74039 0.15007 0.17025 0.33015 0.50033 0.55004 0.58056 0.0502-0.27984 0.74121-0.66928 1.0414-0.76061 0.52002-0.14938 0.5807 0.23093 0.80971 0.59036 0.26034 0.42009 0.60093 0.39987 0.99111 0.66993 0.47044 0.33986 0.1703 0.57013 0.33994 1.0405 0.24011 0.66015 1.1307 0.93021 1.2815 1.711 0.0992 0.51012-0.28122 0.81019-0.55134 1.1703-0.31906 0.42988-0.36017 0.8702-0.70989 1.3307-0.49001 0.63015-0.74969 1.3497-0.86062 2.1305-0.0496 0.36009-0.25968 0.60014-0.5807 0.72017-0.27991 0.0991-1.1203-0.03-1.0407 0.44032 0.47043 0.21004 0.98067 0.63014 1.3604 0.95043 0.29035 0.24006 0.55982 0.48011 0.80058 0.75996 0.23098 0.2805 0.55004 0.57013 0.84039 0.77039 0.25968 0.17026 0.57026 0.20092 0.5011 0.62036-0.0698 0.45989-0.45021 0.66015-0.66096 1.0104-0.23032 0.39074-0.0692 0.47033-0.60028 0.57013-0.3693 0.0802-0.68053 0.12068-0.91085 0.43967-0.49001 0.6608 0.14942 1.3803 0.2499 2.0516 0.0502 0.36921-0.01 0.77039 0.13049 1.1207 0.12919 0.32029 0.4202 0.51012 0.58005 0.78996 0.6205 0.18004 1.2704-0.0998 1.791 0.24984 0.50045 0.33008 1.1705 0.46054 1.8609 0.39075 0.3308-0.0411 0.42084-0.15004 0.66095-0.38031 0.24011-0.24005 0.38039-0.32029 0.67988-0.48989 0.31971-0.18005 0.55003-0.27007 0.79014-0.53034 0.17943-0.19048 0.33016-0.3503 0.55004-0.48011 0.28056-0.17026 0.60027-0.30007 0.90041-0.11025 0.33015 0.19048 0.36996 0.59036 0.76079 0.69995 0.20031 0.0502 0.84038 0.10045 1.0205 0 0.23032-0.12003 0.34972-0.57013 0.61071-0.73974 0.6603-0.4501 1.0205 0.44945 1.7108 0.48011 0.39017 0.0196 0.77057-0.0502 1.1203 0.14025 0.33994 0.17939 0.48022 0.42923 0.95066 0.30986 0.35037-0.0802 0.53046-0.27985 0.93042-0.3203 0.33081-0.03 0.65052-0.01 1.0009 0 0.36016 0.0111 0.89062 0.0907 1.2508 0 0.36016-0.09 0.5807-0.42988 0.88084-0.66015 0.68053-0.5199 1.5405-0.12002 2.2315-0.69016 0.57026-0.46054 1.3108 0.0398 1.5698 0.70973 0.28121 0.7704-0.74969 1.3405-0.19052 2.1409 0.49 0.69016 1.1608 1.1898 1.761 1.8004 0.67988 0.69929 1.2306 1.5702 1.9118 2.2805 0.33015 0.33007 0.71054 0.58056 1.0002 0.96022 0.33015 0.43053 0.79015 0.71038 0.91085 1.2707 0.12006 0.54991-0.0404 1.1703-0.0698 1.73-0.0405 0.69995 0.0698 1.4403 0.0502 2.1514-0.53046 0.47946-1.1307 0.91977-1.9411 0.87998-0.47108 1.1703 0.0803 2.6106-0.39083 3.7809-1.5007 0.53034-1.5398 1.8311-2.6412 2.561-1.8211 1.1814-2.2112-0.17939-2.5212-1.6804-0.6603-0.17939-1.4302-0.27985-2.1212-0.15917-0.10962 2.1005 0.0607 2.7704-2.161 3.1703-1.0505 2.0516-1.9013 2.8311-4.2019 3.3021-1.3904 0.28898-1.6501 0.0991-2.5414 1.1292-0.30013 0.33986-0.24989 0.83041-0.63029 1.2101-0.36081 0.36008-1.0903 0.19048-1.4609 0.69016-0.81038 1.0907-0.0502 1.3503-1.3715 2.1409-0.28057 0.16048-1.9914 1.12-2.3306 1.1703-1.1014 0.15982-1.4407-1.0907-2.6719-0.68037-0.93956 0.32029-0.88997 1.6706-2.4814 1.7-0.2499 0.6308-0.74056 1.0802-0.88084 1.7802-1.7519 0.14025-1.9607-0.39988-3.1926-1.4306-0.31058-0.25962-1.0002-0.39009-1.2508-0.74039-0.3693-0.5199-0.17943-1.2401-0.53046-1.7704-1.4407-2.1709-4.9627-1.5101-7.1739-1.8702-1.7408-0.2805-4.9425-2.4899-6.3832-0.3803-1.5209 2.261 1.5809 5.6615-1.6201 6.882-2.191 0.8402-5.2224-0.0404-7.6744 0.33073-1.3911 0.2094-2.3711 0.58057-3.4522-0.20091-0.96958-0.71038-1.5509-1.8709-2.4311-2.5806-1.8511-1.4808-4.7128-0.85976-6.834-2.1807-1.9613-1.2205-3.3824-3.1507-5.163-4.4912-1.0805-0.81019-1.7108-0.39074-2.8017-0.8702-0.95065-0.40966-1.2404-1.3001-1.9913-1.9602-1.4002-1.2401-2.3411-2.0907-3.462-3.5917-1.2208-1.6497-3.0216-2.1696-4.0917-3.621-1.0414-1.4299-1.1405-3.0809-2.5512-4.2114 0.58984-0.96935 1.6312-1.7202 2.5414-2.4599 0.47044-0.39074 1.1908-0.75017 1.5614-1.2003 0.38039-0.46054 0.17943-0.91064 0.33994-1.4305 0.2897-0.92043 1.1705-1.4906 1.5607-2.3608 0.4502-1.0007 0.91085-1.6908 1.5614-2.6008 0.30013-0.42923 0.49-1.15 0.55982-1.6602 0.11027-0.84019 0.11027-1.1403 0.69097-1.8096 0.54025-0.63993 0.63942-0.99088 0.67988-1.8004 0.06-1.2309 0.5807-2.5617 0.88083-3.762 0.36996-1.4703 1.6312-2.1005 2.4109-3.381 0.50045-0.83041 0.61072-1.7906 1.1705-2.651 0.36995-0.55904 0.92064-1.5206 1.5607-1.6602 1.0413-0.24006 4.1928 1 3.7824-1.2394-0.54025-0.22048-0.92064 0.12916-1.4106 0.0992-0.0411-0.23027 0.5807-1.1298 0.74056-1.4103 0.30013-0.53034 0.68053-0.92043 0.86061-1.5304 0.33994-1.1305 0.65051-1.9407 1.6201-2.6706 0.70076-0.53034 1.562-1.3007 2.5218-1.4403 1.1803-0.18004 2.3802-0.39988 3.5618-0.50099 0.59049-0.06 1.2103 0.0202 1.8008-0.01 0.2499-1.3503 1.2208-2.621 2.5009-3.1312 0.0907-0.98045 1.0505-1.1103 1.5809-1.7802 0.49001-0.6197 0.44107-1.2805 0.49001-2.0803 0.0607-0.81997 0.53046-1.4703 1.0805-2.0307 0.44042-0.44032 0.97088-1.3307 1.562-1.5401-0.0202 0.04044-0.0111 0.09067 0 0.15004 0.45999 0.0202 0.50958 0.30985 0.91085 0.46054 0.27991 0.12003 1.0603 0.14938 1.3715 0.09 0.68053-0.12981 1.1007-1.7306 1.7904-1.5401 0.0803 0.24006 0.0404 0.52056 0.17029 0.74104 0.0992 0.17939 0.3693 0.36922 0.50958 0.54991 0.3804 0.4899 0.41106 0.98044 0.41106 1.6204-0.0111 0.90021 0.44956 1.0405 1.2808 1.0405 0.56112-5e-3 1.301 0.0346 1.7212 0.32486z",
+                Taipei:"m351.36 53.383c0.0104 0.32029 0.0104 0.65037 0 0.97066-0.52002-0.02022-1.0407 0.06915-1.5705 0.09915-0.25968 0.01044-0.5807-0.06001-0.82994 0.02022-0.20031 0.0698-0.4202 0.36008-0.56048 0.39987-0.50045 0.14938-0.96044-0.11024-1.5307-0.09067-0.63029 0.03066-0.92064 0.32029-1.4909 0.44097-0.90042 0.19048-2.3313-0.39987-3.141 0.17026-0.20096 0.1396-0.10962 0.44032-0.28056 0.63014-0.15986 0.17026-0.42933-0.05023-0.58984 0.26028-0.35038 0.66928 0.3693 0.87998 0.82016 1.0196 0.0692 1.2805-1.0303 5.092 1.0909 4.8318 0.06 0.3503 1.3004 0.54991 1.6605 0.66994 0.25968 0.96935-0.47043 0.77953-1.151 0.81997-0.82995 0.05023-0.77123 0.41031-1.4106 0.66928-0.59049 0.22048-1.2208-0.2394-1.761-0.31964-0.61071-0.09981-1.3708 0.23027-1.5098-0.59035-0.67009 0.13046-1.0414 0.65037-1.7414 0.57013-0.55004-0.06001-0.85996-0.47032-1.1601-0.92043-0.47108-0.67972-1.3506-1.6804-1.2704-2.5708-0.3804 0.02022-0.8704-0.03001-1.1705-0.2394-0.39997-0.2805-0.25969-0.74104-0.47044-0.94-0.72033-0.66994-1.4609 0.47032-1.9117 0.83041-0.01-1.2009 1.791-2.1905 0.74121-3.3412-0.44107-0.48011-0.97023-0.68037-1.4009-1.1703-0.44042-0.50098-0.60028-0.96087-1.3604-0.90021-0.82016 0.06001-1.0505 0.72016-1.4909 1.2505-0.61072 0.74039-0.79015 0.88977-1.3604 0.09981-0.46065-0.63928-0.42019-0.95044-0.55982-1.681-0.0907-0.43967-0.61137-1.1801-0.59049-1.5904 0.06-1.06 2.2308-1.06 2.8115-2.0209 0.59049-0.94 0.61137-2.8011 0.61137-3.9818 0-1.2205-0.73077-2.1507-1.5816-2.9811-0.41041-0.39922-0.69032-0.8004-1.2501-1.0196-0.57091-0.21983-1.2404-0.10959-1.8315-0.24984-0.52002-0.12981-1.0603-0.20092-1.5607-0.39987-0.84038-0.32029-0.75034-0.42075-0.79014-1.1905-0.0202-0.54991-0.19053-1.2903 0.03-1.8095 0.0992-0.23092 1.2306-1.0202 1.2208-0.69081 0.0405-0.8004-0.2101-1.7606 0.42998-2.2407 0.7001-0.53034 1.331-0.10959 1.2612-1.3999 1.0309-0.06001 1.2097 0.12981 1.4909-0.85063 0.16051-0.57992 0.28056-0.97 0.65052-1.5003 0.28904-0.42075 0.67987-1.1011 1.1803-1.2609 0.54025-0.17026 1.4211 0.01957 1.9914 0 0.19052-1.1703-0.0802-1.8102 1.3415-1.8206 0.5807-0.01044 1.0002-0.06915 1.4902-0.25962 0.24011-0.09067 0.89062-0.3803 1.0205-0.57013 0.2101-0.36008-0.1605-1.06 0.0502-1.4403 0.21989-0.39074 0.89063-0.4899 1.1301-0.80105 0.18008-0.23027 0.36082-1.03 0.64007-1.1703 0.58005-0.28963 0.96045 0.42075 1.3904 0.65037-0.33994 1.6308 0.90041 1.8617 2.191 1.9309 0.60028 1.5003-0.03 3.3308 0.76013 4.822 0.14942 0.27006 0.50958 0.50033 0.61072 0.7293 0.15007 0.36987 0.0202 0.86042 0.06 1.2707 0.0698 0.85063 0.53046 1.2401 1.151 1.7704 0.20944 0.77105 0.85996 0.80105 0.85082 1.8206-0.0111 1.1011-0.69097 0.98044-1.0909 1.8311-0.10962 0.21983-0.13963 0.82976-0.0803 1.0907 0.14029 0.51012 0.0104 0.30007 0.66944 0.40966 0.78036 0.12981 1.3917 0.60014 2.1512 0.68037 0.0307 1.0405 1.1908 0.69994 1.4309 1.6504 0.2499 0.93935-0.48022 2.9707-1.0002 3.6706-0.85083 1.1507-0.63029 1.0705-0.33015 2.4208 0.32036 1.4808 2.0011 2.8011 3.2519 3.3301 0.53047 0.23092 1.1007 0.3803 1.7512 0.42075 0.76666 0.04175 1.1966-0.49838 1.8974-0.23875z",
+                Newtaipei:"m400.14 55.204c1.2012 4.4117-4.7722 2.1905-5.6935 4.7613-1.1901 0.06001-2.1904-0.84019-3.3909-0.36987-0.6316 0.25049-0.66161 0.85063-1.2319 1.1305-0.4202 0.21005-1.3911 0.18004-1.8511 0.23092-1.181 0.12916-2.4318 0.74039-3.2722 1.6497-0.49001 0.5199-0.7497 0.97001-1.5705 1.12-0.65051 0.12981-1.4211 0.1109-2.0801 0.15003-1.562 0.0698-2.7221-0.25962-3.8215 0.91064-0.91085 0.99023-1.6012 1.6308-1.1712 3.0711 1.0609-0.04044 2.3613 0.88064 2.1414 1.9407-0.15007 0.71038-1.6508 1.5401-2.2315 1.9107-0.46 0.30007-0.77122 0.76061-1.1405 1.0202-0.42085 0.30007-1.1705 0.23027-1.7004 0.23027-1.2612 0-2.4416 0.09981-3.6526 0.3503-0.47043 0.78018-0.0104 2.4906-1.4106 2.5004-0.31972 0.80105 0.28056 0.84084 0.38039 1.4208 0.11027 0.6308-0.46 0.74104-0.75035 1.3007-1.2906 0.39988-1.7408 1.3503-2.9009 2.0105-1.2012 0.69994-2.6008 0.21983-3.9416 0.48011-1.0113 0.20026-2.6614 1.15-3.312 1.9302-0.36082 0.42988-0.67988 1.06-1.1705 1.4305-0.4502 0.33986-1.2312 0.5199-1.6012 0.96935-0.4502 0.54991-0.29035 1.4103-0.33015 2.1005-1.4009 0.0698-2.7717 0.01044-4.1523 0.09067-1.2808 0.08024-3.0418 0.0098-4.0721 0.77039-0.49 0.36987-0.75034 0.88064-0.85082 1.4814-0.15007 0.96935 0.11027 1.1298-1.0002 1.1703-0.99046 0.03001-3.282 0.21983-3.3518 1.6497-0.0104 0.08024-0.0502 0.21983-0.0502 0.33986 1.2606 0.42988 0.38039 1.5701 0.0502 2.2603-0.44042 0.94-0.33015 1.8108 0 2.6908 0.76078 2.0007 0.73077 4.1912-1.9711 4.0712 0.0803 1.2505-0.28905 1.6602-1.5098 1.6602-0.94021-0.01-2.8924 0.14025-3.4327 0.9002-0.53046 0.72995-0.20944 2.0105-1.0707 2.5108-0.24011 0.15003-0.63029 0.13046-0.92064 0.23092-0.35038 0.12981-0.63029 0.40966-0.98066 0.54991-0.65052 0.26027-1.4707 0.06-2.1812 0.20026-0.69097 0.1409-1.1908 0.6308-1.7708 0.92043-0.73077 0.36987-1.1203 0.39074-2.0011 0.43053-0.1703 0.0104-0.36017 0.0202-0.57026 0.0202 0.01-0.92043 0.0398-1.8409-0.0104-2.7508-0.94022 0.11024-0.91086-0.74039-1.6312-1.1814-0.42084-0.24984-0.54024-0.33986-1.0205-0.4201-0.36016-0.0502-0.85017 0.11024-1.151-0.0998-0.64007-0.42989-0.21988-1.3301-0.54025-1.9602-0.26033-0.51011-0.72033-1.0307-1.0407-1.5206-0.75035-1.15-1.4511-2.1605-1.8615-3.501-0.17029-0.57013-0.21988-1.3197-0.33015-1.9198-0.20031-0.98044-0.14028-1.2009 0.60028-1.6412 1.0603-0.63014 1.3715-1.9302 2.7215-2.1201 0.31123-0.2805 0.29035-0.76061 0.2499-1.2205-2.3411 0.1409-0.99959-2.6504-1.7304-3.6811-0.39997-0.57013-1.3004-0.06001-1.6906-0.99023-1.1105 0.12003-1.6612-1.8709-2.2315-2.4514-0.68053-0.69016-2.7019-1.5806-3.5919-0.7306-0.44956 0.43053-0.30014 1.0711-1.1601 1.2505-0.81037 0.17091-1.331-0.58057-1.9209-0.91978-1.3108-0.74104-2.5009-0.59035-3.9918-0.68037-0.21988-1.0502 2.0612-1.3007 2.7319-1.3307 0.03-0.44097 0.0803-0.82976-0.21988-1.1814-0.2101-0.24984-0.91086-0.21983-1.0805-0.57992-0.43063-0.89042 1.6808-1.1403 1.3408-1.9909-0.24989-0.61058-1.1705 0.08024-1.6207-0.23092-0.36017-0.25962-0.38039-1.2303-0.33994-1.6602-0.12005 0-0.28056-0.04044-0.39018-0.03001-0.35038-0.30007-0.39083-1.0007-0.76078-1.2407-0.31123-0.20026-1.0205 0.01109-1.3415-0.24006-0.69031-0.53034 0.0405-1.4808-0.0104-2.4103-0.30992-0.01044-0.63029-0.01044-0.91085-0.0698 0.0202-0.14025 0.0411-0.90021 0.11092-0.93021 0.23946-0.09981 0.44956-0.23092 0.72033-0.27006 0.15007-0.3803 0.19052-1.1807 0.01-1.4906-0.30993-0.54012-0.72033-0.14025-1.0707-0.4899-0.42998-0.42988 0-1.1005 0.39997-1.2603 0.36016-0.15003 1.1007 0.01044 1.4909-0.01044 0.12005-0.77953-0.33994-1.2805-0.49001-1.9909-0.14093-0.71038-0.19052-1.5095-0.16051-2.2505 0.0104-0.33986-0.0802-1.0705 0.0992-1.3405 0.30014-0.4501 0.44107-0.21005 0.90041-0.33008 0.74121-0.18983 1.3115-0.30007 2.1016-0.1396 1.1301 0.23027 3.0118 0.57013 4.1523 0.14938 1.1301-0.43053 0.74056-2 2.4011-1.9407 0.19052-0.39987 0.77057-0.82976 1.1705-1 0.0398-0.54012 0.03-0.8702-0.30014-1.2603-0.18987-0.21983-0.72033-0.21005-0.84039-0.57013-0.32036-0.96087 1.3604-1.0307 1.9711-1.0007-0.03-0.92043-0.58984-1.0405-0.88019-1.7606-0.31058-0.74039-0.09-1.8004 0.12984-2.4599-0.0411-0.01044-0.09-0.02022-0.14028-0.03001-0.0405-0.2805-0.0998-0.55056-0.19052-0.81019-0.99111-0.24006-0.94022-0.55969-1.0002-1.5003-0.31123-0.0698-0.54025-0.2805-0.5807-0.58057-1.1712-0.12003-2.052-0.54991-3.2422-0.60014-0.76078-0.02022-1.6012-0.44032-2.071-0.93021-0.30992-0.32029-0.33015-0.63993-0.53046-0.98044-0.32036-0.53034-0.5011-0.44032-0.90041-0.75017-0.68053-0.51012-1.3611-0.90021-1.6808-1.6602-1.0303-0.02022-2.0912-0.05023-3.1417-0.11024-0.0692-0.20026-0.18008-0.24984-0.20031-0.47033-0.36995-0.29028-0.5807-0.67972-1.0714-0.8702-0.47957-0.19048-1.0002-0.0411-1.4407-0.36987-0.66031-0.5199-0.42933-1.9107-0.39932-2.8109 0.21989-0.01044 0.39018-0.02022 0.46065-0.05023 0.42933-0.15003 1.7512-0.15982 2.5505-0.33008 1.8817-0.39074 3.5729-0.15003 5.5128-0.24006 0.86061-0.0411 1.5007-0.17026 2.2419-0.76061 1.0198-0.81019 1.32-1.3705 2.7515-2.0007 0.0404-0.21983 0.90041-0.28963 1.0009-0.50033 1.9809-1.1011 6.8738-4.0509 2.7815-5.702 1.5307-0.33986 0.9102-1.3105 1.4609-2.3105 0.47043-0.86042 1.7512-1.6106 2.2112-2.3007 0.94022-1.4299 1.9509-3.2603 1.8413-5.4006 0-0.13046 2.4311-0.0698 2.6712-0.18004 1.2103-0.60014 1.0002-1.3601 1.7806-2.2603 1.3408-1.5604 3.402-2.561 4.5523-4.3112 1.2508 0.01109 4.703 0.96087 3.4816-1.4899 0.67009 0.33986 0.53046-0.05023 1.0205 0.66015 1.38 0.08024 3.8418 0.53034 4.6521-0.62036 0.80058 0.63014 1.0407 0.69016 2.0214 0.4501 0.12071 0.21983-0.0202 0.44032 0.0803 0.66928 1.2006 0.20092 1.7408 1.0202 2.7117 1.5401 1.2606 0.66994 0.59048 0.66015 2.251 0.74952 0.06 0.97 1.3708 1.6804 1.7003 2.5917 0.42085 1.1801 0.12985 2.8604 0.33994 4.1201 0.55917-0.12003 1.3604 0.20092 1.9202 0.08024-0.25903 2.2805 1.5712 2.6308 1.581 4.6713 0.96109 0.04044 1.962 0.04044 2.9224 0 0.69032-1.0007 2.071-0.93021 2.9916-1.9302 0.1703 2.2603-1.9613 3.1709-2.1616 4.9322 0.0502-0.4899 1.5105 0.7704 2.4716 1.6308-1.1399 0.53034-1.9307 1.0796-2.9505 1.7208-0.47043 0.29028-0.43063 1.2094-1.0505 1.4508-0.66944 0.25962-1.9907-0.01044-2.7215 0.03001-0.65052 1.8409-2.3913 1.4103-4.0023 1.501-0.12984 0.40966-0.12984 1.2603 0 1.6706 0.58071-0.14938 1.3708 0.0411 1.9209-0.17026 0.09 1.711-0.26034 6.0209 2.0005 6.002 0.03 0.27985-0.03 0.65037 0.0802 0.92043 0.42998-0.02022 1.0009 0.14938 1.4211 0.07958 0.42085 1.1403 1.4511 1.5708 2.5512 0.81019-0.21009 0.15982-0.43063 0.55056-0.7797 0.78018 0-0.01957 0.0796 0.55056 0.06 0.58057 1.4504-0.30007 2.5708 0.5199 2.5009 2.0007 2.0801 0.12003 3.5619 1.0405 5.5323 1.2205 0.47108 0.05023 1.0107 0.44945 1.6912 0.33008 0.60027-0.09981 0.48022-1.06 1.0414-1.2101 1.2697-0.34965 2.7515 0.58057 3.2121-1.0405 0.36017-1.2603-0.95065-2.1709-1.9711-2.3001 0.0998-1.8311-0.13963-3.1312-1.4504-4.2218 1.0498-0.24006 1.8406-1.1103 2.9009-1.2505 1.2012-0.16047 2.0605 0.78996 3.4712 0.47098-0.09-0.63993 0.33994-1.1103 0.33015-1.6713 0.3308 0.0698 0.84038-0.12003 1.1705-0.08024 0.0613-0.32029 0.39148-1.09 0.42149-1.4208v-0.03001c0.36017 0.01044 0.73012 0.01957 1.0805 0.03001-0.12136 0.55969 0.20031 1.3607 0.0796 1.9204 1.1099 0.07958 1.6612-0.84019 2.2504-0.92043 1.271-0.15982 1.8622 0.33008 2.7117 0.46054 1.4211 0.23027 4.7526-0.42075 5.043 1.2094 1.1405 0.18983 2.6216 0.39009 2.7515-0.92043 0.53046 0.06001 1.4811-0.28898 1.7108-0.28898-0.42084 0.74039-0.33015 1.5695-0.21009 2.4599 0.23097 0.0698 0.44042 0 0.67074 0.08024 0.36017 1.4299-2.5714 5.9316 0.2499 6.002 0.24011 1.1801 0.7908 1.7202 0.98067 2.9009 0.14028 0.85976-0.2101 2.4899-0.15007 3.5206 2.4115 1.5701 4.2535 0.91064 7.1739 1.0802 0.41106 1.1507 2.512 0.84084 3.6225 0.71038zm-48.785-0.84998c0.0104-0.32029 0.0104-0.65037 0-0.97066-0.69946-0.25962-1.1301 0.2805-1.9013 0.24006-0.65052-0.0411-1.2201-0.19048-1.7512-0.42075-1.2508-0.53034-2.9316-1.8506-3.2519-3.3301-0.30014-1.3503-0.52002-1.2701 0.33015-2.4208 0.52068-0.69994 1.2508-2.7313 1.0002-3.6706-0.24011-0.95044-1.4002-0.61123-1.4302-1.6504-0.76013-0.08024-1.3715-0.55056-2.1512-0.68037-0.66096-0.10959-0.53046 0.09981-0.67009-0.40966-0.06-0.26028-0.03-0.8702 0.0802-1.0907 0.40062-0.85063 1.0805-0.72995 1.0909-1.8311 0.01-1.0196-0.64008-1.0496-0.85083-1.8206-0.6205-0.53034-1.0805-0.91978-1.151-1.7704-0.0405-0.41031 0.0907-0.90021-0.06-1.2707-0.0998-0.23027-0.46064-0.45924-0.61071-0.7293-0.79015-1.4906-0.15986-3.3216-0.76013-4.822-1.2912-0.06915-2.5316-0.30007-2.191-1.9309-0.43063-0.23027-0.81037-0.93935-1.3904-0.65037-0.28056 0.14025-0.46065 0.94-0.64008 1.1703-0.23945 0.31116-0.91085 0.41031-1.1301 0.80105-0.2101 0.3803 0.15986 1.0802-0.0502 1.4403-0.12984 0.19048-0.78036 0.47946-1.0198 0.57013-0.49066 0.19048-0.91085 0.24984-1.4909 0.25962-1.4211 0.01044-1.151 0.65037-1.3415 1.8206-0.57027 0.01957-1.4511-0.17026-1.9914 0-0.50045 0.15982-0.89063 0.84019-1.1803 1.2609-0.36995 0.53034-0.49001 0.92043-0.65051 1.5003-0.28057 0.98044-0.46 0.78996-1.4909 0.85063 0.0692 1.2909-0.56047 0.8702-1.2606 1.3999-0.64008 0.47946-0.39084 1.4403-0.43064 2.2407 0.0104-0.33008-1.1203 0.46054-1.2208 0.69081-0.21989 0.5199-0.0502 1.2603-0.03 1.8095 0.0398 0.77039-0.0502 0.8702 0.79015 1.1905 0.50044 0.20026 1.0407 0.27006 1.5607 0.39988 0.59049 0.14025 1.2612 0.03001 1.8315 0.24984 0.55982 0.21983 0.84038 0.62036 1.2508 1.0196 0.85017 0.83041 1.5809 1.7606 1.5809 2.9811 0 1.1807-0.0202 3.0411-0.61137 3.9818-0.5807 0.96022-2.7515 0.96022-2.8115 2.0209-0.0202 0.41031 0.50044 1.1507 0.59048 1.5904 0.14029 0.7306 0.0992 1.0411 0.55983 1.681 0.57026 0.78996 0.75034 0.63993 1.3604-0.0998 0.44042-0.53034 0.67009-1.1905 1.4909-1.2505 0.76078-0.06067 0.92064 0.39922 1.3604 0.90021 0.43063 0.4899 0.9611 0.69016 1.4009 1.1703 1.0498 1.15-0.75034 2.1396-0.74121 3.3412 0.45021-0.36074 1.1908-1.501 1.9118-0.83041 0.2101 0.20026 0.0692 0.66015 0.47043 0.94 0.30014 0.2094 0.79015 0.25962 1.1705 0.2394-0.0803 0.89042 0.80124 1.8904 1.2704 2.5708 0.30013 0.4501 0.61071 0.86042 1.1608 0.92043 0.7001 0.08024 1.0707-0.43967 1.7408-0.57013 0.13963 0.82062 0.90041 0.4899 1.5098 0.59035 0.54025 0.08024 1.1705 0.54012 1.761 0.31964 0.64008-0.25897 0.58071-0.61971 1.4106-0.66928 0.68053-0.04044 1.4106 0.14938 1.151-0.81997-0.36017-0.12068-1.6012-0.32029-1.6606-0.66994-2.1212 0.25962-1.0198-3.5512-1.0909-4.8318-0.45021-0.14025-1.1705-0.3503-0.82016-1.0196 0.1605-0.31116 0.43063-0.09067 0.58983-0.26028 0.17095-0.18983 0.0803-0.4899 0.28057-0.63014 0.81037-0.57013 2.2412 0.02022 3.141-0.17026 0.57026-0.12068 0.85996-0.41031 1.4909-0.44097 0.57027-0.01957 1.0309 0.24006 1.5307 0.09067 0.14093-0.0411 0.36081-0.33008 0.56047-0.39988 0.2499-0.08024 0.57026-0.01044 0.82995-0.02022 0.53372-0.03066 1.0537-0.12068 1.5744-0.10046z",
+                Taoyuan:"m324.59 106.65c0.0502 0.91065 0.0202 1.8304 0.0104 2.7508-1.2208 0.0691-2.8918 0.21005-3.5619 0.95044-0.24011 0.25962-0.59048 0.69994-0.71054 1.0307-0.26034 0.78018 0.15007 0.57991 0.45999 1.2394 0.29035 0.60079-0.06 1.8311-0.27991 2.5004-1.1105 0.81019-2.1616 1.2609-2.5714 2.681-0.2101 0.71038-0.19053 1.4103-0.65052 2.0105-0.55069 0.71038-1.0009 0.47033-1.7114 0.72017-0.8704 0.3105-1.3806 1.561-1.3708 2.621-0.78035 0.0998-1.9418 0.33008-2.6719 0.0502-0.58984-0.21983-1.0798-0.98044-1.8406-0.99088-0.84039-0.50033-0.72033-1.7508-1.5809-2.2505-0.0405-0.72017 1.1209-4.291-0.33994-4.002 0.0411-0.92043-0.30014-0.97979-0.76013-1.5904-0.39997-0.5199-0.28057-0.96087-0.2499-1.5708 0.03-0.43967 0.16964-1.5701-0.15007-1.8506-0.2897-0.25963-1.5307-0.06-1.9202-0.0802-0.18008-0.67972-0.0202-1.4403-0.18008-2.1507-0.13963-0.63014-0.67988-0.93021-1.0198-1.3901-0.51023-0.69081-0.36995-1.0502-1.3115-1.1905-0.72033-0.11025-1.8308-0.0802-2.2706 0.39987-0.12984 0.03-0.2499 0-0.38039 0-0.67009-1.8409 1.1301-3.0111 0.72033-4.8115-0.12005 0-0.27991-0.0411-0.39018-0.0202-0.12984-0.09-0.03-0.12068-0.2499-0.17026-0.17029-0.52055-0.33993-1.3412-0.18008-1.9009 0.15007-0.57013 0.70011-0.84019 0.82995-1.501 0.28056-1.4208-0.6205-2.79-1.9209-3.0907-0.80059-0.18004-0.93043-0.28963-1.581-0.74104-0.23097-0.15917-0.55068-0.28898-0.85082-0.4899-0.19052-0.12003-0.39997-0.44032-0.5011-0.50033-0.63943-0.39009-1.181-0.08024-1.6312-0.67972-0.36016-0.48011-0.39931-1.2303-0.3693-1.8206-0.50109-0.08024-1.5105-0.24006-1.9013-0.51012-0.60028-0.4201-0.26034-1.3803-1.1705-1.3405-0.57026 0.03001-1.1908 0.8702-1.8315 0.75017-0.77057-0.15004-0.47957-1.1514-0.50958-1.8206-0.52068 0.01957-1.0309-0.16047-1.5614-0.08024 0.03 0.2094-0.11027 0.36922-0.11027 0.54991-1.2097 0.24006-1.8511-1.0007-2.8918-1.3307-0.15007-0.69081-0.47109-1.3901-1.331-1.2505 0.12006-0.86042-1.0414-0.81997-1.5907-1.0104-0.33015-0.12068-0.79015-0.32029-1.0805-0.5199-0.25968-0.18004-0.5807-0.75996-0.7797-0.85976-0.24011-0.12003-0.42085-0.21983-0.72033-0.19048-0.15986-0.72016 0.29035-0.7306 0.66095-1.1403 0.42933-0.48011 0.49001-0.66015 0.47957-1.3307-0.01-0.3803-0.0196-1.1605-0.16964-1.5003-0.11027-0.24984-0.38039-0.08024-0.48022-0.44032-0.0692-0.21983 0.21009-0.44097 0.17095-0.58057-0.20097-0.66015-1.7108-1.0007-2.422-1.0007-0.74969 0-2.0005 0.23092-2.7012-0.0098-0.0104-0.01044-1.3611-0.98044-1.4609-0.65037 0.17094-0.54012 0.1207-1.2003 0.23097-1.7404-0.72033-0.04044-1.3806 0.0411-2.071 0.0698-0.82081 0.03001-1.1608-0.23092-1.8315-0.5199-1.121-0.48011-3.3309-0.3503-3.5919-1.5708-0.2499-1.1703 0.54025-3.2505-0.27012-4.1423-0.27991-0.30007-1.2508-0.95044-1.6606-1.1703-0.52002-0.27985-1.3806-0.39922-1.9907-0.27006-0.73077 0.16047-1.2103 0.53034-2.0814 0.39987-0.61985-0.09981-1.1803-0.55904-1.81-0.3803-0.61137 0.17026-0.8306 0.76061-1.4407 0.90021-0.39083 0.09067-1.0805 0.09067-1.5614-0.03979 0.45999-0.30007 0.92064-0.60014 1.2704-0.99088 0.60028-0.66015 1.9307-2.561 2.2308-3.4514 0.47043-1.3901-0.39018-4.4208 1.271-4.7313 0.49-2.7411 2.2608-4.6909 4.6326-6.002 2.1714-1.2003 5.133-1.0104 5.9532-3.6706 0.66096-0.04958 0.82016-0.44945 1.4217-0.58057 0.0692-4.3014 8.9037-0.39009 9.8347-3.9211 2.512-0.54012 4.6221-2.5708 6.9534-3.6113 3.0118-1.3405 4.6025-0.98044 7.5145-1.9302 0.35038-0.10959 1.3806-0.0998 1.9914-0.12003-0.03 0.90021-0.25968 2.291 0.39931 2.8109 0.44108 0.33008 0.9611 0.18004 1.4407 0.36987 0.49 0.19048 0.7001 0.57992 1.0714 0.8702 0.0202 0.21983 0.12984 0.27006 0.20031 0.47032 1.0505 0.06001 2.1114 0.09002 3.1417 0.11024 0.32036 0.75996 1.0009 1.15 1.6808 1.6602 0.39996 0.30985 0.5807 0.21983 0.90041 0.75017 0.20031 0.33986 0.21988 0.66015 0.53046 0.98044 0.47044 0.4899 1.3108 0.91064 2.071 0.93021 1.1908 0.05023 2.0716 0.48011 3.2421 0.60014 0.0405 0.30007 0.27013 0.51012 0.5807 0.57992 0.06 0.94065 0.01 1.2609 1.0002 1.501 0.09 0.25962 0.14941 0.53034 0.19052 0.80953 0.0502 0.01044 0.0992 0.02022 0.14028 0.03001-0.21988 0.6608-0.44042 1.7215-0.12984 2.4606 0.2897 0.72017 0.85017 0.84019 0.88084 1.7606-0.61137-0.03001-2.2921 0.04044-1.9711 1.0007 0.12006 0.36008 0.65052 0.34965 0.84039 0.57013 0.33015 0.39009 0.33994 0.72017 0.30014 1.2603-0.40062 0.17026-0.98067 0.60014-1.1705 1-1.6605-0.06067-1.2704 1.5095-2.4011 1.9407-1.1405 0.42075-3.0223 0.08024-4.1523-0.14938-0.79015-0.16047-1.3604-0.05023-2.101 0.1396-0.46064 0.12003-0.60092-0.12068-0.90106 0.33008-0.17943 0.27006-0.09 1-0.0992 1.3405-0.03 0.74039 0.0196 1.5401 0.16051 2.2505 0.14942 0.71038 0.61072 1.2094 0.49001 1.9909-0.39083 0.02022-1.1307-0.14025-1.4909 0.01044-0.39997 0.15982-0.82995 0.82976-0.39997 1.2603 0.35038 0.3503 0.76078-0.05023 1.0707 0.4899 0.18008 0.31051 0.14093 1.1103-0.01 1.4906-0.27012 0.03979-0.48022 0.1696-0.72033 0.27006-0.0698 0.03001-0.0907 0.78996-0.11027 0.93021 0.28057 0.06001 0.60028 0.06001 0.91086 0.0698 0.0502 0.93021-0.67988 1.8806 0.0104 2.4103 0.32036 0.24984 1.0302 0.04044 1.3415 0.24006 0.3693 0.24006 0.41041 0.94 0.76078 1.2407 0.10962-0.01109 0.27013 0.03001 0.39018 0.03001-0.0404 0.42988-0.0202 1.3999 0.33994 1.6602 0.44956 0.31051 1.3708-0.3803 1.6201 0.23027 0.33994 0.85128-1.7708 1.1011-1.3408 1.9915 0.1703 0.36008 0.8704 0.33008 1.0805 0.57992 0.30013 0.3503 0.25055 0.74039 0.21988 1.1807-0.67009 0.03001-2.9511 0.28115-2.7319 1.3307 1.4909 0.09067 2.681-0.06001 3.9918 0.68037 0.59049 0.33986 1.1105 1.09 1.9209 0.92043 0.85996-0.17939 0.71054-0.81997 1.1601-1.2505 0.89062-0.84998 2.912 0.0411 3.5925 0.7306 0.56961 0.57992 1.1203 2.5708 2.2308 2.4508 0.39018 0.93021 1.2906 0.42075 1.6906 0.99088 0.73077 1.0307-0.61072 3.8207 1.7304 3.6811 0.0411 0.46054 0.0607 0.94-0.2499 1.2205-1.35 0.18983-1.6605 1.4906-2.7215 2.1201-0.74056 0.44032-0.80059 0.66015-0.60028 1.6406 0.10962 0.60014 0.15986 1.3503 0.33015 1.9204 0.41041 1.3405 1.1105 2.351 1.8615 3.501 0.31971 0.4899 0.7797 1.0104 1.0407 1.5206 0.32037 0.63014-0.0998 1.5304 0.54025 1.9602 0.30014 0.21005 0.79015 0.0502 1.151 0.0998 0.48022 0.0802 0.60028 0.17025 1.0205 0.42009 0.71577 0.44684 0.6851 1.2975 1.626 1.1872z",
+                Keelung:"m354.05 44.801c-1.1007 0.76061-2.131 0.33008-2.5505-0.81019-0.42085 0.0698-0.99176-0.09915-1.4217-0.08024-0.10962-0.26941-0.0502-0.63928-0.0803-0.91978-2.2615 0.01892-1.9111-4.2916-2.0005-6.002-0.55069 0.2094-1.3415 0.01957-1.9209 0.17026-0.12984-0.40966-0.12984-1.2603 0-1.6706 1.611-0.09067 3.3518 0.33986 4.0023-1.501 0.73077-0.04044 2.052 0.23092 2.7215-0.03001 0.6205-0.24006 0.58135-1.1598 1.0505-1.4508 1.0205-0.63993 1.8106-1.1905 2.9511-1.7208 0.46064 0.42988 0.80972 0.76061 0.82016 0.77039 1.4811 1.0502 2.6621 1.0705 4.6326 1.1801 0.4502 1.8617-0.28057 2.7906-0.14942 4.4423 0.68053-0.86042 1.7004-1.4005 1.7304-2.6908 2.4611-1.3203 4.0525 1.6706 6.6742 0.7306-0.11027 0.4899 0.17878 1.2003 0.0796 1.6902 0.52068 0.02022 1.0498 0.03001 1.5907 0.05023v0.03001c-0.03 0.33008-0.36016 1.1005-0.42084 1.4208-0.33015-0.04044-0.84039 0.15004-1.1705 0.08024 0.0104 0.56035-0.42084 1.0307-0.33015 1.6706-1.4106 0.32029-2.2706-0.63014-3.4718-0.47032-1.0603 0.14025-1.8511 1.0104-2.9009 1.2505 1.3108 1.0907 1.5503 2.3908 1.4511 4.2212 1.0198 0.13046 2.3306 1.0411 1.9711 2.3007-0.46064 1.6204-1.9418 0.69016-3.2121 1.0405-0.55982 0.15003-0.44042 1.1103-1.0407 1.2101-0.68053 0.12003-1.2208-0.2805-1.6912-0.33008-1.9711-0.18004-3.4516-1.1011-5.5323-1.2205 0.0698-1.4814-1.0505-2.3007-2.5009-2.0007 0.0196-0.03001-0.06-0.60014-0.06-0.58057 0.34907-0.23027 0.56896-0.62036 0.77971-0.78018z",
+                Kinmen:"m41.675 107.89c-0.0762 4e-3 -0.14595 0.0243-0.18718 0.0468-0.0375 0.0225-0.0711 0.0402-0.0936 0.0702l-0.0468 0.0936c-0.05235 0.16473-0.0159 0.38094-0.0234 0.53817-0.77124 0.0375-1.3965-0.23867-2.1526-0.16379-0.17222 0.015-0.27516 0.0412-0.32758 0.0936-0.015 8e-3 -9e-3 9e-3 -0.0234 0.0234-0.09735 0.11235-0.102 0.2967-0.30418 0.49137-0.21714 0.20217-0.453 0.4034-0.46797 0.72537-0.0075 0.41931 0.2527 0.74409 0.1404 1.1933-0.09735 0.34443-0.40246 0.4268-0.51478 0.74877-0.08985 0.2471 0.015 0.66641 0 0.93596-0.0225 0.3669-0.1095 0.46984-0.49137 0.51477-0.15724 0.0225-0.32666 0.0524-0.49138 0-0.09735-0.0225-0.24522-0.1563-0.32757-0.16379-0.75626-0.0973-0.35661 1.154-0.3042 1.521 0.045 0.34443-0.0135 0.56532-0.1404 0.84236-0.1422 0.32946-0.03375 0.42867-0.0936 0.79557-0.045-7e-3 -0.0795 0-0.117 0-0.03 0.10485-0.1011 0.16098-0.0936 0.28078-0.38936 0.0748-0.53722-0.27891-0.88916-0.23398-0.0225 0.11235 0.07485 0.23959 0.1872 0.37438 0.03 0.0375 0.072 0.0795 0.117 0.117 0.15723 0.1497 0.32384 0.27611 0.42117 0.35097 0.0375 0.0225 0.087 0.0552 0.117 0.0702 0.1422 0.0599 0.26301 0.0468 0.39778 0.0468 0.09735 8e-3 0.20778 0.0328 0.32758 0.0702 0.11235 0.0375 0.21434 0.10485 0.30418 0.1872 0.05235 0.0375 0.1029 0.0954 0.1404 0.1404 0.0375 0.0448 0.0795 0.0954 0.117 0.1404l0.0702 0.0468 0.0468 0.0702c0.1797 0.1797 0.39498 0.30699 0.70197 0.18719 0.35192-0.1347 0.1161-0.47265 0.28078-0.77216 0.22462-0.41182 0.906-0.78433 1.3103-0.88917 0.21789-0.0598 0.66546-0.25176 0.91256-0.117 0.23211 0.1497 0.1104 0.43898 0.1404 0.67857 0.0075 0.0748 0.0411 0.1347 0.0936 0.1872 0.015-0.0225 0.0243-0.0318 0.0468-0.0468 0.1497-0.1497 0.41368-0.27705 0.60837-0.37438 0.25458-0.1347 0.5026-0.33975 0.77217-0.44459 0.07485-0.26206-0.10395-0.43615-0.35098-0.42117-0.11235-0.45675-0.0468-0.63364 0.32758-0.86577 0.31448-0.20965 0.58497-0.3697 0.95936-0.44457 0.36688-0.0823 0.69354-0.0795 1.0529 0.0702 0.2995 0.11985 0.55222 0.34349 0.88916 0.35099 0.1497-0.20966 0.0486-0.47079 0.0936-0.72537 0.015-0.12735-0.04215-0.20685 0.0702-0.30419 0.09735-0.0898 0.25272 0.0206 0.32758-0.0468 0.26208-0.20965 0.045-0.94999 0.1872-1.2869 0.0225-0.0448 0.0243-0.072 0.0468-0.117 0.0375-0.0899 0.0795-0.19842 0.117-0.28078 0.0225-0.0448 0.0477-0.0795 0.0702-0.117 0.03-0.0523 0.072-0.0795 0.117-0.117 0.11985-0.11235 0.24615-0.19374 0.35098-0.35099 0.22462-0.37438 0.0543-1.0389 0.0468-1.4507-0.2471-0.0225-0.57 0.0263-0.77217-0.0936-0.05235-0.03-0.1188-0.072-0.16378-0.117-0.03-0.03-0.0636-0.0561-0.0936-0.0936-0.05985-0.0748-0.09645-0.1591-0.1638-0.23398-0.03-0.0375-0.0795-0.0795-0.117-0.117-0.4268-0.3594-0.98836-0.45674-1.3103-0.93596-0.0225-0.0375-0.0243-0.0881-0.0468-0.1404-0.0225-0.0524-0.0636-0.10395-0.0936-0.16378-0.0375-0.0824-0.0645-0.18158-0.117-0.23399-0.0225-0.0225-0.0477-0.0318-0.0702-0.0468-0.18718-0.11235-0.59433-0.0468-0.81896-0.0468-0.15162 0-0.47348-0.0594-0.70197-0.0468zm32.666-14.206c-0.71882-0.05985 0.19842 0.96028 0.28078 1.1699v0.0234c0.03 0.07485 0.0468 0.17596 0.0468 0.28078 0 0.21714-0.0468 0.45114-0.0468 0.60837 0 0.3669 0.0402 0.51946-0.30418 0.63177-0.20217 0.06735-0.3332 0.08805-0.46798 0.1404-0.05235 0.0225-0.10395 0.0327-0.16378 0.0702-0.03 0.015-0.0561 0.0477-0.0936 0.0702-0.10485 0.06735-0.21526 0.13575-0.32758 0.2106-0.11235 0.08235-0.22276 0.15818-0.32758 0.21058-0.1422 0.06735-0.29482 0.0702-0.44458 0.0702-0.05235 0.0075-0.11145 0-0.16378 0-0.06735 0-0.14325 9e-3 -0.21058 0.0234-0.0375 0.0075-0.0795 9e-3 -0.117 0.0234-0.25458 0.07485-0.44085 0.21058-0.72537 0.21058-0.07485 0.12735-0.1338 0.30513-0.1638 0.51478-0.04485 0.45675 0.06645 1.0408 0.35098 1.3103 0.0375 0.0375 0.072 0.0711 0.117 0.0936 0.0075 0.0075 0.0159 0 0.0234 0 0.04485 0.015 0.0954 0.0393 0.1404 0.0468v-0.117c0-0.015-0.0075-0.0318 0-0.0468v-0.0234c-0.0075-0.0075 0.0075-0.0159 0.0234-0.0234-0.0075-0.0075-0.0075-0.0159 0-0.0234-0.0075-0.0225-0.01515-0.0318 0-0.0468-0.0075-0.03 9e-3 -0.0711 0.0234-0.0936 0.0075-0.03-0.0075-0.0402 0-0.0702 0-0.015 0.01605-0.0234 0.0234-0.0234v-0.0468c0.0225-0.07485 0.04035-0.14325 0.0702-0.2106 0.0225-0.06735 0.0477-0.12735 0.0702-0.18718 0.015-0.0225 0.0159-0.0711 0.0234-0.0936 0.08235-0.0075 0.19281-0.0075 0.32758 0 0.05985 0 0.13575-0.0075 0.2106 0 0.0375 0 0.072 0.0234 0.117 0.0234 0.0225 0 0.0318-0.0075 0.0468 0 0.0375 0 0.0795-0.0075 0.117 0 0.08985 0.0075 0.19936 0.0318 0.30418 0.0468l0.0936 0.0234h0.0234c0.05985 0.0075 0.10395 9e-3 0.16378 0.0234 0.05985 0.015 0.1347 0.0318 0.18718 0.0468 0.05235 0.0225 0.08805 0.0552 0.1404 0.0702 0.04485 0.015 0.1029 0.0402 0.1404 0.0702 0.05985 0.0225 0.0954 0.0561 0.1404 0.0936 0.045 0.03 0.0945 0.07215 0.117 0.117 0.045 0.06735 0.0777 0.12825 0.0702 0.21058v0.0234c-0.0075 0-0.0318-0.0159-0.0468-0.0234h-0.0231c-0.18718-0.015-0.42117 0.0216-0.60837-0.0234-0.22462-0.04485-0.33694-0.19467-0.56157-0.18718h-0.0702c-0.0375 0-0.0795 0.0159-0.117 0.0234-0.015 0.0075-0.0318 0.0234-0.0468 0.0234-0.0375 0.015-0.0636 0.0243-0.0936 0.0468-0.06735 0.05985-0.09735 0.1535 0 0.28078 0.0075 0.015 0.0318 9e-3 0.0468 0.0234 0.08235 0.05985 0.19188 0.0543 0.30418 0.0468 0.10485 0 0.21246 0.0135 0.25738 0.1404 0.0225 0 0.0477 0.01575 0.0702 0.0234 0.0225-0.0075 0.0318-0.0075 0.0468 0 0.10485 0.31448 0.12825 0.45861 0.0234 0.79556l-0.0234 0.0936c-0.03 0.0973-0.04965 0.18345-0.117 0.28079-0.05985 0.0823-0.18999 0.12075-0.25738 0.2106l-0.0468 0.0468c-0.0075 0.015 0 0.0243 0 0.0468-0.0075 0.0448-0.0075 0.0881 0 0.1404 0.04485 0.16473 0.19094 0.32571 0.28078 0.46797 0.11235 0.17221 0.19188 0.46705 0.30418 0.63177l0.0468 0.0468c-0.03-7e-3 -0.0402-0.0159-0.0702-0.0234-0.0375-8e-3 -0.087-9e-3 -0.117-0.0234-0.05985-0.0225-0.11145-0.0561-0.16378-0.0936-0.0375-0.015-0.0636-0.0243-0.0936-0.0468-0.35193-0.25458-0.44178-0.67482-0.56158-1.1465-0.22462-0.0974-0.14595-0.27237-0.28078-0.44459l-0.0702-0.0702-0.0234-0.0468c-0.0375-0.03-0.1029-0.0477-0.1404-0.0702-0.08235-0.0375-0.17595-0.0636-0.28078-0.0936-0.1422-0.0375-0.263-0.0486-0.39778-0.0936-0.04485-0.015-0.08805-0.0243-0.1404-0.0468 0 0-0.0234-0.0157-0.0234-0.0234-0.0225-0.015-0.0477-0.0168-0.0702-0.0468-0.015-0.0075-9e-3 -0.0318-0.0234-0.0468-0.0225-0.03-0.0477-0.04785-0.0702-0.0702-0.015-0.015-0.0318-0.0393-0.0468-0.0468-0.07485-0.04485-0.1769-0.04305-0.30418 0.0468-0.21039 0.1422-0.22725 0.48951-0.0468 0.63177 0.1497 0.11235 0.26114 0.0561 0.35098 0.0936l0.0468 0.0234c0.03 0.03 0.0561 0.058 0.0936 0.1404 0.1422 0.26957 0.2705 0.74034 0.2106 1.0998-0.015 0.0749-0.0477 0.12735-0.0702 0.18718-0.15724 0.015-0.30232 0.0402-0.44458 0.0702-0.1497 0.03-0.29482 0.0795-0.44458 0.117-0.08985 0.03-0.17595 0.0478-0.28078 0.0702-0.05235 8e-3 -0.1029 0.0318-0.1404 0.0468s-0.0636 0.0243-0.0936 0.0468c-0.0375 0.0225-0.0711 0.0402-0.0936 0.0702-0.015 0.0225-0.0318 0.0636-0.0468 0.0936-0.015 0.0448-0.0234 0.10395-0.0234 0.1638-0.0075 0.0748-7.5e-4 0.15255-0.0234 0.25739-0.0075 0.0449-0.0243 0.10395-0.0468 0.16378-0.07485 0-0.16004 8e-3 -0.25738 0h-0.1404c-0.0225 0-0.0552-7e-3 -0.0702 0-0.10485 8e-3 -0.18999 0.0252-0.25738 0.0702-0.03 0.015-0.0552 0.0402-0.0702 0.0702-0.1872 0.29951 0.1011 0.6168 0.28078 0.81897 0.0225 0.015 0.0552 0.0318 0.0702 0.0468 0.37438 0.4268 0.41182 0.96872 0.37438 1.5678-0.0075 0.0973-0.0075 0.18251-0.0234 0.25739-0.0075 0.0748-0.0243 0.14325-0.0468 0.21058-0.045 0.11985-0.11415 0.24803-0.23398 0.39779-0.0375 0.045-0.0795 0.087-0.117 0.117-0.03 0.0375-0.0636 0.0478-0.0936 0.0702-0.03 0.0225-0.0402 0.0552-0.0702 0.0702s-0.07965 0.0159-0.117 0.0234c-0.08235 0.0225-0.20124 0.0234-0.35098 0.0234-0.31448 1e-5 -0.66734-5e-3 -0.95936 0.0702-0.2995 0.0748-0.44739 0.22557-0.70197 0.39778-0.27704 0.19467-0.3126 0.25646-0.70197 0.23399-0.21714-0.32946-0.52881-0.25083-0.86576-0.28079-0.40432-0.03-0.4998-0.33132-0.88916-0.42118-0.08985-0.0225-0.18345-0.0393-0.28078-0.0468-0.23961-0.015-0.49324-1e-3 -0.72537-0.0468-0.61398-0.10485-1.0988-0.2499-1.638-0.63177-0.89103-0.62897-1.5668-1.5612-2.4802-2.1526-0.48669-0.32198-0.94156-0.32384-1.2635-0.79556-0.26206-0.41182-0.46518-0.85921-0.77216-1.2635-0.29952-0.40434-0.69356-0.92566-1.053-1.2402-0.55408-0.47172-0.87138-0.13755-1.0062 0.49138-0.614 0.03-1.1194-0.1236-1.5912 0.28079-0.44176 0.37438-0.8199 0.74782-1.4039 0.91255-0.89852 0.23961-1.856 1.7043-1.4741 2.7376 0.19468 0.48669 0.6065 0.32945 0.93596 0.56157 0.1347 0.0898 0.18532 0.19842 0.32758 0.28079 0.0225 8e-3 0.0477 0.0393 0.0702 0.0468 0.045 0.0225 0.0954 0.0318 0.1404 0.0468 0.045 0.0225 0.08805 0.0318 0.1404 0.0468 0.11235 0.03 0.22276 0.0542 0.32758 0.0468 0.0375-0.20217 6e-3 -0.3566-0.0702-0.49139-0.05235-0.10485-0.1422-0.20778-0.18718-0.32758-0.0075-0.0225-0.0159-0.0402-0.0234-0.0702l-0.0468-0.0936c-0.10485-0.19467-0.27237-0.47358-0.25738-0.60837 0.24708-0.0449 0.44644 0.0786 0.67856 0.0936 0.25458 0.03 0.36783-0.1329 0.58498-0.1404 0.38936-0.015 0.88728 0.73095 0.84236-0.0702h0.21058c0.22464 7e-3 0.44178 0.015 0.56158-0.18719 0.10485-0.1797-0.11235-0.57936 0.18718-0.63177 0.32198-0.0524 0.23025 0.44364 0.32758 0.60837 0.07485 0.11985 0.61866 0.4764 0.117 0.49137-0.18718 0.29202-0.25738 0.30606-0.25738 0.72537 0 0.41183 0.08985 0.68138-0.37438 0.74877h-0.0702c-0.12735 0.0225-0.32384 0.03-0.42118 0-0.1422-0.0524-0.27048-0.32853-0.39777-0.35098-0.1422-0.0225-0.21996 0.0272-0.2574 0.117-0.0075 0.015-0.0234 0.0243-0.0234 0.0468-0.0075 0.015-0.0234 0.0477-0.0234 0.0702-0.0225 0.1347-0.0168 0.28546-0.0468 0.39778-0.25458 0.015-0.51758 8e-3 -0.77216 0.0234-0.015 0.20966 0.16566 0.14505 0.21058 0.25739 0.015 0.03 0.0234 0.0636 0.0234 0.0936 0.0075 0.0225 0.0234 0.0477 0.0234 0.0702 0.0075 0.0523 0.0075 0.10395 0 0.16378v0.117c0 8e-3 0.0075 0.0159 0 0.0234 0.0075 0.0375-0.01575 0.0636-0.0234 0.0936-0.0225 0.23961-0.0711 0.45395-0.0936 0.67857-0.0375 0.5466 0.39966 1.0314 0.63177 1.4507 0.21714 0.39684 0.34443 0.58029 0.37438 1.0296 0.03 0.32196 0.117 0.58309 0.117 0.91255 0 0.26955 0.0162 0.54098 0.0234 0.79556 0.0075 0.35941 0.0234 0.69261 0.0234 1.0296 0 0.20966 0.0972 0.76374 0 0.93596-0.11235 0.19468-0.55408 0.26767-0.74877 0.32758-0.08235 0.0225-0.18344 0.0477-0.28078 0.0702-0.06735 0.015-0.11985 9e-3 -0.18718 0.0234-0.09735 0.0225-0.21434 0.0402-0.30418 0.0702-0.12735 0.0448-0.24522 0.11235-0.32758 0.18719-0.11235 0.11235-0.16098 0.27517-0.0936 0.51478 0.05985 0.23211 0.25458 0.47172 0.18718 0.74876 0 0.015 0.0075 0.0159 0 0.0234 0 0.03-0.0075 0.0477-0.0234 0.0702-0.0225 0.0448-0.07215 0.0954-0.117 0.1404-0.03 0.0225-0.0636 0.0552-0.0936 0.0702-0.0375 0.0225-0.072 0.0477-0.117 0.0702-0.06735 0.0448-0.12735 0.0795-0.18718 0.117-0.03 0.0225-0.0711 0.0477-0.0936 0.0702-0.29202 0.23212-0.33507 0.23961-0.70197 0.1872-0.08235-7e-3 -0.26206-9e-3 -0.37438-0.0234-0.0225 0-0.0318 7e-3 -0.0468 0-0.015-2e-5 -0.0318-0.0157-0.0468-0.0234-0.03-0.015-0.0552-0.0168-0.0702-0.0468-0.0075 7e-3 0-0.0157 0-0.0234-0.05985-0.0599-0.06555-0.11985-0.1404-0.1872-0.20216-0.18719-0.36128-0.27891-0.60837-0.23399-0.04485 8e-3 -0.08805 0.0318-0.1404 0.0468-0.0375 0.0973-0.09645 0.18158-0.16378 0.23399-0.0225 0.0225-0.0402 0.0318-0.0702 0.0468-0.12735 0.0898-0.28827 0.0918-0.46798 0.0468-0.08235-0.015-0.17502-0.0243-0.25738-0.0468-0.0225 0-0.0318-0.0162-0.0468-0.0234-0.08235-0.0225-0.17502-0.0552-0.25738-0.0702h-0.0234c-0.1422-0.0225-0.2939-0.0135-0.42118 0.0234-0.0375 0.015-0.0561 0.0318-0.0936 0.0468-0.0375 0.0225-0.0636 0.0168-0.0936 0.0468-0.04485 0.0375-0.1029 0.0879-0.1404 0.1404-0.15723 0.21715-0.14505 0.33882-0.0702 0.42118 0.05235 0.0524 0.14415 0.1029 0.234 0.1404 0.08985 0.03 0.19094 0.0561 0.28078 0.0936 0.24708 0.11235 0.59994 0.50636 0.77216 0.67857 0.0375 0.015 0.0795 0.0168 0.117 0.0468 0.045 0.03 0.0954 0.072 0.1404 0.117 0.26956 0.23961 0.5438 0.68699 0.67857 0.88916 0.05235 0.0748 0.0636 0.10395 0.0936 0.1638 0.015 0.015 0.0318 0.0402 0.0468 0.0702 0.0225 0.0599 9e-3 0.22836 0.0468 0.28078 0.03 0.03 0.0486 0.0627 0.0936 0.0702 0.04485 0.015 0.11145 0.0159 0.1638 0.0234h0.0234c0.04485 8e-3 0.0954 9e-3 0.1404 0.0234 0.03 7e-3 0.0477 0.0159 0.0702 0.0234 0.0225 7e-3 0.0318 0.0318 0.0468 0.0468 0.10485 0.0973 0.17408 0.23211 0.23398 0.37437 0.0375 0.0898 0.0636 0.20685 0.0936 0.3042 0.045 0.1422 0.08895 0.27704 0.16378 0.37437 0.05985 0.0824 0.16848 0.13485 0.28078 0.1872 0.11985 0.0448 0.23212 0.087 0.37438 0.117 0.13485 0.03 0.28641 0.0552 0.42118 0.0702 0.12735 0.015 0.26114 0.0318 0.35098 0.0468 0.03 0.12735 0.09735 0.23772 0.18718 0.32759 0.07485 8e-3 0.12735 0 0.1872 0 0.06735 0 0.1422 9e-3 0.18718 0.0234 0.0375 8e-3 0.0636-6e-3 0.0936 0.0234 0.05235 0.0375 0.0954 0.10485 0.1404 0.18718 0.0225 0.0448 0.0477 0.088 0.0702 0.1404 0.045 0.10485 0.0795 0.22277 0.117 0.32759 0.015 0.0524 0.0477 0.0954 0.0702 0.1404 0.05235 7e-3 0.087 0.0486 0.117 0.0936 0.09735 0.11985 0.16098 0.34723 0.28078 0.44458 0.25458 0.2396 0.2939 0.1694 0.60837 0.117 0.32946-0.0448 0.86109-0.20122 1.1232 0.0234 0.0225 0.015 0.0552 0.0402 0.0702 0.0702 0.0375 0.0524 0.0552 0.11235 0.0702 0.18719 0.15723 0.11985 0.43054 0.19749 0.65517 0.25738 0.03 0.015 0.0402 0.0159 0.0702 0.0234 0.03 7e-3 0.0711 0.0234 0.0936 0.0234 0.1347 0.03 0.2293 0.03 0.30418 0 0.015 0 0.0393-8e-3 0.0468-0.0234 0.0225-8e-3 0.0318-0.0243 0.0468-0.0468 0.05235-0.0674 0.0795-0.17782 0.117-0.32758 0.0375-0.015 0.0954-0.0234 0.1404-0.0234 0.10485-0.0225 0.19935-0.0309 0.30418-0.0234 0.10485 0 0.20684-7.5e-4 0.30418-0.0234 0.0225 0 0.0477 7e-3 0.0702 0 0.03-8e-3 0.0477-0.0161 0.0702-0.0234 0.0375-0.015 0.0795-0.0477 0.117-0.0702s0.0711-0.0402 0.0936-0.0702c0.20217-0.20216 0.26768-0.51758 0.32758-0.77216 0.15723-0.6664 0.14415-1.0436 0.60837-1.5678 0.39684-0.45675 0.52881-1.096 0.86576-1.5678 0.1497-0.20965 0.23118-0.4839 0.35098-0.67857 0.0375-0.0524 0.0795-0.0954 0.117-0.1404 0.08235-0.0824 0.1591-0.15163 0.23398-0.234 0.04485-0.0375 0.087-0.088 0.117-0.1404 0.0225-0.015 9e-3 -0.0477 0.0234-0.0702 0.1872-0.45673-0.0318-0.7029 0.51478-0.91255 0.23211-0.0974 0.30324-0.1161 0.46797-0.28079 0.43428-0.44176 0.58592-0.64113 1.1699-0.86575 0.32198-0.12735 0.5569-0.31167 0.81897-0.49139 0.17222-0.1347 0.35847-0.23772 0.53817-0.32758 0.35192-0.18719 0.73378-0.34161 1.1232-0.49137 0.61398-0.23961 1.082-0.4764 1.7782-0.49137 0.68138 0 1.3534-0.0748 2.0122-0.1872 0.63645-0.11235 1.183-0.23399 1.8718-0.23399 0.16473 0 0.31072 9e-3 0.46797 0.0234 0.1497 8e-3 0.31822 0.0168 0.46798 0.0468 0.07485 0.015 0.1347 0.0477 0.18718 0.0702 0.17222 0.0598 0.26582 0.13665 0.46798 0.23399 0.32944 0.1497 0.50634 0.1086 0.67856 0.46798 0.09735 0.1797 0.12825 0.41369 0.2106 0.60837 0.03 0.0598 0.0486 0.11145 0.0936 0.16379 0.04485 0.0523 0.10395 0.0795 0.16378 0.117 0.19468 0.0974 0.453 0.1179 0.65517 0.1404 0.15724 0.0225 0.34162-4e-3 0.49138 0.0468 0.1497 0.0598 0.2396 0.20497 0.37437 0.2574 0.15724 0.0523 0.32666 7.3e-4 0.49138 0.0234 0.03 0 0.0636 0.0159 0.0936 0.0234 0.0375 0.015 0.0636 0.0243 0.0936 0.0468 0.06735 0.0448 0.11985 0.0956 0.18718 0.1404 0.03 0.0225 0.0561 0.0552 0.0936 0.0702 0.15724 0.0898 0.31917 0.0824 0.49138 0.18718 0.1497 0.0824 0.20122 0.19749 0.35098 0.25739h0.0234l0.0234 0.1404c0.0075 0.0448 0.01605 0.0795 0.0234 0.117 0.015 0.0824 0.04875 0.17502 0.0936 0.25738 0.11985 0.23961 0.24522 0.36878 0.32758 0.60837 0.11235 0.28454 0.18063 0.52602 0.21058 0.79557 0.0075 0.0448 0.0234 0.0954 0.0234 0.1404 0.015 0.0898 0.0075 0.17595 0 0.28079-0.57656 0.20217-1.8064-0.30699-1.7316 0.56157 0.49419 0.0225 0.97246-0.0459 1.4741-0.0234 0.05985 0.41931-1.0333 0.20685-1.3103 0.30418-0.05235 0.20217 0.1245 0.28266 0.30418 0.32759 0.045 0.1347 0.0702 0.30231 0.0702 0.44458 0.30699-0.0375 0.57374-0.24241 0.86576-0.25738 0.26206-0.015 0.58965 0.1077 0.88916 0.0702 0.55334-0.0524 0.37083-0.1422 0.49138-0.56159 0.11985-0.42679 0.41276-0.29763 0.77216-0.32758 0.60651-0.0448 0.81054-0.70383 1.3571-0.93596 0.29202-0.11985 0.68325-0.0411 0.98276-0.0936 0.05985-8e-3 0.13485-0.0477 0.18718-0.0702 0.1497-0.0749 0.24054-0.19935 0.2106-0.49137-0.0225-0.20965-0.06555-0.30138-0.1404-0.42118-0.03-0.0448-0.0402-0.0647-0.0702-0.117l-0.0234-0.0234c-0.0225-0.0375-0.0318-0.0636-0.0468-0.0936-0.10485-0.16473-0.11235-0.18533 0-0.32759 0.015-0.0225 0.0243-0.0636 0.0468-0.0936 0.03-0.0449 0.0879-0.0954 0.1404-0.1404 0.2396-0.24709 0.61586-0.48201 0.79556-0.0702 0.33694 0.0973 0.57 0.15537 0.95936 0.1404 0.20966-0.24709 0.57375-0.61678 0.49138-1.0062-0.1497-0.0898-0.27986-0.20498-0.44458-0.25739-0.05235-0.12735-0.0375-0.27798 0-0.39778-0.16473-0.12735-0.53444-0.31355-0.63177-0.53817-0.08235-0.19467 7.5e-4 -0.64862 0.0234-0.86576 0.08985-0.74128 0.6636-0.80211 1.2401-0.58497-0.0225 0.22463 0.49138 0.27143 0.67857 0.23399 0.40434-0.0974 0.2527-0.40434 0.32758-0.74877 0.05985-0.25458 0.18158-0.48669 0.23398-0.74876 0.0075-0.03 0-0.0636 0-0.0936 0.0075-0.0748 0.0318-0.15912 0.0468-0.234 0.0075-0.03 9e-3 -0.0636 0.0234-0.0936 0.0075-0.015 0.0159-9e-3 0.0234-0.0234 0.05985-0.0898 0.2106-0.21432 0.2106-0.30418 0-0.45674-1.0923-0.1254-1.4741-0.51477-0.03-0.03-0.0786-0.072-0.0936-0.117-0.09735-0.2471 0.1125-0.54192 0-0.81896-0.09735-0.25458-0.41649-0.4165-0.49137-0.67857-0.1497-0.50916-0.05235-1.4732 0-2.0122 0.045-0.43428 0.28452-1.534 0.74876-1.6614 0.10485-0.23211 0.43522-0.34068 0.39778-0.65517-0.0075-0.10485-0.13005-0.24615-0.25738-0.35097-0.05235-0.0375-0.08805-0.0711-0.1404-0.0936-0.0225-8e-3 -0.0711-0.0159-0.0936-0.0234-0.05985-0.015-0.10395-0.0234-0.16378-0.0234-0.05985 0-0.11145 7e-3 -0.1638 0.0234-0.0225 8e-3 -0.0477 8e-3 -0.0702 0.0234-0.0225 0-0.0477 0.0159-0.0702 0.0234-0.05235 0.0225-0.1188 0.0477-0.16378 0.0702-0.1497 0.0748-0.263 0.1404-0.39778 0.1404-0.11985 0-0.25552-0.0459-0.39778-0.2106-0.06735-0.0824-0.12735-0.16659-0.18718-0.23398-0.05985-0.0824-0.1188-0.15911-0.1638-0.23399-0.05985-0.10485-0.1263-0.21528-0.16378-0.32758-0.03-0.10485-0.0318-0.2237-0.0468-0.35099-0.015-0.10485-0.03075-0.20029-0.0234-0.32758 0.03-0.614 0.25364-1.3272-0.39778-1.5444-0.05235-0.015-0.0954-0.0477-0.1404-0.0702-0.08235-0.0375-0.1422-0.0645-0.18718-0.117-0.20966-0.1872-0.19376-0.46611-0.1638-0.79557l0.0234-0.16379v-0.1872c0.0075-0.20216-0.0075-0.453 0.0234-0.65517 0.0075-0.06735 7.5e-4 -0.10395 0.0234-0.16378 0.11235-0.2995 0.3566-0.3828 0.30418-0.77217-0.05235-0.0075-0.1188-0.0159-0.16378-0.0234-0.0225 0-0.0318-0.0234-0.0468-0.0234-0.26956-0.015-0.51759 0.01785-0.77217 0.0702-0.16473 0.0375-0.31822 0.08055-0.46798 0.1404-0.03 0.015-0.0636 0.0393-0.0936 0.0468-0.05985 0.0225-0.12735 0.0402-0.18718 0.0702l-0.0702 0.0468c-0.11985 0.07485-9e-3 0.23306-0.23398 0.2106-0.1797-0.0075-0.36034-0.39591-0.39778-0.53817-0.03-0.0375-0.0327-0.0411-0.0702-0.0936-0.12735-0.0075-0.26206-0.0159-0.37438-0.0234-0.23211 0-0.43521-0.0135-0.58497-0.1404-0.08235-0.06735-0.1347-0.15351-0.18718-0.2808-0.04485-0.11985-0.0627-0.24708-0.0702-0.37437 0-0.06735 0.0075-0.12735 0-0.1872-0.015-0.06735-0.0318-0.12735-0.0468-0.18718-0.08985-0.28454-0.20498-0.497-0.2574-0.81897-0.0375-0.1797-0.1188-0.3828-0.16378-0.58497-0.015-0.05235-0.0159-0.11145-0.0234-0.16378-0.0075-0.07485-0.0075-0.15912 0-0.234v-0.1404c0.0075-0.11985 0.02265-0.26206 0-0.37437-0.0075-0.04485-0.01605-0.07215-0.0234-0.117-0.0375-0.1347-0.11415-0.26674-0.23398-0.30418-0.03-0.0075-0.072-0.015-0.117 0-0.015-0.0075-0.0318 0.0159-0.0468 0.0234l-0.0702 0.0234c-0.13485 0.08235-0.16473 0.30512-0.37438 0.32758-0.06735-0.16473-0.0243-0.35098-0.0468-0.53818-0.38187-0.1797-1.257 0.09825-1.6614 0.2106h-0.0234c-0.05985 0.0225-0.1029 0.0393-0.1404 0.0468h-0.0234c-0.16473 0.0375-0.24802 0.01785-0.39778-0.117-0.0375-0.03-0.072-0.0645-0.117-0.117h-0.0234c-0.16473-0.1497-0.36876-0.42962-0.60837-0.44458z",
+                Matsu:"m47.89 49.587c-0.5391 0.81864-0.3307 2.5646-0.0312 3.463-0.75874 0.08984-1.3228 0.52164-1.8719 1.0607 0.87854 1.6672-0.22714 1.5961-0.68638 2.9638-0.56906 1.6672 0.4917 2.5258 1.5599 3.2446 0.40934 0.27954 0.76624 0.68512 1.1856 0.90476 1.0383 0.46922 0.98962 0.07608 1.7783-0.09354 0.7288-0.18968 0.60276-0.31948 1.5911-0.24958 0.62896 0.02994 1.2292 0.46298 2.028 0.34318 0.39934-0.75874 1.4738-2.1078 2.4022-2.028 0.51914 1.6772 2.6594-0.27828 3.3382-0.71756 1.4876-0.98836 2.26-1.5712 2.0904-3.5878-1.797 0.08986-3.4904-0.45424-5.3974-0.37438-1.1381 0.04992-1.7571-0.1273-2.2464 0.81116-0.1198 0.22962-0.1572 0.47672-0.1872 0.68636l-0.0312 0.28078c0 0.03994-0.0212 0.08486-0.0312 0.1248-0.01 0.08986-0.012 0.1797-0.0312 0.24958-0.01 0.03994-0.012 0.09484-0.0312 0.1248-0.03 0.0599-0.065 0.10608-0.1248 0.156-0.1798 0.12978-0.52538 0.19468-1.1543 0.1248-0.1398-1.6972-0.2683-4.0908-2.7142-3.6814 0.32944-0.609 0.76498-1.0795 1.4039-1.2791 0.1598-0.16972 0.40708-0.72506 0.46798-0.90476 0.1598-0.32946-2.9376-1.4726-3.307-1.6223zm23.56-17.784c-0.38328 0.04264-0.8218 0.14792-1.2479 0.24958-0.21306 0.05082-0.42916 0.11702-0.62396 0.156-0.1948 0.03894-0.37314 0.05302-0.53038 0.0624-0.34942 0.02-0.85984-0.07238-1.2791-0.0624h-0.0312c-0.1698 0-0.31698 2e-3 -0.43678 0.0624-0.70882 0.26956-0.46922 0.52664-0.99836 0.93596-0.34442 0.24958-0.7213 0.5831-1.1231 0.87356s-0.82864 0.53786-1.2479 0.59278c-1.228 0.13978-1.807-0.80616-2.7454 0.31198-1.0882 1.2679 0.1548 1.9006 0.37438 3.0886 0.1198 0.6689-0.0212 0.95716-0.2808 1.2167-0.0698 0.0599-0.1386 0.12728-0.21838 0.18718-0.31948 0.24958-0.74252 0.54536-1.092 1.1543-0.1398 0.25958-0.2421 0.56532-0.31198 0.90476-0.02 0.1198-0.0524 0.25458-0.0624 0.37438-0.0598 0.58902 8e-3 1.2068 0.1872 1.7159 0.1598 0.04992 0.1872-0.04492 0.1872 0.1248 0.20966-0.02996 0.52914 0.09234 0.74876 0.0624-0.1572 0.84736 0.41046 1.3996 1.1232 1.2167 0.1018-0.02616 0.2059-0.06738 0.31198-0.1248-0.0486-0.1872-0.091-0.41458-0.1248-0.65516-0.23696-1.6842-0.0236-4.4052 1.8719-4.4926-0.0224-0.5441 0.0872-0.94332 0.28078-1.2479 0.0968-0.1523 0.20398-0.30146 0.34318-0.40558 0.69598-0.5206 1.8782-0.47422 3.0574-0.37438-0.0798 0.49918 0.1884 0.94468 0.21838 1.4039 1.797-0.7887 2.9938-1.7147 5.2102-0.93596 0.1872 0.38936-0.093 2.9332 0.49918 3.5254 0.0494 0.04932 0.125 0.07348 0.1872 0.09354s0.1106 0.0138 0.1872 0c0.153-0.02786 0.34192-0.1198 0.56156-0.31198 0.0674-0.0587 0.1122-0.13966 0.156-0.2184 0.0438-0.07876 0.1006-0.1542 0.1248-0.2496 0.1936-0.76316-0.191-2.0002-0.1248-2.839 8e-3 -0.10486 8e-3 -0.22142 0.0312-0.31198 0.024-0.09056 0.0812-0.14556 0.1248-0.2184 0.0436-0.07288 0.089-0.13552 0.156-0.1872 0.20096-0.15502 0.5154-0.22214 0.99836-0.1248 0.0798-0.45924 0.0798-1.1107 0-1.5599-0.76874-0.04992-3.01 0.68512-2.8702-0.34318 0.1598-0.99836 1.6186-0.7238 1.2791-2.371-1.1381 0.24958-1.1656-0.99836-2.184-1.2479-0.1798-0.04742-0.43086-0.0596-0.68636-0.03114z"
+                };
+            var i = {};
+            for (var s in r) {
+                i = {};
+                if (this.options.stateSpecificStyles[s]) {
+                    e.extend(i, t, this.options.stateSpecificStyles[s])
+                } else {
+                    i = t
+                }
+                this.stateShapes[s] = n.path(r[s]).attr(i);
+                this.topShape = this.stateShapes[s];
+                this.stateHitAreas[s] = n.path(r[s]).attr({
+                    fill: "#000",
+                    "stroke-width": 0,
+                    opacity: 0,
+                    cursor: "pointer"
+                });
+                this.stateHitAreas[s].node.dataState = s
+            }
+            this._onClickProxy = e.proxy(this, "_onClick");
+            this._onMouseOverProxy = e.proxy(this, "_onMouseOver"),
+            this._onMouseOutProxy = e.proxy(this, "_onMouseOut");
+            for (var s in this.stateHitAreas) {
+                this.stateHitAreas[s].toFront();
+                e(this.stateHitAreas[s].node).bind("mouseout", this._onMouseOutProxy);
+                e(this.stateHitAreas[s].node).bind("click", this._onClickProxy);
+                e(this.stateHitAreas[s].node).bind("mouseover", this._onMouseOverProxy)
+            }
+        },
+        _initCreateLabels: function() {
+            var t = this.paper;
+            var n = [];
+            var r = 860;
+            var i = 220;
+            var s = this.options.labelWidth;
+            var o = this.options.labelHeight;
+            var u = this.options.labelGap;
+            var a = this.options.labelRadius;
+            var f = s / this.scale;
+            var l = o / this.scale;
+            var c = (s + u) / this.scale;
+            var h = (o + u) / this.scale * .5;
+            var p = a / this.scale;
+            var d = this.options.labelBackingStyles;
+            var v = this.options.labelTextStyles;
+            var m = {};
+            for (var g = 0, y, b, w; g < n.length; ++g) {
+                w = n[g];
+                y = (g + 1) % 2 * c + r;
+                b = g * h + i;
+                m = {};
+                if (this.options.stateSpecificLabelBackingStyles[w]) {
+                    e.extend(m, d, this.options.stateSpecificLabelBackingStyles[w])
+                } else {
+                    m = d
+                }
+                this.labelShapes[w] = t.rect(y, b, f, l, p).attr(m);
+                m = {};
+                if (this.options.stateSpecificLabelTextStyles[w]) {
+                    e.extend(m, v, this.options.stateSpecificLabelTextStyles[w])
+                } else {
+                    e.extend(m, v)
+                }
+                if (m["font-size"]) {
+                    m["font-size"] = parseInt(m["font-size"]) / this.scale + "px"
+                }
+                this.labelTexts[w] = t.text(y + f / 2, b + l / 2, w).attr(m);
+                this.labelHitAreas[w] = t.rect(y, b, f, l, p).attr({
+                    fill: "#000",
+                    "stroke-width": 0,
+                    opacity: 0,
+                    cursor: "pointer"
+                });
+                this.labelHitAreas[w].node.dataState = w
+            }
+            for (var w in this.labelHitAreas) {
+                this.labelHitAreas[w].toFront();
+                e(this.labelHitAreas[w].node).bind("mouseout", this._onMouseOutProxy);
+                e(this.labelHitAreas[w].node).bind("click", this._onClickProxy);
+                e(this.labelHitAreas[w].node).bind("mouseover", this._onMouseOverProxy)
+            }
+        },
+        _getStateFromEvent: function(e) {
+            var t = e.target && e.target.dataState || e.dataState;
+            return this._getState(t)
+        },
+        _getState: function(e) {
+            var t = this.stateShapes[e];
+            var n = this.stateHitAreas[e];
+            var r = this.labelShapes[e];
+            var i = this.labelTexts[e];
+            var s = this.labelHitAreas[e];
+            return {
+                shape: t,
+                hitArea: n,
+                name: e,
+                labelBacking: r,
+                labelText: i,
+                labelHitArea: s
+            }
+        },
+        _onMouseOut: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("mouseout", e, t)
+        },
+        _defaultMouseOutAction: function(t) {
+            var n = {};
+            if (this.options.stateSpecificStyles[t.name]) {
+                e.extend(n, this.options.stateStyles, this.options.stateSpecificStyles[t.name])
+            } else {
+                n = this.options.stateStyles
+            }
+            t.shape.animate(n, this.options.stateHoverAnimation);
+            if (t.labelBacking) {
+                var n = {};
+                if (this.options.stateSpecificLabelBackingStyles[t.name]) {
+                    e.extend(n, this.options.labelBackingStyles, this.options.stateSpecificLabelBackingStyles[t.name])
+                } else {
+                    n = this.options.labelBackingStyles
+                }
+                t.labelBacking.animate(n, this.options.stateHoverAnimation)
+            }
+        },
+        _onClick: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("click", e, t)
+        },
+        _onMouseOver: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("mouseover", e, t)
+        },
+        _defaultMouseOverAction: function(t) {
+            this.bringShapeToFront(t.shape);
+            this.paper.safari();
+            var n = {};
+            if (this.options.stateSpecificHoverStyles[t.name]) {
+                e.extend(n, this.options.stateHoverStyles, this.options.stateSpecificHoverStyles[t.name])
+            } else {
+                n = this.options.stateHoverStyles
+            }
+            t.shape.animate(n, this.options.stateHoverAnimation);
+            if (t.labelBacking) {
+                var n = {};
+                if (this.options.stateSpecificLabelBackingHoverStyles[t.name]) {
+                    e.extend(n, this.options.labelBackingHoverStyles, this.options.stateSpecificLabelBackingHoverStyles[t.name])
+                } else {
+                    n = this.options.labelBackingHoverStyles
+                }
+                t.labelBacking.animate(n, this.options.stateHoverAnimation)
+            }
+        },
+        _triggerEvent: function(t, n, r) {
+            var i = r.name;
+            var s = false;
+            var o = e.Event("usmap" + t + i);
+            o.originalEvent = n;
+            if (this.options[t + "State"][i]) {
+                s = this.options[t + "State"][i](o, r) === false
+            }
+            if (o.isPropagationStopped()) {
+                this.element.trigger(o, [r]);
+                s = s || o.isDefaultPrevented()
+            }
+            if (!o.isPropagationStopped()) {
+                var u = e.Event("usmap" + t);
+                u.originalEvent = n;
+                if (this.options[t]) {
+                    s = this.options[t](u, r) === false || s
+                }
+                if (!u.isPropagationStopped()) {
+                    this.element.trigger(u, [r]);
+                    s = s || u.isDefaultPrevented()
+                }
+            }
+            if (!s) {
+                switch (t) {
+                case "mouseover":
+                    this._defaultMouseOverAction(r);
+                    break;
+                case "mouseout":
+                    this._defaultMouseOutAction(r);
+                    break
+                }
+            }
+            return !s
+        },
+        trigger: function(e, t, n) {
+            t = t.replace("usmap", "");
+            e = e.toUpperCase();
+            var r = this._getState(e);
+            this._triggerEvent(t, n, r)
+        },
+        bringShapeToFront: function(e) {
+            if (this.topShape) {
+                e.insertAfter(this.topShape)
+            }
+            this.topShape = e
+        }
+    };
+    var c = [];
+    s(e, "usmap", l, c)
+})(jQuery, document, window, Raphael)
+
+
+
+endingPicker = (out, totv, aa, quickstats) => {
+    
+    //out = "win", "loss", or "tie" for your candidate
+    //totv = total votes in entire election
+    //aa = all final overall results data
+    //quickstat = relevant data on candidate performance (format: your candidate's electoral vote count, your candidate's popular vote share, your candidate's raw vote total)
+  
+    /*
+    e.header = "<h2></h2>"
+    e.pages = ["<p></p>",
+               "<p></p>"]
+    */
+  
+    // NORMAL ENDINGS
+  e.final_overall_results.sort((a, b) => b.popular_votes - a.popular_votes);
+  map = document.getElementById("map_container");
+
+  //不帮助果冻，果冻失败
+  
+  if (aa[0].candidate === 2001557 && e.player_answers.includes(1950399)) {
+  used=false
+  if (used != true) {
+              setInterval(function () {
+                  used = true;
+                  imgg = document.getElementsByClassName("person_image")[0];
+                  if (imgg != null) {
+                      imgg.src =  "https://cc.tvbs.com.tw/img/upload/2023/05/11/20230511101843-4fbdaa77.jpg";
+                  }
+              }, 100);
+          }
+  return "<div style='overflow-y:scroll;height:250px;'><h3>KMT's Landslide Failure, DPP Re-elected</h3><p>Since the nomination of Terry Gou on May 17, 2023, the Kuomintang (KMT) has made a significant mistake. Gou's campaign encountered numerous issues over the months, ultimately leading to the current outcome. Firstly, Gou's involvement in past scandals resurfaced, severely impacting his and the KMT's image. Many within the KMT were also dissatisfied with the influence he had on the party in 2019, including a considerable number of Han Kuo-yu's supporters, as he competed against Han in 2019 and played a role in his significant defeat.</p><p>Mayor Hou You-yi focused on municipal governance and did not actively support Gou's campaign, lacking the backing of the initially popular presidential candidate Hou You-yi. Gou's campaign suffered from a lack of enthusiasm and support.</p><p>Things took a turn for the worse when Ko Wen-je refused to form a KMT-TPP ticket with Gou. Ko was wary of Gou's extensive business background and unclear ties with Beijing, as Gou had substantial business interests in mainland China. Gou insisted on running for president instead of vice president, refused to let the outcome be decided by polls, and even made statements like 'Let the Older brother go first for four years.' By November 23, Ko Wen-je still refused to communicate with Gou. At this point, Gou's approval ratings had fallen to the level of Eric Chu in 2016, and he still had not found a vice president. Ultimately, on November 24, Hung Hsiu-chu, who had been nominated in 2016 before being abolished, became Gou's vice president in an attempt to salvage his candidacy and keep the KMT in the election. Unfortunately, these efforts were in vain, and Gou's defeat was a reality.</p><p>With Gou's defeat, you have one less opponent to deal with in the next four years. Despite achieving high satisfaction ratings in polls for excellent municipal governance, earning the title of 'Five-Star Mayor,' it came at the cost of the KMT's survival and development. After this election, the KMT's electoral capabilities have once again been undermined. How many years will it take for this party to emerge from the shadow of 2016? Perhaps it will never happen.</p></div>"  
+  
+    } 
+    //帮助果冻，果冻失败
+
+    if (aa[0].candidate === 2001557 && e.player_answers.includes(1950400)) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://image.cache.storm.mg/styles/smg-800x533-fp-wm/s3/media/image/2019/11/23/20191123-114039_U4040_M570673_9ed1.jpg?itok=or7yughm";
+                        }
+                    }, 100);
+                }
+        return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Sets Historic Record, KMT Faces Third Defeat</h3><p>Since the Drafted of Terry Gou, his approval ratings have been consistently unstable, ultimately resulting in the current consequences. Lai Ching-te and the Democratic Progressive Party (DPP) have once again emerged victorious, setting a historical record in Taiwan by securing a third term. Meanwhile, you have also set a historical record of failure, a responsibility that Terry Gou must bear. If it weren't for his mishandling of the KMT-TPP Ticket in the later stages of the election, the KMT might have won by tens of thousands or even hundreds of thousands of votes against the DPP. However, his disdainful remarks towards Ko Wen-je and his supporters led Ko's supporters to refuse to transfer their votes to him, even when he was leading in the polls. He publicly stated that Ko Wen-je would absolutely not win and requested Ko's supporters to vote for him to defeat the DPP. His insistence on Ko Wen-je being the vice president further angered the TPP and its supporters. On registration day, Terry Gou, an outsider in politics, appointed actress Lai Pei-hsia as vice president, who had starred in the Taiwanese TV series Wave Makers, a show that exposed sexual harassment issues within the DPP. Despite her good and excellent image as well as eloquence, she lacked political experience and was questioned for the KMT's governing capabilities. Although Hou You-yi consistently supported Terry Gou, he ultimately faced defeat.</p> <p>With Terry Gou's defeat, you have one less opponent to deal with in the next four years. Despite achieving high satisfaction ratings in polls for excellent municipal governance, earning the title of 'Five-Star Mayor,' and establishing numerous connections and enhancing your strength and network in the local community, this success comes at the cost of the KMT's survival and development. After this election, the KMT's electoral capabilities have once again been undermined, and people are losing confidence in the party. However, due to the relatively small gap in this election, they are now looking towards you as the wise rising star. Can you secure victory in 2028? How many years will it take for the KMT to emerge from the shadow of 2016? Perhaps it will never happen. Perhaps it will be in the next four years.</p></div>"  
+        
+          } 
+
+    //不帮助果冻，果冻获胜
+
+    if (aa[0].candidate === 2001591 && e.player_answers.includes(1950399) ) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/800/20240113/2000x1333_wmky_495863372336_0.jpg";
+                        }
+                    }, 100);
+                }
+        return "You fool! I told you not to support him, to make sure he loses, and then let him give up in four years! Now he's the president, and in 2028, Terry Gou will definitely choose to run for re-election. What are you going to do then? After 2026, you can just go home and sleep. Goodbye, Mayor Hou!"  
+        
+          } 
+
+    //帮助果冻，果冻获胜
+    if (aa[0].candidate === 2001591 && e.player_answers.includes(1950400) ) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://news-data.pts.org.tw/media/149657/cover.jpg";
+                        }
+                    }, 100);
+                }
+        return "<div style='overflow-y:scroll;height:250px;'><h3>Terry Gou and Kuomintang Secure Victory! Political Alternation Achieved</h3><p>Since Terry Gou was drafted on May 17, avoiding the internal primary conflicts, his approval ratings have been neck-and-neck with Lai Ching-te until he was officially confirmed as the candidate in July. Gou gradually gained a stable lead over Lai. However, the rise of Ko Wen-je and the TPP caused a decline in Gou's approval ratings. Gou had to consider the KMT-TPP Tickets, and after sporadic negotiations over several months, a decision was made on November 15 to determine the outcome through polls. However, Ko Wen-je regretted the agreement after signing, leading to a loss of confidence in him. Voters looking to oust the Democratic Progressive Party (DPP) ultimately rallied towards Terry Gou. Gou nominated political outsider Lai Pei-hsia as vice president, bringing a positive media image. In the vice presidential debate, her unique eloquence, speaking skills, and sincere words resonated with many voters. According to polls, a staggering 62% considered Lai Pei-hsia the best in the debate. Ultimately, on January 13, Terry Gou emerged victorious and assumed the presidency.</p> <p>With Terry Gou's victory, your support for him will not go unnoticed. He has promised you a position in the cabinet, and the position of Premier is highly likely to be yours! Additionally, your high satisfaction ratings in municipal governance, earning the title of 'Five-Star Mayor,' and building numerous connections and enhancing strength and relationships in the local community have contributed to the survival and development of the Kuomintang. After this election, the electoral capabilities of the Kuomintang seem to have returned, and people's confidence in the party has been proven at the ballot box. Media and the public are speculating on who the DPP will field in the 2028 or even 2032 elections, while in the Kuomintang camp, attention is now turning to you, the rising star. If Terry Gou is willing to serve only one term, can you secure victory in 2028? Or do you plan to compete in the primaries against the incumbent president at that time? Regardless, you have considerable strength to contend with, and I wish you the best of luck, Mayor Hou!</p></div>"  
+        
+          } 
+          ///侯侯本体结局
+          if (aa[0].candidate === 2001591 && quickstats[1] > 40 && quickstats[1] < 46.0) {
+            used=false
+            if (used != true) {
+                        setInterval(function () {
+                            used = true;
+                            imgg = document.getElementsByClassName("person_image")[0];
+                            if (imgg != null) {
+                                imgg.src =  "https://i.imgur.com/hT2wDhP.jpeg";
+                            }
+                        }, 100);
+                    }
+            return "<div style='overflow-y:scroll;height:250px;'><h3>Fourth Party Alternation! KMT Victory, DPP Rule Ends</h3><p>I believe Ko Wen-je must be regretting now, why he didn't accept the offer to be the Vice President on November 18. Because if he did, he would have gained many administrative resources for free, the second-highest position in the country, and the expansion of TPP's strength. But he chose to give up. In November, when the opposition alliances parted ways, many predicted that DPP would unprecedentedly enter its third term. However, when Zhao Shao-kang appeared as the Vice President, the enthusiasm of the blue camp voters was fully ignited. Faced with the untrustworthy Ko Wen-je and the political prodigy who rose to fame 30 years ago, they immediately flocked to the latter. This led to a sharp increase in KMT's poll numbers after November, and Zhao Shao-kang brought at least 500,000 to 1 million blue votes for you, helping you secure victory. Zhao Shao-kang promised not to take a salary if elected and to turn his Vice Presidential residence into social housing.</p><p>In terms of this legislative yuan, you witnessed a complete victory. With 57+2 seats in the National Assembly, you will ensure your majority without having to consider DPP and TPP. You can pass any bills you want, ensuring the smooth operation of the Hou You-yi government in the parliament. However, to push for the cabinet system and other reforms you have promised, cooperation between the three parties must be promoted.</p><p>On May 20 this year, you will become the President of the Republic of China, a son of a pork vendor from rural Chiayi, who has been serving the country since entering the police academy, facing countless gunshots, confrontations, and battles against criminals. But if it weren't for Eric Chu promoting you to Deputy Mayor of New Taipei in 2010, you probably wouldn't have entered politics. In just over a decade, you have become the president. Perhaps your Mandarin is not good, perhaps your appearance is not as impressive as others, perhaps you don't even have much personal charm, but you are steadfast and down-to-earth, which has won the favor of the majority of Taiwanese voters. The first thing you will face after taking office is the mayoral by-election in New Taipei, as well as the major elections for mayors across the country in 2026. You must firmly grasp the local base of the blue camp, and in 2028, your prospects for re-election will be very promising! Good luck, President Hou You-yi!</p></div>"  
+            
+          } 
+          else if (aa[0].candidate === 2001591 && quickstats[1] < 40 && quickstats[1] > 35.0 ) {
+            used=false
+            if (used != true) {
+                        setInterval(function () {
+                            used = true;
+                            imgg = document.getElementsByClassName("person_image")[0];
+                            if (imgg != null) {
+                                imgg.src =  "https://i.imgur.com/FiVAzjB.jpeg";
+                            }
+                        }, 100);
+                    }
+            return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Loses Third Term, 8-Year Curse Continues, Underdog Emerges Victorious</h3> <p>In an intense duel, the one who fights to the end is the true winner. With the possibility of Joint Tickets completely lost, Hou You-yi could only find Zhao Shao-kang as the vice presidential candidate. To put it positively, he is a deep-blue anti-communist candidate who can strengthen your base. To put it negatively, there is simply no other KMT member willing to be your vice president because polls show you lagging behind Lai Ching-te. No one is willing to waste time and sacrifice their political future to help you. They are all wrong because the deep-blue return led by Zhao Shao-kang and a large voter base will ensure that you are on par with the DPP and defeat Lai Ching-te in the final stage of the election. It's truly a thrilling and exciting battle! Ko Wen-je must be regretting now; he could have become vice president, but now he can only be elected as Taipei City citizen. Haha.</p> <p>In terms of this legislative session, you have just obtained a majority, but it's very fragile. The 55+2 seats in the National Assembly will ensure your absolute majority without having to consider the faces of DPP and TPP. You can pass any bills you want, ensuring the smooth operation of the Hou You-yi government in the parliament. However, to push for the cabinet system and other promised reforms, cooperation between the three parties must be promoted. Additionally, if someone in the National Assembly does not vote for you, even one or two people whose party lines are inconsistent, it may lead to you losing the majority. So, you must uphold party discipline. After all, you are now the president, and you might also serve as the party chairman.</p><p>On May 20 next year, you will become the President of the Republic of China, a son of a pork vendor from rural Chiayi, who has been serving the country since entering the police academy, facing countless gunshots, confrontations, and battles against criminals. But if it weren't for Eric Chu promoting you to Deputy Mayor of New Taipei in 2010, you probably wouldn't have entered politics. In just over a decade, you have become the president. Perhaps your Mandarin is not good, perhaps your appearance is not as impressive as others, perhaps you don't even have much personal charm, but you are steadfast and down-to-earth, which has won the favor of the majority of Taiwanese voters. The first thing you will face after taking office is the mayoral by-election in New Taipei, as well as the major elections for mayors across the country in 2026. You must firmly grasp the local base of the blue camp, and in 2028, your prospects for re-election will be very promising! Good luck, President Hou You-yi!</p></div>    "
+          }
+            else if (aa[0].candidate === 2001557 && quickstats[1] <40 && quickstats[1] > 35.0 ) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/1024/20231231/1200x814_wmky_053032638365_202312030108000000.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Unprecedentedly Enters Third Term: KMT Fails to Achieve Party Alternation</h3><p>As predicted, the miracle did not happen. Lai Ching-te maintained his high approval ratings until the last day of the election. Everyone knew that the lack of cooperation between the blue and white camps would benefit Lai Ching-te. As expected, both you and Ko Wen-je lost in the election. However, Lai Ching-te's vote share is not as high as expected, staying below 40%, which means he didn't even secure full support from the DPP base. Zhao Shao-kang's entry brought a strong boost to the blue camp, but the Triumph Apartments incident and the influence of Ma Ying-jeou may have affected your base and votes. You may have also performed poorly in the early stages of the campaign, leading to a drag, but since this was a result that everyone could foresee, it might not be as bad as it seems.</p> <p>Fortunately, we have maintained a relative majority in the Legislative Yuan. The 53+2 seats will ensure that we are the largest party in the legislature. While we didn't achieve an absolute majority, meaning we have to cooperate with the TPP to pass bills, they will become a crucial minority in the parliament.</p> <p>After the election, you must return to the position of Mayor of New Taipei City. Your deputy mayor has been acting on your behalf for the past few months. Your term will continue until 2026. Although some extremists talk about replicating the outcome of Han Kuo-yu in 2020 and attempting to recall you as mayor, their chances of success are unlikely, and you are not particularly disliked. They are not likely to succeed. In 2026, you must step down, and at that time, you will be a free person, able to enjoy retirement and the remaining years of your life. However, if you still have ambitions for 2028, this election is just a stepping stone. Failure is the mother of success. Since the DPP can be re-elected, what reason do you have not to strive for the nomination in 2028?</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Zhao Shao-kang for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>    "
+            }
+            else if (aa[0].candidate === 2001557 && quickstats[1] > 40.0 && quickstats[1] < 46.0) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://d1j71ui15yt4f9.cloudfront.net/wp-content/uploads/2023/12/03223725/20231203000125.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>Narrow Defeat with High Votes: KMT Loses to DPP with Over 40%</h3><p>Once, people believed that getting 40% of the votes in a three-way race would guarantee victory. Unfortunately, luck wasn't on your side, and the DPP secured a victory with just a slightly higher vote count. You garnered nearly the same number of votes, yet you have to return to your position as the mayor of New Taipei City. Is there a flaw in our electoral system? Despite securing a substantial 40% of the votes, achieving a party alternation proved elusive. Your supporters blame Ko Wen-je for siphoning off many of your votes, but despite our best efforts, party alternation couldn't be realized.</p><p>For you, the consolation is that Ko Wen-je secured third place. Before the election, he had significant momentum with substantial support from young people, and TPP supporters made their voices heard online. However, these were ultimately futile dreams. Even if Ko Wen-je had said he would let you run alone, you wouldn't have won. You proved that the KMT, with a solid base, wouldn't easily lose to the TPP, which has only been around for a few years. Among the opposition voters, there's a saying: whoever is in third place is the culprit for the opposition's failure. Judging by the voting pattern, he is indeed the third, and he lost by a significant margin. After the election, his Facebook was turned upside down by angry opposition voters.</p><p>Although Lai Ching-te becomes president, his governance won't be smooth. The high satisfaction with the Tsai administration won't be fully inherited by him. He is destined to face a minority government and a parliament where the opposition party is in power. Currently, the KMT has 56+2 seats, making it the largest party in the Legislative Yuan and securing an absolute majority. This means that, barring any surprises, Han Kuo-yu, who supports you, will become the president of the Legislative Yuan. This is a significant payback for him. Zhao Shao-kang can go back to hosting his show, and you can go back to being the mayor of New Taipei City. You can try running again in 2028, as your performance has at least matched that of Han Kuo-yu in 2020, and this was in a three-way race. If you enter the race in 2028, the presidency could very well be yours. Good luck, Mayor Hou!</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Zhao Shao-kang for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>"
+            }
+          else if (aa[0].candidate === 2001557 && quickstats[1] < 35.0 && quickstats[1] > 30.0) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://images.ctee.com.tw/newsphoto/2024-01-13/1024/20240113700644_20240113212416.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Triumphs Again, KMT Faces Another Defeat: When Will the Chapter of 2016 End?</h3> <p>On the night of your defeat, you had a nightmare: perhaps the KMT will never govern again? It's a frightening thought, but since 2016, the KMT has lost the presidential election three times in a row. The last time they won was 12 years ago, a cycle ago, but it feels as distant as a century ago. The DPP has achieved an unprecedented third term, even though their government is a minority one without the support of the majority of the people. The KMT's failure was anticipated, as the DPP had a few percentage points of a lead, and every step forward for you was challenging, ultimately leading to the KMT's defeat.</p><p>For you, the consolation is that Ko Wen-je came in third. Before the election, he had significant momentum, with substantial support from young people and a large voice among internet users, especially TPP supporters. However, these were ultimately futile dreams. Even if Ko Wen-je said he would let you run alone, you wouldn't have won. You proved that the KMT, with a solid base, wouldn't easily lose to the TPP, which has only been around for a few years. Among the opposition voters, there's a saying: whoever is in third place is the culprit for the opposition's failure. Judging by the voting pattern, he is indeed the third, so he might be the culprit?</p> <p>Although Lai Ching-te becomes president, his governance won't be smooth. The high satisfaction with the Tsai administration won't be fully inherited by him. He is destined to face a minority government and a parliament where the opposition party is in power. Currently, the KMT has 52+2 seats, making it the largest party in the Legislative Yuan. This means that, barring any surprises, Han Kuo-yu, who supports you, will become the president of the Legislative Yuan. This is a significant payback for him. Zhao Shao-kang can go back to hosting his show, and you can go back to being the mayor of New Taipei City. The world seems unchanged, just like before! You can try running again in 2028... if the ROC can survive until then.</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Zhao Shao-kang for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>"
+              map.style.backgroundImage = "url(https://i.imgur.com/VjbWx3Q.jpeg)"; 
+            }
+          else if (aa[0].candidate === 2001591 && quickstats[1] > 46.0 ) {
+              used=false
+              if (used != true) {
+                          setInterval(function () {
+                              used = true;
+                              imgg = document.getElementsByClassName("person_image")[0];
+                              if (imgg != null) {
+                                  imgg.src =  "https://s.newtalk.tw/album/news/843/636fa5b4b0eaf.jpg";
+                              }
+                          }, 100);
+                      }
+              return "<div style='overflow-y:scroll;height:250px;'><h3>Hou's Crushing Comeback: KMT Triumphs Over DPP in 2024, Regaining Power!</h3><p>As the lights lit up at the KMT campaign headquarters, the audience below had anticipation and anxiety in their eyes. For most of the past year, Lai Ching-te had been leading in the polls, only recently trading victories with Hou You-yi in the last couple of months. In the audience, there were infants in cradles, elderly individuals in their seventies and eighties, and middle-aged people in their forties and fifties, all hoping for a KMT victory to bring them a better future. When the vote counting began, Hou You-yi and Lai Ching-te were neck and neck. However, people noticed that Hou You-yi had a significantly high vote share in deep-blue regions. In battleground areas like Changhua and Taichung, he also performed admirably, gradually widening the gap. In the end, Hou You-yi secured victory in the presidential election with over 46% of the votes, becoming the 16th president.</p><p>Zhao Shao-kang immediately shouted 'Long live the Republic of China' three times at the scene. You and your campaign team quickly conducted a simulated inauguration ceremony, preparing for the formal inauguration on May 20. Zhao Shao-kang was delighted to become the vice president and pledged to donate all his salary, converting the vice president's residence into social housing for young people through a lottery system. The DPP suffered a major defeat in this election, prompting them to reflect on whether their governance over the past eight years had left the people extremely dissatisfied, leading them to choose the strongest candidate even in the face of opposition division, ultimately ousting the DPP. Lai Ching-te's days as vice president were also coming to an end.</p><p>As the president who led the KMT back to power and won a challenging battle, the rewards for you are substantial. The KMT holds 59+2 seats in the Legislative Yuan, becoming the largest party and securing an absolute majority in the legislature. Han Kuo-yu, who supports you, is destined to become the president of the Legislative Yuan, and party chairman Eric Chu can become the premier. According to tradition, the party chairman should be the president, a significant reward for You. Zhao Shao-kang, as vice president, can handle diplomatic affairs and even represent you on foreign visits. Due to the enormous victory you achieved this year, it's almost certain that you will be nominated for re-election by the KMT in 2028. However, the upcoming New Taipei City mayoral by-election and the 2026 county and city mayoral elections will test your governing abilities. If you can navigate them successfully, then you have a great chance of winning re-election in 2028. Good luck, President Hou You-yi!</p></div>"
+            }
+            else if (aa[0].candidate === 2001622 ) {
+            used=false
+            if (used != true) {
+                        setInterval(function () {
+                            used = true;
+                            imgg = document.getElementsByClassName("person_image")[0];
+                            if (imgg != null) {
+                                imgg.src =  "https://d1b8dyiuti31bx.cloudfront.net/NewsPhotos/20231231/109_025527539611.jpg";
+                            }
+                        }, 100);
+                    }
+            return "<div style='overflow-y:scroll;height:250px;'><h3>Taiwan's Political Earthquake: Blue and Green Parties Overturned, Ko Wen-je Emerges Victorious</h3> <p>A year ago, nobody would have believed that Ko Wen-je and his TPP could secure the presidency of the ROC. However, it happened. Ko Wen-je and his People Party (TPP) claimed the presidency, leaving both the blue and green camps and their supporters in shock. Ko Wen-je's young fanbase erupted in joy, filling the internet with their celebrations, contrasting with the disappointment among blue and green supporters.</p><p>The world's attention turned to Ko Wen-je and the TPP. Media outlets from major countries, including China, the United States, South Korea, Japan, Russia, the United Kingdom, and France, featured front-page coverage on the process and outcome of Ko Wen-je and the TPP securing the presidency in Taiwan. However, Ko Wen-je is destined to be a crippled president as the TPP is the smallest party in the parliament. The solid foundations of the KMT and DPP in the legislature cannot be easily shaken. Can you imagine a president from the third-largest party dealing with a parliament full of opponents? It's almost unimaginable, but it happened. Ko Wen-je can choose to collaborate with either the blue or green camp, but he will never have dominance.</p> <p>With Ko Wen-je's election, your campaign turned into a joke. The KMT lost to a small party that had only been established for five years, and the defeat was embarrassing. The only consolation is that the DPP also suffered a severe setback, so you're not alone in this. As for the future, who knows? Ko Wen-je is an unpredictable figure, and the stance of his government remains uncertain. We know nothing at this point.</p></div> "
+               }
+               else if (aa[0].candidate === 2001557 && quickstats[1] > 46.0 ) {
+                  used=false
+                  if (used != true) {
+                              setInterval(function () {
+                                  used = true;
+                                  imgg = document.getElementsByClassName("person_image")[0];
+                                  if (imgg != null) {
+                                      imgg.src =  "https://cdn.hk01.com/di/media/images/dw/20240112/822423439976435712294650.jpeg/DZO8aeGaT0u6zDkTim6YltXgdsj2Ey8DbXl0JW15dCU?v=w1280r16_9";
+                                  }
+                              }, 100);
+                          }
+                  return "<div style='overflow-y:scroll;height:250px;'><h3>Head-to-Head Showdown Upended: DPP Defeats KMT-TPP Alliance</h3><p>In the November polls, most surveys indicated that the KMT-TPP joint ticket, whether led by Ko Wen-je or Hou You-yi, could defeat Lai Ching-te by at least several hundred thousand votes. However, on January 13th, how did things take such a turn? Lai Ching-te has emerged victorious over you, reminiscent of 2004 when the KMT's poll numbers remained high but were caught up and surpassed in the final stages. It was a painful night, with the supporters of the KMT and TPP left speechless, while not far away, the cheers of DPP supporters echoed through the skies.</p><p>In the Legislative Yuan, the KMT only leads the DPP by one seat, and the 51+2 seats will mean that you only need one person to abstain from voting to lose the relative majority. This is not good news for the KMT, and the TPP might consider choosing to cooperate with the DPP because your failure has brought about bitter political consequences. However, at least in the Legislative Yuan, there is some room for cooperation and contention among the three parties, and the election for the Legislative Yuan President on February 1st will be intense.</p><p>Given your lackluster performance in what was considered a sure-win game, you are being blamed as the main culprit for the failure. Your lack of proficiency in Mandarin, running for office while holding another position, and the image of a charmless rural figure have all weighed you down – issues of your own making. More importantly, your failure to handle some crucial issues properly undoubtedly impacted your votes and the likelihood of ultimate victory. You may not even be able to retain the position of New Taipei City Mayor, as some angry and extreme TPP and KMT supporters are planning to recall you as a failed leader. The saying goes,'a drowning man will clutch at a straw', and now you must find a way to return to city governance and regain the favor of the citizens. Good luck, Mayor Hou.</p><h3>Mayor Hou You-yi Expresses Defeat: Regretful for Failing Party Alternation</h3><p>As the results of the 2024 election become clear, Kuomintang (KMT) presidential candidate Mayor Hou You-yi concedes defeat. Mayor Hou delivered his concession speech around 8 p.m., expressing regret for not achieving a party change. He respects the final choice made by the people of Taiwan and congratulates the Democratic Progressive Party (DPP) presidential and vice-presidential candidates, Lai Ching-te and Hsiao Bi-Khim, on their victory. Mayor Hou urges everyone to transform the power of sorrow and disappointment into a force for supervising the DPP. He emphasizes that, starting tomorrow, they will roll up their sleeves and work hard, not letting down the expectations of their supporters and dedicating themselves more earnestly to the country.</p><p>Mayor Hou's face appears solemn, and at the beginning of his speech, he expresses gratitude to the supporters present, the people watching on television, and friends on the internet. However, he expresses regret for not accomplishing the party change, apologizing deeply for disappointing everyone. Mayor Hou You-yi: 'Regarding the results of the presidential election, my personal efforts were completely insufficient. Regrettably, we failed to achieve the party change. I deeply express my apologies, I'm sorry, sorry to everyone.'</p><p>Mayor Hou You-yi mentions the unity within the KMT during this election, with strong support from various levels and cities. He thanks Eric Chu for leading city mayors in substantial assistance, acknowledges the full assistance of regional and at-large legislators, and appreciates the care from supporters. He also expresses gratitude to Zhao Shao-kang for unwavering support at a crucial moment, and thanks former President Ma Ying-jeou, former Vice President Vincent Siew, former KMT Chairman Lien Chan, Wu Po-hsiung, and former Legislative Yuan Speaker Wang Jin-ping, as well as King Pu-tsung.</p><p>Mayor Hou You-yi points out that he respects the final choice made by the people of Taiwan, emphasizing that democratic choices are made by the people. He congratulates DPP presidential candidate Lai Ching-te and vice-presidential candidate Hsiao Mei-chin on their victory, expressing hope that they won't let down the expectations of the people of Taiwan as they assume office.</p><p>Mayor Hou You-yi expresses hope that after the election, facing the challenges of Taiwan, all political parties should unite. He emphasizes the importance of a united Taiwan rather than one divided by conflicts. He notes that Taiwan must address issues related to security in the Taiwan Strait and the relationship between the United States, China, and Taiwan. He hopes the DPP will listen to the people's expectations, building a clean, capable, and efficient government.</p><p>Mayor Hou You-yi also urges turning the power of sorrow and disappointment into a force for supervising the DPP. He asserts that they will not disband, nor will they disappear. Instead, they will become stronger and stride forward, as this is the spirit of the people of Taiwan. He emphasizes that starting tomorrow, they will roll up their sleeves and work hard, ensuring they do not disappoint their supporters, and they will dedicate themselves more seriously and diligently to the country.</p><p>During Mayor Hou You-yi's concession speech, he bows in apology to his supporters three times before leaving in a car. When asked by the media if this defeat would lead to his resignation, Eric Chu did not provide much response, swiftly getting into a car and leaving.</p></div>        "
+                }
+                else if (aa[0].candidate === 2001591 && quickstats[1] < 35.0 ) {
+                  used=false
+                  if (used != true) {
+                              setInterval(function () {
+                                  used = true;
+                                  imgg = document.getElementsByClassName("person_image")[0];
+                                  if (imgg != null) {
+                                      imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/800/20230628/1152x768_wmky_0_C20230628000018.jpg";
+                                  }
+                              }, 100);
+                          }
+                  return "<div style='overflow-y:scroll;height:250px;'> <h3>Narrow Victory in the Presidential Race: Hou You-yi Wins Presidency with Less Than 35% of Votes</h3> <p>In this intense multi-candidate competition, the DPP evidently lost its political stronghold, while the KMT's support base remained robust. Although several camps believed they could secure the presidency, the actual results were astonishing. Hou You-yi won the presidency with less than 35% of the vote, with the remaining 65% distributed among other candidates. This marks the lowest presidential vote percentage since the direct election of presidents. Nevertheless, you have secured the presidency, which may be challenging, but you did achieve it. After all, in a multi-candidate election, the support base is the most crucial factor.</p><p>In the Legislative Yuan, you maintain the status of the largest party but only lead the DPP by two seats. The upcoming parliament will undoubtedly involve party cooperation, and Han Kuo-yu is likely to become the next President of the Legislative Yuan without unexpected events. The TPP will inevitably become a crucial third force, and may your dealings with them be smooth! During your presidential term, challenges and opportunities will coexist. The difficulties presented by the challenging parliament and the diplomatic and domestic issues left by the DPP may be bothersome, but a reformed KMT government may gain more support and assistance from the people. The by-election for the mayor of New Taipei City and the 2026 county and city mayor elections will be your test. If you perform well, you may secure the nomination for reelection in 2028. However, if your performance is subpar, the KMT may prefer to nominate a new figure to replace you. Best of luck, President Hou You-yi!</p></div>"
+                }
+                //隐藏结局：2004重演。蓝白合输给民进党
+                else if (aa[0].candidate === 2001557 && quickstats[1] > 49.99 && quickstats[1] < 50.12 && aa[1].candidate === 2001591 ) {
+                  used=false
+                  if (used != true) {
+                              setInterval(function () {
+                                  used = true;
+                                  imgg = document.getElementsByClassName("person_image")[0];
+                                  if (imgg != null) {
+                                      imgg.src =  "https://rwnews.tw/upload/newstemp_13273/wide_j861buk_FotoJet-(72).jpg";
+                                  }
+                              }, 100);
+                          }
+                  return "<div style='overflow-y:scroll;height:250px;'><h3>Taiwan Election Deadlocked!</h3><p>Chairman Lai, something big has happened!</p><p>Your campaign office director, Yao Li-ming, hurriedly entered the hallway, finding you enjoying Taiwan's signature hand-shaken milk tea with extra sugar, evidently influenced by the locals in Tainan.</p><p>'Yao Director, what's the urgency?'</p><p>'Haven't you been watching? The vote count is at 95%, and there's still no winner declared!'</p><p>'I'm concerned about my health; high blood pressure, you know. What's going on?'</p><p>Yao quickly turned on the TV in your office, switching to SETN. Hou You-yi's and Lai Ching-te's images were swapping positions every half-minute, and their rankings kept changing. Each channel showed a different story, with Hou leading more on CTI, while Formosa TV and SETN favored Lai.</p><p>'Isn't there still 5% left? Let's wait until all votes are counted; I believe we'll win.'</p><p>One hour later, at the joint campaign headquarters of Hou You-yi and Ko Wen-je, the roar of car horns shattered the sky and everyone's hearts and ears.</p><p>'Everyone, please be quiet; President Hou can't speak in this noise.'</p><p>Hou You-yi stood silent on the stage.</p><p>'Chairman Ko, you go first.'</p><p>Ko Wen-je stepped forward, took the microphone, revealing an unprecedented solemnity in his expression.</p><p>'This is evidence of the DPP rigging the election. Their election staff used various methods, including disabling cameras, not singing the ballots, and much more. Our TPP and KMT supervisors have discovered many flaws in the electoral process, suspected of cheating... Please, everyone, look at the big screen.'</p><p>Hou You-yi added, 'The gap in our defeat is... very, very marginal. This slight difference is clouded in suspicion, raising many doubts. It gives the impression that this is an unfair election. We are preparing to file a lawsuit for the invalidation of the election.'</p><p>Supporters: 'Invalid! Invalid! Invalid!'</p><p>As the chants subsided, Hou You-yi continued, 'The second request is for the CEC to immediately seal all ballot boxes as a basis for future verification.'</p><p>Supporters: 'Verify! Verify! Verify!'</p><p>'If Taiwan really cannot lose, it's here. Everyone, right?'</p><p>Supporters: 'Yes!'</p><p>'Taiwanese people, democracy is our most effective weapon against the CCP. When we destroy this weapon, what other defenses do we have? Unfair elections not only make us hear about the doubts just mentioned but also clearly witness manipulative actions throughout the election. Everyone knows this, and we are using the most rational and gentle method to expose the deception carried out by Lai Ching-te and the DPP throughout this election. Let the whole world understand, shall we?'</p><p>Supporters: 'Go Hou-Ko! Go Hou-Ko!'</p><p>What happened in the world was unclear, but it was certain that Taiwan would once again enter bitter days of election violence and confrontation.</p></div>"
+                }
+                //白莲教赢过侯，侯大于23%
+                else if (aa[1].candidate === 2001622 && aa[2].candidate === 2001591 && quickstats[1] >= 23.1 && quickstats[1] < 30.0) {
+                    used=false
+                    if (used != true) {
+                                setInterval(function () {
+                                    used = true;
+                                    imgg = document.getElementsByClassName("person_image")[0];
+                                    if (imgg != null) {
+                                        imgg.src =  "https://imgcdn.cna.com.tw/www/webphotos/WebCover/800/20231223/1200x900_118527508580.jpg";
+                                    }
+                                }, 100);
+                            }
+                    return "<div style='overflow-y:scroll;height:250px;'> Is this the result of your self-sabotage? Well, I must say you succeeded because you managed to make a century-old political party lose to a third-party newcomer that has only been around for 5 years. It's quite a failure, and everyone on the internet is mocking you. </div>"
+                  }
+                  else if (aa[1].candidate === 2001622 && aa[2].candidate === 2001591 && quickstats[1] < 23.1 && quickstats[1] < 30.0) {
+                    used=false
+                    if (used != true) {
+                                setInterval(function () {
+                                    used = true;
+                                    imgg = document.getElementsByClassName("person_image")[0];
+                                    if (imgg != null) {
+                                        imgg.src =  "https://img.ltn.com.tw/Upload/news/600/2015/10/21/php4Ic3tg.jpg";
+                                    }
+                                }, 100);
+                            }
+                    return "<div style='overflow-y:scroll;height:250px;'>Your votes is even lower than Lien Chan's in 2000. I'm speechless. Now, Ko Wen-je and his supporters can openly mock the Kuomintang and you!</div>"
+                  }
+}
+
+// in-game achievements
+
+setInterval(endingPicker, 250);
+
+//注释代码
+function getTooltips(str) {
+    let matches = [];
+
+    tooltipList.forEach((tooltip, index) => {
+        // Adjust the regex to match searchString potentially surrounded by “ and followed by optional punctuation
+       let regex = new RegExp(`(?<=\\b|\\s|^|“)${tooltip.searchString}(?=[.,;!?]?\\b|\\s|”|$)`, 'g');
+
+
+        let match;
+        while ((match = regex.exec(str)) !== null) {
+            matches.push({
+                start: match.index + (match[0].startsWith('“') ? 1 : 0), // Adjust for potential starting “
+                end: match.index + match[0].length - (match[0].endsWith('”') ? 1 : 0) - (match[2] ? 1 : 0), 
+                tooltipIndex: index
+            });
+        }
+    });
+
+    // Sort by starting position; if two start at the same position, longer match comes first
+    matches.sort((a, b) => a.start - b.start || b.end - b.start - (a.end - a.start));
+
+    // Filter out overlaps
+    for (let i = 0; i < matches.length - 1; ) {
+        if (matches[i + 1].start < matches[i].end) {
+            matches.splice(i + 1, 1); // Remove the next match since it overlaps
+        } else {
+            i++; // Move to next match
+        }
+    }
+
+    return matches;
+}
+function applyTooltips(str) {
+    const matches = getTooltips(str);
+    let result = '';
+    let lastIndex = 0;
+
+    matches.forEach(match => {
+        const tooltip = tooltipList[match.tooltipIndex];
+        result += str.slice(lastIndex, match.start);
+        result += `<span class='mytooltip'>${tooltip.searchString}<span class='mytooltiptext'>${tooltip.explanationText}</span></span>`;
+        lastIndex = match.end;
+    });
+
+    result += str.slice(lastIndex); // Add the remainder of the original string
+    return result;
+}
+
+function applyTooltipsToObject(obj) {
+    for (let key in obj) {
+        if (typeof obj[key] === 'string') {
+            obj[key] = applyTooltips(obj[key]);
+        } else if (typeof obj[key] === 'object') {
+            applyTooltipsToObject(obj[key]); // Recursive call
+        }
+    }
+}
+
+applyTooltipsToObject(campaignTrail_temp.questions_json);
+applyTooltipsToObject(campaignTrail_temp.answers_json);
+applyTooltipsToObject(campaignTrail_temp.answer_feedback_json);

--- a/static/mods/2024ROC_Ko-Hou.json
+++ b/static/mods/2024ROC_Ko-Hou.json
@@ -1,0 +1,10013 @@
+e=campaignTrail_temp // this is redundant, but Decstar uses this because it looks nicer in the code.and The final resul
+campaignTrail_temp.multiple_endings=true
+campaignTrail_temp.cyoa = true
+campaignTrail_temp.questions_json = [
+    {
+        "model": "campaign_trail.question",
+        "pk": 13004,
+        "fields": {
+            "priority": 0,
+            "description": "Happy New Year, Chairman Ko Wen-je! This year marks an election year, and it is destined to be a lengthy one. Currently, the most likely candidates for the 2024 election are DPP's Lai Ching-te and KMT's Hou You-yi. As a commemoration of your first presidential election campaign, what is your overall agenda for this election?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13005,
+        "fields": {
+            "priority": 0,
+            "description": "Unlike other candidates, you have been preparing for the 2024 presidential election very early, and the TPP is a party with limited political power and resources. However, your extraordinary charisma can compensate for this. In the early part of this year, what do you want to accomplish?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13006,
+        "fields": {
+            "priority": 0,
+            "description": "This April, you visited the United States, adding to your diplomatic experience. It contributes to your international image and builds trust among domestic voters. What is the most memorable thing during your trip?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13007,
+        "fields": {
+            "priority": 0,
+            "description": "May 17th, you were selected as the presidential candidate for the 2024 elections by the TPP Central Committee. On the same day, the KMT also chose Hou Youyi as their presidential candidate. In this thrilling moment, do you have anything you'd like to say?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13008,
+        "fields": {
+            "priority": 0,
+            "description": "Recently, there have been a series of scandals and incidents involving sexual harassment within the Democratic Progressive Party (DPP). This seems to be our best opportunity to criticize them. What statement should we make here?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13009,
+        "fields": {
+            "priority": 0,
+            "description": "As a small party, TPP faces challenges such as the lack of political celebrities, capital, and local presence. Another significant constraint is the empty wallet, as TPP is in dire need of campaign funds. To overcome this financial challenge, where do you plan to seek funding?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13010,
+        "fields": {
+            "priority": 0,
+            "description": "As our online followers continue to grow, it's time to translate the online momentum into offline support. Some grassroots internet celebrities who are close to us have obtained the right to organize a protest on Ketagalan Boulevard in front of the Presidential Office. It's time to turn the public's anger towards the DPP into a tangible movement. The event, named the \"716 Fair and Just Grand Parade,\" will serve as the starting point for our path to victory. Do you have any specific plans or actions you'd like to take for this event?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13011,
+        "fields": {
+            "priority": 0,
+            "description": "With Hou You-Yi's declining poll numbers due to the university speech and kindergarten incidents, we seem to be getting closer to Lai Ching-te. However, at the same time, Terry Gou appears to be restless, preparing for an independent run. He has yet to openly support Hou You-Yi, suggesting that his assistance may be merely verbal. what should we do to clarify our goals?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13012,
+        "fields": {
+            "priority": 0,
+            "description": "On August 28th, Terry Gou announced his independent candidacy for the presidency, dispelling rumors of a potential partnership with you as president and vice president. His insistence on running for the presidency was unacceptable to you and your supporters, as it would tarnish the new political image you've been cultivating. What is your assessment of Terry Gou's independent candidacy?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13013,
+        "fields": {
+            "priority": 0,
+            "description": "As the election enters its mid-stage, you need to emphasize specific policies to gain the trust of the people. TPP has many noteworthy policies. Which ones would you like to emphasize the most?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13014,
+        "fields": {
+            "priority": 0,
+            "description": "As a nationwide political party, the foundation of the TPP is still relatively weak. A lack of a strong presence in various regions could lead to lower vote counts. Therefore, it is essential for you to visit different areas to gain more support. In which regions do you plan to focus your efforts?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13015,
+        "fields": {
+            "priority": 0,
+            "description": "At this crucial moment in the election, with both Lai Ching-te and Hou You-yi making consecutive visits to the United States and Terry Gou steadily increasing his number of citizen signatures, Lai Ching-te still maintains a lead. At this juncture, what specific aspects do you intend to focus on to boost your popularity?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13016,
+        "fields": {
+            "priority": 0,
+            "description": "Entering October, there is significant discussion among opposition supporters about the possibility of a KMT-TPP joint ticket. Currently, Lai Ching-te still maintains a lead in the polls, leading many to believe that the only way to defeat the DPP is through a blue-white alliance. Polls indicate that such an alliance could effectively overcome Lai Ching-te's lead. What is your stance on this matter?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13017,
+        "fields": {
+            "priority": 0,
+            "description": "Chairman Ko, the KMT is boycotting this year's National Day celebration because they believe that the event's logo has lost the distinctive features and name of the Republic of China. They see it as another step by the DPP in diminishing the ROC's presence. As a response, they have decided to organize their own flag-raising ceremony and event. What are your thoughts on this matter?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13018,
+        "fields": {
+            "priority": 0,
+            "description": "In these Joint Tickets negotiations, opinion polls are a crucial issue. There is considerable controversy surrounding the polling methods, agencies, and approaches during the election season. Given the significance of determining the presidential and vice-presidential candidates, public opinion polls play a crucial role. Your supporters are not fond of the polls from Formosa and Ettoday as they consistently place you below Hou You-yi. What are your thoughts on this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13019,
+        "fields": {
+            "priority": 0,
+            "description": "While there's no agreement on joint presidential and vice-presidential tickets, we can find common ground in legislative and local elections. This year, TPP has local candidates running for legislative seats. Without KMT's support, they may struggle. What's your approach to cooperating with KMT at non-presidential levels?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13020,
+        "fields": {
+            "priority": 0,
+            "description": "Recent developments in Terry Gou's campaign have garnered attention. He has successfully surpassed the required number of citizen signatures, but still relies on substantial financial resources to boost signature numbers and drive his campaign momentum. However, his poll numbers have been steadily declining. What is your stance on his campaign?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13021,
+        "fields": {
+            "priority": 0,
+            "description": "As November approaches, it's time for your national campaign headquarters to make its debut. We still have the flexibility to choose the specific location. In which major city among the six municipalities would you prefer to establish your campaign headquarters?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13022,
+        "fields": {
+            "priority": 0,
+            "description": "On November 15th, you attended a secret meeting with Eric Chu, Ma Ying-jeou, and Hou You-yi, signing an agreement to determine the presidential candidate through nationwide polls. The terms, stating that if the Ko-Hou poll is within the margin of error, it would be considered a victory for Hou You-yi, have sparked widespread speculation that you might accept the role of vice president. In tonight's news program, when asked why you made this decision, you responded...",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13023,
+        "fields": {
+            "priority": 0,
+            "description": "On November 18th, after intensive calculations and investigations, the polling experts designated by TPP and KMT are in intense discussions regarding the polling outcomes and margin of error. The final results are:",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13024,
+        "fields": {
+            "priority": 0,
+            "description": "As you succeed and unbelievably surpass both the KMT and Mayor Hou Yu-yi, it is crucial to manage your relationship with the KMT. Meanwhile, many core supporters also have reservations about the KMT. In order to ensure the longevity of this alliance, what do you hope to say or do to eliminate internal divisions caused by the alliance?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13025,
+        "fields": {
+            "priority": 0,
+            "description": "As each party finalizes their running mates, the DPP has selected Hsiao Bi-khim as the vice president. This signifies that the current Green-White showdown has completely taken shape! How do you plan to balance your campaign strategy and policies in response to this development?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13492,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou You-yi proposes that, considering his limited authority and influence as vice president, he would like to actively campaign for you across Taiwan to strengthen the TPP-KMT alliance's presence and support in various regions. Where do you think he should focus his efforts?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13026,
+        "fields": {
+            "priority": 0,
+            "description": "Some of your aides suggest that, following the tradition of KMT candidates, you add a small Republic of China (ROC) flag emblem on top of your KP badge to increase appeal to blue-leaning voters. Will you consider this suggestion?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13027,
+        "fields": {
+            "priority": 0,
+            "description": "Chairman Ko, in a recent interview with a newspaper, you discussed various policy details. Certainly, the TPP has many comprehensive policy ideas and visions. Among these policies, what do you like the most and what would you like to emphasize the most?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13028,
+        "fields": {
+            "priority": 0,
+            "description": "As the presidential election enters its final stage, some of your former green supporters have become disappointed due to your cooperation with the Kuomintang (KMT) and have left your camp. At the same time, some elderly blue camp voters find it difficult to accept a candidate with a deep-green background and may choose not to vote. In light of this situation, how do you plan to respond?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13029,
+        "fields": {
+            "priority": 0,
+            "description": "Chairman Ko, the opportunity for an attack has arrived!As the presidential election enters its final stage, it has been discovered that Lai Ching-te's ancestral home is found to have violated building regulations. Although this issue has been known for quite some time, it has only recently been sensationalized. This could be our only opportunity to undermine Lai Ching-te before the election. Do you want to pursue this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13030,
+        "fields": {
+            "priority": 0,
+            "description": "It seems that the DPP has launched a counterattack against your campaign. It was revealed that agricultural land you own in Hsinchu City, designated for specific agricultural and husbandry purposes, has been exposed during the presidential election for not being used for farming but rather illegally converted into a parking lot. The DPP is using this to attack your personal integrity, similar to Lai Ching-te's building violation controversy. How do you plan to respond?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13031,
+        "fields": {
+            "priority": 0,
+            "description": "In this year's presidential election, you and Lai Ching-te will engage in a one-on-one debate on the stage, which could be the most crucial moment in your life. The outcome of the debate is likely to influence public perception and generate significant media coverage. What would you like to emphasize the most in this debate?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13032,
+        "fields": {
+            "priority": 0,
+            "description": "In the final week before the election, you have the opportunity to visit specific regions nationwide to boost local support. In which areas do you hope to campaign in a final effort?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13033,
+        "fields": {
+            "priority": 0,
+            "description": "On the night of November 18th, as the people of Taiwan slept, in a dark and windy evening, polling experts from the TPP and KMT were nervously discussing issues related to the margin of error in the polls and the number of victories for each party. and The final results are.....",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13350,
+        "fields": {
+            "priority": 0,
+            "description": "On November 18th, another shocking news rocked the political scene: the KMT and TPP were embroiled in disputes within the margin of error in the polls, leading to conflicting victory claims. The TPP insisted on a margin of error of 3%, with a range of plus or minus 1.5%, while the KMT argued that each poll should be calculated based on its own determined maximum margin of error. For example, Formosa Poll indicated a maximum sampling error of ±3.0% at a 95% confidence level, totaling 6%. Now, at this crucial moment deciding Taiwan's fate, how do you perceive the negotiations reaching a deadlock?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13509,
+        "fields": {
+            "priority": 0,
+            "description": "On November 23rd, you and Terry Gou invited Mayor Hou Yu-yi to the Taipei Grand Hyatt to discuss the last hope for Joint Tickets. However, Mayor Hou Yu-yi brought President Ma Ying-jeou and Chairman Eric Chu to the scene, causing dissatisfaction from Terry Gou. Chairman Ko Wen-je, what points do you need to emphasize during the meeting?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13510,
+        "fields": {
+            "priority": 0,
+            "description": "As Joints Tickets completely failed, on November 24th, you unexpectedly chose legislator Cynthia Wu as the vice president. She is the daughter of a major business tycoon, bringing an impressive background to your campaign. Additionally, being an American-born Chinese (ABC), what special qualities do you see in her that led to your choice of her as the vice president?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13511,
+        "fields": {
+            "priority": 0,
+            "description": "November 24th, after you registered as a presidential candidate at the CEC, Hou Youyi called you, but you ignored it. An hour later, he teamed up with Zhao Shao-kang, the chairman of China Broadcasting Corporation, and other media figures to form the presidential and vice-presidential ticket. In the following days, many blue camp voters were emotionally stirred by this, and it seems that many blue voters who had temporarily supported you are returning to the KMT's base.....",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13512,
+        "fields": {
+            "priority": 0,
+            "description": "In this year's presidential election, there are three candidates on the stage: Hou from the KMT, you from the TPP, and Lai from the DPP. This will be your moment to showcase your debating skills in the presidential election. What do you want to emphasize during the debate?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13513,
+        "fields": {
+            "priority": 0,
+            "description": "Your vice president, Cynthia Wu, has many noteworthy qualities. Handing over the floor to her, what do you think she should say to attract voters?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13577,
+        "fields": {
+            "priority": 0,
+            "description": "This year's unprecedented presidential election features four candidates participating in a debate: yourself from the TPP, Hou from the KMT, Lai from the DPP, and the independent candidate Gou. Just a month ago, you suggested that Gou should withdraw from the election, but he did not consider this proposal and chose to run independently. In this debate, what main points would you like to emphasize?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13631,
+        "fields": {
+            "priority": 0,
+            "description": "In the final week before the election, you have the opportunity to visit specific regions nationwide to boost local support. In which areas do you hope to campaign in a final effort?",
+            "likelihood": 1
+        }
+    }
+]
+
+campaignTrail_temp.answers_json = [
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13034,
+        "fields": {
+            "question": 13004,
+            "description": "The Kuomintang (KMT) and the Democratic Progressive Party (DPP) are both mired in corruption. We must create a new chapter in Taiwan's political history. Please support the Taiwan People's Party (TPP) and let us write the records of Taiwan's history!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13035,
+        "fields": {
+            "question": 13004,
+            "description": "Nowadays, many young people cannot afford homes, the standard of living is declining, and prices and inflation are steadily rising. The DPP government has made their lives worse, but where is the accountability? The promises made in the past seem to have disappeared."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13036,
+        "fields": {
+            "question": 13004,
+            "description": "Ah, it's just that the two major parties have monopolized for too long, and the interest groups underneath have become deeply intertwined. The DPP has been in power for 8 years, and the rate of decay is even faster than the KMT. Taiwan cannot continue like this."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13037,
+        "fields": {
+            "question": 13004,
+            "description": "I guess that's how it is. Since the KMT doesn't have the ability to regain power and has given you two chances, but still can't defeat the DPP, what can be done? Only our TPP can do it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13047,
+        "fields": {
+            "question": 13005,
+            "description": "We plan to visit various regions of Taiwan to strengthen our visibility among voters. Many people in Taiwan have been dissatisfied with the political monopoly of the blue and green camps. We want to make them aware that there is a new choice this time!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13048,
+        "fields": {
+            "question": 13005,
+            "description": "We need to strengthen our online presence and ensure visibility on the internet. Let's focus on managing our YouTube channel effectively and create a buzz around supporting Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13049,
+        "fields": {
+            "question": 13005,
+            "description": "Strengthening our presence and offline organizations in major cities across the country is essential. Relying solely on online activities is virtual and misleading. Only by translating online supporters into real-life voters can we reap greater benefits."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13056,
+        "fields": {
+            "question": 13006,
+            "description": "Taiwan should act as a bridge for communication between the United States and China, rather than being a pawn. If I assume office, Taiwan can not only maintain a strong relationship with the United States but also work towards improving ties with China."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13057,
+        "fields": {
+            "question": 13006,
+            "description": "Do you know who I met? I met with Pompeo, Rosenberger, and Texas Governor Greg Abbott! This will bring me a lot of positive international coverage, letting Americans know that Taiwan's TPP is fighting for democracy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13058,
+        "fields": {
+            "question": 13006,
+            "description": "Of course, I held a banquet with Taiwanese students and young people in the United States to build connections. Every candidate comes to the U.S. for campaigning, so we must win the hearts and votes of young Taiwanese studying there."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13067,
+        "fields": {
+            "question": 13007,
+            "description": "My presence is aimed at breaking the blue-green barrier in Taiwan. Let's no longer be monopolized by the two major parties. Join me, Ko Wen-je, in moving towards a Taiwan characterized by integrity and clean new politics!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13068,
+        "fields": {
+            "question": 13007,
+            "description": "I have been collaborating and communicating with Hou You-yi. However, to be honest, his current poll numbers don't seem to be very promising, and it's uncertain what Guo Taiming's plans are for the future."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13076,
+        "fields": {
+            "question": 13006,
+            "description": "I visited major U.S. cities such as New York, San Francisco, Houston, etc., and connected with the local Taiwanese communities. I also had meetings with various congressmen and American political figures, undoubtedly enhancing my diplomatic experience."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13081,
+        "fields": {
+            "question": 13008,
+            "description": "Believe in the system, not individuals. When facing problems, think about how to address them within the system. The DPP should speed up their handling process. We have resolved similar issues quickly."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13083,
+        "fields": {
+            "question": 13008,
+            "description": "Our party has also had incidents of sexual harassment in the past, but we promptly addressed them. However, I do not support turning this issue into a political weapon!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13084,
+        "fields": {
+            "question": 13008,
+            "description": "The DPP claims every day that I harbor hatred towards women. Yet, their party is rife with sexual harassment cases. Do they really respect women? It's quite amusing. Before criticizing others, they should take a look at their own actions."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13097,
+        "fields": {
+            "question": 13009,
+            "description": "We will start selling some campaign-related merchandise, such as badges, flags, folders, and other accessories. This will provide us with a steady source of sales revenue."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13098,
+        "fields": {
+            "question": 13009,
+            "description": "I will ask my supporters for small donations, as little as 500 New Taiwan Dollars per person. The People's Party can make good use of these funds for an extended period because we are financially prudent and committed to preventing corruption."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13099,
+        "fields": {
+            "question": 13009,
+            "description": "Let's secretly reach out to some major corporations. We are the third party in Taiwan, but we have already surpassed the KMT in the polls. This is the best evidence that we might win. Let them know that we are a dark horse, and investing in us will be beneficial!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13100,
+        "fields": {
+            "question": 13009,
+            "description": "I have a great idea, let's organize a concert with Ko P singing personally. Set the ticket price at 8800 NTD, and this way, we can address a significant portion of our funding needs!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13113,
+        "fields": {
+            "question": 13010,
+            "description": "I heard that Lai Ching-te won't be coming here. It's truly laughable. If a governing party and its leader refuse to face the questions and challenges from the people, shouldn't they step down?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13114,
+        "fields": {
+            "question": 13010,
+            "description": "Arrange some people in the audience to boo when Hou You-yi speaks today. Let him know that young people don't appreciate the old-fashioned ways of the Kuomintang."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13115,
+        "fields": {
+            "question": 13010,
+            "description": "That's my place, and I will certainly give a speech. I'll strongly criticize the DPP and enhance my image. As long as I appear on stage, the enthusiasm among young people will soar."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13116,
+        "fields": {
+            "question": 13010,
+            "description": "Let's focus our attention on judicial reform and the pursuit of fairness and justice, avoiding turning it into a personal showcase. I don't want to be criticized for overly politicizing the parade."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13130,
+        "fields": {
+            "question": 13011,
+            "description": "We need to take over Lai Ching-te's light-green and moderate voters. The DPP government has been quite unpopular in recent years, as evident from the last local elections. My green background allows me to attract them."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13135,
+        "fields": {
+            "question": 13011,
+            "description": "I believe Chairman Guo has his own independence, but to secure victory, I must obtain his resources and supporters. This will ensure that I outperform Hou You-Yi and stand on equal footing with Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13136,
+        "fields": {
+            "question": 13011,
+            "description": "Of course, we choose to continue attracting Hou You-Yi's blue voters. Many deep-blue voters are dissatisfied with Hou You-Yi's relationship with Han Kuo-yu and even dislike his local Taiwanese image. Let me say something that resonates with deep-blue voters to draw them in."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13147,
+        "fields": {
+            "question": 13012,
+            "description": "Well, he insists on running for president? Haha, that makes Lai Ching-te even more secure, doesn't it? He's taking away votes from both me and Hou. Although everyone has the right to run in this society, we shouldn't be guaranteeing the DPP a third term, right?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13148,
+        "fields": {
+            "question": 13012,
+            "description": "I still have the highest and most powerful support in the current polls among the opposition candidates. We have a steady support base and continue to work hard. Let's focus on our own campaign strategy and not worry too much about Terry Gou for now."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13155,
+        "fields": {
+            "question": 13013,
+            "description": "TPP advocates for the establishment of an anti-media monopoly law to restore professionalism and independence to the media. It also calls for strict prohibition of political interference in public media. The fact is that the media has already been under the control of the blue and green camps, hasn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13156,
+        "fields": {
+            "question": 13013,
+            "description": "The alternation of parties should not result in a worse situation. This election is a showdown between corruption and integrity, old forces and new politics, and governing ability versus party interests. TPP is the strongest force transcending the blue and green camps!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13157,
+        "fields": {
+            "question": 13013,
+            "description": "I advocate for vigorously building social housing, reforming the tax system, and providing rent subsidies to tenants. The TPP has the ability and confidence to make housing affordable for young people, ensuring they can buy or rent a good place to live."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13158,
+        "fields": {
+            "question": 13013,
+            "description": "Lai Ching-te, do you dare to come out and declare that Taiwan will definitely be a non-nuclear homeland by 2025? Just saying this sentence guarantees you'll be criticized to death. Let's see if you dare to say it!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13170,
+        "fields": {
+            "question": 13014,
+            "description": "Certainly, I will focus on strengthening my presence in Taipei, where I served as mayor for eight years. Additionally, I will concentrate efforts in the neighboring New Taipei and Taoyuan. This region has a population of 5 million voters, and winning here is crucial for anyone aspiring to become president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13171,
+        "fields": {
+            "question": 13014,
+            "description": "I miss my mother. Let me go back to my hometown Hsinchu to take a look. We can also visit Miaoli. I believe I can gain many votes in this region, and there are also many young people here."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13172,
+        "fields": {
+            "question": 13014,
+            "description": "I think Tainan, Kaohsiung, Chiayi, and Pingtung are the most suitable places for me. I am also a local Taiwanese, so speaking Taiwanese is not a problem. Let's visit the southern region, which is the stronghold of the DPP, and see how we can gain support there!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13173,
+        "fields": {
+            "question": 13014,
+            "description": "The central region is an area where we need to strengthen our presence. Swing voters in places like Taichung, Changhua, Yunlin, and Nantou may find our platform appealing, so it's crucial for us to focus on strengthening our support in these areas."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13194,
+        "fields": {
+            "question": 13015,
+            "description": "Certainly, since they are visiting the United States, I will also make a trip there. I plan to make my second visit to the United States and participate in economic forums to increase my visibility."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13196,
+        "fields": {
+            "question": 13015,
+            "description": "let's engage with more senior citizens. I haven't been receiving much support from the elderly in the polls; the support rate among those aged 60-70 is almost zero. We can organize events at temples and market entrances, conducting on-site speeches to connect with them."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13197,
+        "fields": {
+            "question": 13015,
+            "description": "We should maximize our influence among the youth. I'll collaborate with online influencers and celebrities to add more vibrancy to my campaign."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13198,
+        "fields": {
+            "question": 13015,
+            "description": "Let's focus on the pan-blue voters dissatisfied with Hou and Terry Gou, as well as the swing voters. The DPP has performed poorly in recent years, and we should be able to welcome them into our camp, shouldn't we?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13213,
+        "fields": {
+            "question": 13016,
+            "description": "In fact, I don't want to form an alliance. It would damage my new political image, and I don't want any association with the KMT, okay? I intend to win the election on my own merits and strength!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13214,
+        "fields": {
+            "question": 13016,
+            "description": "Let's propose a demand to the KMT – let the victory or defeat be determined by the comprehensive results of various polls. Given our current advantage in the polls, this is advantageous for us and places the KMT in an embarrassing position."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13225,
+        "fields": {
+            "question": 13016,
+            "description": "Ah, Mayor Hou, with your low poll numbers, why don't you just withdraw from the election? Anyway, I'll give it to you, and you won't win!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13230,
+        "fields": {
+            "question": 13017,
+            "description": "Honestly, I don't want to associate with Lai Ching-te and Tsai Ing-wen. I won't attend this year's National Day celebration. How about organizing our own National Day event?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13231,
+        "fields": {
+            "question": 13017,
+            "description": "National Day should be a day of unity for the entire nation. However, the controversies surrounding Taiwan National Day have led many citizens to feel like outsiders in the national celebration. Taiwan is currently facing a severe crisis of identity, where right and wrong become blurred by political colors. When will such situations come to an end?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13232,
+        "fields": {
+            "question": 13017,
+            "description": "Alright, I'll go to the National Day celebration after all. After all, it's the country's birthday and commemoration day. However, I don't need to attack the KMT; they have their own autonomy."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13247,
+        "fields": {
+            "question": 13018,
+            "description": "We need to emphasize the stereotypical impression voters have. Young people are not fond of using landline phones anymore, yet Formosa's polls persist with 100% reliance on landline calls. When will they start adopting mobile survey methods? Landline polls are unreliable!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13248,
+        "fields": {
+            "question": 13018,
+            "description": "We respect these polls and the results they produce. However, some seem to be a bit outrageous, don't they? It's evident that I am the strongest opposition candidate, yet they place me below Hou You-yi. What's going on?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13249,
+        "fields": {
+            "question": 13018,
+            "description": "Hey, compared to those polls using both mobile and landline phones, street interviews with passersby are the most accurate and genuine, right? We record the entire process, asking voters for their most authentic opinions – much more accurate than any phone polls!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13262,
+        "fields": {
+            "question": 13019,
+            "description": "We can consider fielding candidates in deep-green constituencies where both KMT and TPP might lack sufficient strength. Areas like Luzhou, Sanchong in New Taipei City, and the coastal line of Taichung could be targeted for TPP candidates, enhancing our chances in opposition."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13263,
+        "fields": {
+            "question": 13019,
+            "description": "I hope KMT can support TPP in those challenging constituencies by endorsing our legislators and candidates. As it's widely known, their support can enhance our local campaign capabilities and visibility. Even if we don't secure a victory, it can help lay the groundwork for future endeavors."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13264,
+        "fields": {
+            "question": 13019,
+            "description": "I'd like to issue a warning to the KMT. I have the ability to divert pan-blue votes and potentially cause their legislators to lose. If each TPP candidate in every district takes away 5% of the KMT votes, how many KMT candidates would end up losing?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13277,
+        "fields": {
+            "question": 13020,
+            "description": "He has consistently insisted on becoming the president, pushing for me to step back as the vice president. This is, of course, impossible. The TPP is my party, right? I am the party chairman, while he doesn't even have party membership. In any case, I cannot be his deputy, as it would mean betrayal of my support base and political suicide."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13278,
+        "fields": {
+            "question": 13020,
+            "description": "Why bother about his campaign? Even if they present a decent vice presidential candidate, his polling numbers are barely reaching 10% in various polls. If he persists in continuing the election, there seems to be no hope, right? I think he will withdraw from the race."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13283,
+        "fields": {
+            "question": 13021,
+            "description": "Certainly, it will be in my home base, Taipei City. I've been the mayor here for so long, and being the capital, it holds significant importance."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13284,
+        "fields": {
+            "question": 13021,
+            "description": "I want to go to Taoyuan City, a place with many young people and emerging high-tech industries. I will be very popular here and let the people of Taoyuan know that Ko Wen-je has noticed them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13285,
+        "fields": {
+            "question": 13021,
+            "description": "I want to compete with Hou You-yi on his turf. Let's set up the campaign headquarters in New Taipei City, a battleground state. We aim to secure the most votes in this city with the largest population nationwide!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13286,
+        "fields": {
+            "question": 13021,
+            "description": "Let's go to Taichung, the famous swing state. This is a crucial city, and if we can't secure victories in the deep blue or deep green north and south, let's explore our opportunities in the central region!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13295,
+        "fields": {
+            "question": 13022,
+            "description": "I dislike the KMT, but I hate the DPP even more. It's as simple as that. I aim to bring down the DPP, complete Taiwan's democratic reform, and prevent one party from dominating indefinitely."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13296,
+        "fields": {
+            "question": 13022,
+            "description": "Let me tell you, under our supervision,KMT won't be as corrupt as before. Our primary role is oversight and checks and balances. In the future coalition government, we will monitor each other, preventing corruption from happening."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13298,
+        "fields": {
+            "question": 13022,
+            "description": "I often say that I make decisions in the last 30 seconds; it's a habit from my medical profession. Therefore, I won't make such decisions until the very last moment. I have thought about it extensively."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13302,
+        "fields": {
+            "question": 13023,
+            "description": "I have always claimed to be the strongest candidate in the opposition, and that's why I agreed to participate in this competition, isn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13303,
+        "fields": {
+            "question": 13023,
+            "description": "I have always claimed to be the strongest candidate in the opposition, and that's why I agreed to participate in this competition, isn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13304,
+        "fields": {
+            "question": 13023,
+            "description": "I have always claimed to be the strongest candidate in the opposition, and that's why I agreed to participate in this competition, isn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13305,
+        "fields": {
+            "question": 13023,
+            "description": "I have always claimed to be the strongest candidate in the opposition, and that's why I agreed to participate in this competition, isn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13322,
+        "fields": {
+            "question": 13033,
+            "description": "As long as Uncle Ko doesn't step back, we'll stand by him with unwavering support, okay? Let's not be disheartened, everyone."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13323,
+        "fields": {
+            "question": 13033,
+            "description": "As long as Uncle Ko doesn't step back, we'll stand by him with unwavering support, okay? Let's not be disheartened, everyone."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13324,
+        "fields": {
+            "question": 13033,
+            "description": "As long as Uncle Ko doesn't step back, we'll stand by him with unwavering support, okay? Let's not be disheartened, everyone."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13325,
+        "fields": {
+            "question": 13024,
+            "description": "I have long advocated that Taiwan should not be trapped in the quagmire of the blue-green political struggle. We need to unite the maximum and largest public opinion to jointly usher in a new era of politics and a coalition government, perhaps even under a cabinet system leadership. Currently, what we most need is to dismantle the dominance of a single party and the unchecked power of the DPP."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13326,
+        "fields": {
+            "question": 13024,
+            "description": "The DPP government has been deceiving the people, hasn't it? Tsai Ing-wen has not held a press conference for over 700 days and refuses to answer the people's questions. In Taiwan, being president seems more enjoyable than being an emperor. We didn't choose a president; we chose an emperor."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13327,
+        "fields": {
+            "question": 13024,
+            "description": "Hou You-yi is not a bad person, I believe he wouldn't engage in corruption. He just lacks a bit of personal charisma, that's all. Moreover, the position of vice president suits him well. He can help me gain more points on issues related to public safety and national security!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13341,
+        "fields": {
+            "question": 13033,
+            "description": "As long as Uncle Ko doesn't step back, we'll stand by him with unwavering support, okay? Let's not be disheartened, everyone."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13351,
+        "fields": {
+            "question": 13350,
+            "description": "KMT is quite amusing. Despite being a century-old party, they now need me to determine the margin of error. Let's make it clear: I've given you the opportunity to choose, and you still can't win!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13352,
+        "fields": {
+            "question": 13350,
+            "description": "Did you hear that? The Kuomintang wants me to concede a 6% margin in the polls. This could mean up to 800,000 votes. Mayor Hou, on January 13th, Lai Ching-te won't be conceding to you!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13353,
+        "fields": {
+            "question": 13350,
+            "description": "Well, it's probably best for us to go our own way and refrain from further negotiations. Due to the incessant disputes over the polls, we don't have the luxury of time for more disruptions. I've decided that I must independently run for election and defeat the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13361,
+        "fields": {
+            "question": 13022,
+            "description": "(On the show, I need to maintain the appearance that things are proceeding as usual. In reality, we only aim to run independently and secure a standalone victory. We don't need to be with the KMT!)"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13370,
+        "fields": {
+            "question": 13025,
+            "description": "To be honest, deep down, I am fundamentally pro-Green. However, the DPP has gone too far in recent years, causing even someone like me, who used to support the DPP, to leave. So, the DPP really needs to reflect on its actions!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13371,
+        "fields": {
+            "question": 13025,
+            "description": "I've made it clear that I will continue with Tsai Ing-wen's approach in diplomacy and national defense. Please note, that cross-strait relations are not included; there will be a shift from Tsai Ing-wen's approach in that regard."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13372,
+        "fields": {
+            "question": 13025,
+            "description": "We don't need to lean towards the Green camp; the DPP's base is around 40%, which we can't easily capture. Instead, let's focus on strengthening our core supporters, who may be somewhat disappointed due to my collaboration with the KMT. We'll launch an online TV channel called KPTV and encourage supporters to subscribe and watch!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13374,
+        "fields": {
+            "question": 13025,
+            "description": "I'll work on enhancing my appeal to the deep-blue and pro-unification voters. Many of them are dissatisfied with Hou You-yi but might support me. I'll make joint appearances with Chiu Yi in campaign events!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13388,
+        "fields": {
+            "question": 13026,
+            "description": "Of course, expressing love for our country is perfectly normal. I will continue to wear this small national flag emblem in future events."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13389,
+        "fields": {
+            "question": 13026,
+            "description": "No, I don't want that. I still want to maintain some distance from the KMT. I don't want to be perceived entirely as a KMT candidate, and I don't need to follow their trends. New politics belong to us, and there's no need to imitate the KMT."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13390,
+        "fields": {
+            "question": 13026,
+            "description": "Not only should we add the emblem, but let's also mobilize young people to hit the streets with flags for promotion. We'll prominently use national flags in our campaign rallies and events. Patriotism is nothing to be ashamed of!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13401,
+        "fields": {
+            "question": 13027,
+            "description": "I advocate maintaining an attitude of mutual understanding, mutual respect, cooperation, and mutual forgiveness in cross-strait relations. I am a candidate acceptable to both mainland China and the United States, rather than being overly pro-China or pro-America like the KMT and DPP."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13402,
+        "fields": {
+            "question": 13027,
+            "description": "Honestly, I opposed nuclear power ten years ago. Now I'm reconsidering due to the high electricity demand from our semiconductor industry. If there's no better solution, this less-than-ideal method may be the best choice for now. Extending the life of nuclear power plants is because renewable energy can't meet the demand."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13403,
+        "fields": {
+            "question": 13027,
+            "description": "I certainly support vigorously constructing social housing, changing the tax system, and altering tenant subsidies. I believe rental income should be taxed separately, so I think the policies of both the blue and green parties have issues! The problem lies in housing prices! It's pitiful not being able to afford a house, and it's even more pitiful after buying one. Becoming a homeowner for a lifetime means being a mortgage slave, constantly paying off the mortgage throughout one's life!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13414,
+        "fields": {
+            "question": 13028,
+            "description": "They can go wherever they want; we are now the largest force in Taiwan's mainstream public opinion. If someone is willing to give up the opportunity to overthrow the DPP government just because they won't vote, so be it! It will only purify my supporters even more!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13419,
+        "fields": {
+            "question": 13029,
+            "description": "Lai Ching-te, you truly are a candidate lacking integrity. I don't understand why so many people are still willing to support you. If you're unwilling to demolish an illegally constructed building, how can we expect you to bring any positive change to Taiwan?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13420,
+        "fields": {
+            "question": 13029,
+            "description": "Lai Ching-te's moral standards are really low. Many others have been involved in illegal constructions, and they've been demolished. my mother did it, Huang Kuo-chang did it, Su Jia-chyuan did it, Han Kuo-yu did it. Why are you the only one not willing to do so? Your attitude is arrogant, and this person is likely to become a dictator. Therefore, he is not suitable to be president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13421,
+        "fields": {
+            "question": 13029,
+            "description": "Lai Ching-te, can't you just demolish your own house? This issue will definitely be exploited, so it's better to bear the pain and take it down. Why shed tears? It's strange; I can't understand that."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13436,
+        "fields": {
+            "question": 13030,
+            "description": "Alright, alright, Lai Ching-te. You should hold yourself to the highest standards regarding your building violation. I will immediately arrange for an excavator to demolish my parking lot. Are you brave enough to take the same action for your building violation?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13437,
+        "fields": {
+            "question": 13030,
+            "description": "You're absolutely right, I made a mistake. I improperly used agricultural land, and I will immediately dismantle it. Moreover, I'll replant it with guava and bananas. That's the right way to handle it, isn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13438,
+        "fields": {
+            "question": 13030,
+            "description": "Alright, alright, not only will I dismantle the parking lot, but I'll also donate all the proceeds from this parking lot to charity. Is that satisfactory for you? Are you pleased now?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13449,
+        "fields": {
+            "question": 13031,
+            "description": "2024 election is a historic choice for the people of Taiwan. Do we want to choose a new political direction or stick with the old power structures? Are we opting for transparency, diligent governance, pragmatism, and a love for our homeland, or are we embracing ideology and governing through slogans?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13450,
+        "fields": {
+            "question": 13031,
+            "description": "Lai Ching-te and the DPP have once again demonstrated what deceit and smear tactics mean. They claim a fiscal surplus in their government, but in reality, it's because they treat loans as income and exclude special budget expenditures, creating a significant surplus. This is truly laughable – are they suggesting that these loans won't need to be repaid in the future?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13451,
+        "fields": {
+            "question": 13031,
+            "description": "Since 2000, Taiwan has witnessed a continuous change in political power, with the blue and green camps taking turns in office. Many believed that the DPP and the Tsai Ing-wen government would bring a humble administration. However, eight years have passed, and the issues left behind during the Ma Ying-jeou era remain unresolved. Moreover, the DPP government has been plagued by corruption. Is this an improvement?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13452,
+        "fields": {
+            "question": 13031,
+            "description": "Lai Ching-te, stop using double standards. When you want to utilize KMT county and city mayors, you praise them as local gentry and heroes. When you don't need them, you label them as members of black gold conglomerates. Let me tell you, your President Tsai Ing-wen has probably taken more photos with these county and city mayors than I have. What do you have to say about that?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13469,
+        "fields": {
+            "question": 13032,
+            "description": "We aim to strengthen our support in the traditional blue camp strongholds of the East Coast and outlying islands. While everyone is focused on the fierce battlegrounds in Taipei, Taichung, and the southern regions, where public opinion is unpredictable, let's secure stable support in Hualien, Taidong, Yilan, Penghu, Kinmen, and Matsu!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13470,
+        "fields": {
+            "question": 13032,
+            "description": "We need to strengthen our hold on Taipei City, where I served as mayor; I cannot afford to lose it. At the same time, we'll compete with Lai Ching-te in New Taipei!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13471,
+        "fields": {
+            "question": 13032,
+            "description": "Changhua, Taichung, and Nantou are the battlegrounds where we need to put in the most effort. Let's strive in these areas and secure a stable stronghold. Victory will be ours tomorrow!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13479,
+        "fields": {
+            "question": 13032,
+            "description": "Let's work hard to increase voter support in my hometown, Hsinchu. If there's one place where my support base is equivalent to both the blue and green camps nationwide, it's Hsinchu. I hope to achieve victory here!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13493,
+        "fields": {
+            "question": 13492,
+            "description": "Mayor Hou, spending a month in Chiayi is a great idea. I believe our support in Chiayi and Yunlin can increase significantly, especially considering that it's your hometown."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13494,
+        "fields": {
+            "question": 13492,
+            "description": "Kaohsiung and Tainan have a large population, so it makes sense to visit these two major cities. Your proficiency in Taiwanese will allow you to connect well with the locals!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13495,
+        "fields": {
+            "question": 13492,
+            "description": "Please help me increase support in your New Taipei City; you don't need to go anywhere else. New Taipei City is a crucial battleground, and we must win it!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13496,
+        "fields": {
+            "question": 13492,
+            "description": "Mayor Hou, please help me with some publicity in Pingtung and Yilan! These are areas with a significant number of Minnan people and strong support for the DPP. I entrust you to carry out the promotion in these regions!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13514,
+        "fields": {
+            "question": 13509,
+            "description": "Mayor Hou, I really didn't expect that you would bring two nannys with you for the election. What does this mean? Can't you make decisions on your own without Chairman Chu and President Ma?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13515,
+        "fields": {
+            "question": 13509,
+            "description": "As a leader, Mayor Hou should have the ability to face difficulties independently. The main purpose of the cooperation between the blue and white camps is to win the election. Do you insist that the Hou-Ko ticket is the strongest combination?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13516,
+        "fields": {
+            "question": 13509,
+            "description": "Chairman Guo, since you are unable to achieve integration now, why not simply withdraw from the election? Are you going to register tomorrow? We already have enough issues within the opposition camp."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13522,
+        "fields": {
+            "question": 13509,
+            "description": "Chairman Guo, since you are unable to achieve integration now, why not simply withdraw from the election? Are you going to register tomorrow? We already have enough issues within the opposition camp."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13533,
+        "fields": {
+            "question": 13510,
+            "description": "She possesses excellent manners and a very graceful image. She is also the candidate that our People's Party needs, capable of attracting more female voters for me. Together, we will have a perfect gender balance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13534,
+        "fields": {
+            "question": 13510,
+            "description": "Of course, it's her international background and fluent English. She speaks English even better than native born Americans, which can be advantageous for TPP and Taiwan's participation in more international conferences, boosting our visibility. This is truly fantastic!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13535,
+        "fields": {
+            "question": 13510,
+            "description": "She is the daughter from the Shin Kong Financial Holding Co., Ltd., I know I can leverage her family connections to secure more campaign funds... which is currently scarce for us."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13548,
+        "fields": {
+            "question": 13511,
+            "description": "Oh, that old guy who ran for mayor in 1994? He's even older than me. Can he really mobilize so many blue camp voters? I find it hard to believe. Anyway, let's stabilize our own pace to secure an independent victory."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13550,
+        "fields": {
+            "question": 13511,
+            "description": "He chose to be the vice president. When is he going to resign from his position as chairman of the broadcasting company? It's embarrassing. Instead of focusing on media affairs, he's running to rescue Hou You-yi's campaign. No matter how you look at it, Zhao Shao-kang seems to be here to play the role of a nanny!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13558,
+        "fields": {
+            "question": 13512,
+            "description": "On the issue of the death penalty, I believe that since the time of Emperor Gaozu of Han, who established the Three Chapter Covenant with the people, the tradition in Chinese culture has been clear: those who commit murder shall face the penalty of death. If we are to abolish the death penalty, then we must introduce a system of life imprisonment, ensuring that criminals are not released after serving just a few years."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13559,
+        "fields": {
+            "question": 13512,
+            "description": "Since 2000, Taiwan has witnessed a continuous change in political power, with the blue and green camps taking turns in office. Many believed that the DPP and the Tsai Ing-wen government would bring a humble administration. However, eight years have passed, and the issues left behind during the Ma Ying-jeou era remain unresolved. Moreover, the DPP government has been plagued by corruption. Is this an improvement?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13560,
+        "fields": {
+            "question": 13512,
+            "description": "Lai Ching-te and the DPP have once again demonstrated what deceit and smear tactics mean. They claim a fiscal surplus in their government, but in reality, it's because they treat loans as income and exclude special budget expenditures, creating a significant surplus. This is truly laughable – are they suggesting that these loans won't need to be repaid in the future?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13561,
+        "fields": {
+            "question": 13512,
+            "description": "Mayor Hou, I would like to ask you, why is China conducting so many fake polls to boost your campaign? What is your relationship with China? What's going on?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13578,
+        "fields": {
+            "question": 13513,
+            "description": "Blackcurrant soda, beer, guava juice, and Johnny Walker are all common beverages at our Chinese banquets, especially Johnny Walker, representing the spirit of Taiwanese people looking forward and the determination that one must strive to win. Isn't that right?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13583,
+        "fields": {
+            "question": 13513,
+            "description": "She criticized that the ECFA and trade in services agreements were \"blocked by the green camp,\" leading to restrictions in Taiwan's youth job market. She expressed dissatisfaction with the blue and green camps' efforts to boost the economy but questioned why Taiwan's economy had not improved over the past eight years. She repeatedly challenged, \"Can't you (referring to the ruling party) even copy (policy proposals)?\""
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13587,
+        "fields": {
+            "question": 13513,
+            "description": "She will criticize the DPP and their policies, stating that wrong policies are as frightening as corruption. These policies have made it difficult for young people to earn money, buy houses, and have led to shortages in various aspects of life, such as money, electricity, eggs, and vaccines. \"Shortage\" has become a keyword for the year 2023."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13591,
+        "fields": {
+            "question": 13513,
+            "description": "The government must adhere to more rigorous fiscal discipline so that we don't leave debts for future generations. We also reject burdening Taiwan with debts and advocate for strengthening fiscal reforms to safeguard the hard-earned money of the people."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13602,
+        "fields": {
+            "question": 13577,
+            "description": "Lai Ching-te, not tearing down your illegal construction is truly hurting the hearts of the Taiwanese people. You are about to become the president, yet you still cherish your house so much. Where is the democracy and progressiveness in your party?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13603,
+        "fields": {
+            "question": 13577,
+            "description": "Mayor Hou, the rent for your building is so high, huh? The students living there have emptied their wallets because of you. Can't you lower the rent a bit?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13604,
+        "fields": {
+            "question": 13577,
+            "description": "Chairman Guo has been talking about forming an opposition alliance and bringing down the DPP together. Now, he's unexpectedly running independently. I really didn't expect Chairman Guo to be such an untrustworthy person."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13605,
+        "fields": {
+            "question": 13577,
+            "description": "I believe the facts are clear. I am the most capable and eloquent candidate in the opposition. Both Mayor Hou and Chairman Guo cannot match me. I am confident that in debates and future elections, I am the one who can defeat Lai Ching-te. Please support me!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13632,
+        "fields": {
+            "question": 13631,
+            "description": "We aim to strengthen our support in the traditional blue camp strongholds of the East Coast and outlying islands. While everyone is focused on the fierce battlegrounds in Taipei, Taichung, and the southern regions, where public opinion is unpredictable, let's secure stable support in Hualien, Taidong, Yilan, Penghu, Kinmen, and Matsu!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13633,
+        "fields": {
+            "question": 13631,
+            "description": "We need to strengthen our hold on Taipei City, where I served as mayor; I cannot afford to lose it. At the same time, we'll compete with Lai Ching-te in New Taipei!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13634,
+        "fields": {
+            "question": 13631,
+            "description": "Changhua, Taichung, and Nantou are the battlegrounds where we need to put in the most effort. Let's strive in these areas and secure a stable stronghold. Victory will be ours tomorrow!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13635,
+        "fields": {
+            "question": 13631,
+            "description": "Let's work hard to increase voter support in my hometown, Hsinchu. If there's one place where my support base is equivalent to both the blue and green camps nationwide, it's Hsinchu. I hope to achieve victory here!"
+        }
+    }
+]
+
+
+campaignTrail_temp.states_json = [
+    {
+        "model": "campaign_trail.state",
+        "pk": 251,
+        "fields": {
+            "name": "Tainan City",
+            "abbr": "Tainancity",
+            "electoral_votes": 1,
+            "popular_votes": 1120238,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 252,
+        "fields": {
+            "name": "Kaohsiung City",
+            "abbr": "Kaohsiungcity",
+            "electoral_votes": 1,
+            "popular_votes": 1636962,
+            "poll_closing_time": 180,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 253,
+        "fields": {
+            "name": "Pingtung County",
+            "abbr": "Pingtung",
+            "electoral_votes": 1,
+            "popular_votes": 475927,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 254,
+        "fields": {
+            "name": "Taidong County",
+            "abbr": "Taidong",
+            "electoral_votes": 1,
+            "popular_votes": 109941,
+            "poll_closing_time": 75,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 255,
+        "fields": {
+            "name": "Hualien County",
+            "abbr": "Hualien",
+            "electoral_votes": 1,
+            "popular_votes": 174157,
+            "poll_closing_time": 90,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 256,
+        "fields": {
+            "name": "Chiayi County",
+            "abbr": "ChiayiCounty",
+            "electoral_votes": 1,
+            "popular_votes": 292534,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 257,
+        "fields": {
+            "name": "Chiayi City",
+            "abbr": "ChiayiCity",
+            "electoral_votes": 1,
+            "popular_votes": 157656,
+            "poll_closing_time": 80,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 258,
+        "fields": {
+            "name": "Nantou County",
+            "abbr": "Nantou",
+            "electoral_votes": 1,
+            "popular_votes": 287296,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 259,
+        "fields": {
+            "name": "Yunlin County",
+            "abbr": "Yunlin",
+            "electoral_votes": 1,
+            "popular_votes": 380619,
+            "poll_closing_time": 130,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 260,
+        "fields": {
+            "name": "Changhua County",
+            "abbr": "Changhua",
+            "electoral_votes": 1,
+            "popular_votes": 741368,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 261,
+        "fields": {
+            "name": "Penghu County",
+            "abbr": "Penghu",
+            "electoral_votes": 1,
+            "popular_votes": 49277,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 262,
+        "fields": {
+            "name": "Taichung City",
+            "abbr": "Taichung",
+            "electoral_votes": 1,
+            "popular_votes": 1707203,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 263,
+        "fields": {
+            "name": "Yilan County",
+            "abbr": "Yilan",
+            "electoral_votes": 1,
+            "popular_votes": 267129,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 264,
+        "fields": {
+            "name": "Hsinchu County",
+            "abbr": "HsinchuCounty",
+            "electoral_votes": 1,
+            "popular_votes": 340310,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 265,
+        "fields": {
+            "name": "Hsinchu City",
+            "abbr": "HsinchuCity",
+            "electoral_votes": 1,
+            "popular_votes": 266389,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 266,
+        "fields": {
+            "name": "Miaoli County",
+            "abbr": "Miaoli",
+            "electoral_votes": 1,
+            "popular_votes": 318665,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 267,
+        "fields": {
+            "name": "New Taipei City",
+            "abbr": "Newtaipei",
+            "electoral_votes": 1,
+            "popular_votes": 2458480,
+            "poll_closing_time": 225,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 268,
+        "fields": {
+            "name": "Taipei City",
+            "abbr": "Taipei",
+            "electoral_votes": 1,
+            "popular_votes": 1542009,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 269,
+        "fields": {
+            "name": "Taoyuan City",
+            "abbr": "Taoyuan",
+            "electoral_votes": 1,
+            "popular_votes": 1350792,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 270,
+        "fields": {
+            "name": "Keelung City",
+            "abbr": "Keelung",
+            "electoral_votes": 1,
+            "popular_votes": 218781,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 271,
+        "fields": {
+            "name": "Kinmen County",
+            "abbr": "Kinmen",
+            "electoral_votes": 1,
+            "popular_votes": 45612,
+            "poll_closing_time": 70,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 272,
+        "fields": {
+            "name": "Lienchiang County",
+            "abbr": "Matsu",
+            "electoral_votes": 1,
+            "popular_votes": 6159,
+            "poll_closing_time": 50,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.issues_json = [
+    {
+        "model": "campaign_trail.issue",
+        "pk": 32,
+        "fields": {
+            "name": "Party coalition",
+            "description": 0,
+            "stance_1": "Deep Green",
+            "stance_desc_1": 0,
+            "stance_2": "Green",
+            "stance_desc_2": 0,
+            "stance_3": "Light Green",
+            "stance_desc_3": 0,
+            "stance_4": "Neutral",
+            "stance_desc_4": 0,
+            "stance_5": "Light Blue",
+            "stance_desc_5": 0,
+            "stance_6": "Blue",
+            "stance_desc_6": 0,
+            "stance_7": "Deep Blue",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 33,
+        "fields": {
+            "name": "Provincial differences",
+            "description": 0,
+            "stance_1": "Mostly Taiwanese",
+            "stance_desc_1": 0,
+            "stance_2": "Taiwanese and Hakka mixed",
+            "stance_desc_2": 0,
+            "stance_3": "Taiwanese,Hakka,Mainlanders mixed",
+            "stance_desc_3": 0,
+            "stance_4": "mixing of ethnic groups",
+            "stance_desc_4": 0,
+            "stance_5": "Aboriginal",
+            "stance_desc_5": 0,
+            "stance_6": "Taiwanese Hakka(Northern)",
+            "stance_desc_6": 0,
+            "stance_7": "Mostly Mainlanders",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 34,
+        "fields": {
+            "name": "Urban/rural differences",
+            "description": 0,
+            "stance_1": "Townships Rural",
+            "stance_desc_1": 0,
+            "stance_2": "Small towns and large towns",
+            "stance_desc_2": 0,
+            "stance_3": "Small cities and towns",
+            "stance_desc_3": 0,
+            "stance_4": "Medium-sized city",
+            "stance_desc_4": 0,
+            "stance_5": "Groups of Small Cities",
+            "stance_desc_5": 0,
+            "stance_6": "Large Cities",
+            "stance_desc_6": 0,
+            "stance_7": "Capitals",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 35,
+        "fields": {
+            "name": "Young population",
+            "description": 0,
+            "stance_1": "Very little",
+            "stance_desc_1": 0,
+            "stance_2": "Little",
+            "stance_desc_2": 0,
+            "stance_3": "Less",
+            "stance_desc_3": 0,
+            "stance_4": "Normal level",
+            "stance_desc_4": 0,
+            "stance_5": "Relatively much more",
+            "stance_desc_5": 0,
+            "stance_6": "Large young population",
+            "stance_desc_6": 0,
+            "stance_7": "Younger society",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 36,
+        "fields": {
+            "name": "Feelings about DPP Government",
+            "description": 0,
+            "stance_1": "DPP is the best!",
+            "stance_desc_1": 0,
+            "stance_2": "That's what we like!",
+            "stance_desc_2": 0,
+            "stance_3": "Pro-DPP",
+            "stance_desc_3": 0,
+            "stance_4": "no feelings for the DPP",
+            "stance_desc_4": 0,
+            "stance_5": "Hate green governance",
+            "stance_desc_5": 0,
+            "stance_6": "Mosquitoes, cockroaches, and the DPP",
+            "stance_desc_6": 0,
+            "stance_7": "Never support the Taiwan Independence Party!!",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.state_issue_score_json = [
+    //台北市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191111,
+        "fields": {
+            "state": 268,
+            "issue": 32,
+            "state_issue_score": 0.22,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191112,
+        "fields": {
+            "state": 268,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191113,
+        "fields": {
+            "state": 268,
+            "issue": 34,
+            "state_issue_score": 1,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191114,
+        "fields": {
+            "state": 268,
+            "issue": 35,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191115,
+        "fields": {
+            "state": 268,
+            "issue": 36,
+            "state_issue_score": 0.1,
+            "weight": 0.5
+        }
+    },
+    //新北市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191116,
+        "fields": {
+            "state": 267,
+            "issue": 32,
+            "state_issue_score": 0.15,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191117,
+        "fields": {
+            "state": 267,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191118,
+        "fields": {
+            "state": 267,
+            "issue": 34,
+            "state_issue_score": 0.65,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191119,
+        "fields": {
+            "state": 267,
+            "issue": 35,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191120,
+        "fields": {
+            "state": 267,
+            "issue": 36,
+            "state_issue_score": 0.0,
+            "weight": 0.5
+        }
+    },
+    //桃园市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191121,
+        "fields": {
+            "state": 269,
+            "issue": 32,
+            "state_issue_score": 0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191122,
+        "fields": {
+            "state": 269,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191122,
+        "fields": {
+            "state": 269,
+            "issue": 34,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191123,
+        "fields": {
+            "state": 269,
+            "issue": 35,
+            "state_issue_score": 0.75,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191124,
+        "fields": {
+            "state": 269,
+            "issue": 36,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    //新竹市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191125,
+        "fields": {
+            "state": 265,
+            "issue": 32,
+            "state_issue_score": 0.4,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191126,
+        "fields": {
+            "state": 265,
+            "issue": 33,
+            "state_issue_score": -0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191127,
+        "fields": {
+            "state": 265,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191128,
+        "fields": {
+            "state": 265,
+            "issue": 35,
+            "state_issue_score": 0.65,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191129,
+        "fields": {
+            "state": 265,
+            "issue": 36,
+            "state_issue_score": 0.35,
+            "weight": 0.5
+        }
+    },
+    //基隆市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191130,
+        "fields": {
+            "state": 270,
+            "issue": 32,
+            "state_issue_score": 0.5,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191131,
+        "fields": {
+            "state": 270,
+            "issue": 33,
+            "state_issue_score": 0.1,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191132,
+        "fields": {
+            "state": 270,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191133,
+        "fields": {
+            "state": 270,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191134,
+        "fields": {
+            "state": 270,
+            "issue": 36,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    //新竹县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191135,
+        "fields": {
+            "state": 264,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191136,
+        "fields": {
+            "state": 264,
+            "issue": 33,
+            "state_issue_score": 0.45,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191137,
+        "fields": {
+            "state": 264,
+            "issue": 34,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191138,
+        "fields": {
+            "state": 264,
+            "issue": 35,
+            "state_issue_score": 0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191139,
+        "fields": {
+            "state": 264,
+            "issue": 36,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    //苗栗縣
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191140,
+        "fields": {
+            "state": 266,
+            "issue": 32,
+            "state_issue_score": 0.85,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191141,
+        "fields": {
+            "state": 266,
+            "issue": 33,
+            "state_issue_score": 0.55,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191142,
+        "fields": {
+            "state": 266,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191143,
+        "fields": {
+            "state": 266,
+            "issue": 35,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191144,
+        "fields": {
+            "state": 266,
+            "issue": 36,
+            "state_issue_score": 0.85,
+            "weight": 0.5
+        }
+    },
+    //宜兰县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191145,
+        "fields": {
+            "state": 263,
+            "issue": 32,
+            "state_issue_score": -0.45,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191146,
+        "fields": {
+            "state": 263,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191147,
+        "fields": {
+            "state": 263,
+            "issue": 34,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191148,
+        "fields": {
+            "state": 263,
+            "issue": 35,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191149,
+        "fields": {
+            "state": 263,
+            "issue": 36,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    //台中市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191150,
+        "fields": {
+            "state": 262,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191151,
+        "fields": {
+            "state": 262,
+            "issue": 33,
+            "state_issue_score": 0,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191152,
+        "fields": {
+            "state": 262,
+            "issue": 34,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191154,
+        "fields": {
+            "state": 262,
+            "issue": 35,
+            "state_issue_score": 0.35,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191155,
+        "fields": {
+            "state": 262,
+            "issue": 36,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    //南投县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191156,
+        "fields": {
+            "state": 258,
+            "issue": 32,
+            "state_issue_score": 0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191157,
+        "fields": {
+            "state": 258,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191158,
+        "fields": {
+            "state": 258,
+            "issue": 34,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191159,
+        "fields": {
+            "state": 258,
+            "issue": 35,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191160,
+        "fields": {
+            "state": 258,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //花莲县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191161,
+        "fields": {
+            "state": 255,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191162,
+        "fields": {
+            "state": 255,
+            "issue": 33,
+            "state_issue_score": 0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191163,
+        "fields": {
+            "state": 255,
+            "issue": 34,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191164,
+        "fields": {
+            "state": 255,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191165,
+        "fields": {
+            "state": 255,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //台东县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191166,
+        "fields": {
+            "state": 254,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191167,
+        "fields": {
+            "state": 254,
+            "issue": 33,
+            "state_issue_score": 0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191168,
+        "fields": {
+            "state": 254,
+            "issue": 34,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191169,
+        "fields": {
+            "state": 254,
+            "issue": 35,
+            "state_issue_score": -0.33,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191170,
+        "fields": {
+            "state": 254,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //彰化县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191171,
+        "fields": {
+            "state": 260,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191172,
+        "fields": {
+            "state": 260,
+            "issue": 33,
+            "state_issue_score": -0.85,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191173,
+        "fields": {
+            "state": 260,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191174,
+        "fields": {
+            "state": 260,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191175,
+        "fields": {
+            "state": 260,
+            "issue": 36,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    //云林县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191176,
+        "fields": {
+            "state": 259,
+            "issue": 32,
+            "state_issue_score": -0.4,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191177,
+        "fields": {
+            "state": 259,
+            "issue": 33,
+            "state_issue_score": -0.85,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191178,
+        "fields": {
+            "state": 259,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191179,
+        "fields": {
+            "state": 259,
+            "issue": 35,
+            "state_issue_score": -0.85,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191180,
+        "fields": {
+            "state": 259,
+            "issue": 36,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    //澎湖
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191181,
+        "fields": {
+            "state": 261,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191182,
+        "fields": {
+            "state": 261,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191183,
+        "fields": {
+            "state": 261,
+            "issue": 34,
+            "state_issue_score": -0.9,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191184,
+        "fields": {
+            "state": 261,
+            "issue": 35,
+            "state_issue_score": -0.75,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191185,
+        "fields": {
+            "state": 261,
+            "issue": 36,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    //嘉义县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191186,
+        "fields": {
+            "state": 256,
+            "issue": 32,
+            "state_issue_score": -0.75,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191187,
+        "fields": {
+            "state": 256,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191188,
+        "fields": {
+            "state": 256,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191189,
+        "fields": {
+            "state": 256,
+            "issue": 35,
+            "state_issue_score": -0.9,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191190,
+        "fields": {
+            "state": 256,
+            "issue": 36,
+            "state_issue_score": -0.75,
+            "weight": 0.5
+        }
+    },
+    //嘉义市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191191,
+        "fields": {
+            "state": 257,
+            "issue": 32,
+            "state_issue_score": -0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191192,
+        "fields": {
+            "state": 257,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191193,
+        "fields": {
+            "state": 257,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191194,
+        "fields": {
+            "state": 257,
+            "issue": 35,
+            "state_issue_score": -0.6,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191195,
+        "fields": {
+            "state": 257,
+            "issue": 36,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+     //台南市
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191196,
+            "fields": {
+                "state": 251,
+                "issue": 32,
+                "state_issue_score": -0.85,
+                "weight": 1
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191197,
+            "fields": {
+                "state": 251,
+                "issue": 33,
+                "state_issue_score": -0.15,
+                "weight": 2
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191198,
+            "fields": {
+                "state": 251,
+                "issue": 34,
+                "state_issue_score": 0.55,
+                "weight": 0.5
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191199,
+            "fields": {
+                "state": 251,
+                "issue": 35,
+                "state_issue_score": 0.15,
+                "weight": 0.5
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191200,
+            "fields": {
+                "state": 251,
+                "issue": 36,
+                "state_issue_score": -0.75,
+                "weight": 0.5
+            }
+        },
+         //高雄市
+             {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191201,
+                "fields": {
+                    "state": 252,
+                    "issue": 32,
+                    "state_issue_score": -0.55,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191202,
+                "fields": {
+                    "state": 252,
+                    "issue": 33,
+                    "state_issue_score": -0.15,
+                    "weight": 2
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191203,
+                "fields": {
+                    "state": 252,
+                    "issue": 34,
+                    "state_issue_score": 0.65,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191204,
+                "fields": {
+                    "state": 252,
+                    "issue": 35,
+                    "state_issue_score": 0.15,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191205,
+                "fields": {
+                    "state": 252,
+                    "issue": 36,
+                    "state_issue_score": -0.75,
+                    "weight": 0.5
+                }
+            },
+            //屏东县
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191206,
+                "fields": {
+                    "state": 253,
+                    "issue": 32,
+                    "state_issue_score": -0.5,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191207,
+                "fields": {
+                    "state": 253,
+                    "issue": 33,
+                    "state_issue_score": -0.25,
+                    "weight": 2
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191208,
+                "fields": {
+                    "state": 253,
+                    "issue": 34,
+                    "state_issue_score": 0.25,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191209,
+                "fields": {
+                    "state": 253,
+                    "issue": 35,
+                    "state_issue_score": 0,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191210,
+                "fields": {
+                    "state": 253,
+                    "issue": 36,
+                    "state_issue_score": -0.55,
+                    "weight": 0.5
+                }
+            },
+              //金门县
+              {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191211,
+                "fields": {
+                    "state": 271,
+                    "issue": 32,
+                    "state_issue_score": 1,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191212,
+                "fields": {
+                    "state": 271,
+                    "issue": 33,
+                    "state_issue_score": 1,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191213,
+                "fields": {
+                    "state": 271,
+                    "issue": 34,
+                    "state_issue_score": -0.75,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191214,
+                "fields": {
+                    "state": 271,
+                    "issue": 35,
+                    "state_issue_score": -0.25,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191215,
+                "fields": {
+                    "state": 271,
+                    "issue": 36,
+                    "state_issue_score": 1,
+                    "weight": 0.5
+                }
+            },
+                //连江县
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191216,
+                    "fields": {
+                        "state": 272,
+                        "issue": 32,
+                        "state_issue_score": 1,
+                        "weight": 1
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191217,
+                    "fields": {
+                        "state": 272,
+                        "issue": 33,
+                        "state_issue_score": 1,
+                        "weight": 1
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191218,
+                    "fields": {
+                        "state": 272,
+                        "issue": 34,
+                        "state_issue_score": -1,
+                        "weight": 0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191219,
+                    "fields": {
+                        "state": 272,
+                        "issue": 35,
+                        "state_issue_score": 0.25,
+                        "weight": 0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191220,
+                    "fields": {
+                        "state": 272,
+                        "issue": 36,
+                        "state_issue_score": 1,
+                        "weight": 0.5
+                    }
+                },
+]
+campaignTrail_temp.candidate_issue_score_json = [
+    //赖清德
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 328,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 32,
+            "issue_score": -0.85 //深绿
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 329,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 33,
+            "issue_score": -0.75 //台湾本省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 330,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 34,
+            "issue_score": -0.35 //矿工之子
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 331,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 35,
+            "issue_score": 0.25 //年轻人支持度还行
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 332,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 36,
+            "issue_score": -1 //我就是现任副总统啊
+        }
+    },
+    //侯友谊
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 333,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 32,
+            "issue_score": 0.15 //浅蓝，甚至蓝皮绿谷
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 334,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 33,
+            "issue_score": -0.9 //比赖清德更本省
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 335,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 34,
+            "issue_score": -0.5 //嘉义乡下卖猪肉的
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 336,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 35,
+            "issue_score": -0.25 //年轻人不喜欢的老蓝男
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 337,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 36,
+            "issue_score": 0.25 //攻击性不强
+        }
+    },
+    //柯文哲
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 338,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 32,
+            "issue_score": -0.5 //我内心本质还是深绿的
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 339,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 33,
+            "issue_score": -0.75 //本省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 340,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 34,
+            "issue_score": 0.15 //家庭条件还可以
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 341,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 35,
+            "issue_score": 0.8 //阿北阿北我爱你
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 342,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 36,
+            "issue_score": 0.5 //攻击性很强，但并不把下架民进党当第一目标
+        }
+    },
+     //郭台铭
+     {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 343,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 32,
+            "issue_score": 0.7 //深蓝
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 344,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 33,
+            "issue_score": 0.75 //外省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 345,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 34,
+            "issue_score": 0.75 //城里人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 346,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 35,
+            "issue_score": -0.25 //老蓝男
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 347,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 36,
+            "issue_score": 0.4 //攻击性一般，下架民进党是说说听得口号
+        }
+    },
+]
+campaignTrail_temp.running_mate_issue_score_json = [
+  //萧美琴
+  {
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9343,
+    "fields": {
+        "candidate": 1002,
+        "issue": 32,
+        "issue_score": -0.7
+    }
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9344,
+    "fields": {
+        "candidate": 1002,
+        "issue": 33,
+        "issue_score": -0
+    }
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9345,
+    "fields": {
+        "candidate": 1002,
+        "issue": 34,
+        "issue_score": -0.25
+},
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9346,
+    "fields": {
+        "candidate": 1002,
+        "issue": 35,
+        "issue_score": 0.25 
+    }
+},
+    {
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9347,
+    "fields": {
+        "candidate": 1002,
+        "issue": 36,
+        "issue_score": -0.5
+    }
+    },
+    //蓝白联票
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9348,
+        "fields": {
+            "candidate": 50001,
+            "issue": 32,
+            "issue_score": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9349,
+        "fields": {
+            "candidate": 50001,
+            "issue": 33,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9350,
+        "fields": {
+            "candidate": 50001,
+            "issue": 34,
+            "issue_score": 0
+    },
+},
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9351,
+        "fields": {
+            "candidate": 50001,
+            "issue": 35,
+            "issue_score": 0.15 
+        }
+    },
+        {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9352,
+        "fields": {
+            "candidate": 50001,
+            "issue": 36,
+            "issue_score": 0.4
+        }
+        },
+        //赵少康
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93481,
+            "fields": {
+                "candidate": 50000,
+                "issue": 32,
+                "issue_score": 0.95
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93491,
+            "fields": {
+                "candidate": 50000,
+                "issue": 33,
+                "issue_score": 0.95
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93501,
+            "fields": {
+                "candidate": 50000,
+                "issue": 34,
+                "issue_score": 0.55
+        },
+    },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93511,
+            "fields": {
+                "candidate": 50000,
+                "issue": 35,
+                "issue_score": 0.1
+            }
+        },
+            {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93521,
+            "fields": {
+                "candidate": 50000,
+                "issue": 36,
+                "issue_score": 0.5
+            }
+            },
+            //韩国瑜
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 934812,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 32,
+                    "issue_score": 0.95
+                }
+            },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 934912,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 33,
+                    "issue_score": 0.95
+                }
+            },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935013,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 34,
+                    "issue_score": -0.25
+            },
+        },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935114,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 35,
+                    "issue_score": 0
+                }
+            },
+                {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935215,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 36,
+                    "issue_score": 0.65
+                }
+                },
+                //柯志恩
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9348121,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 32,
+                        "issue_score": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9349121,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 33,
+                        "issue_score": -0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9350131,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 34,
+                        "issue_score": -0.15
+                },
+            },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9351141,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 35,
+                        "issue_score": 0.55
+                    }
+                },
+                    {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9352151,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 36,
+                        "issue_score": 0.42
+                    }
+                    },
+                    //赖佩霞
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93481211,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 32,
+                            "issue_score": 0.1
+                        }
+                    },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93491211,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 33,
+                            "issue_score": 0
+                        }
+                    },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93501311,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 34,
+                            "issue_score": 0.25
+                    },
+                },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93511411,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 35,
+                            "issue_score": 0.15
+                        }
+                    },
+                        {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93521511,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 36,
+                            "issue_score": 0.15
+                        }
+                        },
+                        //白蓝联票
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410110,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 32,
+                                "issue_score": -0.1
+                            }
+                        },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410111,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 33,
+                                "issue_score": 0
+                            }
+                        },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410112,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 34,
+                                "issue_score": 0
+                        },
+                    },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410113,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 35,
+                                "issue_score": 0.75
+                            }
+                        },
+                            {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410114,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 36,
+                                "issue_score": 0.25
+                            }
+                            },
+                            //吴欣盈
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241000,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 32,
+                                    "issue_score": 0
+                                }
+                            },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241001,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 33,
+                                    "issue_score": 0
+                                }
+                            },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241002,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 34,
+                                    "issue_score": 0
+                            },
+                           },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241003,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 35,
+                                    "issue_score": 0.75
+                                }
+                            },
+                                {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241004,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 36,
+                                    "issue_score": 0.25
+                                }
+                        }
+    ]
+
+campaignTrail_temp.candidate_state_multiplier_json = [
+       //台南市
+       {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25191,
+        "fields": {
+            "candidate": 2001557,
+            "state": 251,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25192,
+        "fields": {
+            "candidate": 2001591,
+            "state": 251,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25693,
+        "fields": {
+            "candidate": 2001622,
+            "state": 251,
+            "state_multiplier": 0.17
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25694,
+        "fields": {
+            "candidate": 2001653,
+            "state": 251,
+            "state_multiplier": 0.07
+        }
+    },
+    //嘉义县
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25691,
+        "fields": {
+            "candidate": 2001557,
+            "state": 256,
+            "state_multiplier": 0.28
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25692,
+        "fields": {
+            "candidate": 2001591,
+            "state": 256,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25693,
+        "fields": {
+            "candidate": 2001622,
+            "state": 256,
+            "state_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25694,
+        "fields": {
+            "candidate": 2001653,
+            "state": 256,
+            "state_multiplier": 0.07
+        }
+    },
+      //花莲县
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25591,
+        "fields": {
+            "candidate": 2001557,
+            "state": 255,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25592,
+        "fields": {
+            "candidate": 2001591,
+            "state": 255,
+            "state_multiplier": 0.366
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25593,
+        "fields": {
+            "candidate": 2001622,
+            "state": 255,
+            "state_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25594,
+        "fields": {
+            "candidate": 2001653,
+            "state": 255,
+            "state_multiplier": 0.1
+        }
+    },
+      //屏东
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25391,
+        "fields": {
+            "candidate": 2001557,
+            "state": 253,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25392,
+        "fields": {
+            "candidate": 2001591,
+            "state": 253,
+            "state_multiplier": 0.27
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25393,
+        "fields": {
+            "candidate": 2001622,
+            "state": 253,
+            "state_multiplier": 0.14
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25294,
+        "fields": {
+            "candidate": 2001653,
+            "state": 253,
+            "state_multiplier": 0.07
+        }
+    },
+    //高雄
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25291,
+        "fields": {
+            "candidate": 2001557,
+            "state": 252,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25292,
+        "fields": {
+            "candidate": 2001591,
+            "state": 252,
+            "state_multiplier": 0.25
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25293,
+        "fields": {
+            "candidate": 2001622,
+            "state": 252,
+            "state_multiplier": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25294,
+        "fields": {
+            "candidate": 2001653,
+            "state": 252,
+            "state_multiplier": 0.07
+        }
+    },
+    //台东
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252912,
+        "fields": {
+            "candidate": 2001557,
+            "state": 254,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252922,
+        "fields": {
+            "candidate": 2001591,
+            "state": 254,
+            "state_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252932,
+        "fields": {
+            "candidate": 2001622,
+            "state": 254,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252942,
+        "fields": {
+            "candidate": 2001653,
+            "state": 254,
+            "state_multiplier": 0.1
+        }
+    },
+        //嘉义市
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114514,
+            "fields": {
+                "candidate": 2001557,
+                "state": 257,
+                "state_multiplier": 0.28
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114515,
+            "fields": {
+                "candidate": 2001591,
+                "state": 257,
+                "state_multiplier": 0.23
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114516,
+            "fields": {
+                "candidate": 2001622,
+                "state": 257,
+                "state_multiplier": 0.15
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114517,
+            "fields": {
+                "candidate": 2001653,
+                "state": 257,
+                "state_multiplier": 0.05
+            }
+        },
+        //南投
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 566666,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 258,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 666666,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 258,
+                        "state_multiplier": 0.31
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 6666666,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 258,
+                        "state_multiplier": 0.20
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 66666666,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 258,
+                        "state_multiplier": 0.08
+                    }
+                },
+                //彰化
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 114514123,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 260,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1145141234,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 260,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 11451414,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 260,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 21412412,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 260,
+                        "state_multiplier": 0.06
+                    }
+                },
+                //云林
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1111,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 259,
+                        "state_multiplier": 0.32
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2222,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 259,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 3333,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 259,
+                        "state_multiplier": 0.19
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 4444,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 259,
+                        "state_multiplier": 0.04
+                    }
+                },
+                //澎湖
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 5555,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 261,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 6666,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 261,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 7777,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 261,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 8888,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 261,
+                        "state_multiplier": 0.05
+                    }
+                },
+                //台中
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412241,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 262,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412411,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 262,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412412,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 262,
+                        "state_multiplier": 0.22
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412511,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 262,
+                        "state_multiplier": 0.05
+                    }
+                },
+                //新竹县
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101001,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 264,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101002,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 264,
+                        "state_multiplier": 0.29
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101003,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 264,
+                        "state_multiplier": 0.24
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101004,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 264,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //新竹市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010012,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 265,
+                        "state_multiplier": 0.29
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010022,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 265,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010032,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 265,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010042,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 265,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //苗栗
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2194,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 266,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2195,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 266,
+                        "state_multiplier": 0.35
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2196,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 266,
+                        "state_multiplier": 0.22
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2197,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 266,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //新北市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12194,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 267,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12195,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 267,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12196,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 267,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12197,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 267,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //台北市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 268,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 268,
+                        "state_multiplier": 0.34
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 268,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 268,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //桃园
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 269,
+                        "state_multiplier": 0.26
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 269,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 269,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 269,
+                        "state_multiplier": 0.13
+                    }
+                },
+                //基隆
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 270,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 270,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 270,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 270,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //金门
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19581,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 271,
+                        "state_multiplier": 0.05
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19582,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 271,
+                        "state_multiplier": 0.55
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19583,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 271,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19584,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 271,
+                        "state_multiplier": 0.15
+                    }
+                },         
+                 //宜兰
+                 {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195813,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 263,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195823,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 263,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195833,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 263,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195843,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 263,
+                        "state_multiplier": 0.08
+                    }
+                },       
+                  //连江
+                  {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195812,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 272,
+                        "state_multiplier": 0.05
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195822,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 272,
+                        "state_multiplier": 0.55
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195832,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 272,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195842,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 272,
+                        "state_multiplier": 0.15
+                    }
+                },      
+]
+
+
+
+campaignTrail_temp.answer_score_global_json = [
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13042,
+        "fields": {
+            "answer": 13034,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13043,
+        "fields": {
+            "answer": 13034,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13045,
+        "fields": {
+            "answer": 13036,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13046,
+        "fields": {
+            "answer": 13037,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13053,
+        "fields": {
+            "answer": 13047,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13064,
+        "fields": {
+            "answer": 13057,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13066,
+        "fields": {
+            "answer": 13056,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13071,
+        "fields": {
+            "answer": 13067,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13072,
+        "fields": {
+            "answer": 13067,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13073,
+        "fields": {
+            "answer": 13068,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.24
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13074,
+        "fields": {
+            "answer": 13067,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13075,
+        "fields": {
+            "answer": 13068,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13078,
+        "fields": {
+            "answer": 13076,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13087,
+        "fields": {
+            "answer": 13084,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13091,
+        "fields": {
+            "answer": 13083,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.008
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13094,
+        "fields": {
+            "answer": 13084,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13095,
+        "fields": {
+            "answer": 13083,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13096,
+        "fields": {
+            "answer": 13081,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13102,
+        "fields": {
+            "answer": 13100,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13107,
+        "fields": {
+            "answer": 13099,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13109,
+        "fields": {
+            "answer": 13098,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13112,
+        "fields": {
+            "answer": 13097,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13121,
+        "fields": {
+            "answer": 13115,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13125,
+        "fields": {
+            "answer": 13114,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13126,
+        "fields": {
+            "answer": 13113,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13129,
+        "fields": {
+            "answer": 13114,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13131,
+        "fields": {
+            "answer": 13113,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": 5.25
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13132,
+        "fields": {
+            "answer": 13114,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": 5.25
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13133,
+        "fields": {
+            "answer": 13115,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": 5.25
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13134,
+        "fields": {
+            "answer": 13116,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": 5.25
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13141,
+        "fields": {
+            "answer": 13135,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13144,
+        "fields": {
+            "answer": 13130,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13145,
+        "fields": {
+            "answer": 13135,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13146,
+        "fields": {
+            "answer": 13136,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13150,
+        "fields": {
+            "answer": 13148,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13151,
+        "fields": {
+            "answer": 13148,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13152,
+        "fields": {
+            "answer": 13147,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13153,
+        "fields": {
+            "answer": 13147,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13161,
+        "fields": {
+            "answer": 13158,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13166,
+        "fields": {
+            "answer": 13156,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13205,
+        "fields": {
+            "answer": 13196,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13206,
+        "fields": {
+            "answer": 13194,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13207,
+        "fields": {
+            "answer": 13194,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13208,
+        "fields": {
+            "answer": 13194,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13209,
+        "fields": {
+            "answer": 13194,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13210,
+        "fields": {
+            "answer": 13196,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13211,
+        "fields": {
+            "answer": 13197,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13212,
+        "fields": {
+            "answer": 13198,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13218,
+        "fields": {
+            "answer": 13213,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13219,
+        "fields": {
+            "answer": 13213,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13221,
+        "fields": {
+            "answer": 13214,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13222,
+        "fields": {
+            "answer": 13214,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13223,
+        "fields": {
+            "answer": 13213,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13224,
+        "fields": {
+            "answer": 13214,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13227,
+        "fields": {
+            "answer": 13225,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13228,
+        "fields": {
+            "answer": 13225,
+            "candidate": 2001622,
+            "affected_candidate": 127890,
+            "global_multiplier": -0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13234,
+        "fields": {
+            "answer": 13232,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13241,
+        "fields": {
+            "answer": 13231,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.034
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13253,
+        "fields": {
+            "answer": 13248,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13254,
+        "fields": {
+            "answer": 13248,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13255,
+        "fields": {
+            "answer": 13248,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13257,
+        "fields": {
+            "answer": 13249,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13258,
+        "fields": {
+            "answer": 13249,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13260,
+        "fields": {
+            "answer": 13247,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13261,
+        "fields": {
+            "answer": 13247,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13266,
+        "fields": {
+            "answer": 13264,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13272,
+        "fields": {
+            "answer": 13263,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13280,
+        "fields": {
+            "answer": 13278,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13281,
+        "fields": {
+            "answer": 13277,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13310,
+        "fields": {
+            "answer": 13302,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13311,
+        "fields": {
+            "answer": 13303,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13312,
+        "fields": {
+            "answer": 13304,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13313,
+        "fields": {
+            "answer": 13305,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13314,
+        "fields": {
+            "answer": 13305,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.38
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13315,
+        "fields": {
+            "answer": 13304,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.38
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13316,
+        "fields": {
+            "answer": 13303,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.38
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13317,
+        "fields": {
+            "answer": 13302,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.38
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13318,
+        "fields": {
+            "answer": 13302,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13319,
+        "fields": {
+            "answer": 13303,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13320,
+        "fields": {
+            "answer": 13304,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13321,
+        "fields": {
+            "answer": 13305,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13331,
+        "fields": {
+            "answer": 13325,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13334,
+        "fields": {
+            "answer": 13326,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13335,
+        "fields": {
+            "answer": 13326,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13337,
+        "fields": {
+            "answer": 13325,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13338,
+        "fields": {
+            "answer": 13327,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13339,
+        "fields": {
+            "answer": 13327,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13346,
+        "fields": {
+            "answer": 13322,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13347,
+        "fields": {
+            "answer": 13323,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13348,
+        "fields": {
+            "answer": 13324,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13349,
+        "fields": {
+            "answer": 13341,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13355,
+        "fields": {
+            "answer": 13351,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13356,
+        "fields": {
+            "answer": 13352,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13357,
+        "fields": {
+            "answer": 13353,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13363,
+        "fields": {
+            "answer": 13295,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13364,
+        "fields": {
+            "answer": 13296,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13365,
+        "fields": {
+            "answer": 13298,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13366,
+        "fields": {
+            "answer": 13361,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13367,
+        "fields": {
+            "answer": 13361,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13378,
+        "fields": {
+            "answer": 13370,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13379,
+        "fields": {
+            "answer": 13374,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13380,
+        "fields": {
+            "answer": 13372,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13381,
+        "fields": {
+            "answer": 13371,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13387,
+        "fields": {
+            "answer": 13372,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13396,
+        "fields": {
+            "answer": 13389,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13407,
+        "fields": {
+            "answer": 13401,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13408,
+        "fields": {
+            "answer": 13402,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13411,
+        "fields": {
+            "answer": 13403,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13416,
+        "fields": {
+            "answer": 13414,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.055
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13426,
+        "fields": {
+            "answer": 13419,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.024
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13428,
+        "fields": {
+            "answer": 13420,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13430,
+        "fields": {
+            "answer": 13421,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13441,
+        "fields": {
+            "answer": 13437,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13442,
+        "fields": {
+            "answer": 13438,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13443,
+        "fields": {
+            "answer": 13437,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13444,
+        "fields": {
+            "answer": 13438,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13447,
+        "fields": {
+            "answer": 13436,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13448,
+        "fields": {
+            "answer": 13436,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13454,
+        "fields": {
+            "answer": 13449,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13457,
+        "fields": {
+            "answer": 13450,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13458,
+        "fields": {
+            "answer": 13450,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13461,
+        "fields": {
+            "answer": 13451,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13466,
+        "fields": {
+            "answer": 13452,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13521,
+        "fields": {
+            "answer": 13514,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13523,
+        "fields": {
+            "answer": 13515,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13526,
+        "fields": {
+            "answer": 13514,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -500
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13527,
+        "fields": {
+            "answer": 13515,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -500
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13528,
+        "fields": {
+            "answer": 13516,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.085
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13529,
+        "fields": {
+            "answer": 13516,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -500
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13531,
+        "fields": {
+            "answer": 13522,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13532,
+        "fields": {
+            "answer": 13522,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13537,
+        "fields": {
+            "answer": 13535,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13538,
+        "fields": {
+            "answer": 13535,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13541,
+        "fields": {
+            "answer": 13534,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13542,
+        "fields": {
+            "answer": 13534,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13545,
+        "fields": {
+            "answer": 13533,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13546,
+        "fields": {
+            "answer": 13533,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13553,
+        "fields": {
+            "answer": 13550,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13554,
+        "fields": {
+            "answer": 13550,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13556,
+        "fields": {
+            "answer": 13548,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13557,
+        "fields": {
+            "answer": 13548,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13563,
+        "fields": {
+            "answer": 13558,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13566,
+        "fields": {
+            "answer": 13559,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13567,
+        "fields": {
+            "answer": 13559,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13569,
+        "fields": {
+            "answer": 13560,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13570,
+        "fields": {
+            "answer": 13560,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13574,
+        "fields": {
+            "answer": 13561,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13575,
+        "fields": {
+            "answer": 13561,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13580,
+        "fields": {
+            "answer": 13578,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13581,
+        "fields": {
+            "answer": 13578,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13585,
+        "fields": {
+            "answer": 13583,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13589,
+        "fields": {
+            "answer": 13587,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13595,
+        "fields": {
+            "answer": 13436,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13596,
+        "fields": {
+            "answer": 13437,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13597,
+        "fields": {
+            "answer": 13438,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13598,
+        "fields": {
+            "answer": 13514,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13599,
+        "fields": {
+            "answer": 13515,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13600,
+        "fields": {
+            "answer": 13516,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13601,
+        "fields": {
+            "answer": 13522,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13607,
+        "fields": {
+            "answer": 13514,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13608,
+        "fields": {
+            "answer": 13515,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13609,
+        "fields": {
+            "answer": 13516,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13610,
+        "fields": {
+            "answer": 13522,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13614,
+        "fields": {
+            "answer": 13603,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13615,
+        "fields": {
+            "answer": 13602,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13616,
+        "fields": {
+            "answer": 13602,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13617,
+        "fields": {
+            "answer": 13604,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13618,
+        "fields": {
+            "answer": 13605,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13619,
+        "fields": {
+            "answer": 13605,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13620,
+        "fields": {
+            "answer": 13605,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13621,
+        "fields": {
+            "answer": 13605,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13622,
+        "fields": {
+            "answer": 13469,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13623,
+        "fields": {
+            "answer": 13469,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13624,
+        "fields": {
+            "answer": 13470,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13626,
+        "fields": {
+            "answer": 13470,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13627,
+        "fields": {
+            "answer": 13471,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13628,
+        "fields": {
+            "answer": 13471,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13629,
+        "fields": {
+            "answer": 13479,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13630,
+        "fields": {
+            "answer": 13479,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13644,
+        "fields": {
+            "answer": 13635,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "global_multiplier": -0.055
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13645,
+        "fields": {
+            "answer": 13635,
+            "candidate": 12776,
+            "affected_candidate": 12947,
+            "global_multiplier": -0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13656,
+        "fields": {
+            "answer": 13633,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13657,
+        "fields": {
+            "answer": 13633,
+            "candidate": 12776,
+            "affected_candidate": 12947,
+            "global_multiplier": -0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13658,
+        "fields": {
+            "answer": 13632,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13659,
+        "fields": {
+            "answer": 13632,
+            "candidate": 12776,
+            "affected_candidate": 12947,
+            "global_multiplier": -0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13661,
+        "fields": {
+            "answer": 13634,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13662,
+        "fields": {
+            "answer": 13634,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.15
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_issue_json = [
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13044,
+        "fields": {
+            "answer": 13035,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13052,
+        "fields": {
+            "answer": 13048,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13055,
+        "fields": {
+            "answer": 13049,
+            "issue": 34,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13061,
+        "fields": {
+            "answer": 13058,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13063,
+        "fields": {
+            "answer": 13057,
+            "issue": 32,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13079,
+        "fields": {
+            "answer": 13076,
+            "issue": 35,
+            "issue_score": 0.03,
+            "issue_importance": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13088,
+        "fields": {
+            "answer": 13084,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13090,
+        "fields": {
+            "answer": 13083,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13092,
+        "fields": {
+            "answer": 13081,
+            "issue": 32,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13093,
+        "fields": {
+            "answer": 13081,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13103,
+        "fields": {
+            "answer": 13100,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13106,
+        "fields": {
+            "answer": 13099,
+            "issue": 34,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13110,
+        "fields": {
+            "answer": 13098,
+            "issue": 35,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13111,
+        "fields": {
+            "answer": 13097,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13118,
+        "fields": {
+            "answer": 13116,
+            "issue": 36,
+            "issue_score": 0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13119,
+        "fields": {
+            "answer": 13116,
+            "issue": 32,
+            "issue_score": -0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13122,
+        "fields": {
+            "answer": 13115,
+            "issue": 35,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13123,
+        "fields": {
+            "answer": 13115,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13127,
+        "fields": {
+            "answer": 13113,
+            "issue": 36,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13138,
+        "fields": {
+            "answer": 13136,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13140,
+        "fields": {
+            "answer": 13135,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13143,
+        "fields": {
+            "answer": 13130,
+            "issue": 32,
+            "issue_score": -0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13160,
+        "fields": {
+            "answer": 13158,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13163,
+        "fields": {
+            "answer": 13157,
+            "issue": 35,
+            "issue_score": 0.12,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13165,
+        "fields": {
+            "answer": 13156,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13168,
+        "fields": {
+            "answer": 13155,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13169,
+        "fields": {
+            "answer": 13155,
+            "issue": 34,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13200,
+        "fields": {
+            "answer": 13198,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13201,
+        "fields": {
+            "answer": 13198,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13203,
+        "fields": {
+            "answer": 13197,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13220,
+        "fields": {
+            "answer": 13213,
+            "issue": 32,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13229,
+        "fields": {
+            "answer": 13225,
+            "issue": 32,
+            "issue_score": -0.09,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13235,
+        "fields": {
+            "answer": 13232,
+            "issue": 32,
+            "issue_score": -0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13238,
+        "fields": {
+            "answer": 13230,
+            "issue": 32,
+            "issue_score": 0.04,
+            "issue_importance": 0
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13239,
+        "fields": {
+            "answer": 13230,
+            "issue": 35,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13240,
+        "fields": {
+            "answer": 13230,
+            "issue": 36,
+            "issue_score": 0.04,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13242,
+        "fields": {
+            "answer": 13231,
+            "issue": 36,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13245,
+        "fields": {
+            "answer": 13231,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13246,
+        "fields": {
+            "answer": 13232,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13251,
+        "fields": {
+            "answer": 13247,
+            "issue": 35,
+            "issue_score": 0.09,
+            "issue_importance": 0.11
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13259,
+        "fields": {
+            "answer": 13249,
+            "issue": 35,
+            "issue_score": 0.05,
+            "issue_importance": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13267,
+        "fields": {
+            "answer": 13264,
+            "issue": 32,
+            "issue_score": -0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13276,
+        "fields": {
+            "answer": 13262,
+            "issue": 32,
+            "issue_score": -0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13332,
+        "fields": {
+            "answer": 13325,
+            "issue": 35,
+            "issue_score": -0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13333,
+        "fields": {
+            "answer": 13325,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13336,
+        "fields": {
+            "answer": 13326,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13340,
+        "fields": {
+            "answer": 13327,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13358,
+        "fields": {
+            "answer": 13351,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13359,
+        "fields": {
+            "answer": 13352,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13360,
+        "fields": {
+            "answer": 13353,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13376,
+        "fields": {
+            "answer": 13374,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13377,
+        "fields": {
+            "answer": 13370,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13383,
+        "fields": {
+            "answer": 13371,
+            "issue": 32,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13384,
+        "fields": {
+            "answer": 13370,
+            "issue": 36,
+            "issue_score": -0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13385,
+        "fields": {
+            "answer": 13374,
+            "issue": 36,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13386,
+        "fields": {
+            "answer": 13372,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13392,
+        "fields": {
+            "answer": 13388,
+            "issue": 32,
+            "issue_score": 0.15,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13394,
+        "fields": {
+            "answer": 13389,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13395,
+        "fields": {
+            "answer": 13389,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13398,
+        "fields": {
+            "answer": 13390,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13399,
+        "fields": {
+            "answer": 13390,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13400,
+        "fields": {
+            "answer": 13388,
+            "issue": 36,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13409,
+        "fields": {
+            "answer": 13402,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.13
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13412,
+        "fields": {
+            "answer": 13403,
+            "issue": 32,
+            "issue_score": -0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13413,
+        "fields": {
+            "answer": 13403,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13417,
+        "fields": {
+            "answer": 13414,
+            "issue": 32,
+            "issue_score": 0.02,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13418,
+        "fields": {
+            "answer": 13414,
+            "issue": 36,
+            "issue_score": 0.03,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13427,
+        "fields": {
+            "answer": 13419,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13429,
+        "fields": {
+            "answer": 13420,
+            "issue": 36,
+            "issue_score": 0.09,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13431,
+        "fields": {
+            "answer": 13421,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13432,
+        "fields": {
+            "answer": 13370,
+            "issue": 33,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13433,
+        "fields": {
+            "answer": 13388,
+            "issue": 33,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13434,
+        "fields": {
+            "answer": 13389,
+            "issue": 35,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13435,
+        "fields": {
+            "answer": 13390,
+            "issue": 33,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13455,
+        "fields": {
+            "answer": 13449,
+            "issue": 35,
+            "issue_score": 0.04,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13459,
+        "fields": {
+            "answer": 13450,
+            "issue": 36,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13462,
+        "fields": {
+            "answer": 13451,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13464,
+        "fields": {
+            "answer": 13451,
+            "issue": 32,
+            "issue_score": 0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13467,
+        "fields": {
+            "answer": 13452,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13468,
+        "fields": {
+            "answer": 13452,
+            "issue": 36,
+            "issue_score": 0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13524,
+        "fields": {
+            "answer": 13515,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13525,
+        "fields": {
+            "answer": 13514,
+            "issue": 32,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13539,
+        "fields": {
+            "answer": 13535,
+            "issue": 34,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13543,
+        "fields": {
+            "answer": 13534,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13547,
+        "fields": {
+            "answer": 13533,
+            "issue": 35,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13555,
+        "fields": {
+            "answer": 13550,
+            "issue": 32,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13564,
+        "fields": {
+            "answer": 13558,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13571,
+        "fields": {
+            "answer": 13559,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13572,
+        "fields": {
+            "answer": 13560,
+            "issue": 36,
+            "issue_score": -0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13576,
+        "fields": {
+            "answer": 13561,
+            "issue": 32,
+            "issue_score": -0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13582,
+        "fields": {
+            "answer": 13578,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13586,
+        "fields": {
+            "answer": 13583,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13590,
+        "fields": {
+            "answer": 13587,
+            "issue": 36,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13593,
+        "fields": {
+            "answer": 13591,
+            "issue": 36,
+            "issue_score": 0.09,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13594,
+        "fields": {
+            "answer": 13591,
+            "issue": 35,
+            "issue_score": 0.09,
+            "issue_importance": 0.1
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_state_json = [
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13174,
+        "fields": {
+            "answer": 13170,
+            "state": 267,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13175,
+        "fields": {
+            "answer": 13170,
+            "state": 268,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13176,
+        "fields": {
+            "answer": 13170,
+            "state": 270,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13177,
+        "fields": {
+            "answer": 13170,
+            "state": 269,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13180,
+        "fields": {
+            "answer": 13171,
+            "state": 264,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13181,
+        "fields": {
+            "answer": 13171,
+            "state": 265,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13182,
+        "fields": {
+            "answer": 13171,
+            "state": 266,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13184,
+        "fields": {
+            "answer": 13172,
+            "state": 251,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13185,
+        "fields": {
+            "answer": 13172,
+            "state": 252,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13186,
+        "fields": {
+            "answer": 13172,
+            "state": 253,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13187,
+        "fields": {
+            "answer": 13172,
+            "state": 256,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13188,
+        "fields": {
+            "answer": 13172,
+            "state": 257,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13190,
+        "fields": {
+            "answer": 13173,
+            "state": 260,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.024
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13191,
+        "fields": {
+            "answer": 13173,
+            "state": 259,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13192,
+        "fields": {
+            "answer": 13173,
+            "state": 258,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13193,
+        "fields": {
+            "answer": 13173,
+            "state": 262,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13274,
+        "fields": {
+            "answer": 13262,
+            "state": 267,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.005
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13275,
+        "fields": {
+            "answer": 13262,
+            "state": 262,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.0075
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13287,
+        "fields": {
+            "answer": 13283,
+            "state": 268,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13288,
+        "fields": {
+            "answer": 13284,
+            "state": 269,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13289,
+        "fields": {
+            "answer": 13285,
+            "state": 267,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13290,
+        "fields": {
+            "answer": 13286,
+            "state": 262,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13473,
+        "fields": {
+            "answer": 13469,
+            "state": 271,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13474,
+        "fields": {
+            "answer": 13469,
+            "state": 272,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13475,
+        "fields": {
+            "answer": 13469,
+            "state": 263,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13476,
+        "fields": {
+            "answer": 13469,
+            "state": 255,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13477,
+        "fields": {
+            "answer": 13469,
+            "state": 254,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13482,
+        "fields": {
+            "answer": 13470,
+            "state": 267,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13483,
+        "fields": {
+            "answer": 13470,
+            "state": 268,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.022
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13484,
+        "fields": {
+            "answer": 13471,
+            "state": 262,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13485,
+        "fields": {
+            "answer": 13471,
+            "state": 260,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13486,
+        "fields": {
+            "answer": 13471,
+            "state": 258,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13487,
+        "fields": {
+            "answer": 13479,
+            "state": 269,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13488,
+        "fields": {
+            "answer": 13479,
+            "state": 265,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13489,
+        "fields": {
+            "answer": 13479,
+            "state": 264,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13490,
+        "fields": {
+            "answer": 13479,
+            "state": 266,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13498,
+        "fields": {
+            "answer": 13495,
+            "state": 268,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13500,
+        "fields": {
+            "answer": 13496,
+            "state": 263,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13501,
+        "fields": {
+            "answer": 13496,
+            "state": 253,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13503,
+        "fields": {
+            "answer": 13494,
+            "state": 251,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13504,
+        "fields": {
+            "answer": 13494,
+            "state": 252,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13506,
+        "fields": {
+            "answer": 13493,
+            "state": 257,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13507,
+        "fields": {
+            "answer": 13493,
+            "state": 256,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13508,
+        "fields": {
+            "answer": 13493,
+            "state": 259,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13640,
+        "fields": {
+            "answer": 13635,
+            "state": 264,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13641,
+        "fields": {
+            "answer": 13635,
+            "state": 265,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13642,
+        "fields": {
+            "answer": 13635,
+            "state": 266,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13643,
+        "fields": {
+            "answer": 13635,
+            "state": 269,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13646,
+        "fields": {
+            "answer": 13634,
+            "state": 260,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13647,
+        "fields": {
+            "answer": 13634,
+            "state": 262,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13648,
+        "fields": {
+            "answer": 13634,
+            "state": 258,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13649,
+        "fields": {
+            "answer": 13633,
+            "state": 267,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13650,
+        "fields": {
+            "answer": 13633,
+            "state": 268,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13651,
+        "fields": {
+            "answer": 13632,
+            "state": 271,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13652,
+        "fields": {
+            "answer": 13632,
+            "state": 272,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13653,
+        "fields": {
+            "answer": 13632,
+            "state": 263,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13654,
+        "fields": {
+            "answer": 13632,
+            "state": 255,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13655,
+        "fields": {
+            "answer": 13632,
+            "state": 254,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.03
+        }
+    }
+]
+
+campaignTrail_temp.answer_feedback_json = [
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13038,
+        "fields": {
+            "answer": 13034,
+            "candidate": 2001622,
+            "answer_feedback": "The standard opening move for a third-party candidate, challenging the monopolistic political system of the two major parties."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13039,
+        "fields": {
+            "answer": 13037,
+            "candidate": 2001622,
+            "answer_feedback": "Although you don't currently have a strong appeal to KMT voters, due to your distinctive candidacy, perhaps you can attract those among them who lean towards the light blue spectrum?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13040,
+        "fields": {
+            "answer": 13035,
+            "candidate": 2001622,
+            "answer_feedback": "Strengthening support among young people has always been one of your strengths, with many supporters in the 20s and 30s age groups."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13041,
+        "fields": {
+            "answer": 13036,
+            "candidate": 2001622,
+            "answer_feedback": "Attacking the DPP can solidify your cohesion with supporters and focus on the strongest adversary."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13050,
+        "fields": {
+            "answer": 13047,
+            "candidate": 2001622,
+            "answer_feedback": "It seems you are the strongest third-party candidate since 2000. Make sure to sustain this momentum and create a political wave."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13051,
+        "fields": {
+            "answer": 13048,
+            "candidate": 2001622,
+            "answer_feedback": "Your YouTube channel's subscriber count, whether real or not, surpasses the fan base of Lai Ching-te and Hou You-yi by several times, or even dozens of times. In this aspect, you rightfully hold the first place."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13054,
+        "fields": {
+            "answer": 13049,
+            "candidate": 2001622,
+            "answer_feedback": "The People's Party has established branches in major cities across Taiwan, and this will be part of your nationwide campaign activities."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13060,
+        "fields": {
+            "answer": 13058,
+            "candidate": 2001622,
+            "answer_feedback": "Your staff uploaded the video of your conversation with young people to YouTube, and as expected, it garnered a large number of likes and comments."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13062,
+        "fields": {
+            "answer": 13057,
+            "candidate": 2001622,
+            "answer_feedback": "These figures are all influential individuals on the international stage. Being mentioned alongside them will provide substantial international exposure and enhance the trust of voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13065,
+        "fields": {
+            "answer": 13056,
+            "candidate": 2001622,
+            "answer_feedback": "This is your latest statement on foreign policy. It is widely known that you are adopting a centrist position on some key stances, aiming to garner the most votes."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13069,
+        "fields": {
+            "answer": 13067,
+            "candidate": 2001622,
+            "answer_feedback": "This is a standard response to strengthen your support base. Let's see how much support and voter turnout the TPP can achieve in this election."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13070,
+        "fields": {
+            "answer": 13068,
+            "candidate": 2001622,
+            "answer_feedback": "The high poll numbers for Hou You-yi seem to be short-lived. Since the start of the KMT primaries, he has been trailing behind Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13077,
+        "fields": {
+            "answer": 13076,
+            "candidate": 2001622,
+            "answer_feedback": "Certainly, gaining more diplomatic experience can only be beneficial for you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13082,
+        "fields": {
+            "answer": 13081,
+            "candidate": 2001622,
+            "answer_feedback": "This is a statement you have consistently emphasized, advocating not to trust individuals but to trust the system. This aligns with your rational, pragmatic, and scientific political agenda."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13085,
+        "fields": {
+            "answer": 13084,
+            "candidate": 2001622,
+            "answer_feedback": "This is part of your intense confrontation with the DPP. While your female voters have been affected, your main support base still relies on young males."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13089,
+        "fields": {
+            "answer": 13083,
+            "candidate": 2001622,
+            "answer_feedback": "This contrasts with the image of the DPP. At least the TPP does not have as many sexual harassment cases, and many people mock the DPP for this."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13101,
+        "fields": {
+            "answer": 13100,
+            "candidate": 2001622,
+            "answer_feedback": "Political observers criticize you for turning politics into entertainment, and older people are less accepting, seeing it as a joke. However, it is popular among young people, and you have earned a significant amount of money."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13104,
+        "fields": {
+            "answer": 13097,
+            "candidate": 2001622,
+            "answer_feedback": "The production of these items incurs costs, but what makes them more advantageous than small donations is their ability to generate a steady and continuous income. Many young people and children, show great enthusiasm for your campaign merchandise."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13105,
+        "fields": {
+            "answer": 13099,
+            "candidate": 2001622,
+            "answer_feedback": "This is a good way to gain support, but be cautious not to let your supporters discover your contacts with various corporations. They dislike the blue-green alliance due to its connections with big business."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13108,
+        "fields": {
+            "answer": 13098,
+            "candidate": 2001622,
+            "answer_feedback": "The enthusiasm from supporters for the TPP is so high that the fundraising goal was reached within just one hour of the campaign launch."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13117,
+        "fields": {
+            "answer": 13116,
+            "candidate": 2001622,
+            "answer_feedback": "You successfully gained political points here and avoided most of the media attacks; however, it may not have a particularly direct benefit for your election campaign."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13120,
+        "fields": {
+            "answer": 13115,
+            "candidate": 2001622,
+            "answer_feedback": "The media and other parties accuse you of turning this march into your personal campaign, but of course, you will benefit from it. Although the offline turnout may not be as high as your online numbers suggest."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13124,
+        "fields": {
+            "answer": 13114,
+            "candidate": 2001622,
+            "answer_feedback": "Afterwards, the young people you arranged were recognized as members of the TPP, which damaged Hou You-yi's image, and, of course, your own image as well. Has the open and hidden struggle of the opposition come to the surface so quickly?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13128,
+        "fields": {
+            "answer": 13113,
+            "candidate": 2001622,
+            "answer_feedback": "Lai Ching-te is certainly afraid to face the opposition crowd, but this won't affect the DPP's voter base. After all, they have a significant amount of support from the elderly, which you lack."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13137,
+        "fields": {
+            "answer": 13136,
+            "candidate": 2001622,
+            "answer_feedback": "According to TVBS and Formosa opinion polls, Hou's KMT intra-party support is only 70%. This is undoubtedly because you and Terry Gou have drawn away those dissatisfied voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13139,
+        "fields": {
+            "answer": 13135,
+            "candidate": 2001622,
+            "answer_feedback": "Terry Gou rejected your proposal; he believes that if you want to utilize his resources, you must let him be president for the first four years while you serve as vice president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13142,
+        "fields": {
+            "answer": 13130,
+            "candidate": 2001622,
+            "answer_feedback": "In 2014, you were a deep-green candidate, harboring strong resentment towards the Kuomintang. However, your current political affiliation just like the TPP, doesn't align with a specific color; it seems adaptable to any color."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13149,
+        "fields": {
+            "answer": 13148,
+            "candidate": 2001622,
+            "answer_feedback": "In fact, Terry Gou took away many of your pan-blue voters, but fortunately, his poll numbers began to decline after announcing an independent candidacy."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13154,
+        "fields": {
+            "answer": 13147,
+            "candidate": 2001622,
+            "answer_feedback": "Anyway, Terry Gou is fourth in the polls, putting too much focus on him may not be very useful. It's better to concentrate on Lai Ching-te and Hou You-yi."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13159,
+        "fields": {
+            "answer": 13158,
+            "candidate": 2001622,
+            "answer_feedback": "A nuclear-free homeland is, of course, impossible to achieve, but your energy policy, like many others, seems to be situated in the middle ground between the blue and green policies."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13162,
+        "fields": {
+            "answer": 13157,
+            "candidate": 2001622,
+            "answer_feedback": "It seems that the political views articulated by young people from the TPP are always much better than those of the KMT, perhaps due to the perception of political parties?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13164,
+        "fields": {
+            "answer": 13156,
+            "candidate": 2001622,
+            "answer_feedback": "You yourselves are a political stance, advocating to abandon the blue-green divide. This type of centrist voters has always existed, that's why James Soong has been in elections so many times, isn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13167,
+        "fields": {
+            "answer": 13155,
+            "candidate": 2001622,
+            "answer_feedback": "If the blue and green parties control traditional media, then you perform well on the internet. However, the internet may not reach the elderly who watch television in rural areas."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13178,
+        "fields": {
+            "answer": 13170,
+            "candidate": 2001622,
+            "answer_feedback": "You have believed that your experience in Taipei is worth promoting. However, the satisfaction of Taipei residents with your performance is not high. Older citizens, who are part of the blue camp, also hold resentment against you for cutting their pensions."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13179,
+        "fields": {
+            "answer": 13171,
+            "candidate": 2001622,
+            "answer_feedback": "After having a meal with your mom, you attended a local gathering of young people and focused on visiting Miaoli."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13183,
+        "fields": {
+            "answer": 13172,
+            "candidate": 2001622,
+            "answer_feedback": "Your deep green background and Taiwanese identity may be helpful in the south, but be mindful that they also dislike those who oppose the Democratic Progressive Party halfway. Keep this in mind."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13189,
+        "fields": {
+            "answer": 13173,
+            "candidate": 2001622,
+            "answer_feedback": "The central region has always been a key to winning elections. If your third-party identity is played well, you might stand out here."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13195,
+        "fields": {
+            "answer": 13194,
+            "candidate": 2001622,
+            "answer_feedback": "Unfortunately, Hou You-yi and Lai Ching-te's visits have garnered more attention, while your second visit to the United States is perceived as following the trend."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13199,
+        "fields": {
+            "answer": 13198,
+            "candidate": 2001622,
+            "answer_feedback": "Now that you have attracted many dissatisfied individuals, it's important to ensure that you can retain them, as they may come and go quickly."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13202,
+        "fields": {
+            "answer": 13197,
+            "candidate": 2001622,
+            "answer_feedback": "This is a good way to double down on your core supporters. However, it might not significantly expand your voter base, as older people still may not be reached, and while many kids enjoy your show, they are not eligible to vote."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13204,
+        "fields": {
+            "answer": 13196,
+            "candidate": 2001622,
+            "answer_feedback": "This has gained you some appreciation, but the majority of elderly people in Taiwan tend to have specific party affiliations, making it challenging for you to sway a significant number of votes in this demographic."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13216,
+        "fields": {
+            "answer": 13213,
+            "candidate": 2001622,
+            "answer_feedback": "This will disappoint opposition voters and send a clear signal that you intend to chart your own course rather than choosing the option with the highest probability of success. While it strengthens your core supporters, it also contributes to the rise in support for Hou You-yi."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13217,
+        "fields": {
+            "answer": 13214,
+            "candidate": 2001622,
+            "answer_feedback": "The KMT immediately raised objections, claiming that polling results are prone to errors. They prefer conducting a democratic primary, allowing voters to cast their ballots in person. However, your party cannot accept a solution that relies more on offline strength."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13226,
+        "fields": {
+            "answer": 13225,
+            "candidate": 2001622,
+            "answer_feedback": "Suggesting directly that your opponent withdraw from the election might be seen as disrespectful to competition and voter choice, but it can strengthen your base, as they often enjoy ridiculing and disliking the KMT."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13233,
+        "fields": {
+            "answer": 13232,
+            "candidate": 2001622,
+            "answer_feedback": "Media captured you falling asleep during the morning assembly, and it has become a subject of amusement among people."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13236,
+        "fields": {
+            "answer": 13231,
+            "candidate": 2001622,
+            "answer_feedback": "This is an opportunity to further strengthen your third-party identity and support base. Taiwan is indeed entangled in confusion and uncertainty regarding national identity, but as an insider, you must make your decisions and choices."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13237,
+        "fields": {
+            "answer": 13230,
+            "candidate": 2001622,
+            "answer_feedback": "Ha ha, not many people attended TPP's events, but at least you taught young people that patriotism is a good thing, right?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13250,
+        "fields": {
+            "answer": 13247,
+            "candidate": 2001622,
+            "answer_feedback": "This deepens the impression among the young people following you, as they believe that indoor telephone polls are outdated and out of touch with the modern scientific trend.However, your own internal polls still use landline phones instead of exclusively relying on mobile phone surveys."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13252,
+        "fields": {
+            "answer": 13248,
+            "candidate": 2001622,
+            "answer_feedback": "Formosa was once the first poll to place you above Hou Youyi, but that's no longer the case. As for Ettoday, it has never ranked you as second."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13256,
+        "fields": {
+            "answer": 13249,
+            "candidate": 2001622,
+            "answer_feedback": "Street polls were proven to be unreliable in the 2020 election, but your young supporters seem to have short memories. They put a lot of trust in street poll videos on YouTube, where you're often depicted neck and neck with Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13265,
+        "fields": {
+            "answer": 13264,
+            "candidate": 2001622,
+            "answer_feedback": "The KMT won't be afraid of such easy blackmail. You've already placed TPP candidates in some of their constituencies, but they might not know whose votes will be drawn away – it could be from the blue camp or the green camp."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13268,
+        "fields": {
+            "answer": 13263,
+            "candidate": 2001622,
+            "answer_feedback": "This will help your campaign capability in some less explored areas. The KMT is willing to make concessions to show goodwill."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13271,
+        "fields": {
+            "answer": 13262,
+            "candidate": 2001622,
+            "answer_feedback": "This will help you gain votes in those deep green areas. The efforts of local legislators and cooperation with your joint campaign will assist you in securing votes in some green regions."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13279,
+        "fields": {
+            "answer": 13278,
+            "candidate": 2001622,
+            "answer_feedback": "Although your observations make sense, whether Terry Gou will become a spoiler or withdraw from the race to decrease Lai Ching-te's chances remains uncertain."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13282,
+        "fields": {
+            "answer": 13277,
+            "candidate": 2001622,
+            "answer_feedback": "This is a wise and sensible choice on your part. Don't be swayed by Terry Gou's substantial funding; ultimately, his resources are not yours to rely on."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13291,
+        "fields": {
+            "answer": 13283,
+            "candidate": 2001622,
+            "answer_feedback": "Strengthening your base is a good thing, but Taipei is a predominantly blue area. Please ensure that you can secure victory here; otherwise, your image might suffer."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13292,
+        "fields": {
+            "answer": 13284,
+            "candidate": 2001622,
+            "answer_feedback": "Taoyuan has seen an influx of a young population and hosts high-tech industries, many of whom could be your solid supporters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13293,
+        "fields": {
+            "answer": 13285,
+            "candidate": 2001622,
+            "answer_feedback": "New Taipei City is a place where both the blue and green camps have solid support bases and numerous battlegrounds. Disrupting the situation here would be beneficial for you. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13294,
+        "fields": {
+            "answer": 13286,
+            "candidate": 2001622,
+            "answer_feedback": "Taichung is a well-known swing region, and if you can establish a stronghold in central Taiwan, it may be possible to compete with both the blue and green parties."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13299,
+        "fields": {
+            "answer": 13298,
+            "candidate": 2001622,
+            "answer_feedback": "On the evening of November 15th, the Facebook and campaign accounts of TPP and KMT were filled with propaganda urging campaign supporters to vote for their respective candidates. Meanwhile, the media was fervently discussing who would emerge victorious and how the results of previous polls would impact the outcome."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13300,
+        "fields": {
+            "answer": 13296,
+            "candidate": 2001622,
+            "answer_feedback": "On the evening of November 15th, the Facebook and campaign accounts of TPP and KMT were filled with propaganda urging campaign supporters to vote for their respective candidates. Meanwhile, the media was fervently discussing who would emerge victorious and how the results of previous polls would impact the outcome."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13301,
+        "fields": {
+            "answer": 13295,
+            "candidate": 2001622,
+            "answer_feedback": "On the evening of November 15th, the Facebook and campaign accounts of TPP and KMT were filled with propaganda urging campaign supporters to vote for their respective candidates. Meanwhile, the media was fervently discussing who would emerge victorious and how the results of previous polls would impact the outcome."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13306,
+        "fields": {
+            "answer": 13302,
+            "candidate": 2001622,
+            "answer_feedback": "Congratulations, Mr. Ko Wen-je! You are very likely to become the next President of the Republic of China . The KMT has confirmed their defeat with a 5:4 ratio, and they cannot bear the responsibility of causing a deadlock. Therefore, they have accepted you as the presidential candidate. Congratulations!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13307,
+        "fields": {
+            "answer": 13303,
+            "candidate": 2001622,
+            "answer_feedback": "Congratulations, Mr. Ko Wen-je! You are very likely to become the next President of the Republic of China . The KMT has confirmed their defeat with a 5:4 ratio, and they cannot bear the responsibility of causing a deadlock. Therefore, they have accepted you as the presidential candidate. Congratulations!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13308,
+        "fields": {
+            "answer": 13304,
+            "candidate": 2001622,
+            "answer_feedback": "The most feared scenario for Lai Ching-te has become a reality: Ko Wen-je secures the presidency, while Hou You-yi assumes the position of vice president. This combination proves to be the most effective against Lai Ching-te. Does this signal the end of hope for the DPP's third term?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13309,
+        "fields": {
+            "answer": 13305,
+            "candidate": 2001622,
+            "answer_feedback": "The most feared scenario for Lai Ching-te has become a reality: Ko Wen-je secures the presidency, while Hou You-yi assumes the position of vice president. This combination proves to be the most effective against Lai Ching-te. Does this signal the end of hope for the DPP's third term?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13328,
+        "fields": {
+            "answer": 13325,
+            "candidate": 2001622,
+            "answer_feedback": "Some of your core supporters are displeased with your cooperation with the KMT, a party they have always disliked. However, since you hold a dominant position, they reluctantly accept it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13329,
+        "fields": {
+            "answer": 13326,
+            "candidate": 2001622,
+            "answer_feedback": "From now on, the election has turned into a showdown between the Green and White camps. A fierce battle between the DPP and TPP is set to unfold, and currently, it appears that the mainstream public opinion in Taiwan is leaning towards opposition to the DPP."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13330,
+        "fields": {
+            "answer": 13327,
+            "candidate": 2001622,
+            "answer_feedback": "This will appease some supporters of the KMT. Even if they do not like Hou You-yi, they cannot accept their party being in a disadvantaged position. Saying some positive words about Hou You-yi can at least help alleviate the resentment within them."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13342,
+        "fields": {
+            "answer": 13341,
+            "candidate": 2001622,
+            "answer_feedback": "During the live broadcast, your emotional moment, wiping away tears with a towel, and the poignant words from your aide Huang Shanshan touched many supporters. However, some astute observers sense that things may not be as simple as they seem."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13343,
+        "fields": {
+            "answer": 13324,
+            "candidate": 2001622,
+            "answer_feedback": "During the live broadcast, your emotional moment, wiping away tears with a towel, and the poignant words from your aide Huang Shanshan touched many supporters. However, some astute observers sense that things may not be as simple as they seem."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13344,
+        "fields": {
+            "answer": 13323,
+            "candidate": 2001622,
+            "answer_feedback": "During the live broadcast, your emotional moment, wiping away tears with a towel, and the poignant words from your aide Huang Shanshan touched many supporters. However, some astute observers sense that things may not be as simple as they seem."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13345,
+        "fields": {
+            "answer": 13322,
+            "candidate": 2001622,
+            "answer_feedback": "During the live broadcast, your emotional moment, wiping away tears with a towel, and the poignant words from your aide Huang Shanshan touched many supporters. However, some astute observers sense that things may not be as simple as they seem."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13354,
+        "fields": {
+            "answer": 13351,
+            "candidate": 2001622,
+            "answer_feedback": "KMT accusing your side of shelving three polls that favored the KMT during negotiations and excluding all indoor telephone polls, including the reputable and internationally recognized Formosa Poll."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13362,
+        "fields": {
+            "answer": 13361,
+            "candidate": 2001622,
+            "answer_feedback": "You responded to the host with a seemingly casual expression, leaving many to speculate if you have alternative plans. Discussions have already started on forums, questioning whether a coalition agreement is now unattainable."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13368,
+        "fields": {
+            "answer": 13352,
+            "candidate": 2001622,
+            "answer_feedback": "What you're saying is indeed factual, but the sentiments of KMT and TPP voters may not align. Since you've already signed an unequal agreement in black and white, why the change of heart now? This is certainly seen as a lack of integrity."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13369,
+        "fields": {
+            "answer": 13353,
+            "candidate": 2001622,
+            "answer_feedback": "If you intended to run independently, you shouldn't have initiated talks with the KMT from the beginning. Perhaps you were only afraid of facing criticism from the broader opposition voters? However, now that cooperation seems unattainable, blue-leaning voters are likely to drift away from your side."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13373,
+        "fields": {
+            "answer": 13370,
+            "candidate": 2001622,
+            "answer_feedback": "Some of your elderly KMT and deep-blue supporters may feel disappointed, but they are unlikely to vote for the DPP, at most, they may choose not to vote, right?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13375,
+        "fields": {
+            "answer": 13374,
+            "candidate": 2001622,
+            "answer_feedback": "This will contribute to shaping your image among the deep-blue and pro-unification voters. Some of them are hesitant to support Hou You-yi but are willing to back you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13382,
+        "fields": {
+            "answer": 13371,
+            "candidate": 2001622,
+            "answer_feedback": "The DPP criticizes your approach, claiming it is similar to theirs, but you strongly condemn their policies. Nevertheless, the TPP does have some distinguishing features from the DPP in terms of policies."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13391,
+        "fields": {
+            "answer": 13388,
+            "candidate": 2001622,
+            "answer_feedback": "This will set you apart from Lai Ching-te, presenting you as a patriotic candidate compared to his pro-independence stance. Just this small emblem can highlight the difference in your national identity."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13393,
+        "fields": {
+            "answer": 13389,
+            "candidate": 2001622,
+            "answer_feedback": "Alright, since you choose to enhance your independence, there's no problem. However, the elderly pan-blue voters may not see your national flag emblem during the debate."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13397,
+        "fields": {
+            "answer": 13390,
+            "candidate": 2001622,
+            "answer_feedback": "The KMT is more than willing to provide you with a substantial amount of national flags and campaign materials related to the Republic of China."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13405,
+        "fields": {
+            "answer": 13401,
+            "candidate": 2001622,
+            "answer_feedback": "As always, you and your policies seek a balance between the blue and green camps. Whether this aligns with the taste of the majority in Taiwan remains to be seen."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13406,
+        "fields": {
+            "answer": 13402,
+            "candidate": 2001622,
+            "answer_feedback": "While achieving a non-nuclear homeland may be unlikely, your policies in this regard lean towards the KMT, as you haven't sought the abolition of nuclear energy, unlike DPP."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13410,
+        "fields": {
+            "answer": 13403,
+            "candidate": 2001622,
+            "answer_feedback": "What you say is very straightforward, but your supporters and many who appreciate you happen to like this kind of blunt honesty."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13415,
+        "fields": {
+            "answer": 13414,
+            "candidate": 2001622,
+            "answer_feedback": "The election results may be more intense than you imagine, so please be prepared and don't lose the victory in the final stages."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13423,
+        "fields": {
+            "answer": 13419,
+            "candidate": 2001622,
+            "answer_feedback": "Although your attacks are quite harsh, it seems that Lai Ching-te has not been significantly affected by this issue. In the end, it's just a reinforcement within the support bases of both sides, without much impact on the swing voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13424,
+        "fields": {
+            "answer": 13420,
+            "candidate": 2001622,
+            "answer_feedback": "These are indeed harsh criticisms, but the damage to Lai Ching-te seems limited as his building violation isn't severe. Even if arrogant, his core support base may still stand by him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13425,
+        "fields": {
+            "answer": 13421,
+            "candidate": 2001622,
+            "answer_feedback": "If you want to demolish his house, you might as well seek help from Mayor Hou You-yi; at least he is the mayor of New Taipei City and can assist you in addressing this issue."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13439,
+        "fields": {
+            "answer": 13438,
+            "candidate": 2001622,
+            "answer_feedback": "The relentless pursuit by the DPP has forced you to donate these funds and demolish the parking lot. Hopefully, this won't affect your chances of victory."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13440,
+        "fields": {
+            "answer": 13437,
+            "candidate": 2001622,
+            "answer_feedback": "This is a swift action that can help you stop the bleeding. Unfortunately, these annoying real estate disputes have indeed impacted your poll numbers."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13445,
+        "fields": {
+            "answer": 13436,
+            "candidate": 2001622,
+            "answer_feedback": "Haha, it seems you are destined for a brawl with Lai Ching-te, and who will have the last laugh remains to be seen."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13453,
+        "fields": {
+            "answer": 13449,
+            "candidate": 2001622,
+            "answer_feedback": "Doubling down on your third-party identity will benefit you. After all, Taiwan has never experienced a third party in power, and you might have a chance to win."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13456,
+        "fields": {
+            "answer": 13450,
+            "candidate": 2001622,
+            "answer_feedback": "The DPP has spent a lot of special budgets on various plans in recent years, and you have been criticizing them for their lack of fiscal discipline because special budgets were not used so frequently in the past."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13460,
+        "fields": {
+            "answer": 13451,
+            "candidate": 2001622,
+            "answer_feedback": "You are the strongest third-party candidate since James Soong in 2000. Emphasizing this point will always be beneficial and attractive."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13465,
+        "fields": {
+            "answer": 13452,
+            "candidate": 2001622,
+            "answer_feedback": "This is a strong counterattack against the DPP, and many people have noticed that you have been assisting the blue camp in attacking Lai Ching-te throughout this debate."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13472,
+        "fields": {
+            "answer": 13469,
+            "candidate": 2001622,
+            "answer_feedback": "As long as you all don't give up, Uncle Ko won't give up either! Let's create another miracle in the history of Taiwan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13478,
+        "fields": {
+            "answer": 13470,
+            "candidate": 2001622,
+            "answer_feedback": "You must not fail in Taipei; otherwise, it would suggest that your achievements in Taipei over the past eight years were not as impressive. I hope the Taipei experience can be extended nationwide!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13480,
+        "fields": {
+            "answer": 13471,
+            "candidate": 2001622,
+            "answer_feedback": "Taichung has a significant number of young supporters, while Changhua and Nantou, with fewer young residents and lower urbanization rates, face challenges in garnering support similar to Taichung."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13481,
+        "fields": {
+            "answer": 13479,
+            "candidate": 2001622,
+            "answer_feedback": "Chairman Ko Wen-je, your mother fervently hopes that you become the president, and she would be very happy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13497,
+        "fields": {
+            "answer": 13495,
+            "candidate": 2001622,
+            "answer_feedback": "Mayor Hou You-yi's ability as a mayor will undoubtedly help you gain more votes here."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13499,
+        "fields": {
+            "answer": 13496,
+            "candidate": 2001622,
+            "answer_feedback": "Mayor Hou has covered the entire east coast for you and has helped boost your visibility in Pingtung and Yilan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13502,
+        "fields": {
+            "answer": 13494,
+            "candidate": 2001622,
+            "answer_feedback": "Kaohsiung and Tainan are solid strongholds of the DPP, but the collaboration between our two parties could potentially disrupt this situation!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13505,
+        "fields": {
+            "answer": 13493,
+            "candidate": 2001622,
+            "answer_feedback": "Hou You-yi hasn't returned to his hometown for a long time, but with his local identity, he can secure many votes."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13518,
+        "fields": {
+            "answer": 13516,
+            "candidate": 2001622,
+            "answer_feedback": "Terry Gou ultimately accepted your suggestion, and he will withdraw from the election to ensure that the pan-blue votes are not further fragmented."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13519,
+        "fields": {
+            "answer": 13515,
+            "candidate": 2001622,
+            "answer_feedback": "No matter what you say, Joint Tickets are on the verge of collapse. The only remaining possibility is theoretical. You need to find a vice president now.\Fortunately, Terry Gou withdrew from the election, preventing further splitting of the pan-blue votes in this election."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13520,
+        "fields": {
+            "answer": 13514,
+            "candidate": 2001622,
+            "answer_feedback": "No matter what you say, Joint Tickets are on the verge of collapse. The only remaining possibility is theoretical. You need to find a vice president now.Fortunately, Terry Gou withdrew from the election, preventing further splitting of the pan-blue votes in this election."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13530,
+        "fields": {
+            "answer": 13522,
+            "candidate": 2001622,
+            "answer_feedback": "Gou said nothing at the moment, and you sensed that something was amiss. On November 24th, he registered as a presidential candidate along with his running mate,Lai Pei-Hsia, for the position of vice president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13536,
+        "fields": {
+            "answer": 13535,
+            "candidate": 2001622,
+            "answer_feedback": "Your voters dislike the image of being associated with big business, but her beautiful and feminine image can compensate for that. The Kuomintang's Hou You-yi also made a surprising choice by selecting Zhao Shao-kang as his running mate. The specific situation remains to be observed."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13540,
+        "fields": {
+            "answer": 13534,
+            "candidate": 2001622,
+            "answer_feedback": "Her English is excellent, but her Chinese may not be as fluent in certain situations. For example, in debates and public speeches, her performance can be like reading from a script."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13544,
+        "fields": {
+            "answer": 13533,
+            "candidate": 2001622,
+            "answer_feedback": "Choosing her will provide a good gender balance, and her beautiful image will capture the hearts of many voters. The People's Party is certainly not lacking in attractive women."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13551,
+        "fields": {
+            "answer": 13550,
+            "candidate": 2001622,
+            "answer_feedback": "Zhao Shao-kang strongly responded, urging you to ensure that there will be no cooperation with dpp after the election. Hou You-yi also remarked that must be quite envious of having a competent Vice President."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13552,
+        "fields": {
+            "answer": 13548,
+            "candidate": 2001622,
+            "answer_feedback": "The return of blue camp voters is happening at a faster pace than anticipated. According to Formosa and TVBS polls, the KMT-TPP has a support rate of 31%, compared to 23%, and 30.5% to 17.7%, respectively."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13562,
+        "fields": {
+            "answer": 13558,
+            "candidate": 2001622,
+            "answer_feedback": "This is a somewhat unclear response, and Mayor Hou has strongly criticized you in this regard. Based on this response, you seem to lean towards abolishing the death penalty."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13565,
+        "fields": {
+            "answer": 13559,
+            "candidate": 2001622,
+            "answer_feedback": "You are the strongest third-party candidate since James Soong in 2000. Emphasizing this point will always be beneficial and attractive."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13568,
+        "fields": {
+            "answer": 13560,
+            "candidate": 2001622,
+            "answer_feedback": "Lai Ching-te angrily countered you, stating that the 57 billion NTD debt repayment you frequently boast about for Taipei was concentrated in a specific year and is not something worth bragging about every day."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13573,
+        "fields": {
+            "answer": 13561,
+            "candidate": 2001622,
+            "answer_feedback": "Hou You-yi replied to you with just a few words, telling you not to shoot the arrow before drawing the target; there is no such thing."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13579,
+        "fields": {
+            "answer": 13578,
+            "candidate": 2001622,
+            "answer_feedback": "This statement directly triggered attacks from the green camp, implying that Wu Xinying has a spoiled style and completely lacks understanding of the people's hardships. In addition, DPP stated, \"We are Taiwanese! You are Chinese. Wu's identity is fundamentally problematic.\" "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13584,
+        "fields": {
+            "answer": 13583,
+            "candidate": 2001622,
+            "answer_feedback": "Many green supporters believe that if the CSSTA is signed, an influx of Chinese people will take away all the local jobs in Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13588,
+        "fields": {
+            "answer": 13587,
+            "candidate": 2001622,
+            "answer_feedback": "These attacks align well with the preferences of your voter base, but whether they can extend to capture more of the moderate voters remains to be seen."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13592,
+        "fields": {
+            "answer": 13591,
+            "candidate": 2001622,
+            "answer_feedback": "This is a response to the DPP's extensive spending plans and misuse of special budgets, supporting your stance on strengthening fiscal discipline."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13606,
+        "fields": {
+            "answer": 13605,
+            "candidate": 2001622,
+            "answer_feedback": "This is a clear signal to opposition voters; however, they might automatically choose the candidate with the highest poll numbers."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13611,
+        "fields": {
+            "answer": 13602,
+            "candidate": 2001622,
+            "answer_feedback": "Lai  immediately countered your agricultural land issue, stating that converting agricultural land into a parking lot is the real illegal activity. He mentioned plans to transform his own home into a mining museum for charitable trust purposes."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13612,
+        "fields": {
+            "answer": 13604,
+            "candidate": 2001622,
+            "answer_feedback": "Your attacks on Terry Gou won't go unnoticed by the voters. Since he started running as an independent, his support has steadily declined. Hopefully, Gou's supporters will come to your camp!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13613,
+        "fields": {
+            "answer": 13603,
+            "candidate": 2001622,
+            "answer_feedback": "Mayor Hou staunchly countered your accusations, stating that the property in question belongs to his wife and is entirely legal and justified. He emphasized that after the contract expires, it will be converted into affordable housing for the community.\""
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13636,
+        "fields": {
+            "answer": 13635,
+            "candidate": 12776,
+            "answer_feedback": "Chairman Ko Wen-je, your mother fervently hopes that you become the president, and she would be very happy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13637,
+        "fields": {
+            "answer": 13634,
+            "candidate": 12776,
+            "answer_feedback": "Taichung has a significant number of young supporters, while Changhua and Nantou, with fewer young residents and lower urbanization rates, face challenges in garnering support similar to Taichung."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13638,
+        "fields": {
+            "answer": 13633,
+            "candidate": 12776,
+            "answer_feedback": "You must not fail in Taipei; otherwise, it would suggest that your achievements in Taipei over the past eight years were not as impressive. I hope the Taipei experience can be extended nationwide!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13639,
+        "fields": {
+            "answer": 13632,
+            "candidate": 12776,
+            "answer_feedback": "As long as you all don't give up, Uncle Ko won't give up either! Let's create another miracle in the history of Taiwan!"
+        }
+    }
+]
+
+
+
+
+cyoAdventure = function (a) {
+    
+    ans = campaignTrail_temp.player_answers[campaignTrail_temp.player_answers.length-1];
+   
+    let pop_vote = e.current_results[0];
+    let playerPolling = pop_vote[2].pvp;
+    let i = 0;
+
+        pop_vote.sort((a, b) => {
+            return a.pk - b.pk;
+        });
+      //柯胜，默认设置
+      if (ans == 13302 || ans == 13303 || ans == 13304 || ans == 13305){     
+        campaignTrail_temp.running_mate_image_url = 'https://i.imgur.com/GCeTdoX.png';
+        campaignTrail_temp.running_mate_last_name = 'Hou';
+    }
+
+    //民调低于30，整合失败
+     if (ans == 13295 || ans == 13296 || ans == 13298 && pop_vote[2].pvp <= 0.30){
+        campaignTrail_temp.questions_json[19] = {
+            "model": "campaign_trail.question",
+            "pk": 13033,
+            "fields": {
+                "priority": 0,
+                "description": "On the Midnight of November 18th, as the people of Taiwan slept, in a dark and windy evening, polling experts from the TPP and KMT were nervously discussing issues related to the margin of error in the polls and the number of victories for each party. and The final results are.....",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[20] = {
+            "model": "campaign_trail.question",
+            "pk": 13350,
+            "fields": {
+                "priority": 0,
+                "description": "On the Morning of November 18th, another shocking news rocked the political scene: the KMT and TPP were embroiled in disputes within the margin of error in the polls, leading to conflicting victory claims. The TPP insisted on a margin of error of 3%, with a range of plus or minus 1.5%, while the KMT argued that each poll should be calculated based on its own determined maximum margin of error. For example, Formosa Poll indicated a maximum sampling error of ±3.0% at a 95% confidence level, totaling 6%. Now, at this crucial moment deciding Taiwan's fate, how do you perceive the negotiations reaching a deadlock?",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[21] = {
+            "model": "campaign_trail.question",
+            "pk": 13509,
+            "fields": {
+                "priority": 0,
+                "description": "On November 23rd, you and Terry Gou invited Mayor Hou You-yi to the Taipei Grand Hyatt to discuss the last hope for Joint Tickets. However, Mayor Hou You-yi brought President Ma Ying-jeou and Chairman Eric Chu to the scene, causing dissatisfaction from Terry Gou. Chairman Ko Wen-je, what points do you need to emphasize during the meeting?",
+                "likelihood": 1
+            }
+        }
+
+        campaignTrail_temp.questions_json[23] = {
+            "model": "campaign_trail.question",
+            "pk": 13511,
+            "fields": {
+                "priority": 0,
+                "description": "November 24th, after you registered as a presidential candidate at the CEC, Hou Youyi called you, but you ignored it. An hour later, he teamed up with Zhao Shao-kang, the chairman of China Broadcasting Corporation, and other media figures to form the presidential and vice-presidential ticket. In the following days, many blue camp voters were emotionally stirred by this, and it seems that many blue voters who had temporarily supported you are returning to the KMT's base.....",
+                "likelihood": 1
+            }
+    }
+    campaignTrail_temp.questions_json[22] = {
+        "model": "campaign_trail.question",
+        "pk": 13510,
+        "fields": {
+            "priority": 0,
+            "description": "As Joint Tickets completely failed, on November 24th, you unexpectedly chose legislator Cynthia Wu as the vice president. She is the daughter of a major business tycoon, bringing an impressive background to your campaign. Additionally, being an American-born Chinese (ABC), what special qualities do you see in her that led to your choice of her as the vice president?",
+            "likelihood": 1
+        }
+}
+    campaignTrail_temp.questions_json[24] = {
+        "model": "campaign_trail.question",
+        "pk": 13513,
+        "fields": {
+            "priority": 0,
+            "description": "Your vice president, Cynthia Wu, has many noteworthy qualities. Handing over the floor to her, what do you think she should say to attract voters?",
+            "likelihood": 1
+        }
+    }
+        campaignTrail_temp.questions_json[25] = {
+            "model": "campaign_trail.question",
+            "pk": 13026,
+            "fields": {
+                "priority": 0,
+                "description": "Some of your aides suggest that, following the tradition of KMT candidates, you add a small Republic of China (ROC) flag emblem on top of your KP badge to increase appeal to blue-leaning voters. Will you consider this suggestion?",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[28] = {
+            "model": "campaign_trail.question",
+          "pk": 13512,
+             "fields": {
+            "priority": 0,
+            "description": "In this year's presidential election, there are three candidates on the stage: Hou from the KMT, you from the TPP, and Lai from the DPP. This will be your moment to showcase your debating skills in the presidential election. What do you want to emphasize during the debate?",
+            "likelihood": 1
+         }
+        }
+    }
+    //直接节目上说不要合
+    else if (ans == 13361 ){
+        campaignTrail_temp.questions_json[19] = {
+            "model": "campaign_trail.question",
+            "pk": 13033,
+            "fields": {
+                "priority": 0,
+                "description": "On the Midnight of November 18th, as the people of Taiwan slept, in a dark and windy evening, polling experts from the TPP and KMT were nervously discussing issues related to the margin of error in the polls and the number of victories for each party. and The final results are.....",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[20] = {
+            "model": "campaign_trail.question",
+            "pk": 13350,
+            "fields": {
+                "priority": 0,
+                "description": "On the Morning of November 18th, another shocking news rocked the political scene: the KMT and TPP were embroiled in disputes within the margin of error in the polls, leading to conflicting victory claims. The TPP insisted on a margin of error of 3%, with a range of plus or minus 1.5%, while the KMT argued that each poll should be calculated based on its own determined maximum margin of error. For example, Formosa Poll indicated a maximum sampling error of ±3.0% at a 95% confidence level, totaling 6%. Now, at this crucial moment deciding Taiwan's fate, how do you perceive the negotiations reaching a deadlock?",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[21] = {
+            "model": "campaign_trail.question",
+            "pk": 13509,
+            "fields": {
+                "priority": 0,
+                "description": "On November 23rd, you and Terry Gou invited Mayor Hou You-yi to the Taipei Grand Hyatt to discuss the last hope for Joint Tickets. However, Mayor Hou You-yi brought President Ma Ying-jeou and Chairman Eric Chu to the scene, causing dissatisfaction from Terry Gou. Chairman Ko Wen-je, what points do you need to emphasize during the meeting?",
+                "likelihood": 1
+            }
+        }
+
+        campaignTrail_temp.questions_json[23] = {
+            "model": "campaign_trail.question",
+            "pk": 13511,
+            "fields": {
+                "priority": 0,
+                "description": "November 24th, after you registered as a presidential candidate at the CEC, Hou Youyi called you, but you ignored it. An hour later, he teamed up with Zhao Shao-kang, the chairman of China Broadcasting Corporation, and other media figures to form the presidential and vice-presidential ticket. In the following days, many blue camp voters were emotionally stirred by this, and it seems that many blue voters who had temporarily supported you are returning to the KMT's base.....",
+                "likelihood": 1
+            }
+    }
+    campaignTrail_temp.questions_json[22] = {
+        "model": "campaign_trail.question",
+        "pk": 13510,
+        "fields": {
+            "priority": 0,
+            "description": "As Joint Tickets completely failed, on November 24th, you unexpectedly chose legislator Cynthia Wu as the vice president. She is the daughter of a major business tycoon, bringing an impressive background to your campaign. Additionally, being an American-born Chinese (ABC), what special qualities do you see in her that led to your choice of her as the vice president?",
+            "likelihood": 1
+        }
+}
+    campaignTrail_temp.questions_json[24] = {
+        "model": "campaign_trail.question",
+        "pk": 13513,
+        "fields": {
+            "priority": 0,
+            "description": "Your vice president, Cynthia Wu, has many noteworthy qualities. Handing over the floor to her, what do you think she should say to attract voters?",
+            "likelihood": 1
+        }
+    }
+        campaignTrail_temp.questions_json[25] = {
+            "model": "campaign_trail.question",
+            "pk": 13026,
+            "fields": {
+                "priority": 0,
+                "description": "Some of your aides suggest that, following the tradition of KMT candidates, you add a small Republic of China (ROC) flag emblem on top of your KP badge to increase appeal to blue-leaning voters. Will you consider this suggestion?",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[28] = {
+            "model": "campaign_trail.question",
+          "pk": 13512,
+             "fields": {
+            "priority": 0,
+            "description": "In this year's presidential election, there are three candidates on the stage: Hou from the KMT, you from the TPP, and Lai from the DPP. This will be your moment to showcase your debating skills in the presidential election. What do you want to emphasize during the debate?",
+            "likelihood": 1
+         }
+        }
+    }
+    if (ans == 13295 || ans == 13296 || ans == 13298 && pop_vote[2].pvp > 0.30){    
+        campaignTrail_temp.questions_json[19] = { 
+            "model": "campaign_trail.question",
+            "pk": 13023,
+            "fields": {
+                "priority": 0,
+                "description": "On November 18th, after intensive calculations and investigations, the polling experts designated by TPP and KMT are in intense discussions regarding the polling outcomes and margin of error. The final results are:",
+                "likelihood": 1
+            }
+     }
+     campaignTrail_temp.questions_json[20] = { 
+        "model": "campaign_trail.question",
+        "pk": 13024,
+        "fields": {
+            "priority": 0,
+            "description": "As you succeed and unbelievably surpass both the KMT and Mayor Hou Yu-yi, it is crucial to manage your relationship with the KMT. Meanwhile, many core supporters also have reservations about the KMT. In order to ensure the longevity of this alliance, what do you hope to say or do to eliminate internal divisions caused by the alliance?",
+            "likelihood": 1
+        }
+ }
+ campaignTrail_temp.questions_json[21] = { 
+    "model": "campaign_trail.question",
+    "pk": 13025,
+    "fields": {
+        "priority": 0,
+        "description": "As each party finalizes their running mates, the DPP has selected Hsiao Bi-khim as the vice president. This signifies that the current Green-White showdown has completely taken shape! How do you plan to balance your campaign strategy and policies in response to this development?",
+        "likelihood": 1
+    }
+}
+campaignTrail_temp.questions_json[22] = { 
+    "model": "campaign_trail.question",
+        "pk": 13026,
+        "fields": {
+            "priority": 0,
+            "description": "Some of your aides suggest that, following the tradition of KMT candidates, you add a small Republic of China (ROC) flag emblem on top of your KP badge to increase appeal to blue-leaning voters. Will you consider this suggestion?",
+            "likelihood": 1
+        }
+}
+campaignTrail_temp.questions_json[23] = { 
+    "model": "campaign_trail.question",
+    "pk": 13027,
+    "fields": {
+        "priority": 0,
+        "description": "Chairman Ko, in a recent interview with a newspaper, you discussed various policy details. Certainly, the TPP has many comprehensive policy ideas and visions. Among these policies, what do you like the most and what would you like to emphasize the most?",
+        "likelihood": 1
+    }
+}
+campaignTrail_temp.questions_json[24] = { 
+    "model": "campaign_trail.question",
+    "pk": 13028,
+    "fields": {
+        "priority": 0,
+        "description": "As the presidential election enters its final stage, some of your former green supporters have become disappointed due to your cooperation with the Kuomintang (KMT) and have left your camp. At the same time, some elderly blue camp voters find it difficult to accept a candidate with a deep-green background and may choose not to vote. In light of this situation, how do you plan to respond?",
+        "likelihood": 1
+    }
+}
+campaignTrail_temp.questions_json[25] = { 
+    "model": "campaign_trail.question",
+    "pk": 13492,
+    "fields": {
+        "priority": 0,
+        "description": "Mayor Hou You-yi proposes that, considering his limited authority and influence as vice president, he would like to actively campaign for you across Taiwan to strengthen the TPP-KMT alliance's presence and support in various regions. Where do you think he should focus his efforts?",
+        "likelihood": 1
+    }
+}
+campaignTrail_temp.questions_json[28] = { 
+    "model": "campaign_trail.question",
+    "pk": 13031,
+    "fields": {
+        "priority": 0,
+        "description": "In this year's presidential election, you and Lai Ching-te will engage in a one-on-one debate on the stage, which could be the most crucial moment in your life. The outcome of the debate is likely to influence public perception and generate significant media coverage. What would you like to emphasize the most in this debate?",
+        "likelihood": 1
+    }
+}
+
+} 
+    if (ans == 13388 || ans == 13390 ){
+        campaignTrail_temp.candidate_image_url = "https://i.imgur.com/84Ealxo.jpeg";
+    }   
+    if (ans == 13034 || ans == 13035 || ans == 13036 || ans ==13037){
+        campaignTrail_temp.election_json[0]["fields"].advisor_url = "https://i.imgur.com/5sM8nVt.jpeg";
+    }
+
+    if (ans == 13514 || ans == 13515 || ans == 13516 || ans == 13522 ){
+        campaignTrail_temp.running_mate_image_url = 'https://i.imgur.com/OdRj8T0.png';
+        campaignTrail_temp.running_mate_last_name = 'Wu';
+    }
+    if( ans == 13522 ){
+        campaignTrail_temp.questions_json[19] = {
+            "model": "campaign_trail.question",
+            "pk": 13033,
+            "fields": {
+                "priority": 0,
+                "description": "On the Midnight of November 18th, as the people of Taiwan slept, in a dark and windy evening, polling experts from the TPP and KMT were nervously discussing issues related to the margin of error in the polls and the number of victories for each party. and The final results are.....",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[20] = {
+            "model": "campaign_trail.question",
+            "pk": 13350,
+            "fields": {
+                "priority": 0,
+                "description": "On the Morning of November 18th, another shocking news rocked the political scene: the KMT and TPP were embroiled in disputes within the margin of error in the polls, leading to conflicting victory claims. The TPP insisted on a margin of error of 3%, with a range of plus or minus 1.5%, while the KMT argued that each poll should be calculated based on its own determined maximum margin of error. For example, Formosa Poll indicated a maximum sampling error of ±3.0% at a 95% confidence level, totaling 6%. Now, at this crucial moment deciding Taiwan's fate, how do you perceive the negotiations reaching a deadlock?",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[21] = {
+            "model": "campaign_trail.question",
+            "pk": 13509,
+            "fields": {
+                "priority": 0,
+                "description": "On November 23rd, you and Terry Gou invited Mayor Hou You-yi to the Taipei Grand Hyatt to discuss the last hope for Joint Tickets. However, Mayor Hou You-yi brought President Ma Ying-jeou and Chairman Eric Chu to the scene, causing dissatisfaction from Terry Gou. Chairman Ko Wen-je, what points do you need to emphasize during the meeting?",
+                "likelihood": 1
+            }
+        }
+
+        campaignTrail_temp.questions_json[23] = {
+            "model": "campaign_trail.question",
+            "pk": 13511,
+            "fields": {
+                "priority": 0,
+                "description": "November 24th, after you registered as a presidential candidate at the CEC, Hou Youyi called you, but you ignored it. An hour later, he teamed up with Zhao Shao-kang, the chairman of China Broadcasting Corporation, and other media figures to form the presidential and vice-presidential ticket. In the following days, many blue camp voters were emotionally stirred by this, and it seems that many blue voters who had temporarily supported you are returning to the KMT's base.....",
+                "likelihood": 1
+            }
+    }
+    campaignTrail_temp.questions_json[22] = {
+        "model": "campaign_trail.question",
+        "pk": 13510,
+        "fields": {
+            "priority": 0,
+            "description": "As Joint Tickets completely failed, on November 24th, you unexpectedly chose legislator Cynthia Wu as the vice president. She is the daughter of a major business tycoon, bringing an impressive background to your campaign. Additionally, being an American-born Chinese (ABC), what special qualities do you see in her that led to your choice of her as the vice president?",
+            "likelihood": 1
+        }
+}
+    campaignTrail_temp.questions_json[24] = {
+        "model": "campaign_trail.question",
+        "pk": 13513,
+        "fields": {
+            "priority": 0,
+            "description": "Your vice president, Cynthia Wu, has many noteworthy qualities. Handing over the floor to her, what do you think she should say to attract voters?",
+            "likelihood": 1
+        }
+    }
+        campaignTrail_temp.questions_json[25] = {
+            "model": "campaign_trail.question",
+            "pk": 13026,
+            "fields": {
+                "priority": 0,
+                "description": "Some of your aides suggest that, following the tradition of KMT candidates, you add a small Republic of China (ROC) flag emblem on top of your KP badge to increase appeal to blue-leaning voters. Will you consider this suggestion?",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[28] =   {
+            "model": "campaign_trail.question",
+            "pk": 13577,
+            "fields": {
+                "priority": 0,
+                "description": "This year's unprecedented presidential election features four candidates participating in a debate: yourself from the TPP, Hou from the KMT, Lai from the DPP, and the independent candidate Gou. Just a month ago, you suggested that Gou should withdraw from the election, but he did not consider this proposal and chose to run independently. In this debate, what main points would you like to emphasize?",
+                "likelihood": 1
+            }
+        }
+    }
+    //柯文哲被弃保：辩论后民调未达30%，选民归队
+    if (ans == 13449 || ans == 13450 || ans == 13451 || ans == 13452 && pop_vote[2].pvp < 0.29){    
+        campaignTrail_temp.questions_json[29] =   {
+            "model": "campaign_trail.question",
+            "pk": 13631,
+            "fields": {
+                "priority": 0,
+                "description": "In the final week before the election, you have the opportunity to visit specific regions nationwide to boost local support. In which areas do you hope to campaign in a final effort?",
+                "likelihood": 1
+            }
+        }
+    }
+    //各党特色颜色，背景图片
+    if ( ans == 13034 || ans == 13035 || ans == 13036 || ans == 13037){    
+        nct_stuff.themes[nct_stuff.selectedTheme].coloring_window = "#ffffff" 
+        nct_stuff.themes[nct_stuff.selectedTheme].coloring_title = "#28c8c8" 
+        $(".container")[0].style.backgroundColor = "#6848ff" 
+        $("#game_window")[0].style.borderColor = "#99A0A8" 
+        $(".container")[0].style.backgroundColor = "#F4F4EE" 
+        $("#game_window")[0].style.borderColor = "#ffffff" 
+        $("#game_window")[0].style.backgroundImage = "url(https://i.imgur.com/xAN3Ufz.png)" 
+        document.getElementById("header").src = "https://i.imgur.com/Q5BQ3fn.jpg" 
+        document.body.background = "https://i.imgur.com/u7NyV06.jpeg"
+    }
+    //成就
+    getResults = function (out, totv, aa, quickstats) {
+        if( quickstats[1] > 33.49 && quickstats[1] < 40.0 ) {
+            unlockAchievement("Cross The Song-Chu Yu wall");
+        }
+    }
+    getResults = function (out, totv, aa, quickstats) {
+        let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 256);
+        if( quickstats[1] > 29.9 && stateResult.result[2].candidate == 2001622 ) {
+            unlockAchievement("The pesky mayor");
+        }
+    }
+    getResults = function (out, totv, aa, quickstats) {
+        if( quickstats[1] <= 50.29 && aa[0].candidate === 2001622 ) {
+            unlockAchievement("Election valid");
+        }
+    }
+    getResults = function (out, totv, aa, quickstats) {
+        if(aa[2].candidate === 2001591 ) {
+            unlockAchievement("Old Third Boxed Lunch");
+        }
+    }
+    getResults = function (out, totv, aa, quickstats) {
+        if(aa[2].candidate === 2001557 ) {
+            unlockAchievement("Lai the third");
+        }
+    }
+    getResults = function (out, totv, aa, quickstats) {
+        if( e.player_answers.includes(13194) && aa[0].candidate === 2001622) {
+            unlockAchievement("Votes White Votes Right");
+        }
+    }
+    getResults = function (out, totv, aa, quickstats) {
+        let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 268);
+        let stateResulttwo = campaignTrail_temp.final_state_results.find((x) => x.state == 265);
+        if( stateResult.result[0].candidate == 2001622 && stateResulttwo.result[0].candidate == 2001622 ) {
+            unlockAchievement("Loves From Hometown");
+        }
+    }
+}
+
+campaignTrail_temp.jet_data = [{}
+]
+
+campaignTrail_temp.candidate_image_url = "https://i.imgur.com/3fQuylW.jpg";
+campaignTrail_temp.running_mate_image_url = "https://i.imgur.com/ZAZoO9r.jpeg";
+campaignTrail_temp.candidate_last_name = "Ko";
+campaignTrail_temp.running_mate_last_name = "For TPP 2024";
+campaignTrail_temp.running_mate_state_id = '265';
+campaignTrail_temp.player_answers = [];
+campaignTrail_temp.player_visits = [];
+campaignTrail_temp.answer_feedback_flg = 1;
+campaignTrail_temp.game_start_logging_id = '3660822';
+
+const style_overwrite = document.createElement("style");
+style_overwrite.innerHTML = 
+`#campaign_sign {
+  background-color: #28c8c8;
+  border-color: #7fcfc8;
+}
+#menu_container {
+  background-color: #c3c3c3;
+}
+#overall_result_container {
+  background-color: #c3c3c3;
+}
+#state_info h3 {
+  background-color: #ffffff;
+}
+#overall_result h3 {
+  background-color: #ffffff;
+}`
+;
+document.head.appendChild(style_overwrite);
+
+let style = document.createElement('style');
+style.type = 'text/css';
+style.id = 'dynamic-style';
+
+style.innerHTML = `
+  .inner_window_question h3 {
+    background-color: #e1e1e1;
+  }
+  .overlay_window h3 {
+    background-color: #b4b4b4;
+  }
+
+  
+`;
+
+document.head.appendChild(style);
+
+
+function checkIfCanAddMap() {
+    map = document.getElementById("map_container");
+    
+    if(map) {
+        map.style.backgroundImage = "url('https://images.rawpixel.com/image_800/czNmcy1wcml2YXRlL3Jhd3BpeGVsX2ltYWdlcy93ZWJzaXRlX2NvbnRlbnQvbHIvdjk5Ni0wMDlfMS1rcm9pcjRkay5qcGc.jpg')"; 
+    }
+}
+
+setInterval(checkIfCanAddMap, 250);
+
+(function(e, t, n, r, i) {
+    function s(e, t, n, r) {
+        r = r instanceof Array ? r : [];
+        var i = {};
+        for (var s = 0; s < r.length; s++) {
+            i[r[s]] = true
+        }
+        var o = function(e) {
+            this.element = e
+        };
+        o.prototype = n;
+        e.fn[t] = function() {
+            var n = arguments;
+            var r = this;
+            this.each(function() {
+                var s = e(this);
+                var u = s.data("plugin-" + t);
+                if (!u) {
+                    u = new o(s);
+                    s.data("plugin-" + t, u);
+                    if (u._init) {
+                        u._init.apply(u, n)
+                    }
+                } else if (typeof n[0] == "string" && n[0].charAt(0) != "_" && typeof u[n[0]] == "function") {
+                    var a = Array.prototype.slice.call(n, 1);
+                    var f = u[n[0]].apply(u, a);
+                    if (n[0] in i) {
+                        r = f
+                    }
+                }
+            });
+            return r
+        }
+    }
+    var o = 1010,
+        u = 500,
+        a = 50;
+    var f = {
+        stateStyles: {
+            fill: "#333",
+            stroke: "#666",
+            "stroke-width": 1,
+            "stroke-linejoin": "round",
+            scale: [1, 1]
+        },
+        stateHoverStyles: {
+            fill: "#33c",
+            stroke: "#000",
+            scale: [1.1, 1.1]
+        },
+        stateHoverAnimation: 500,
+        stateSpecificStyles: {},
+        stateSpecificHoverStyles: {},
+        click: null,
+        mouseover: null,
+        mouseout: null,
+        clickState: {},
+        mouseoverState: {},
+        mouseoutState: {},
+        showLabels: true,
+        labelWidth: 20,
+        labelHeight: 15,
+        labelGap: 6,
+        labelRadius: 3,
+        labelBackingStyles: {
+            fill: "#333",
+            stroke: "#666",
+            "stroke-width": 1,
+            "stroke-linejoin": "round",
+            scale: [1, 1]
+        },
+        labelBackingHoverStyles: {
+            fill: "#33c",
+            stroke: "#000"
+        },
+        stateSpecificLabelBackingStyles: {},
+        stateSpecificLabelBackingHoverStyles: {},
+        labelTextStyles: {
+            fill: "#fff",
+            stroke: "none",
+            "font-weight": 300,
+            "stroke-width": 0,
+            "font-size": "10px"
+        },
+        labelTextHoverStyles: {},
+        stateSpecificLabelTextStyles: {},
+        stateSpecificLabelTextHoverStyles: {}
+    };
+    var l = {
+        _init: function(t) {
+            this.options = {};
+            e.extend(this.options, f, t);
+            var n = this.element.width();
+            var i = this.element.height();
+            var s = this.element.width() / o;
+            var l = this.element.height() / u;
+            this.scale = Math.min(s, l);
+            this.labelAreaWidth = Math.ceil(a / this.scale);
+            var c = o + Math.max(0, this.labelAreaWidth - a);
+            this.paper = r(this.element.get(0), c, u);
+            this.paper.setSize(n, i);
+            this.paper.setViewBox(-500, 0, c, u, false);
+            this.stateHitAreas = {};
+            this.stateShapes = {};
+            this.topShape = null;
+            this._initCreateStates();
+            this.labelShapes = {};
+            this.labelTexts = {};
+            this.labelHitAreas = {};
+            if (this.options.showLabels) {
+                this._initCreateLabels()
+            }
+        },
+        _initCreateStates: function() {
+            var t = this.options.stateStyles;
+            var n = this.paper;
+            var r = {
+                Tainancity:"m178.94 309.54c1.821 0.85976 1.9013 1.8004 3.9722 1.3601 0.52002 1.6719-1.5712 1.0502-1.4009 2.6113 0.8704 0.21983 2.3913 0.20091 2.5009 1.2003 2.4514 1.3001-0.0196 1.501 0.46065 3.6413 2.191-0.12068 3.2917 1.4299 5.2733 1.8898 0.13963 1.4005-0.8306 1.1807-1.6207 1.8011-1.0903 0.85976-1.1105 1.2309-1.181 2.6706-0.0698 1.411-0.89063 5.8318 0.97023 6.032 0.0496 0.85128 0.0496 1.7515 0 2.6008-0.82081 0.37966-1.1705 1.4814-1.1105 2.3405 0.5807 0.0202 1.2006 0.03 1.7806 0.06 0.17029 0.33986 0.2897 0.71103 0.39083 1.0607 1.7114-0.20939 1.8902 1.5512 3.2813 1.8904 0.16051-0.81019 1.3415-1.1305 1.7219-0.3503 0.0692 0 0.55983-0.0104 0.61072 0 0.84039-1.4103 2.5114-1.3803 2.8611-3.2414 0.73077 1.1709 1.2312 1.6308 2.6314 1.7411 1.4909 0.10959 2.4716-0.39988 3.8418-0.0998 0.76079 1.1598 1.6618 0.69994 1.8817-0.36074 0.39931 0.31051 0.63942 0.76061 0.63029 1.3007-0.15986 0.0398-0.30014 0-0.45021 0.06-0.12984 1.3803-0.89063 1.4599-1.6501 2.4606-0.97023 1.2694-0.14094 1.9498-0.3804 3.1696-0.3308 1.6608-3.2924 3.1214-4.3331 4.6817-1.5007 2.2616-2.7815 3.6608-3.7217 6.3217-0.85083 2.4208-1.6612 4.5519-3.9122 5.5415-2.3711 1.0496-3.1919 3.0013-4.8727 4.8018-0.71055 0.74886-1.9209 1.7593-2.8317 2.1696-1.4204 0.63993-2.4814 0.69081-3.1815 2.3412-0.21009 0.50098-0.16051 1.4899-0.4502 1.8611-0.53047 0.68038-0.94022 0.39009-1.581 0.75996-1.0707 0.62036-1.4707 1.6112-2.281 2.6217-1.0505 1.291-1.0603 2.12-1.6906 3.5917-0.52068 1.2303-1.5509 2.2799-2.2915 3.3706-0.74056 1.0711-1.4707 2.1814-2.0312 3.1312-0.46065 0.77953 0.15007 1.1905-0.97088 1.3197-0.79015 0.0998-1.1705-0.12916-1.0603-0.96936-0.64008-0.0307-1.3108-0.0307-1.9509 0-1.2006 1.4703-2.7515 1.5004-4.0323 2.7711-1.0707 1.0705-0.46065 1.2303-2.0011 1.5695-0.89062 0.21005-2.3809 0.51991-2.1812-0.84019-1.8008-0.15982-3.432-0.77039-5.4827-0.69081-1.3604 0.0502-3.862-0.33008-4.8531 0.43053-1.3708-0.99153-4.3024-0.48011-4.8524-2.9113-1.641 0.95044-6.023-1.3503-7.784 0.42923-0.26034-1.9707-0.0803-4.4417-0.65052-5.7913-0.99045-2.3803-1.2103-4.501-3.1619-6.2114-2.0612-1.8102-4.8929-2.9609-6.513-5.122-1.4009-1.8806-2.9916-3.0216-5.3731-3.8415-5.5428-1.9009-6.4536-7.8024-2.5009-11.954 1.1608-1.2198 1.4811-1.2603 1.5007-3.2107 0.01-1.4606-0.20031-3.1207 0.15985-4.501 0.63029-2.3901 3.1521-3.9714 4.0225-6.3817 0.98067-2.7208-0.42019-5.6817 0.86062-8.4522 0.65051-1.4005 0.52002-2.7606 0.97022-4.1612 0.35038-1.1305 0.68053-0.7306 1.331-1.6308 0.52002-0.72016 0.39018-0.96087 0.49001-1.8813 0.21009-1.9198 0.97022-2.3601 1.7806-3.7815 1.4609 0.61123 2.4911 1.8709 4.0323 2.3008 0.1703 0.8702 0.81037 1.561 1.0603 2.4508 0.51024-0.0404 1.0903 0.09 1.611 0.0502 0.15007 1.9707 3.6819 4.7417 3.5618 1.1598 0.2499 0.3503 0.49001 0.45989 0.6603 0.96935 0.77057 0.0802 1.6012 1.1814 2.3111 1.0202 0.50045-0.11025 0.80059-1.1814 1.1608-1.6713 0.86062-1.1807 2.1108-1.7711 2.3613-3.4704 1.4211-1.5701 4.8028 0.42988 4.2822-2.8311-1.121-0.58122-0.30014-1.8513 0.65052-1.9113 0.98066-0.06 1.271 1.1403 2.6914 0.55121-0.30993-1.3614-1.2808-2.4221 0.31058-3.5512 1.4811-1.0405 2.8513 0.25897 2.7417-2.261 0.84038 0.0404 1.731 0.27006 2.6412 0.14025 1.5405-0.21984 0.94022-0.34965 1.9907-1.3001 1.3806-1.261 3.1521-1.0907 5.013-1.3705 1.611-0.24005 2.9316-1.0007 4.6626-1.0007 1.4707 0 3.9618 1.1102 5.0025-0.34965 0.97936 0.81476 2.5198 1.3144 3.6708 1.8546z",
+                Kaohsiungcity:"m156.17 440.89c0.0502 0.35029 0.20031 0.66993 0.12984 1.0502-0.0803-0.0111-0.15985 0-0.23032-0.0111-0.27991-0.50033-0.60027-0.33986-1.0309-0.58905-0.39996-0.24006-0.4502-0.63014-0.67009-0.96152-0.44042-0.67973-1.1105-1.3301-1.6312-1.9498-1.0707-1.291-2.0612-2.6908-3.0516-4.002-0.20031-0.27006-0.29035-0.8004-0.56047-0.93021-0.0202-0.06 0.01-0.12003-0.0202-0.17026-0.2499-0.34964-0.93043-0.3803-1.2404-0.63993 0.48022-0.15916 1.1608-0.0691 1.6808-0.0489-0.0202 0.17874 0.0803 0.30007 0.0803 0.47881 0.73077-0.0998 0.16051 0.93086 0.85083 0.96152 0.0202 0.0489-0.0104 0.12916 0.0202 0.17026 0.16964 0.14938 0.42998 0.17873 0.57026 0.30007 0.13963 0.12981 0.2897 0.47032 0.42998 0.63014 0.4502 0.49055 0.67009 0.78018 0.93043 1.3307 0.10961 0.2394 0.18986 0.5199 0.39017 0.72995 0.23033 0.24984 0.45021 0.2805 0.66031 0.47033 0.39018 0.36986 0.55068 0.78996 1.0603 1.06 0.12984 0.51012 0.52002 1.1103 0.78035 1.5408 0.0503 0.01 0.0998 0.01 0.15986 0.0196 0.0515 0.37052 0.29166 0.62036 0.69162 0.56035zm102.79-136.88c-0.15007 0-0.25968 0.0104-0.27012 0.0496-0.24011 0.69082-0.0502 1.1409 0.77057 1.3307 0.30992 1.6406 0.55982 2.8402 0.33994 4.6113-1.5203 0.24984-4.1014-0.3503-4.3226 1.5395-0.03 0.28116 0.51023 0.45011 0.51023 0.82063 0 0.77952-0.28969 0.71038-0.47043 1.2101-0.35038 0.93934-0.79014 1.5401-0.67009 2.6002 1.8015-0.20092 1.0309 0.68037 2.0109 1.3307 0.79015 0.53947 1.8413 0.33986 2.7717 0.39009-0.0692 0.3503 0.20096 0.81019 0.19052 1.0705 1.4609-0.61057 3.342 2.9113 3.1417 4.0412-1.0205 0.36987-1.1705 1.0705-0.95065 1.7704-0.8704 0.52056-2.052 0.29029-2.9818 0.6308-1.2006 0.42988-2.0409 1.3803-3.2115 1.9302-1.331 0.61122-2.4716 0.88129-3.832 1.2009-1.731 0.41031-2.2615 1.1507-3.3315 2.3412-0.7497 0.8291-1.4511 2.291-2.3411 2.9609-0.82929 0.61906-2.7012 0.25897-3.3113 1.2303-0.57026 0.92043 0.14028 3.2114-0.0202 4.3106-0.0698 0.54012-0.45021 0.92043-0.5011 1.4906-0.06 0.75996 0.29035 1.4514 0.17095 2.1703-0.28056 1.6204-1.6716 1.2616-2.3515 2.6608-0.30014 0.63014 0.21009 1.1807-0.35038 1.8011-0.39018 0.42075-1.4211 0.53034-1.9411 0.57013-0.27012 1.03 0.81037 1.291 1.611 1.5004 0.14028 2.6504 0.4104 5.9629-0.0998 8.5135-0.1703 0.91912-0.77057 2.0294-1.3604 2.8311-0.47043 0.63928-0.88997 0.75996-1.0498 1.5904-0.2101 1.0907 0.21988 0.88128 0.54025 1.5316 0.33015 0.66929 1.7604 2.621 0.96044 3.4808-0.89063 0.96087-2.9414-0.47098-3.462 1.1898-0.44108 1.4103 1.3108 2.0711 0.30013 3.6308-0.6205 0.95044-2.2419 1.6406-3.0118 2.4208-1.9809 2.0105-3.1514 6.702-1.6005 9.2728 0.24011-0.0189 0.55982 0.0802 0.79014 0.0502 0.53046 1.3999-0.06 3.1312 0.18009 4.6322 0.27012 1.6608 2.1212 2.0796 2.0305 3.651 1.9711-0.24005 1.7408 0.76061 1.8315 2.3308 2.0305 0.0189 1.3911 1.0705 0.28056 1.6497-0.0502-0.12916-0.11027-0.2394-0.18008-0.3503-0.74056-1.0796-3.5012-2.3901-4.7924-2.2799-1.4609 0.12916-2.3215 1.1298-3.5116 1.6797-1.2103 0.56035-2.1714 0.19048-2.0214 2.1409-2.251 0.10959-4.1125-0.60079-4.5021-3.1214-1.641-1.0705-2.9218-2.3105-4.8126-3.0209-1.1307-0.4201-1.7206-0.54012-2.9916-0.33007-1.2404 0.20091-1.5007 0.60013-2.4716 1.0202-0.30014 0.8702-1.4909 1.7293-2.071 2.5408-2.0011-2.0907-2.8122-4.2303-5.9936-3.561-1.38 0.28963-2.4409 1.2205-3.8013 1.7-1.1307 0.39074-2.9224 0.27006-3.8431 1.0802-0.90042 0.79062-1.0309 1.9707-1.8308 2.7104-0.71055 0.64972-1.791 1.9204-2.6314 2.3803-2.0312 1.1005-5.9232 0.28898-7.724-0.50098-1.0505-0.46054-2.3913-0.88064-3.6519-0.55056-1.5712 0.4214-1.4309 1.1703-1.3408 2.8409 0.0502 0.91064 0.73012 3.1996 0.33994 4.0014-0.45999 0.93021-1.1705 0.17874-1.6808 0.77887-0.35038 0.41097-0.15986 1.4814-0.15986 2.0516 0.01 2.7815 0 5.5617 0 8.3321 0 1.2101 0.2499 2.9309-0.36995 3.972-0.84038 1.4097-1.4707 1.079-1.4609 3.1996v4.3327c0 1.5604-0.39996 2.3706-0.68053 3.6602-0.58005 2.7815 0.28057 5.4221 0.64008 8.0118 0.18008 1.2407 0.39018 2.7411 0.2101 4.0014-0.32037 2.1514-1.2606 1.0007-2.3411 2.1709-1.3604 1.4814-0.50045 6.3817-0.50045 8.3321v0.21005c-0.92064-0.63993-1.301-0.42141-2.6614-0.54013-2.4213-0.23092-3.0118-2.5806-5.043-3.6308-1.4211-0.72995-2.1316-0.82911-3.2519-1.9107-0.96044-0.93086-2.4416-2.2009-3.2617-3.1918-0.2499-0.52055-0.8704-1.291-1.4309-1.5206 0.11027-0.53034 0.39018-0.50034 0.93043-0.47033 0.01 0.06 0 0.11024 0.0202 0.15982 0.03 0.0104 0.0698 0.0196 0.0998 0.03 0.0502 0.18982 0.15986 0.2805 0.2101 0.47032 0.2499 0.11024 0.69032 0.21005 0.86061 0.3914 0.24011 0.2394 0.2101 0.69994 0.50045 0.85911 0.28056 0.15982 0.91085-0.0189 1.1908-0.0496 0.46065-0.0404 0.72034 0.0404 1.181 0.14025 0.0104 0.69929 0.90041 0.25049 1.2508 0.7306 0.15007-0.97066-1.2208-1.2407-1.8713-1.7006-0.33994-0.24005-0.82016-0.45988-1.1105-0.74038-0.39997-0.39075-0.36995-0.78997-0.57026-1.2401-0.40976-0.8702-1.7108-0.54012-2.3809-1.3105-0.38039-0.42988-0.24011-0.88064-0.5807-1.3001-0.25968-0.33008-0.71054-0.60014-0.99045-0.93935-0.30993-0.36986-0.75035-0.66993-1.1307-1.0111-0.42019-0.39074-0.7001-0.91064-1.0303-1.3797-0.61071-0.83041-1.2006-1.6504-2.0116-2.231 0.42019-0.0307 1.331-0.17091 1.6912 0.03 0.40975 0.23027 0.36995 0.93086 0.55982 1.3803 0.38039 0.17026 1.4106 0.63015 1.3708 1.06 0.81037 0-0.35038-1.1011-0.56048-1.1898-0.19052-0.42075-0.23032-0.82975-0.49-1.1703-0.25969-0.33072-0.61007-0.48011-0.82995-0.86041-0.2499-0.44945-0.23032-0.57992-0.80058-0.84998-0.46-0.22048-0.86062-0.16047-1.3408-0.29028-0.81037-0.24006-1.5307-1.15-2.1714-1.6993-0.94021-0.81018-0.88084-1.3999-0.88084-2.6217v-2.1807c0-0.33073-0.0698-0.71038 0.1305-0.94 0.15985-0.19048 0.6603-0.23092 0.89062-0.42075 0.36017-0.31964 0.81037-1.06 0.91086-1.5206 0.15985-0.80105-0.29036-1-0.63029-1.6106-0.06-0.0307-0.12985-0.0496-0.18009-0.0698 0.39997-0.24984 0.70011 0.12981 0.96044 0.36073 0.40976 0.34965 0.47044 0.40966 1.1007 0.37965 0.0502-0.88976-0.0502-1.8891-0.38039-2.6706-0.97023-0.0907-0.88084 0.31051-1.1203 1.0405-0.50045 0.06-0.59049-1.3196-0.69032-1.73-0.16051-0.68103-0.74056-1.261-0.8704-1.9413-0.0698-0.39987 0.0698-0.77039-0.12984-1.1207-0.1703-0.30007-0.61072-0.45989-0.79015-0.75996-0.35037-0.61123 0.11027-1.2701-0.48022-1.8206 0.23033-1.4103-1.5307-2.2505-2.1616-3.1612-0.57026-0.82128-0.7001-1.6915-0.82995-2.6608-0.29035-2.0405-0.54024-1.5904-1.8713-2.9713-0.88084-0.91064-0.64008-1.3301-0.8306-2.6713-0.32036-2.2505-1.4811-4.1716-1.5105-6.4919-0.0202-2-0.53046-3.8911-1.3604-5.6517-1.1405-0.27006-1.581-1.4508-1.7806-2.9002 1.761-1.7802 6.1437 0.52055 7.784-0.42988 0.55003 2.4312 3.4816 1.9198 4.8524 2.9113 0.99046-0.76061 3.492-0.38031 4.8531-0.43054 2.0514-0.0796 3.6819 0.53034 5.4827 0.69147-0.20031 1.3601 1.2906 1.0496 2.1812 0.84019 1.5405-0.33986 0.93043-0.50098 2.0011-1.5701 1.2808-1.2707 2.8317-1.3007 4.0323-2.7711 0.64008-0.03 1.3108-0.03 1.9509 0-0.10962 0.84019 0.27012 1.0705 1.0603 0.97 1.121-0.12981 0.51023-0.54012 0.97088-1.3203 0.55982-0.94978 1.2906-2.06 2.0312-3.1312 0.74055-1.09 1.7708-2.1403 2.2915-3.3706 0.63029-1.471 0.64008-2.3008 1.6906-3.591 0.81037-1.0111 1.2103-2.0007 2.281-2.6223 0.64008-0.36922 1.0505-0.0796 1.5809-0.75996 0.29035-0.36922 0.24011-1.3601 0.45021-1.8611 0.7001-1.6504 1.761-1.7 3.1815-2.3405 0.91085-0.41031 2.1212-1.4214 2.8317-2.1703 1.6808-1.8011 2.5009-3.7515 4.8727-4.8018 2.251-0.99023 3.0614-3.1207 3.9122-5.5415 0.94021-2.6608 2.221-4.0614 3.7217-6.321 1.0407-1.561 4.0023-3.0216 4.3324-4.6824 0.24011-1.2198-0.58984-1.9002 0.38104-3.1696 0.76013-1.0007 1.5203-1.0802 1.6501-2.4606 0.15007-0.06 0.29035-0.0202 0.4502-0.06 0.0104-0.54012-0.23097-0.99088-0.63028-1.3007 0.01-0.0496 0.0189-0.10959 0.03-0.17026 0.12919-1.0496-0.43063-2.4306-0.71054-3.3308-0.65052-2.0509-1.3911-4.9316-0.64008-7.1521 0.8704-0.14025 2.8115-0.12916 3.6519 0.14025 1.5209 0.51012 0.67009 1.8513 1.9809 2.5114 2.8715 1.4508 2.482-2.7013 4.0121-3.8409 1.1405-0.85128 1.9809-0.11089 3.171-0.66145 0.35038-0.15982 1.9509-1.8402 2.1714-2.1305 0.65052-0.85063 0.5011-2.1207 1.4909-2.7515 0.98066-0.61971 2.6516-0.25963 3.8124-0.31964 0.28056-1.4306 0.39996-2.5506 1.821-3.1918 0.96109-0.42075 3.3315 0.25049 4.0519-0.39922 0.36995-0.33986 0.77122-2.8918 1.1105-3.6015 0.53046-1.1103 0.86061-2 1.2103-3.1514 0.38039-1.3105 0.82081-2.2805 2.1714-2.7593 1.2006-0.43053 3.0908 0.23941 4.0114-0.70059 0.21009-0.21983 0.36995-1.3601 0.6205-1.7202 0.27991-0.41031 0.93043-1.0802 1.3206-1.3418 1.0302-0.66928 2.4011-0.8004 3.5514-0.94978 1.1816-0.14025 1.9914-0.2094 2.6914-1.1298 0.79015 0.0802 1.821-0.27984 2.4018-0.88977 0.24989-0.0691 0.50044-0.12981 0.74055-0.18004 1.2208-0.24984 1.0903-0.11024 2.1714 0.36987 1.5509 0.69081 2.9316 0.59035 4.8022 0.69994 0.0104 0.33008 0.25055 0.55056 0.2101 0.93087 0.35037-0.0104 0.74055 0.27985 1.1307 0.23027 0.14942 0.98109-0.26033 1.7104-0.29035 2.6217 0.14028-0.0104 0.32037 0.0104 0.46065 0.0404 0.0176 0.12981-0.0124 0.30986-0.0124 0.45924z",
+                Pingtung:"m166.08 473.61c0.38039 0.47033 0.52002 0.84019 0.50045 1.4403-0.0398 0-2.1408 2.4514-2.3515 2.681-0.8704 0.88912-2.5212 1.7104-2.9016-0.16047 1.2808-0.74952 0.64008-2.0405 1.3206-3.1116 0.71054-1.1279 2.2615-0.91913 3.432-0.84933zm69.867-77.268c0.47044 1.2205-0.3693 2.9909 0.65052 4.0907 0.52002 0.57013 2.9218 1.4305 3.7119 1.7906 1.121 0.51012 1.121-0.18982 1.5007 1.1598 0.19052 0.6608 0.10961 1.9198 0.12984 2.5414 0.0692 1.8611-0.53046 2.5806-2.1016 3.4912 0.61137 1.8317 1.1307 5.6928-0.85017 7.1521-1.0107 0.75017-2.7613-0.18983-4.0121 0.32029-0.88997 0.36074-1.6605 1.4814-2.5414 2.1207-1.4106 1.0411-1.9607 1.03-3.802 1.2205-1.0603 0.10959-2.822-0.19047-3.5318 0.78997-0.73077 0.99153 0.25968 2.6413-0.1305 3.8722-0.39018 1.2205-1.6312 2.06-2.0005 3.3412-0.35038 1.2094-0.2499 1.8806-1.0002 2.9498-0.73077 1.0405-1.2906 1.76-1.701 2.8807-0.77057 2.0907-1.0303 4.201-1.1601 6.4828-3.0314 0.03 0.39932 5.3817 0.74056 6.1919 0.7001 1.6797 1.1608 5.4508 0.63029 7.0425-0.32037 0.96935-1.2006 2.1507-0.51024 3.4612 0.76079 1.4299 1.8015 0.21004 2.9616 1.0404 1.2704 0.90021 1.9013 5.1312 1.6808 6.6022-1.6612 0.0698-4.0114 0.74039-4.472 2.3601-0.25055 0.87085-0.0411 2.1011-0.18008 3.0013-0.10962 0.77105-0.46 1.6915-0.30014 2.471 0.48022-0.0802 0.8704 0.21983 1.2808 0.21983 0.45021 2.0516 2.0011 1.5401 3.5318 2.6419 1.671 1.1807 1.581 2.4808 1.4707 4.6406-2.2412 0.03-2.3711 1.6902-2.2817 3.5004 0.86061-0.0685 2.9414 0.40053 3.6421 0.82063 1.9711 1.1703-0.77058 1.8017-0.47044 3.1807 0.90042-0.12003 1.1908 0.50163 1.0002 1.3418 1.8511 0.0992 2.1212 0.57013 3.4712 1.1807 1.1908 0.53947 3.2421-0.0307 3.5318 1.6412 1.8008-0.23092 1.5907 1.9498 3.4418 0.99936 0.73077-0.38031 1.9711-1.7208 2.681-2.4508 0.33081 1.1598 0.67009 2.3608 0.39997 3.3608-0.2101 0.82062-0.6205 1.0907-0.71055 2.1207-0.09 0.91977-0.12984 1.7208-0.30013 2.5506-0.56048 2.7398 0.29035 6.411 0.0998 9.5931-0.98066 0.4201-1.2612 1.8206-0.97022 2.8611 0.38039 1.3601 0.94021 1.4292 2.4716 1.3601 0.09 0.48011 0.09 1.1403 0 1.6106-0.73077 0.6608-1.4511 0.59035-1.8113 1.531-0.33015 0.8702 0.0111 2.5617 0.0111 3.501 0 0.98044-0.27012 2.4103-0.0111 3.3406 0.32036 1.1011 1.2508 1.2101 0.98067 2.6308-0.61985 0.12981-1.2006 0.24006-1.7806 0.39988-0.0411 0.55056-0.21989 1.0404-0.21989 1.6002-1.5509 0.40966-0.93042 0.77104-1.4707 1.8702-0.70076 1.3908-0.68053 0.85976-2.3013 1.2003-2.5212 0.53034-2.0409 2.4814-2.0409 4.8011 0 1.8506-0.60028 4.9218 0.72033 6.2923 0.67988 0.69994 1.151 0.45989 1.6207 1.3712 0.29035 0.58971 0.38039 2.4808 0.30014 3.1507-1.7708 0.45989-1.8106-1.2309-2.7606-2.1905-0.51024-0.51991-0.95066-0.4899-1.3911-1.1207-0.34972-0.5199-0.4104-1.2198-0.82994-1.8004-1.0603-1.4703-1.8811-0.78018-3.5018-1.3608-0.71054-0.25962-1.2906-0.91977-1.9907-1.1814-0.59048-0.21983-1.3506-0.18982-1.9711-0.36008-0.79014-1.5003-4.5021-2.561-5.3327-0.44032-0.49001 1.2401 0.79014 1.6008 0.63029 2.8011-0.16965 1.3203-1.6606 1.3705-2.6712 1.8206-0.53046-0.78018-1.6605-1.4606-2.0011-2.1507-0.47956-0.97001-0.1592-2.7208-0.1592-3.8311 0-1.3007 0.1703-2.7208 0-4.0014-0.23097-1.7606-0.99111-1.5401-1.962-2.711-0.83973-1-0.69945-1.8891-1.0798-3.0809-0.20096-0.63079-0.65052-0.79061-0.63029-1.5506 0.03-0.82976 0.50958-0.75996 0.66944-1.501 0.12071-0.55056-0.25903-1.5095 0-2 0.51023-0.96087 0.56047-0.12068 1.331-0.66081 0.81038-0.55056 1.8511-2.1311 0.53046-2.8611-0.24011-0.39987-0.43063-0.99088-0.50109-1.4508 0.44041 0.0802 1.0107-0.12982 1.4518-0.0496 0.20944-1.2505 0.42933-2.4814 0.36016-3.8115-0.0998-1.8806-0.36995-1.8206-1.4707-3.0411-1.6906-1.8904-0.35038-4.8911-1.0309-7.2923-0.35038-1.2309-1.4909-1.8402-1.8008-3.1709-0.30013-1.291-0.13962-2.4599-0.54024-3.6608-0.8704-2.5695-3.1521-3.0007-4.3722-5.3014-0.60027-1.1292-0.46064-2.471-0.46064-3.8715 0-1.6112-0.46065-2.3608-1.0009-3.6713-0.84038-2.0405-2.0409-3.6817-3.7217-5.291-0.85082-0.82063-1.7304-1.2805-2.1108-2.381-0.54025-1.5395-0.65051-1.79-1.7108-3.1612-1.6508-2.1403-3.1019-2.7208-5.4632-4.0105-1.0714-0.5897-2.7117-0.83954-3.5018-1.8311-1.3904-0.17939-3.3518-0.50034-4.3722-1.2903-0.89063-0.7006-1.3108-1.8409-2.131-2.6719-1.7708-1.7906-4.8531-2.3797-6.0034-4.3706-0.72033-1.2401-0.95065-1.8617-2.1212-2.8709-0.2101-0.17026-0.39018-0.31051-0.55004-0.42075v-0.2094c0-1.9504-0.86061-6.852 0.50045-8.3321 1.0805-1.1703 2.0214-0.0202 2.3411-2.1709 0.18008-1.2603-0.03-2.7593-0.2101-4.0014-0.36017-2.591-1.2208-5.2316-0.64008-8.0118 0.28057-1.291 0.68053-2.1011 0.68053-3.6602v-4.3327c-0.0104-2.1207 0.62051-1.79 1.4609-3.1996 0.6205-1.0411 0.36995-2.7606 0.36995-3.972 0-2.7711 0.01-5.5519 0-8.3321 0-0.57013-0.19052-1.6412 0.15986-2.0516 0.51023-0.60014 1.2208 0.15003 1.6808-0.77888 0.39018-0.8017-0.2897-3.0907-0.33994-4.002-0.09-1.6712-0.23032-2.4208 1.3408-2.8402 1.2606-0.33007 2.6014 0.09 3.6519 0.55056 1.8008 0.78997 5.6935 1.6002 7.724 0.50099 0.84039-0.45989 1.9209-1.7306 2.6314-2.3803 0.80123-0.74039 0.93042-1.9198 1.8308-2.7111 0.92064-0.80953 2.7117-0.69016 3.8431-1.0796 1.3604-0.47946 2.4213-1.4103 3.802-1.7 3.1815-0.66994 3.9912 1.4703 5.993 3.561 0.58071-0.81019 1.7708-1.6706 2.071-2.5408 0.97022-0.4214 1.2306-0.82127 2.4716-1.0202 1.271-0.21005 1.8615-0.09 2.9916 0.33008 1.8909 0.71038 3.1717 1.9504 4.8126 3.0209 0.39083 2.5206 2.251 3.231 4.5021 3.1214-0.15007-1.9504 0.81037-1.5806 2.0214-2.1409 1.1908-0.54991 2.052-1.5506 3.5116-1.6797 1.2912-0.1109 4.0519 1.2003 4.7931 2.2799 0.0672 0.10763 0.12789 0.21787 0.17747 0.34703z",
+                Taidong:"m327.47 304.02c-0.32036 0.81019-0.64007 1.6302-0.96044 2.5004-0.7001 1.9204-0.23097 3.9309-0.55068 5.9518-0.27013 1.7417-1.1601 3.3412-1.4407 5.0627-0.25055 1.5904-0.0196 4.8415-1.181 6.0614-1.0903 1.1598-3.1417 1.2309-4.3122 2.6908-1.3108 1.6412-1.6508 2.9713-1.761 5.2519-0.0803 1.5708 0.36995 4.6217-0.50045 5.8116-0.76079 1.0607-2.852 0.77105-3.5723 2.3712-0.63095 1.4208-0.0698 3.651 0.0692 5.0712 0.29035 2.8611-0.1703 8.1527 3.7322 7.8129-1.0798 0.39009-1.35 1.6002-2.2308 2.1403-0.63029 0.39922-1.3004-0.0496-2.0116 0.50033-0.47956 0.36073-0.58983 1.1403-0.93042 1.3608-1.8211 1.1598-5.4827 0.12981-4.8126 3.9413 0.0502 1.7104-0.68053 3.561-1.331 4.8311-0.61072 1.1703-0.32037 2.4599-0.71055 3.621-0.42998 1.2805-1.4909 2.441-1.9607 3.732-0.44042 1.1807-0.36995 2.2199-1.0407 3.3216-1.301 2.1305-4.1621 2.5108-4.9229 4.8716-0.4502 1.3803-0.0907 2.3405-0.88084 3.591-0.59048 0.93021-1.0498 1.9504-1.7003 2.8611-0.42085 0.60013-0.98067 0.85063-1.2912 1.4814-0.25968 0.51991-0.10048 1.319-0.3693 1.8304-0.70075 1.2707-2.1114 0.97001-1.992 2.8409-2.2204 0.12003-6.4138-0.59035-7.4441 2.0607-1.0798 2.7698 0.82082 4.9603 1.6312 7.1319 0.71054 1.8898-0.31971 2.0411-1.5007 2.7111-1.5607 0.88063-1.1301 1.1403-1.331 2.9609-0.24989 2.2799-3.1619 3.1696-4.5223 5.1605-0.03 0.0502 0.01 0.39139-0.0104 0.48011-0.97023 0.75995-2.3913 1.1298-3.312 1.8904-0.93042 0.75996-1.2006 2.321-2.3313 2.9707-1.0107 0.59035-2.5212 0.14938-3.7021 0.6308-1.2208 0.50098-1.6312 1.5199-2.5009 2.5004-1.6012 1.8102-4.4022 2.1109-5.9232 3.9218-0.64008 0.74104-0.90041 2.3803-1.2103 3.2916-0.39931 1.2003-0.57026 2.4006-0.63029 3.7013-0.12005 2.5004-0.17029 4.3712-2.2014 5.8116-1.1203 0.78996-1.9202 0.91064-2.6308 1.9909-0.66095 0.99023-1.1908 2.1605-1.6716 3.3301-0.52003 1.2609-0.4202 2.5206-0.8704 3.8011-0.44042 1.2401-1.181 2.2805-1.5105 3.5408-0.63942 2.4821-0.44042 5.0327-1.181 7.4724-1.8308 0.47098-1.5607 4.6824-2.2713 6.203-0.88997 1.9002-1.2997 3.651-1.9111 5.5904-0.57026 1.8108-1.2208 4.4123-2.8017 5.5722-0.85017 0.6308-0.43977 2.3405-0.8293 3.6608-0.28121 0.91978 0.33016 7.2023 0.33016 8.1723 0 0.69016 0.24011 1.5004 0.47956 2.351-0.71054 0.72995-1.9502 2.0705-2.681 2.4508-1.8511 0.95043-1.6416-1.2303-3.4418-0.99936-0.28969-1.6719-2.3411-1.1011-3.5318-1.6412-1.35-0.61058-1.6201-1.0802-3.4712-1.1807 0.19052-0.84019-0.0998-1.4606-1.0002-1.3418-0.30013-1.379 2.4409-2.0105 0.47044-3.1807-0.70076-0.42009-2.7815-0.88911-3.6421-0.82062-0.09-1.8096 0.0411-3.4704 2.2817-3.5004 0.10962-2.1612 0.20031-3.4612-1.4707-4.6406-1.5307-1.1011-3.0816-0.59035-3.5318-2.6419-0.41041 0-0.80059-0.30007-1.2808-0.21983-0.15985-0.77953 0.19052-1.7 0.30014-2.471 0.14028-0.90021-0.0698-2.1305 0.18008-3.0014 0.46-1.6197 2.8115-2.2903 4.472-2.3601 0.21989-1.471-0.4104-5.702-1.6808-6.6022-1.1601-0.8291-2.2014 0.39074-2.9616-1.0405-0.69032-1.3105 0.18987-2.4906 0.51023-3.4612 0.53046-1.5904 0.0698-5.3628-0.63029-7.0425-0.33994-0.81019-3.772-6.1618-0.74056-6.1919 0.12919-2.2805 0.39018-4.3908 1.1601-6.4828 0.41041-1.1207 0.97023-1.8396 1.701-2.8807 0.75034-1.0705 0.65052-1.7404 1.0002-2.9498 0.3693-1.2805 1.611-2.1207 2.0005-3.3412 0.39083-1.2309-0.60028-2.8807 0.13049-3.8722 0.70989-0.98044 2.4716-0.68037 3.5318-0.78996 1.8406-0.19048 2.3913-0.17939 3.802-1.2205 0.88084-0.63927 1.6508-1.76 2.5414-2.1207 1.2508-0.50947 3.0027 0.42988 4.012-0.31964 1.9809-1.4599 1.4609-5.321 0.85018-7.1527 1.5712-0.91064 2.1714-1.6302 2.101-3.4912-0.0196-0.62036 0.0607-1.8806-0.12919-2.5414-0.38039-1.3497-0.38039-0.64971-1.5007-1.1598-0.79079-0.36008-3.1926-1.2205-3.7119-1.7906-1.0205-1.1011-0.18008-2.8702-0.65051-4.0907 1.1105-0.58057 1.7512-1.6308-0.28057-1.6497-0.0907-1.5701 0.14028-2.5708-1.8315-2.3308 0.0907-1.5701-1.7604-1.9902-2.0305-3.6511-0.24011-1.501 0.35038-3.231-0.18008-4.6322-0.23032 0.03-0.55069-0.0691-0.79015-0.0502-1.5509-2.5695-0.38039-7.2623 1.6005-9.2728 0.77057-0.77952 2.3913-1.4703 3.0118-2.4208 1.0107-1.561-0.74121-2.2205-0.30014-3.6302 0.52002-1.6615 2.5708-0.23092 3.462-1.1905 0.80059-0.85976-0.63028-2.8115-0.96044-3.4808-0.32036-0.65037-0.75034-0.44097-0.54024-1.5317 0.15985-0.8291 0.58004-0.94978 1.0498-1.5904 0.59048-0.80171 1.1908-1.9113 1.3604-2.8311 0.51024-2.5506 0.24011-5.8618 0.0998-8.5135-0.80058-0.2094-1.8811-0.47033-1.611-1.5004 0.52003-0.0404 1.5509-0.14938 1.9411-0.57013 0.55982-0.62036 0.0502-1.1709 0.35038-1.8011 0.67988-1.3999 2.071-1.0405 2.3515-2.6608 0.12005-0.72017-0.23098-1.4103-0.17095-2.1703 0.0502-0.57013 0.43063-0.95044 0.5011-1.4899 0.16051-1.1011-0.55004-3.3908 0.0202-4.3112 0.61072-0.97 2.4814-0.61122 3.3113-1.2303 0.89062-0.66993 1.5907-2.1318 2.3411-2.9609 1.0714-1.1905 1.6012-1.9309 3.3315-2.3405 1.3604-0.32029 2.5009-0.59036 3.832-1.2016 1.1705-0.54991 2.0109-1.5004 3.2115-1.9302 0.93043-0.33986 2.1114-0.11024 2.9818-0.6308 0.17943 0.65037 0.66031 1.3105 1.0309 1.7208 0.99046 1.1103 2.1401 2.0516 2.4905 3.7111 0.36082 1.7404 0.0111 2.8311 1.2508 4.2114 0.97023 1.0705 3.2617 0.81018 3.4118 2.09 1.4002 0.0907 4.1217-0.14938 5.133 0.69081 1.5209 1.2609 0.36016 3.1918 3.0014 3.3412 1.5509 0.09 3.3022-1.4508 4.8531-0.33986 1.3108 0.94979 1.4302 3.1996 1.5098 4.8115 0.81038 0.0489 1.6508 0.01 2.4514 0.06 0.06 1.03-0.03 2.1305 0.19052 3.1312 0.30014 1.3503 2.1414 2.1807 3.4816 2.03-0.33994 1.5095 0.63029 1.561 1.8315 1.501 0.21988 0.94 1.2208 1.4703 1.7408 2.2603 0.52002 0.79061 0.58918 1.9707 1.611 2.3908 2.131 0.89043 4.7226-0.91064 6.6533-1.03 0.11027-1.2694-0.28057-2.3712-0.14094-3.6413 0.0998-0.93934 0.9611-2.0105 0.9611-2.8696 0.0104-1.3203-1.2704-1.7606-1.2912-2.972-0.0196-1.2101 1.0603-2.2407 2.3013-2.0209 0.88084-2.3405 1.671-4.7117 2.8317-7.0118 0.63029-1.2505 0.03-2.6008 0.53046-3.8115 0.47044-1.1605 1.9914-1.3908 2.6308-2.4906 0.70011-1.2094 0.42998-2.6308 0.54025-4.0014 0.12071-1.4703 0.70989-2.2205 1.1705-3.501 0.15007-0.4201 0.0411-1.3503 0.48022-1.6406 0.50045-0.33007 1.5607 0.57013 2.2014-0.06 0.69031-0.69994 0.28969-2.6217 1.1503-3.471 1.0009-0.99153 2.5316-0.66993 1.5007-2.1709-0.30014-0.42988-2.1708-1.8304-2.6412-2.0202-0.10961-1.8709 0.12985-3.3914 0.84039-4.9414 1.2306-0.71038 0.7001-3.6308 2.2713-3.4012 0.68053-0.97001 2.4605-0.45011 2.2308-2.2707 1.0909-0.64972 2.9113-0.31964 3.9722 0.14025 0.41041 0.18004 1.1405 0.85128 1.5307 0.96087 0.62572 0.18004 1.1164-0.10894 1.7564-0.1396zm-3.9279 119.23-0.0202-0.18004c0.23097-0.12003 4.063-0.30985 4.3722-0.0189 1.5209-0.91064 2.4018-0.82975 2.6614 0.99088 0.15986 0.0404 0.29035 0.0196 0.45021 0.06-0.48022 0.80105-0.81037 1.7704-1.0002 2.7815-0.79015 0.12916-0.75035 0.21984-0.95066 0.82911 0.27013-0.0496 0.66031 0.0802 0.94022 0.0502-0.0607 0.78018 0.09 1.6302 0.33994 2.2694-1.5412 0.83041-3.4522-1.6706-5.1128-1.9902-0.21988-0.40053-0.29035-0.98044-0.17029-1.441 1.7003-0.91978-1.5509-2.3301-2.052-3.0307 0.1318-0.3105 0.29231-0.30007 0.5422-0.32029zm19.79 101.38c0.68053 1.6706 0.32037 2.231 0.33994 3.9518-1.301 0.17939-2.3222-0.39922-3.6121-0.33986-1.3611-2.1709-2.5616-3.0307-5.0025-3.171-0.60028-1.2609-2.6112-2.2407-3.573-3.4312-0.70989-0.88064-0.47043-2.1905-0.79014-3.201-0.27013-0.84019-1.7408-2.1005-1.3108-2.8109 0.8704-0.0802 1.5712 0.20026 2.4513 0.15982 0.0405 0.15916 0 0.30006 0.0502 0.44945 1.8106 0.0907 5.5428 0.55969 6.9834-0.41031 0.23098 0.81018 0.11027 0.33007 0.64008 0.8004 0.0104 0.58122 0.03 1.1905 0.0405 1.7802 0.15986 0.0404 0.30014 0.0104 0.46065 0.0502 0.2101 1.09-0.47043 1.1807-0.65052 1.6706-0.21988 0.61122-0.36995 1.1102-0.30014 1.9504 1.0903-0.18005 1.1105 0.85063 1.1608 1.6608 0.82994 0.03 0.68052 0.0496 1.0009 0.66994 0.70076-0.0398 1.4615 0.0307 2.1114 0.22048z",
+                Hualien:"m262.01 324.77c-0.21989-0.69994-0.0698-1.3999 0.95065-1.7704 0.20031-1.1298-1.6808-4.6517-3.1417-4.0411 0.0104-0.25897-0.25903-0.72017-0.19052-1.0705-0.93043-0.0496-1.9809 0.14938-2.7717-0.39009-0.98001-0.65037-0.20944-1.5317-2.0109-1.3307-0.12006-1.06 0.32036-1.6602 0.67009-2.6002 0.18008-0.50098 0.47043-0.43053 0.47043-1.2101 0-0.36921-0.54025-0.53947-0.50958-0.82062 0.21988-1.8898 2.8017-1.291 4.3226-1.5395 0.21988-1.7717-0.0307-2.972-0.33994-4.6113-0.82081-0.18983-1.0107-0.63993-0.77057-1.3307 0.0104-0.0404 0.12005-0.0496 0.27012-0.0496 0.2897-0.0196 0.72033-0.0104 0.84039-0.12981 0.20031-0.2094 0.15985-0.61057 0.47956-0.88977 0.8704-0.74104 0.48022-0.69081 1.7108-0.94978 0.72033-0.15004 1.4707-0.15004 2.1414-0.36987 0.14941-2.4906-2.191-1.9504-1.3108-4.3112 0.61985-1.6497 1.3304-3.3301 2.3802-4.8004 1.8713-2.6413 7.6137-2.561 10.085-0.72016 0.49001-0.7704 1.331-0.90021 2.0116-1.3405 0.10961-1.8311-0.2101-3.5715-0.0998-5.4417 1.6312-0.48011 1.4106-0.72017 1.7806-2.1709-0.27012 0.06-0.68053-0.0998-0.95065-0.0496-0.13963-0.78018-0.24011-1.6308 0.61136-1.8409 0.03-0.12003-0.0307-0.34899 0.06-0.43966 1.1601-0.5597 2.0514 0.60013 2.972 0.31963 0.48022-0.14025 1.4309-1.9002 1.5209-2.321 1.0198-0.71104 1.1908 0.20939 1.9411 0.20026 0.57026-0.0104 1.1014-0.32029 1.6716-0.42988 0.50045-0.71038 0.10961-1.3503 0.3693-2.1311 0.33994-1.0502 0.72033-0.5897 1.1712-1.3803 0.55982-1.0007-0.16051-2.3608 0.2499-3.441 0.39017-1 1.7003-1.7404 1.9111-3.0209 0.16051-0.9002-0.59049-1.5003-0.51023-2.3308 0.0907-0.8291 0.73011-1.2505 0.84038-2.3308 0.09-0.88064 0.0998-1.9707 0.01-2.8402-0.23946-2.1207-1.81-2.2805-2.0109-4.1612-0.2897-2.8213-0.2897-2.651-2.972-3.201-0.27991-1.4808 1.331-3.6113 2.7822-3.8311-0.17095-1.4103-0.24011-2.9211 0.21988-4.2812 0.53046 0 0.77971-0.2805 1.2808-0.39074 0.69031-1.3405 0.51023-3.06 1.1503-4.471 0.23097-0.5199 0.69031-0.65037 0.88083-1.1703 0.14094-0.3803 0.0411-0.93087 0.16051-1.3307 0.27013-0.84019 0.70011-1.2609 1.0303-1.9804 0.21988 0.0404 0.55003-0.0202 0.78036-0.0502 0.0698-1.3803-0.80059-5.8018 1.331-5.6615 0.1703-3.3816 0.51024-6.7822 0.33994-10.124-0.69945-0.0404-1.4204-0.01-2.1205-0.0502-0.12005-2.4808 0.64008-3.4312 1.3206-5.4717 0.42998-1.2903 0.75034-2.0607 1.3708-3.291 0.73011-1.4508 0.47108-2.4006 0.6205-3.8813 0.21988-2.2505 0.96109-1.0196 2.4611-1.8709 0.85996-0.47945 1.5405-1.6706 2.2112-2.4306 1.2912-1.4703 2.1812-4.9414 0.45999-6.1716-0.82994-0.59035-2.3313-0.90021-3.2513-1.5708-1.181-0.8702-1.0707-1.2903-2.8513-1.3105-0.23098-0.72017-0.3308-1.6902-0.0698-2.351 0.30013-0.72995 0.97022-0.77039 1.2208-1.2505 0.3804-0.70973 0.03-1.5304 0.32037-2.2199 0.42019-0.97979 0.4104-0.5199 1.3708-0.95043 1.6012-0.71038 2.4213-1.1814 3.6023-2.2205 1.2201-1.06 1.9411-0.93022 3.6721-1.0196 0.17943-0.80105 0.14028-1.6712-0.78036-1.8408-0.0998-1.1605 0.1305-1.5904 0.55069-2.1612 0.16964-0.21983 0.36995-0.47033 0.60028-0.8004 0.47108-0.67972 0.82994-2.3706 1.5209-2.9707 0.94087-0.82063 2.7326-0.0802 3.312-1.0307 0.59048-0.97979-0.35038-3.0607-0.01-4.1723 0.44042-1.4103 1.7304-1.4201 2.5205-2.4899 0.53046-0.74104-0.01-0.95043 0.82082-1.5108 0.49-0.33986 1.151-0.20026 1.7108-0.66994 0.78036-0.63014 1.7519-1.5095 2.1218-2.3301 0.50045-1.1403-0.30079-2.8317 0.20031-3.972 0.24011-0.54991 1.4504-1.7098 2.2412-2.1807 0.0411 0.0907 0.0907 0.18004 0.15007 0.27006 0.4104 0.60014 0.93956 0.39074 1.5712 0.59035 0.74056 0.23027 1.1705 0.87999 1.8811 1.2003 0.46064 0.21005 1.0009 0.27006 1.4302 0.54012 0.44107 0.27006 0.72033 0.59035 1.0805 0.93022 0.15986 0.15003 0.32037 0.25962 0.5011 0.39074 0.2897 0.18982 0.19052 0.21983 0.41041 0.0992 0.3693-0.19048 0.48022-0.66015 1.0407-0.50033 0.24011 0.0691 0.27013 0.21983 0.58005 0.24984 0.25055 0.0202 0.38039-0.0502 0.59049-0.0802 0.45021-0.0698 0.93043-0.06 1.3715 0.0411 0.61006 0.12916 1.1503 0.30985 1.7904 0.36921 0.41106 0.0404 0.84038 0 1.2508 0.0502 0.98067 0.0998 1.151 1.1905 1.761 1.8206 0.62051 0.63928 0.8306 1.3301 1.8106 1.4606 0.81037 0.10959 1.5809 0.01 2.3613 0.2094 0.39018 0.0998 0.82016 0.26027 1.2397 0.22048 0.26034-0.0307 0.47108-0.12981 0.74121-0.0907 0.23946 0.03 0.42019 0.15003 0.66944 0.12068-0.0998-0.25049-0.0398-0.53034-0.0803-0.82062-0.0502-0.47946-0.23032-0.45924-0.60027-0.80954-0.17943-0.17091-0.33015-0.28963-0.27013-0.55969 0.06-0.29029 0.03-0.14938 0.21989-0.14025 0.12984 0.0202 0.15006 0.18004 0.32036 0.17026 0.18987-0.0104 0.30014-0.19048 0.42998-0.31051 0.20031-0.20092 0.41041-0.65037 0.70076-0.72995 0.28904-0.0802 0.39018 0.21983 0.6205 0.10959 0.23946-0.10959 0.21988-0.63015 0.28904-0.84998 0.0901-0.27006 0.30014-0.53034 0.54025-0.66993 0.0502 0.24005 0.23098 0.48011 0.46065 0.53033 0.42019 0.11025 0.40975-0.1409 0.71054 0.23027 0.15986 0.20027 0.2897 0.78018 0.59049 0.58057 0.16964-0.11024 0.16964-0.61057 0.18987-0.80953 0.03-0.27006 0.0803-0.69994 0.0104-0.96087-0.11027-0.42989-0.44955-0.33986-0.74056-0.66016-0.19052-0.21004-0.19052-0.45988-0.33994-0.67972-0.2003-0.27984-0.55982-0.39009-0.6603-0.77039-0.20031-0.75017 0.49001-1.6308 1.2404-1.1305 0.32037 0.21984 0.68053 0.68038 0.95066 0.96022 0.33015 0.3503 0.63942 0.69995 0.98066 1.0411 1.1503 1.1507 0.0803-1.1011 1.2006-0.76061 0.24011 0.0802 0.36016 0.44032 0.55003 0.63015 0.38039 0.3803 0.90041 0.51011 1.2612 0.92043 0.36017 0.41031 0.66031 0.84997 1.1099 1.1598 0.35038 0.25049 0.66095 0.19048 1.0805 0.25049 0.46064 0.0691 0.53046 0.3105 0.90041 0.50033 0.39996 0.21005 0.96109-0.0404 1.3904 0.12003 0.29035 0.11024 0.59049 0.36073 0.8704 0.5199 0.53046 0.29028 0.99111 0.61123 1.5816 0.79062 0.46 0.14938 0.93043 0.12002 1.4204 0.12002 0.53046-0.01 0.92064 0.12982 1.4106 0.29029 0.61985 0.19048 1.4713 0.0196 2.0514 0.33986 0.33994 0.18983 0.60093 0.54012 0.93108 0.72995 0.2897 0.17026 0.58136 0.23027 0.90042 0.31051 0.49066 0.12981 1.5405 0.7606 2.022 0.3803 0.0196-0.01 0.0405-0.03 0.0405-0.0496 0.0796 0.42988 0.18987 0.96022 0.0411 1.3405-0.15007 0.43053-0.76078 0.27006-0.87105 0.88064-2.0905 1.3112-2.9414 2.9218-3.2219 5.4019-0.18987 1.7104-0.15985 2.2805-1.8811 2.8807-1.3708 0.48011-2.1904 0.8702-3.3518 1.6406 0.06 1.1305-1.0107 2.3908-1.9313 2.8311-0.57027 0.2805-1.2802 0.44032-1.8406 0.68037-0.95065 0.39009-1.0707 0.74952-1.7512 1.4508-0.99111 1.0196-1.4217 1.7606-1.5105 3.4006-0.0404 0.92043-0.33993 3.8011 0.61007 4.1416 0.57091 1.9615 0.39083 4.5115-1.2606 5.702-0.63943 0.4501-1.4707 0.72016-2.0612 1.1514-0.61071 0.44945-1.4511 1.3705-1.9411 1.9707-1.8504 2.2812-1.9307 8.5428-0.0698 10.763 0.39997 0.47032 1.0414 0.91064 1.5809 1.0502 0.97023 1.4508 1.7715 3.5506 0.62051 5.2016-0.36017-0.03-0.62051 0.16047-0.95066 0.17026-0.0496 0.1709-0.12919 0.29028-0.17029 0.46054-0.39997 0.0998-0.81037 0.19047-1.2097 0.29028-0.0998 0.23027-0.18987 0.21983-0.2897 0.45989-3.002 0.20026-1.7512 9.1221-1.8615 11.283-0.0907 1.8304-0.86062 3.8611-1.3611 5.5219-0.60028 1.9602-0.44042 3.8813-0.76079 5.972-0.17943 1.2303-1.0603 2.3706-1.8811 3.351-1.1601 1.4005-1.2397 2.1409-1.2397 4.0314 0 1.7508 0.68053 3.9818 0.12006 5.6322-0.53046 1.5806-1.9711 2.5004-2.4912 4.2512-1.0407 3.5708 0.0698 8.1723-1.5607 11.684-0.91085 1.9707-2.0807 2.2107-2.4513 4.5617-0.32037 2.0405 0.23032 4.2114 0.01 6.2623-0.21009 1.8611-1.4002 3.2805-1.761 4.9909-0.41041 1.9609-0.0796 3.9211-0.74056 5.762-0.59049 1.6706-2.1316 4.0907-0.12006 5.4913-0.57026 2.7411-1.4818 5.0418-2.4416 7.4926-0.64008 0.03-1.1307 0.31898-1.7519 0.13959-0.39018-0.10959-1.1203-0.77952-1.5307-0.96087-1.0603-0.45924-2.8813-0.78996-3.9723-0.14025 0.23097 1.8206-1.5503 1.3007-2.2308 2.2707-1.5712-0.23092-1.0407 2.6908-2.2713 3.4012-0.71054 1.5499-0.95065 3.0705-0.83973 4.9414 0.47043 0.18982 2.3411 1.5904 2.6412 2.0202 1.0309 1.501-0.5011 1.1814-1.5007 2.1709-0.86061 0.85063-0.45999 2.7711-1.151 3.471-0.63943 0.63015-1.7004-0.27006-2.2014 0.06-0.44042 0.28964-0.33015 1.2205-0.47957 1.6406-0.46064 1.2805-1.0505 2.0307-1.1705 3.501-0.11092 1.3712 0.1592 2.7906-0.54025 4.0014-0.64008 1.1011-2.1616 1.3301-2.6314 2.4906-0.5011 1.2094 0.0998 2.561-0.53046 3.8115-1.1601 2.3001-1.9502 4.6713-2.8317 7.0118-1.2397-0.21983-2.3215 0.81019-2.3006 2.0216 0.0196 1.2101 1.3004 1.6497 1.2906 2.9713 0 0.85977-0.86061 1.9302-0.96044 2.8702-0.13963 1.2694 0.25055 2.3712 0.14028 3.6406-1.9307 0.12068-4.5223 1.9204-6.6533 1.03-1.0198-0.4201-1.0903-1.6002-1.611-2.3908-0.52067-0.78996-1.5209-1.319-1.7408-2.2603-1.2006 0.06-2.1714 0.0104-1.8308-1.501-1.3415 0.14938-3.1821-0.67972-3.4822-2.03-0.21988-1.0007-0.12919-2.1011-0.19052-3.1312-0.80059-0.0502-1.641-0.0104-2.4513-0.06-0.0803-1.6112-0.20031-3.8618-1.5098-4.8115-1.5509-1.1102-3.3028 0.42988-4.8531 0.33986-2.6412-0.14938-1.4811-2.0803-3.0014-3.3412-1.0107-0.83954-3.7322-0.60014-5.133-0.69081-0.15007-1.2799-2.4416-1.0196-3.4118-2.09-1.2404-1.3803-0.89063-2.471-1.2508-4.2114-0.35037-1.6608-1.5013-2.6008-2.4911-3.7104-0.37778-0.41814-0.858-1.0783-1.0381-1.7287z",
+                ChiayiCity:"m184.85 297.29c0.06 1.2094-0.28056 1.4703-1.301 1.9994-0.12984 0.89042-0.33994 2.5317-1.6005 1.8017-0.42019-0.24005-0.55069-0.76061-1.0805-0.89042-0.39017-0.10959-1.2808-0.14938-1.671-0.09-0.75034 0.12003-1.4707 1.1005-1.9907 1.6706-0.51023 0.57013-1.4113 1.5506-2.3313 1.4005-0.48022-0.50164-0.2499-1.1709-0.67988-1.711-0.52002-0.64972-0.99046-0.55056-0.93043-1.5904-0.71054-0.0404-1.4309 0.0104-2.1414-0.03-0.0698-1.1011-1.1803-0.61057-1.8308-0.55056-0.98001 0.0992-1.4106-0.69994-0.27012-1.0404 0.0998-0.63993 0.76078-1.5904-0.39997-1.501-0.42019-0.53034-0.53046-1.4899-0.6205-2.1403-0.12984-0.97001-0.01-0.91978 0.94022-1.261 0.4502-0.17025 0.91085-0.42988 1.181-0.82062 0.0998-0.0104 0.21989 0.0104 0.30993 0 0.0502 0.33986 0.12005 0.66081 0.19052 0.98044 0.77057-0.0404 0.99045-0.63014 1.6605-0.82062 0.62051-0.17939 1.3911-0.0698 2.0612-0.0998-0.18009-1.3601 1.2606-0.94979 2.1714-1 0.0196-0.34899 0.17029-0.63014 0.42998-0.8291 0.33994 0.21983 0.26034 0.50033 0.48022 0.78018 0.20031 0.27985 0.63029 0.4488 0.79014 0.70973 0.49001 0.77952 0.03 1.2701 1.3004 1.1709 0.0998-0.29029 0.1703-0.57013 0.19053-0.89042 0.38039 0.03 1.5105 0.24005 1.7512 0.49054 0.32036 0.33008 0.24989 1.2101 0.33993 1.6497 0.93108 0.17026 1.3004 0.84019 2.3013 0.85976 0.03 0.4899 0.0398 0.93087 0.10961 1.3914 0.22967 0.17026 0.33994 0.2805 0.64008 0.36073z",
+                ChiayiCounty:"m205.81 336.38c-0.21988 1.0607-1.1216 1.5206-1.8817 0.36073-1.3708-0.30007-2.3515 0.2094-3.8418 0.0998-1.4002-0.11024-1.9013-0.57013-2.6314-1.741-0.35038 1.8611-2.0207 1.8311-2.8611 3.2414-0.0502-0.0104-0.54025 0-0.61071 0-0.38039-0.78018-1.5614-0.45988-1.7219 0.3503-1.3904-0.33986-1.5705-2.1011-3.2813-1.8904-0.0998-0.34965-0.22053-0.72017-0.39083-1.0607-0.5807-0.03-1.2006-0.0398-1.7806-0.06-0.0607-0.85912 0.2897-1.9609 1.1105-2.3405 0.0496-0.85063 0.0496-1.7508 0-2.6008-1.8615-0.20026-1.0414-4.6211-0.97023-6.032 0.0692-1.4397 0.09-1.8096 1.181-2.6706 0.79014-0.62036 1.761-0.39922 1.6207-1.8011-1.9816-0.45989-3.0816-2.0105-5.2733-1.8898-0.48022-2.1403 1.9914-2.3412-0.46064-3.6413-0.10962-0.99936-1.6312-0.98045-2.5009-1.2003-0.1703-1.561 1.9209-0.93935 1.4009-2.6112-2.071 0.44032-2.1512-0.50033-3.9723-1.3601-1.1503-0.54012-2.6915-1.0404-3.6721-1.8506-1.0407 1.4599-3.5318 0.34965-5.0025 0.34965-1.731 0-3.0516 0.76061-4.6626 1.0007-1.8609 0.27985-3.6317 0.10959-5.013 1.3705-1.0505 0.95044-0.45021 1.0802-1.9907 1.3001-0.91085 0.12982-1.8008-0.0998-2.6412-0.14025 0.10961 2.5206-1.2606 1.2205-2.7417 2.261-1.5907 1.1298-0.6205 2.1905-0.31057 3.5512-1.4204 0.58905-1.7108-0.61123-2.6915-0.55056-0.95065 0.06-1.7708 1.3294-0.65051 1.9106 0.52002 3.261-2.8618 1.2609-4.2822 2.8311-0.24989 1.7-1.5007 2.291-2.3613 3.471-0.36016 0.4899-0.6603 1.5604-1.1608 1.6706-0.71054 0.15982-1.5405-0.93934-2.3111-1.0196-0.17029-0.51012-0.40975-0.61971-0.6603-0.97 0.12005 3.5812-3.4118 0.81018-3.5618-1.1598-0.52003 0.0405-1.1007-0.0907-1.611-0.0502-0.2499-0.88912-0.89063-1.5806-1.0603-2.4508-1.5405-0.42989-2.5714-1.6908-4.0323-2.3001 0.03-0.0607 0.0698-0.12068 0.0998-0.17939 0.74056-1.3607-0.0404-3.7313 1.4811-4.471 0.21988-0.1109 0.48022-0.15982 0.7001-0.24006 0.30014-0.12133 0.42019-0.25962 0.67074-0.39074 0.10962-0.0607 0.76014-0.16047 0.82016-0.23092 0.67988-0.80106-2.3815-1.4201-2.6712-1.5199 1.8909-0.17025 6.6232-0.12068 4.6521-3.1814-0.36995-0.0411-0.55003 0.31051-0.80058 0.55969-0.53046-0.42074-1.2103-1.5506-0.93043-2.1011 0.20031-0.39987 0.58005-0.45989 0.56047-0.96935-0.0202-0.45011-0.33993-0.42988-0.0698-0.93087-0.48022-0.0104-0.86061-0.54012-0.81037-1.0104 0.06-0.62036 0.78036-0.88064 1.0505-1.3196 0.49001-0.79127 0.06-2.4019-1.0505-1.9309-0.44042 0.18983-0.44042 0.85977-1.1203 0.69081-0.53046-0.12981-0.70076-0.76061-0.44042-1.2309 0.35038-0.63993 0.78036-0.34965 1.3108-0.5199 0.7001-0.22114 0.38039-0.82128 0.38039-1.441 0-1.2401 0.88084-1.441 1.5607-2.2499 0.72033-0.86042 0.38039-2.0516-0.99046-1.5506-0.18987 0.0796-0.36995 0.31898-0.57026 0.37965-0.25968 0.0907-0.55003-0.0196-0.82016 0.0496-0.27012 0.0607-0.39996 0.33073-0.60027 0.39075-0.36995 0.11024-0.42019-0.0907-0.70076-0.15982-0.21988-0.06-0.63029 0.0104-0.82016-0.0998-0.42998-0.25049-0.17029-0.39922-0.30992-0.75996-0.20031-0.50098-0.73077-0.54012-0.94087-0.99087-0.27991-0.58971 0.21988-1.1905 0.36995-1.7104 0.0803-0.25962 0.0803-0.55969 0.20031-0.79061 0.13963-0.31051 0.36996-0.40966 0.50045-0.69081 0.47043-0.11025 0.58005 0.20091 0.96044 0.33072 0.33994 0.11025 0.80059 0.0405 1.1608 0.0405 0.58005 0 1.8909 0.25962 1.611-0.62036-0.12006-0.36008-0.66031-0.4201-0.55004-0.87999 0.06-0.27006 0.33994-0.35029 0.48022-0.59035 0.70011 0.45989 1.2006 0.95044 1.0505 2.0607 0.32036-0.0502 0.79014 0.12981 1.1105 0.06 0.42019 0.75996 2.9714 0.95044 3.862 1.1403 1.6508 0.35029 3.2317 0.85063 4.8224 1.1605 2.0312 0.39922 3.8724 0.40966 3.522-2.1709-0.0998-0.66994-0.89063-1.3601-0.98067-1.8617-0.14028-0.78997 0.38039-1.5304 0.50045-2.2805 0.33015-0.01 1.5607-0.21983 1.8113-0.03 0.63029 0.47098 0 1.0913 0.36996 1.6412 0.92064 1.3712 2.221 0.69081 1.9907-0.93021 1.9209-0.63993 1.1705-1.1403 2.101-2.7404 0.85082-1.441 1.6207-0.68038 3.342-0.82063-0.10049-0.63993-0.59049-1.1102-0.61072-1.7802 1.0407-0.09 2.161 0.18983 3.1214 0.4501 0.0405-2.2707 0.15007-2.651 2.3515-2.8122 1.4106-0.0998 3.0314-1.0405 2.7019-2.8004 0.88019-0.36008 1.9809-0.17939 2.9414-0.23027-0.2101-1.6615 1.9013-3.0516 3.3615-2.972 1.5007 0.0698 2.3515 2.9511 4.5125 1.6804 0.77057-0.4501 0.54025-1.3203 1.5307-1.6804 0.76013-0.27006 2.1512 0 2.9616 0 0.90041 0 1.9411 0.14025 2.8017-0.0398 0.96044-0.19048 1.38-0.86041 2.5114-0.60013 0.2499 1.3105 1.6207 1.8806 1.7206 3.1109 0.23098-0.0189 0.55004 0.0802 0.78036 0.06 0.80059 4.1514 4.6123 2.6112 7.694 3.3014 1.7114 0.39074 2.8115 1.291 4.8531 1.1703 1.7519-0.10959 3.1514-0.85976 4.9627-0.81019 0.35038 2.1514 0.06 3.1012 2.6614 2.4514 0.24011-0.49055 0.46064-0.47946 0.82994-0.79062 0.20096 2.0516 2.452 0.69994 3.5423 0.65037 1.4811-0.0692 3.6121 1.4103 5.0025 1 1.1007-0.33008 0.80059-0.71038 0.79015-1.8311 0-0.53034 0.09-2.0209-0.12071-2.5114-0.25903-0.62036-1.2306-0.4899-1.3604-1.3405-0.06-0.42988 0.64007-1.2003 1.1405-1.4305 0.2101 0.12068 0.5011 0.21983 0.89062 0.27006 1.2006 0.17026 2.5714-0.20026 3.9723-0.14025 0.0104 0.32029 0.19053 0.4899 0.2101 0.78018 0.75034 0.0502 1.5307 0.0202 2.2817 0.06 0.92064 0.68038 0.52002 1.4005 1.6906 1.8213 0.79014 0.27006 2.3111 0 3.1521-0.0404 0.0502-0.15004 0.01-0.29029 0.0502-0.45011 0 0 0.47957-0.0202 0.44955 0.0104 0.36995 0.66081 1.0903 1.3908 1.2012 2.1403 0.0692 0.55056-0.31123 1.9204-0.33994 2.6608-0.0502 0.98045-0.12985 1.6908-0.70011 2.4606-0.53046 0.7293-1.5007 0.77953-1.4511 1.8506 0.15986 0.0489 0.30014 0.0104 0.46065 0.0489 0.06 1.5904 0.70989 2.9811 1.01 4.4815 0.25055 1.2309 0.16051 3.7711 1.6508 4.1918 0.06 2.2499 0.52003 2.2805 2.6915 2.3001 1.6201 0.0196 3.0516 0.45011 4.6417 0.31116 0.39997-2.242 7.5844-0.54012 9.1849-0.44097 0 0-0.06 0.30007-0.0802 0.30007 0.0698 0.22049 0.28056 0.36074 0.29035 0.63993 0.45999-0.0698 0.94021-0.21005 1.4002-0.33008-0.58071 0.61058-1.6116 0.97001-2.4018 0.88977-0.7001 0.91978-1.5098 0.99088-2.6914 1.1298-1.151 0.14938-2.5212 0.27985-3.5514 0.94978-0.39084 0.26028-1.0414 0.93087-1.3206 1.3412-0.2499 0.36073-0.41041 1.501-0.6205 1.7208-0.92064 0.93934-2.8115 0.27006-4.0114 0.69994-1.3506 0.47946-1.791 1.4508-2.1714 2.76-0.35038 1.1507-0.67988 2.0411-1.2103 3.1514-0.33994 0.71038-0.74056 3.261-1.1105 3.6015-0.72033 0.64971-3.0908-0.0196-4.0519 0.39987-1.4204 0.63993-1.5398 1.76-1.821 3.1918-1.1601 0.06-2.8317-0.30007-3.8124 0.31899-0.99046 0.63145-0.84039 1.9009-1.4909 2.7522-0.21988 0.28898-1.821 1.9707-2.1714 2.1305-1.1901 0.55056-2.0305-0.18982-3.171 0.66081-1.5307 1.1403-1.1412 5.291-4.0121 3.8415-1.3108-0.6608-0.45999-2-1.9809-2.5114-0.84038-0.27006-2.7815-0.2805-3.6519-0.14025-0.75035 2.2205-0.01 5.1012 0.64008 7.1521 0.27991 0.90086 0.83973 2.2812 0.71054 3.3308-9e-3 0.0626-0.0189 0.12264-0.0287 0.17222zm-22.262-37.091c1.0198-0.53033 1.3604-0.78996 1.301-1.9994-0.30014-0.0802-0.41106-0.19048-0.64008-0.36008-0.0698-0.46054-0.0803-0.90151-0.10961-1.3914-1.0009-0.0196-1.3708-0.69081-2.3013-0.85976-0.09-0.43967-0.0202-1.3196-0.33993-1.6497-0.24012-0.25049-1.3708-0.46054-1.7512-0.49054-0.0202 0.32029-0.09 0.60013-0.19053 0.89042-1.2704 0.0992-0.81037-0.3914-1.3004-1.1709-0.1605-0.25963-0.59048-0.42988-0.79014-0.70973-0.21988-0.28115-0.14028-0.56035-0.48022-0.78018-0.25969 0.20026-0.41041 0.47946-0.42998 0.8291-0.91085 0.0502-2.3515-0.36008-2.1714 1-0.67009 0.03-1.4407-0.0796-2.0612 0.0998-0.67009 0.19048-0.89062 0.77953-1.6605 0.82062-0.0698-0.31963-0.14028-0.63992-0.19052-0.98044-0.09 0.0104-0.2101-0.0104-0.30993 0-0.27012 0.39074-0.73077 0.65037-1.181 0.82063-0.95066 0.33986-1.0707 0.28963-0.94022 1.2603 0.09 0.65037 0.20031 1.6112 0.6205 2.1409 1.1608-0.0907 0.50045 0.85976 0.39997 1.5004-1.1405 0.33986-0.70989 1.1403 0.27012 1.0411 0.65052-0.0607 1.761-0.55121 1.8308 0.55057 0.71055 0.0398 1.4309-0.0104 2.1414 0.03-0.06 1.0405 0.41041 0.94 0.93043 1.5904 0.42998 0.53947 0.20031 1.2094 0.67988 1.7104 0.92064 0.14938 1.821-0.82976 2.3313-1.3999 0.52002-0.57013 1.2404-1.5506 1.9907-1.6706 0.39018-0.0607 1.2808-0.0196 1.671 0.09 0.53047 0.12982 0.66031 0.65037 1.0805 0.89042 1.2606 0.7293 1.4707-0.91194 1.6005-1.8024z",
+                Nantou:"m217.09 275.91c-0.88997-0.5199-0.50958-1.5506-1.671-2.351-1.581-1.0907-0.96044 0.88977-1.7806 1.79-0.74056 0.81019-2.9805-0.4899-3.0314 0.98109-1.4818 0.0692-2.7515-0.20091-4.1125-0.33986-0.39084-0.82975-0.2101-1.8206-0.57027-2.6106-1.121 0.36009-1.7806 2.1905-2.9316 1.9504-0.39997-2.0307-0.12071-3.3308 0.25968-5.1918 0.36082-1.7515 1.4909-2.7906 1.9118-4.4214 0.36017-1.3307-0.35038-1.3001-0.7001-2.2009-0.36017-0.91065-0.27991-1.6504-0.32037-2.6706-0.0404-0.66993-0.58005-2.351-0.18008-3.0013 0.47109-0.77952 1.5209-0.47032 2.4716-0.52055 0.10962-2.0607-0.15986-3.7913-0.63942-5.6406-0.26034-1.0202-0.54025-1.2505-1.0903-1.9805 0.18987 0 0.39997-0.03 0.57027-0.0502-0.0698-0.8004 0.51023-1.2003 0.88997-1.7802 1.7519-0.41031 2.972-0.95043 4.9425-1.0496-0.01-0.0698-0.01-0.39074 0-0.4501-0.49 0-0.82994-0.31051-1.2808-0.39009-0.03-0.4899-0.27991-0.90021-0.21988-1.4403-0.33994-0.33008-0.86062-0.59035-1.2808-0.66994 0.03 1.7515-3.8118 0.54013-4.0519-0.50033-1.6605-0.42988-1.4609-2.9107-2.7815-3.0509 0.50958-1.2707-0.21989-6.3021 1.2697-6.8422 0.0698-1.1403-0.09-2.3308 0.32036-3.351 0.21989-0.55056 0.71055-0.6608 0.8815-1.291 0.12005-0.47032 0-1.1605-0.0307-1.6406-0.23032 0.03-0.55004-0.0802-0.77971-0.0502-0.0907-1.561-0.55003-3.2708-0.33015-4.7815 3.1208 0.12003 3.2806-4.201 1.9411-6.002-0.47043 0.09-0.85017-0.19048-1.2704-0.21983-0.3693-4.1012 4.553-0.39009 5.8931-2.6706 0.28057 0.15982 0.58071 0.29029 0.91086 0.36922 1.2006 0.3105 2.9218-0.0104 4.1726-0.0104 1.8106 0 2.3913 0.31116 3.8424 0.80105 3.342 1.1396 4.6221-0.93086 6.4543-3.1814 0.66944-0.81997 1.5007-1.7704 1.8902-2.7704 0.42085-1.1011 0.62051-2.8813 1.6912-3.6413 0.82081-0.58057 1.9711-0.3503 2.942-0.39987 0.12005-2.4808-0.21989-5.0516 0.65051-7.3119 0.47957-1.2101 1.2906-1.9602 2.7019-1.3203 0.58005 0.25962 0.75034 0.97 1.3004 1.2003 0.73077 0.29029 0.82015-0.03 1.6808-0.17938 0.44955 1.1102-0.33081 2.9211 0.23032 3.9302 0.88084 1.5904 2.4011 0.48011 2.6314-0.96023 0.19052-1.1605-1.1105-3.321 0.84038-3.0007 1.3408 0.20939 1.121 1.8898 2.9616 1.4703 0.54025-1.1814 1.7708-1.1814 2.8409-1.6602 2.3613-1.09 4.4825-0.32029 7.234 0.0196 0.33994-1.0196 0.79015-1.8402 2.052-1.73 0.09-2.291 1.151-4.0111 3.631-4.1012 2.6014-0.09 3.6023-0.40053 5.6635-1.6712 1.8308-1.1298 2.3711-2.8702 3.9618-4.1612 1.5614-1.2799 4.4434-0.58905 6.4738-0.69929 0.12919-1.4814 0.0496-2.7411 1.3604-3.1409 1.0198-0.3105 2.9414-0.63014 4.0023-0.50033 0.55982 0.0802 1.0498 0.60992 1.6312 0.47033 0.42998-0.0998 0.81037-0.95044 1.5398-1.1305 0.70076-0.17939 1.4217-0.12916 2.1714-0.33986 0.66096-0.19048 0.84039-1.2205 1.3604-0.19048 0.72033 0.0404 1.5509 0.10046 2.2713 0.06 1.1405-0.0691 0.48022 0.48011 1.2006-0.69994 0.82016-1.3497 0.99111-2.6406 3.1417-2.3105-0.33994 2.1507 1.6201 1.0411 2.2204 2.1103 0.7001 0.12002 1.4818 0.0502 2.1108-0.15982 0.24011-2.0105 6.0934-0.0202 6.7936 1.0202-0.0802 0.19048-0.0502 0.28963-0.0698 0.47946 0.0196 0 0.03 0.0104 0.0502 0-0.42019 0.57013-0.65052 1-0.55069 2.1612 0.92064 0.17025 0.96044 1.0404 0.78036 1.8402-1.731 0.0907-2.452-0.0404-3.6728 1.0202-1.181 1.0404-2.0005 1.5101-3.6023 2.2205-0.96044 0.42988-0.95065-0.03-1.3708 0.95043-0.29035 0.69016 0.06 1.5101-0.32036 2.2199-0.2499 0.48011-0.92064 0.5199-1.2208 1.2505-0.26033 0.66081-0.16051 1.6308 0.0692 2.351 1.7806 0.0202 1.6716 0.44032 2.852 1.3105 0.92064 0.66993 2.4213 0.98044 3.2513 1.5708 1.7212 1.2303 0.82995 4.7013-0.45999 6.1716-0.67009 0.76061-1.3506 1.9504-2.2112 2.4306-1.5007 0.85128-2.2419-0.38031-2.4611 1.8709-0.14942 1.4814 0.10961 2.4312-0.62051 3.8813-0.61985 1.2303-0.94021 2.0007-1.3708 3.291-0.67988 2.0405-1.4407 2.9909-1.3206 5.4717 0.7001 0.0411 1.4211 0.0104 2.1205 0.0502 0.17095 3.3412-0.16964 6.7418-0.33994 10.124-2.1323-0.14025-1.2612 4.2812-1.331 5.6615-0.23097 0.03-0.56047 0.09-0.78035 0.0502-0.33016 0.72016-0.76079 1.1403-1.0303 1.9804-0.12005 0.39988-0.0202 0.95044-0.16051 1.3307-0.19052 0.5199-0.65051 0.65037-0.88084 1.1703-0.64007 1.4103-0.45999 3.1305-1.1503 4.471-0.5011 0.10959-0.75034 0.39074-1.2815 0.39074-0.45999 1.3608-0.39017 2.8702-0.21988 4.2812-1.4511 0.21983-3.0608 2.351-2.7815 3.8311 2.6817 0.54991 2.6817 0.3803 2.972 3.201 0.20097 1.8806 1.7715 2.0405 2.0109 4.1612 0.0907 0.8702 0.0802 1.9602-0.01 2.8402-0.11027 1.0802-0.75034 1.501-0.84039 2.3308-0.0802 0.83041 0.67009 1.4306 0.51024 2.3308-0.2101 1.2805-1.5209 2.0209-1.9111 3.0209-0.4104 1.0802 0.31058 2.441-0.25055 3.441-0.44955 0.78997-0.82994 0.33008-1.1705 1.3803-0.25904 0.77953 0.13049 1.4208-0.3693 2.1311-0.57092 0.10959-1.1014 0.42075-1.6716 0.42988-0.74969 0.0104-0.92064-0.91064-1.9411-0.20026-0.09 0.42075-1.0407 2.1807-1.5209 2.321-0.92064 0.2805-1.8113-0.88064-2.972-0.31964-0.0907 0.0907-0.03 0.31964-0.0607 0.43966-0.85017 0.21005-0.74969 1.0607-0.61072 1.8409 0.27013-0.0502 0.68053 0.10959 0.95066 0.0496-0.36995 1.4508-0.15007 1.6908-1.7806 2.1709-0.11027 1.8702 0.21009 3.6106 0.0998 5.4417-0.68053 0.44032-1.5209 0.57014-2.0116 1.3405-2.4716-1.8396-8.214-1.9198-10.085 0.72017-1.0498 1.4703-1.761 3.1507-2.3802 4.8004-0.8815 2.3608 1.4602 1.8206 1.3108 4.3112-0.67009 0.21984-1.4217 0.21984-2.1414 0.36987-1.2306 0.25897-0.84039 0.20874-1.7108 0.94978-0.32036 0.2805-0.28056 0.68038-0.48022 0.88977-0.12005 0.12068-0.55003 0.11025-0.84038 0.12981 0-0.14938 0.0307-0.33007 0.0111-0.45988-0.14028-0.03-0.32037-0.0502-0.46065-0.0405 0.03-0.91064 0.44042-1.6412 0.29035-2.6217-0.39083 0.0496-0.78036-0.24005-1.1307-0.23027 0.0411-0.3803-0.20031-0.60079-0.2101-0.93086-1.8713-0.10959-3.2513-0.0104-4.8022-0.69995-1.0805-0.48011-0.95065-0.6197-2.1714-0.36986-0.24011 0.0502-0.49 0.11024-0.74055 0.18004-0.46 0.12003-0.94022 0.25897-1.4002 0.33007-0.0104-0.2805-0.21989-0.42074-0.29035-0.63993 0.0202 0 0.0802-0.30006 0.0802-0.30006-1.6012-0.0992-8.7849-1.8011-9.1849 0.44097-1.5907 0.14025-3.0216-0.29029-4.6417-0.31116-2.1714-0.0196-2.6314-0.0502-2.6915-2.3001-1.4909-0.42074-1.4002-2.9609-1.6508-4.1918-0.30014-1.5003-0.95066-2.8911-1.01-4.4815-0.16051-0.0398-0.30014 0-0.46065-0.0489-0.0502-1.0711 0.92064-1.1213 1.4511-1.8506 0.57026-0.77104 0.65052-1.4814 0.70011-2.4606 0.03-0.74039 0.4104-2.1103 0.33994-2.6608-0.11027-0.74952-0.82995-1.4808-1.2006-2.1403 0.03-0.03-0.44955-0.0104-0.44955-0.0104-0.0411 0.16047 0 0.30007-0.0502 0.4501-0.84039 0.0405-2.3613 0.31051-3.1521 0.0405-1.1705-0.42075-0.77057-1.1409-1.6906-1.8213-0.75034-0.0398-1.5314-0.01-2.2817-0.06-0.0196-0.29028-0.20031-0.46054-0.21009-0.78017-1.4002-0.06-2.7717 0.31115-3.9723 0.14024-0.39083-0.0489-0.68053-0.14873-0.89063-0.26875z",
+                Yunlin:"m204.7 249.7c0.55004 0.72995 0.82929 0.96022 1.0903 1.9805 0.47957 1.8506 0.7497 3.5806 0.63943 5.6406-0.95066 0.0502-2.0005-0.25897-2.4716 0.52055-0.39932 0.65037 0.14028 2.3308 0.18008 3.0014 0.0411 1.0196-0.0405 1.7606 0.32037 2.6706 0.35037 0.90021 1.0603 0.8702 0.7001 2.2009-0.42085 1.6308-1.5503 2.6706-1.9118 4.4214-0.38039 1.8611-0.6603 3.1612-0.25968 5.1918 1.151 0.24006 1.8106-1.5904 2.9316-1.9504 0.36017 0.78997 0.17943 1.7802 0.57026 2.6106 1.3604 0.14025 2.6308 0.41032 4.1125 0.33986 0.0502-1.471 2.2908-0.17025 3.0314-0.98109 0.82147-0.90021 0.20097-2.88 1.7806-1.79 1.1608 0.8004 0.78036 1.8304 1.671 2.351-0.50045 0.23092-1.2006 1.0007-1.1405 1.4305 0.12984 0.84998 1.1014 0.72017 1.3604 1.3405 0.2101 0.49055 0.12071 1.9804 0.12071 2.5114 0.01 1.1207 0.30992 1.501-0.79015 1.8311-1.3904 0.41031-3.522-1.0705-5.0025-1-1.0903 0.0496-3.342 1.3999-3.5416-0.65037-0.36996 0.31116-0.59049 0.30007-0.8306 0.79062-2.6014 0.64971-2.3111-0.30007-2.6614-2.4514-1.8113-0.0496-3.2115 0.7006-4.9627 0.81019-2.0409 0.12068-3.141-0.77953-4.8531-1.1703-3.0816-0.69016-6.8934 0.85063-7.694-3.3008-0.23032 0.0196-0.55003-0.0802-0.78036-0.0607-0.0992-1.2303-1.4707-1.8004-1.7206-3.1109-1.1307-0.25962-1.5509 0.41032-2.5114 0.60014-0.86061 0.17939-1.902 0.0398-2.8017 0.0398-0.81037 0-2.2014-0.27006-2.9616 0-0.9911 0.36009-0.76078 1.2303-1.5307 1.6804-2.1616 1.2707-3.0118-1.6106-4.5125-1.6804-1.4609-0.0802-3.5723 1.3105-3.3615 2.972-0.96044 0.0502-2.0612-0.13046-2.9414 0.23027 0.33015 1.7606-1.2912 2.7013-2.7019 2.8004-2.2014 0.15982-2.3111 0.54012-2.3515 2.8122-0.96044-0.26027-2.0807-0.54012-3.1214-0.4501 0.0202 0.66994 0.51024 1.1403 0.61072 1.7802-1.7212 0.14025-2.4912-0.62036-3.342 0.82063-0.93043 1.6002-0.18009 2.1005-2.101 2.7404 0.23033 1.6197-1.0707 2.3001-1.9907 0.93021-0.36996-0.54991 0.25968-1.1703-0.36996-1.6412-0.25055-0.18982-1.4811 0.0202-1.8113 0.0307-0.12006 0.74952-0.64008 1.4899-0.50045 2.2799 0.09 0.50164 0.88084 1.1905 0.98067 1.8617 0.35038 2.5806-1.4909 2.5708-3.522 2.1709-1.5907-0.31116-3.1717-0.81019-4.8224-1.1605-0.89063-0.18983-3.4418-0.38031-3.862-1.1403-0.32037 0.0698-0.79015-0.11024-1.1105-0.06 0.15006-1.1102-0.35038-1.6008-1.0505-2.0607 0.0405-0.0496 0.06-0.11024 0.0803-0.18004 0.26033-1.0705-0.55004-0.88912-0.95066-1.5304-0.0502-0.0104-0.11026 0-0.1605-0.0196-0.0503-0.87085-0.06-1.8011-0.01-2.6804 0.0405-0.71038 0.27991-0.36987 0.50045-0.81019 0.21988-0.45988-0.21989-0.63993-0.4202-0.88977-0.57026-0.71038-0.38039-1.6908-0.33015-2.621 0.0202-0.52056 0.30014-0.66994 0.36995-1.0607 0.0803-0.40966-0.24011-0.75017-0.31057-1.1403-0.0803-0.48011 0.0202-1.0405-0.01-1.5304-0.36995-0.13047-1.151-0.74104-1.0505-1.2107 0.0998-0.5199 0.85082-0.27006 1.1105-0.80105 0.18008-0.36922 0.0104-1.2505 0.0104-1.6797 0-0.72017 0.32036-0.94 0.50044-1.5708 0.18009-0.62036 0.4202-1.0098 0.88084-1.5101 0.49001-0.53034 0.6205-0.84019 0.85996-1.5095 0.24011-0.66993 0.39018-1.09 0.45021-1.7906 0.0398-0.56035 0.27012-0.89043 0.64008-1.3007 0.57026-0.62036 2.2112-1.6008 1.7206-2.6308-0.21989-0.45989-0.45021-0.48989-0.48022-1.1403-0.03-0.4201 0.0998-0.97979-0.0803-1.3601-0.21009-0.44945-0.48022-0.3803-0.85082-0.30985-0.32037 0.06-0.20031 0.36008-0.57026 0.10959-0.18009-0.12068-0.27992-0.33986-0.26034-0.56034 0.12005-0.97979 1.8413-0.62036 2.5016-0.70973 0.0398-0.8702-0.15007-1.7404-0.18008-2.6008-0.0398-0.99022 0.20031-1.2505 0.70076-2 0.81037-0.0404 2.681 0.30007 3.1214-0.44032-0.0998-0.52055-0.20031-0.99088-0.20031-1.561 0-0.27985-0.0803-0.69016 0.0802-0.93021 0.18009-0.27007 0.55069-0.27007 0.73077-0.50034-0.6603-0.30007-0.88084 0.2505-1.181 0.66994-0.27991 0.39987-0.81037 0.75996-1.0205 1.1905-0.45021 0.12003-0.72033 0.63993-1.121 0.87999-0.32037 0.19047-0.67988 0.12068-0.99046 0.25049-0.24011 0.0998-0.42019 0.30007-0.67987 0.30007-0.09-0.68038-0.59049-1.2101-1.0205-1.7215-0.51024-0.6197-0.47043-1.0796-0.49001-1.8806 0.21988 0.51011 0.70011 1.0307 1.3004 0.93999 0.52002-0.0907 0.59049-0.54991 0.78036-1.0007 0.38039-0.89042 0.47043-1.8904 0.42019-2.8807-0.68053 0.0698-1.0309 0.24984-1.5105 0.74038-0.46065 0.45989-0.78036 0.58057-1.3506 0.8702-0.09-0.50033 0.74055-1.0307 1.1105-1.2903 0.47043-0.33986 0.68053-0.7306 1.1307-1.0711 0.39018-0.28898 0.89063-0.74952 1.3708-0.9002 0.88084-0.28964 1.3206-0.57013 1.9711-1.2094 0.6205-0.62036 1.2906-1.1703 2.1616-1.4005 0.75034-0.21005 3.3015 0.46054 2.9414-1-0.15007-0.60014-0.88084-0.63928-0.24011-1.3001 0.27991-0.2805 0.67009-0.36987 1.0603-0.39075 0.30014 0.12068 0.74056 0.18005 1.1307 0.11025 0.67009 2.0516 3.5919 0.81997 4.3918 2.2805 2.3411 0.66015 4.3226 0.86042 6.9736 0.86042 1.1908 0 2.681 0.24984 3.8418 0.01 1.4009-0.30007 1.9013-1.2903 3.1319-0.20026 0.97023-2.0516 1.7708-1.8102 4.0323-1.8102 0.92064 0 1.8308-0.06 2.6216 0.21005 1.0407 0.35029 1.241 0.9002 2.5212 0.82062-0.0398 0.27006 0.11027 0.66994 0.06 0.94 0.20031 0.20026 0.20031 0.01 0.33015 0.33986 1.581 0.0907 2.4611 0.06 3.6317 0.69081 0.99045 0.53034 1.7212 1.3307 2.6614 1.6608 2.651 0.90999 5.593 0.20939 8.3543 0.33986 0.4104 0.0202 1.4818-0.0189 1.8413 0.16047 0.47043 0.23092 0.73012 1.06 1.1908 1.3105 0.91085 0.47097 2.7417 0.48011 3.802 0.53034 1.6801 0.0802 3.3818 0.17025 5.0626 0.14938 1.9111-0.0189 2.0214-0.0802 3.141 1.4814 0.0215 0.0157 0.0313 0.0359 0.0418 0.0555z",
+                Penghu:"m30.865 336.76c0.46065 0.0698 0.20031 0.18004-0.06003 0.3503-0.51023 0.33986-0.21988 1.15-0.59049 1.6504-0.15007 0.20026-0.32036 0.4788-0.49001 0.64906-0.23032 0.21005-0.47043 0.0907-0.7001 0.25114-0.28056 0.20027-0.14028 0.50947-0.2499 0.8004-0.09004 0.24006-0.27012 0.39988-0.32036 0.66994-0.04045 0.24006 0.0098 0.50033-0.33015 0.50033-0.1703-0.21983-0.40975-0.47032-0.60028-0.69016-0.15986-0.19047-0.56048-0.33072-0.6603-0.53034-0.10962-0.23027 0.1305-0.58904 0.16051-0.80953 0.02023-0.18982 0.02023-0.52055-0.06981-0.69081-0.21988-0.41031-0.76078-0.48989-1.0009-0.90021-0.03001-0.0698-0.05024-0.19047-0.09983-0.24005-0.09983-0.0998-0.18987-0.0405-0.30014-0.11024-0.1703-0.09-0.25968-0.4488-0.47043-0.45989 0.45021 0 0.90041-0.03 1.3506-0.0405 0.32036 0 0.39018-0.0411 0.61072-0.21983 0.23032-0.19048 0.2897-0.18004 0.64008-0.18004 0.48022 0 0.95065 0.0404 1.3708-0.12003 0.20031-0.0698 0.36016-0.0502 0.56047-0.0998 0.27012-0.0607 0.15986-0.22049 0.33994-0.31116 0.10896 0.4214 0.56961 0.48076 0.90955 0.53099zm9.855-23.999c0.12006 0.36008 0.21988 0.66015 0.06981 1.06-0.15986 0.4214-0.55004 0.48011-0.59049 0.96087-0.02023 0.42075 0.24011 0.69994 0.4104 1.0496-0.73077 0.11024-4.3827 0.0907-4.3925-0.78996 0.33015-0.0202 0.60028-0.19048 0.6603-0.50034 0.80058-0.41031 1.3904-1.1905 1.3108-2.0803-0.09983-0.0104-0.2101-0.0307-0.31058-0.0307-0.55982-0.66015-0.09004-0.97-0.09983-1.6497 0-0.54013-0.64008-1.3412 0.26034-1.6713 0.13963-0.03 0.33994 0.17026 0.48022 0.17939 0.11027 0.78997 0.51023 0.0998 0.85082 0.15982 0.81037 0.12981 0.2499 0.25049 0.58005 0.75017 0.1703 0.25898 0.73077 0.42989 0.82016 0.60014 0.24011 0.4201-0.2101 0.85063-0.24011 1.06-0.06916 0.55186 0.03067 0.38226 0.19052 0.90216zm4.2326 0.90021c0.01957 0.25962 0.06981 0.21005-0.1703 0.34964-0.12006 0.0607-0.29035 0.12134-0.43063 0.18004-0.53046 0.25898-0.40975-0.20091-0.85017-0.24983-0.31058-0.0411-0.20031 0.18982-0.33015 0.33986-0.08025 0.11024-0.11027 0.0998-0.2101 0.17025-0.09983 0.0613-0.24011 0.16047-0.36995 0.24006-0.0098 0.22048 0.08025 0.55056-0.1703 0.65036-0.36995 0.12982-0.40975-0.33007-0.45999-0.55056-0.50045 0.03-0.43063-0.69994-0.43063-1.0404 0.33015 0 0.6603 0.0104 0.99046-0.0111 0.09004-0.25898 0.08025-0.57013 0.06003-0.85911-0.11027-0.0111-0.23032-0.0998-0.24011-0.22049-0.04045-0.3105 0.24011-0.14025 0.38039-0.25962 0.11027-0.0998 0.03001-0.27007 0.11027-0.34965 0.10962-0.0907 0.39997 0 0.49001 0.12981 0.20031 0.31051-0.1703 0.55056 0.33994 0.60014 0.19052 0.0196 0.42019-0.12981 0.5807-0.09 0.14028 0.03 0.15007 0.14938 0.2499 0.20874 0.09983 0.0613 0.2101 0.0111 0.30014 0.10046 0.1703 0.15134 0.15072 0.46185 0.16051 0.66146zm0.24011-20.209c-0.21988 0.4201-0.13963 0.91978-0.16964 1.3901-0.90041 0.0502-1.6012 0.2805-2.4213 0.20027-0.42019-0.0489-0.7399-0.16961-1.1503 0-0.32036 0.13046-0.09983 0.63993-0.73077 0.55121-0.0398-0.18004-0.15986-0.21983-0.20031-0.39074-0.21988 0.0411-0.50045-0.0607-0.72033-0.03-0.06003-0.6308 0.71054-0.60079 0.6603-1.1507 0.73012 0.17874 1.7108-0.22048 2.3913-0.42988 0.77057-0.25049 1.4909-0.2107 2.3411-0.14025zm0.26034-23.275c0.19052 0.0998 0.19052 0.8402 0.09004 1.09-0.6603 1.6112-2.3913 0.72016-3.7419 1.2609-0.02023 0.74952-0.0098 0.82975 0.30014 1.4299 0.30014 0.55056 0.36995 0.75017 0.33015 1.4606-0.04045 0.95044 0.15986 2.7019-1.2103 2.6106-0.14028 0.53034 0.98002 1.8011-0.25055 1.8409-0.01957 0.33986-0.12006 0.90021-0.01957 1.2401 0.09983 0.3105 0.43977 0.45989 0.57026 0.75995 0.44042 1.0705-0.38039 1.1807-1.2208 1.1403 0.02023-0.12068-0.0398-0.2805-0.01957-0.39075-0.76078-0.0404-1.7512-0.53034-2.4018-0.09 0.30014 1.3405-1.6207 0.0496-1.611 1.06-0.69032-0.0802-1.0805 0.32029-1.8008 0.25049-0.39997-0.98044 0.06981-1.1102 0.75034-1.5095 0.58005-0.33986 0.27012-0.3803 0.57026-0.81018 0.2101-0.31116 0.1703-0.52056 0.72033-0.58122 0.30992 0.51012 0.51023 0.61971 1.0505 0.60079 0.26034-0.0111 1.1412-0.27006 1.331-0.42075 0.60028-0.50099 0.67009-2.1507 0.38039-2.9211-1.3911 0-1.4009-1.3412-0.08026-0.86041 0.03001-0.61123-0.03001-0.92043 0.32036-1.3803 0.33015-0.44032 0.76078-0.42075 0.85082-1.09-0.14028 0.03-0.33994-0.0502-0.48022-0.03 0.02023-0.11024-0.0398-0.28115-0.02023-0.39074-0.24011-0.0404-0.47043-0.16047-0.73012-0.11024 0.27012-0.8004-0.2499-1.9198 0.09004-2.6406 0.85017-0.0104 0.70989-0.25049 0.98002-0.85063 0.2101-0.44032 0.61072-0.66015 0.75034-1 0.36995-0.8004-0.18008-0.69016 0.75034-1.0802 0.45021-0.19048 0.86061-0.46054 1.3108-0.65037l0.03001 0.0698c0.1305-0.01 0.27012-0.01 0.40062 0.0104-0.2101 0.36074-0.39018 0.6608-0.63029 1.0111-0.29035 0.39922-0.69032 0.39922-0.51024 1.0496 0.77057-0.0502 1.3708 0.57013 2.2412 0.3503 0.21923-0.0587 0.71902-0.52838 0.90955-0.42858zm8.5742-4.4032c-0.23032 1.3803 1.641 2.2205 1.5007 3.8109-0.36995 0.0202-0.76078 0.0104-1.1405 0.0307-0.26034 0.38031-0.32036 1.2401-0.2499 1.7208 0.84039-0.19048 0.82995 0.8004 0.39018 1.1703-0.63029-0.0404-0.50045 0.63014-0.47043 1.0802 1.5307 0.03 1.2912 1.1005 1.2208 2.4208-0.4104 0.03-0.89063-0.2805-1.2306-0.48989-0.7001-0.45011-0.29035-0.48011-0.59049-1.2505-0.39018-1.0411-1.761-0.57013-1.3206-1.9915 0.54025-0.09 0.33015-1.1096 0.31058-1.5806-0.86061 0.0411-0.49001-0.77953-0.75034-1.2603-0.16051-0.29029-0.53046-0.33986-0.65052-0.66994-0.09983-0.24984 0-0.72016-0.01957-0.99023-0.8704-0.26027-2.191-0.63014-2.0814 0.63928-0.53046-0.0196-0.44042 0.52056-0.74056 0.78018-0.50045-0.3803-0.69032-0.93935-1.331-0.65037 0.09004-0.06 0.01044-0.16047 0.08025-0.27984h0.09004c0.31058-0.76061-0.38039-1.1905-0.32036-1.9009 0.56048 0.10959 0.84039-0.36987 1.4009-0.43054 0.54025-0.0691 1.2306 0.0998 1.8211 0.0698-0.04045-0.15982 0.06003-0.39987 0.03001-0.56035 0.41041-0.03 1.0309 0.17026 1.0805-0.33007 0.7001-0.21005 0.84039 0.41031 1.3408 0.63014 0.52981 0.22179 1.0505-0.058 1.6305 0.032zm1.592-17.163c0.09004 0.40966 0.1703 0.78997 0.16051 1.2205-0.18008-0.0411-0.45021 0.0691-0.64008 0.03-0.04045 0.78996-0.31058 0.85976-0.67009 1.3999-0.23032 0.33986-0.15007 1.4606-0.91085 1.2401 0.02023-0.1396-0.08025-0.18004-0.09983-0.24005-0.0098-0.66016-0.10962-1.3503 0.27012-1.9009 0.30014-0.44031 1.1307-0.55056 1.1405-1.1703-0.32036-0.06-0.52002-0.33987-0.59049-0.66994-0.39018 0.0411-0.65052-0.20026-0.64008-0.57992 0.78036-0.21005 1.1803 0.78018 1.9803 0.67059zm0.75687 4.9772c0.27012 0.19048 1.1405 1.0007 1.0009 1.4208-0.14028 0.42988-1.4811 0.24984-1.8511 0.39988-0.5807 0.24005-1.0603 0.92043-1.2306 1.5708-0.39018-0.31116-0.47043-0.78996-0.42998-1.291-0.24011 0.0411-0.43063-0.10959-0.64008-0.10959-0.19052-0.63014 0.40975-0.54012 0.67009-0.9002 0.25968-0.36009 0.23032-0.60014 0.24011-1.0705 0.45999-0.0907 0.78036-0.80105 0.99046-1.1814 0.25968 0.75147 0.64986 0.75147 1.2501 1.1611zm9.1868 29.42c1.0309 0.25049 1.4211 0.16047 1.3904 1.4097-1.1608 0.0913-2.5812 1.0411-2.5009-0.88912-1.3506-0.0698-2.8415-0.14025-4.1523-0.0907-0.82016 0.0307-1.2704 0.22049-1.5007 0.91064-0.2499 0.72017 0.02023 1.1207-0.82995 1.4208-0.30014 0.11024-0.64008-0.0405-0.92064 0.0998-0.35038 0.17939-0.45021 0.52055-0.73012 0.74952-0.46065 0.39074-1.0009 0.33986-1.3408 0.84019-0.75034 1.1103 0.81037 2.8918-0.08026 3.9818-0.30992 0.37965-0.89063 0.25897-1.4204 0.23027-0.43063-1.561-2.0011 0.12068-3.1019 0.17939-0.61072 0.0404-1.4009-0.14939-1.5907-0.82976-0.14028-0.50033 0.42998-1.2394-0.06003-1.7704-0.49001-0.55056-1.2404 0.0998-1.8308-0.50033-0.47043-0.47032-0.21988-1.1605-0.77057-1.5617-0.44042-0.31899-1.5509 0.0698-1.7708-0.64972-0.18987-0.58056 0.55069-0.82062 0.6205-1.3412 0.43063-0.20027 0.30014-0.66015 0.5807-1 1.2103-0.33007-0.02023 2.3412 1.3108 2.1703 0.27991 0.72016 0.75034 1.0104 0.69032 1.8904 0.52002 0.14938 0.8704-0.0998 0.8306-0.63993 1.6207-0.0796 0.81037 0.53034 1.2508 1.6412 1.0407 0.20026 1.2906-0.66994 1.2508-1.561 0.67988 0.0496 2.9616 1.6204 2.5512 0.0111-0.0398-0.19048-0.45999-0.27007-0.48022-0.52121-0.04045-0.47946 0.30014-0.45924 0.50045-0.66929 0.27012-0.30006 0.49001 0.0496 0.51023-0.59035 0-0.12981-0.28056-0.63014-0.36016-0.74039-1.1007-1.3901-2.101 0.20092-3.1417 0.33073-0.97023 0.12003-2.6216-0.76061-2.4911-1.9009 0.68053-0.0691 1.7108 1.2101 2.2412 0.24006 0.65052-1.2101-1.0407-1.4703-1.7408-1.2401-0.09004 0.48011-0.59049 0.31116-1.0107 0.31964 0.15007-0.88977 0.31058-1.1801 1.151-1.6002 0.12006-0.68038-0.98067-1.6106-0.6603-2.0607 0.2499-0.33986 2.0311-0.01 2.4716 0-0.33994-0.90021 0.33994-0.85911 1.0205-0.82911 0.03001 0.66929-0.18008 1.9994 0.36995 2.471 0.09983 0.09 1.0303 0.30007 1.1405 0.26941 0.67009-0.17939 0.39997-0.36987 0.44042-0.94 0.10962-1.6902 0.96044-0.33986 1.5705-1.15 0.64008-0.84084-0.65052-1.4703-0.85017-1.9009-0.12006-0.03-0.1703-0.06-0.2499-0.0998 0.45021-0.12002 0.82016-0.67972 1.4302-0.50033 0.53046 0.16047 0.35038 0.88977 1.2306 0.4899-0.12006-0.74104 0.91085-1.1403 1.2808-0.4899 0.16051 0.28963-0.36016 0.99023-0.42998 1.3405-0.09004 0.4501-0.09983 1.3001 0 1.7508 0.10962 0.48011 0.58005 1.1514 1.0903 0.50099-0.26034-0.36987-0.18008-1.5506-0.06981-1.9413 0.27991-1.0196 0.88084-0.30007 1.8008-0.41031 0.06982-1.3999-0.16051-2.1709 1.5007-1.8898 0.09983 0.67972 0.33015 1.1292 0.36016 1.8898 0.2499-0.03 0.55069 0.0502 0.81037 0.03 0.06981 0.0802 0.09004 0.0907 0.1703 0.17091-0.04045 0.19048 0.02023 0.45989 0.02023 0.72016 0.76078-0.0802 0.23032-1.1605 0.39997-1.6608 0.24011-0.66016 0.76078-0.51991 1.4909-0.48011 0.02023 0.4501-0.15007 1.2205 0.01044 1.6504 0.23032 0.59035 0.52002 0.57991 0.59049 1.3307 0.09722 1.1285-0.05285 2.2884 0.0072 3.409z",
+                Changhua:"m211.1 246.37c-0.01 0.0607-0.01 0.3803 0 0.4501-1.9711 0.0998-3.1919 0.63928-4.9425 1.0496-0.38039 0.58057-0.96044 0.98044-0.88997 1.7802-0.17095 0.0202-0.38039 0.0502-0.57026 0.0502-0.0111-0.0202-0.0202-0.0411-0.0411-0.06-1.1203-1.561-1.2306-1.501-3.141-1.4814-1.6808 0.0202-3.3824-0.0692-5.0632-0.14938-1.0603-0.0502-2.8918-0.0607-3.8013-0.53034-0.46064-0.24984-0.72033-1.0802-1.1908-1.3105-0.36017-0.18004-1.4309-0.14025-1.8413-0.16047-2.7606-0.12981-5.7033 0.57013-8.3543-0.33986-0.94022-0.33008-1.671-1.1298-2.6614-1.6608-1.1705-0.63014-2.0514-0.60014-3.6317-0.69016-0.12984-0.33007-0.12984-0.13959-0.33015-0.33986 0.0502-0.26941-0.0998-0.66928-0.06-0.93934-1.2802 0.0802-1.4805-0.47033-2.5212-0.82063-0.79015-0.27006-1.7004-0.21004-2.6216-0.21004-2.2608 0-3.0614-0.24006-4.0323 1.8102-1.2306-1.0907-1.731-0.0998-3.1319 0.20027-1.1608 0.24005-2.651-0.01-3.8418-0.01-2.6517 0-4.6326-0.20091-6.9736-0.86041-0.80059-1.4606-3.7217-0.23093-4.3918-2.2805-0.39018 0.0698-0.8306 0.01-1.1307-0.11024 0.18009-0.01 0.36996-0.01 0.54025 0 0.60028 0.03 1.4309 0.27006 1.8909-0.21983 0.48022-0.53034-0.18008-0.72017-0.32036-1.3503-0.20031-0.90021 0.59048-1.6008 1.4309-1.561 0.11027-0.69081 0.0803-0.91065 0.8306-0.93022 0.6205-0.0202 1.5105 0.17026 2.0514-0.12981 0.4502-0.25049 0.84038-1.0502 1.0903-1.4814 0.30014-0.53033 0.20031-1.1102 0.42998-1.6406 0.53046-1.2205 1.4309-2.1103 2.2112-3.1312 0.33015-0.43967 0.60028-1.1011 0.77057-1.6204 0.06-0.21004 0.0202-0.57013 0.12984-0.75017 0.19053-0.30985 0.36996-0.23027 0.50045-0.60992 0.10962-0.31051 0.06-0.94 0.06-1.2603-1.1007-0.29028-2.071-0.40053-1.3506-1.6608 0.54025-0.95043 1.3806-1.7 1.731-2.8506 0.27012-0.89042 0.43063-1.8506 1.0009-2.6713 0.15985-0.23027 0.36016-0.36921 0.52002-0.63927 0.12984-0.23093 0.12005-0.48011 0.35037-0.63015 0.50045-0.32029 1.3911 0.30007 1.8811-0.0698 0.33993-0.25049 0.39017-1.0907 0.48022-1.4703 0.15985-0.66994 0.35037-1.3503 0.78035-1.8898 0.58071-0.72016 1.181-1.1807 1.3206-2.1103 0.14028-0.88064 0.7001-1.3712 1.3604-1.9407 0.48022-0.42074 1.9711-0.97 2.131-1.5101 0.88083-0.15004 2.6014-0.66994 2.4213-1.8709-1.0002-0.0802-2.131 0.11024-3.1717 0.0502-0.80058-0.0404-0.78036-0.21983-0.71054-0.95044 0.0502-0.44031-0.0405-1.09 0.0803-1.5506 0.28057-1.1305 1.761-1.1605 2.7613-1.2505 0.57026-0.0502 1.0707-0.26028 1.611-0.31116 0.56047-0.0496 1.1412 0 1.6912 0 0.61071 0 1.5809 0.21005 1.9209-0.42923 0.27991-0.53034 0.0196-1.3412-0.06-1.8709-0.0998-0.65037 0.12984-1.09 0.26034-1.7006 0.13963-0.5897 0.09-1.3196 0.06-1.9302-0.53046-0.0202-1.0309-0.06-1.5607-0.0691-0.77057-0.0104-0.71054 0.0802-0.75034 0.8004-0.06 0.0202-0.11027 0-0.1703 0.0202-0.0202 0.33986 0 0.70059-0.0202 1.0496-0.64007-0.09-0.28056 1.1011-0.44042 1.4906-0.84038 0.0502-1.9914-0.21984-2.8011 0.0111-0.57026 0.1696-0.40061 0.69929-0.95065 0.99022-0.15007 0.0802-0.45021 0.0404-0.61071 0.09-0.2897 0.0907-0.3804 0.33987-0.73012 0.29029 0.21988-1.1703 1.1608-1.4208 1.8511-2.2407 0.76078-0.91065 1.4407-1.8506 2.251-2.7104 0.7001-0.74039 1.5007-1.5108 2.2713-2.2812 0.33015-0.33008 0.67988-0.72017 0.92064-1.1403 0.29035-0.53034 0.36016-1.0502 0.81037-1.4906 1.0205-1.0007 3.0216-0.43053 4.4322-0.51011 0-0.53947 0.06-0.5199-0.12005-0.99023-0.45021-1.2603 0.92064-1.4403 1.4002-2.3608 0.27012-0.53034 0.2003-1.2701 0.71054-1.7202 0.96109-0.85063 2.7913-0.50033 4.0121-0.31116-0.0405-0.12002-0.0803-0.23027-0.12071-0.31963 0.0803 0.03 0.15986 0.0691 0.24011 0.11024 0.0803 1.3497 0.11027 2.2903 0.54025 3.4612 0.42084 1.15 1.0714 1.8402 1.5007 2.8409 0.49001 1.1703 0.0907 2.9002 0.7001 3.9713 0.72033 1.2505 2.0312 0.78997 3.1019 1.2303 0.09 0.68037 0.67009 0.81018 1.331 0.66015-0.0692 0.32029 0.12984 0.80105 0.06 1.1102 1.1405 0.58122 2.0011 1.0502 3.3028 1.2003 1.4106 0.15982 2.6712-0.0802 3.9723 0.36073-0.09 1.8004 0.58005 1.8102 1.2404 3.1012 0.58984 1.15 0.3804 3.0007 2.2706 2.5604-0.11027 0.46054 0.0202 0.21983-0.28056 0.51012-0.0803 0.96022-0.93043 1.5604-1.0303 2.471-0.11027 0.98044 0.33994 2.1005 0.36017 3.1403 0.64007 0.03 1.3108 0.03 1.9509 0-0.0802-0.38031 0.1305-0.91 0.0502-1.2903 2.1512 0.25962 3.2017 2.6106 5.0626 3.621-1.3408 2.2805-6.2631-1.4306-5.8931 2.6706 0.42084 0.03 0.80123 0.30986 1.2704 0.21983 1.3408 1.8004 1.181 6.1221-1.9418 6.002-0.21988 1.5101 0.24011 3.2212 0.3308 4.7815 0.23033-0.03 0.55004 0.0802 0.77971 0.0502 0.03 0.47945 0.15007 1.1703 0.03 1.6406-0.17029 0.63015-0.6603 0.74039-0.88084 1.291-0.4104 1.0196-0.24989 2.2107-0.32036 3.351-1.4909 0.54012-0.76078 5.5715-1.2697 6.8422 1.32 0.14025 1.1203 2.621 2.7815 3.0509 0.24011 1.0404 4.0825 2.2512 4.0519 0.50033 0.42019 0.0802 0.93956 0.33986 1.2808 0.66994-0.06 0.54012 0.19052 0.95043 0.21988 1.4403 0.45151 0.0776 0.79145 0.38813 1.2821 0.38813z",
+                Taichung:"m182.09 177.11c-0.03-0.84997-0.10962-2.0907 0.38039-2.8004 0.42998-0.63015 1.5209-1.4606 2.3515-1.5206-0.0411-0.8004 0.47957-1.09 0.0496-1.8604-0.27012-0.4899-0.80058-0.80106-1.2097-1.1814 1.2397 0.63993 2.5707 0.71038 2.6712 2.4814 0.33015 0.0398 0.57026-0.20092 0.80124-0.36987 0.11027-0.91065 0.26947-1.0202 1.121-1.0705 0.21988-0.97979-0.93108-0.39988-1.0603-1.291-0.74121-0.12982-1.5209-0.21005-2.2817-0.20027 0.82995 0 1.3108-0.48989 1.8713-1 0.3693-0.33986 0.39932-0.29028 0.47957-0.81018 0.06-0.36009 0.0907-0.74039 0.0502-1.1103-0.0692-0.03-0.11027-0.0502-0.18008-0.0802 0.43063 0.0104 1.1307-0.0802 1.701-0.06 0.96044 0.0411 0.76078 0.11024 1.0009 0.8702 0.40975-0.01 0.81037-0.09 1.1705-0.25897 0.0405-0.33073 0.31058-1.1703 0.12005-1.4103-0.0803-0.0998-0.52002-0.15003-0.6603-0.21004-0.24011-0.10959-0.32036-0.32029-0.75034-0.30986 0.41105-0.44097 1.6207 0.0992 1.9809-0.30007 0.56047-0.63079-0.17943-1.9504 0.0411-2.6719 0.2897-0.96936 1.4909-1.5206 2.0801-2.2701 0.97022-1.2205 0.17094-2.591 0.80123-3.8813 0.39018-0.78018 1.1105-1.15 1.761-1.7306 0.60028-0.54012 1.1803-1.2394 1.5698-1.9504 0.32037-0.57991 0.97088-1.1598 1.1816-1.7704 0.24011-0.65036 0.16051-1.1102 0.63942-1.6908 0.8306-1.0104 2.0716-1.4906 2.7019-2.6106 0.0196-0.03 0.0404-0.0691 0.06-0.0998 1.4106 1.1305 1.5105 2.7815 2.5512 4.2114 1.0707 1.4514 2.8709 1.9707 4.0917 3.6217 1.121 1.5003 2.0612 2.351 3.4627 3.591 0.74969 0.66015 1.0407 1.5506 1.9907 1.9602 1.0909 0.47946 1.7212 0.06 2.8017 0.8702 1.7806 1.3405 3.2017 3.2714 5.163 4.4912 2.1212 1.3203 4.9829 0.7006 6.834 2.1807 0.88084 0.70973 1.4609 1.8702 2.4318 2.5806 1.0798 0.78018 2.0605 0.41031 3.4522 0.20092 2.4514-0.36987 5.4821 0.50946 7.6737-0.33073 3.2017-1.2198 0.0998-4.6211 1.6201-6.882 1.4413-2.1096 4.6423 0.0998 6.3831 0.3803 2.2119 0.36008 5.7333-0.30007 7.174 1.8702 0.35038 0.53034 0.15985 1.2505 0.53046 1.7704 0.2499 0.3503 0.93956 0.48011 1.2508 0.74039 1.2306 1.0307 1.4407 1.5708 3.1919 1.4305 0.14028-0.69994 0.63029-1.1507 0.88084-1.7802 1.5907-0.0307 1.5405-1.3803 2.482-1.7006 1.2306-0.41031 1.5712 0.8402 2.6712 0.68038 0.33994-0.0502 2.0514-1.0104 2.3313-1.1703 1.32-0.78997 0.55917-1.0502 1.3708-2.1409 0.36995-0.50033 1.1014-0.33007 1.4609-0.69016 0.38039-0.3803 0.33015-0.8702 0.63029-1.2101 0.89062-1.03 1.151-0.84019 2.542-1.1292 2.3006-0.47098 3.1514-1.2505 4.2013-3.3021 2.221-0.39922 2.052-1.0705 2.1616-3.1703 0.69032-0.12067 1.4602-0.0202 2.1212 0.15917 0.31058 1.501 0.70011 2.8618 2.5205 1.6804 1.1014-0.72995 1.1412-2.03 2.6419-2.561 0.47044-1.1703-0.0802-2.6106 0.39018-3.7809 0.81038 0.0404 1.4106-0.39988 1.9411-0.87999v0.1396c1.6208 0.0802 3.4627 0.0802 5.043-0.15982 1.32-0.20092 2.4905-0.84019 3.4118-1.7802 0.0411 0.03 0.0803 0.0502 0.12071 0.0698 0.2499 0.15982 0.51023 0.28963 0.7001 0.5199 0.20031 0.25962 0.26948 0.60014 0.42998 0.87998 0.33081 0.60014 0.2101 1.1703 0.2101 1.8506-0.01 0.35029-0.0502 0.65036-0.2101 0.92043-0.14941 0.25962-0.35037 0.48011-0.42998 0.78017-0.0607 0.24984-0.18008 0.74039-0.0698 1.0007 0.11027 0.30007 0.49001 0.45989 0.74056 0.63928 0.28056 0.21004 0.44042 0.52055 0.68053 0.78018 0.29035 0.32029 0.42998 0.29028 0.8704 0.29028 0.83059 0 2.0109-0.20092 2.7019 0.17026 0.31971 0.18004 0.91085 0.29028 1.121 0.57991 0.17029 0.23092 0.0998 0.76061 0.0998 1.0411 0 0.82062-0.0202 1.6908 0.82929 2.0111 0.38039 0.14025 0.90041 0.17939 1.3206 0.12003 0.49-0.0691 0.55003-0.3105 0.85017-0.66015 0.2499-0.29028 0.56047-0.3803 0.89062-0.58122 0.41041-0.2394 0.68053-0.21983 1.1412-0.30985 0.50045-0.0998 1.0107-0.12003 1.5607-0.12003 0.35038 0 0.39996 0 0.65051-0.15982 0.16051-0.11024 0.26034-0.28115 0.46065-0.33986 0.48022-0.12981 1.0505-0.12981 1.5307-0.0992 0.73012 0.03 0.85083 0.2094 1.2808 0.76061 0.24011 0.30986 0.25968 0.17939 0.61071 0.30007 0.5807 0.20027 0.70076 0.61971 0.79015 1.1703 0.03 0.20027 0.0802 0.38031 0.14941 0.5597-0.79014 0.47097-2.0005 1.6308-2.2412 2.1814-0.50045 1.1396 0.30014 2.8311-0.20031 3.9713-0.36995 0.81997-1.3415 1.7-2.1212 2.3301-0.56048 0.47098-1.2208 0.33073-1.7114 0.66994-0.82995 0.56035-0.2897 0.77039-0.82081 1.5108-0.79015 1.0705-2.0801 1.0796-2.5205 2.4899-0.33993 1.1103 0.60028 3.1918 0.01 4.1723-0.58005 0.95044-2.3711 0.2094-3.312 1.0307-0.69032 0.60014-1.0498 2.291-1.5209 2.9707-0.23032 0.33007-0.43063 0.58056-0.60028 0.8004-0.0202 0.0104-0.03 0-0.0502 0 0.0196-0.19048-0.0104-0.28963 0.0698-0.47946-0.70011-1.0411-6.5534-3.0307-6.7936-1.0202-0.63029 0.21005-1.4106 0.27985-2.1108 0.15982-0.60027-1.0705-2.5616 0.0411-2.2204-2.1103-2.1512-0.33008-2.3222 0.96087-3.1417 2.3105-0.72033 1.1807-0.06 0.63079-1.2006 0.69994-0.72033 0.0411-1.5509-0.0202-2.2706-0.06-0.52067-1.03-0.70011 0-1.3611 0.19048-0.74969 0.21004-1.4707 0.16047-2.1708 0.33986-0.73012 0.18004-1.1105 1.0307-1.5405 1.1305-0.5807 0.1396-1.0707-0.39009-1.6312-0.47032-1.0603-0.13047-2.9818 0.18982-4.0023 0.50033-1.3115 0.39987-1.2312 1.6602-1.3604 3.1409-2.0312 0.11024-4.9125-0.58057-6.4732 0.69929-1.5907 1.291-2.1323 3.0307-3.9625 4.1618-2.0612 1.2694-3.0614 1.5806-5.6628 1.6706-2.482 0.09-3.5423 1.8102-3.6317 4.1012-1.2606-0.11024-1.7108 0.70973-2.052 1.7306-2.7515-0.33986-4.8727-1.1103-7.234-0.0202-1.0707 0.47945-2.3006 0.47945-2.8409 1.6602-1.8406 0.4201-1.6207-1.2603-2.9616-1.4703-1.9509-0.32029-0.65052 1.8402-0.84039 3.0007-0.23032 1.4403-1.7512 2.5506-2.6314 0.96087-0.55983-1.0111 0.21988-2.8206-0.23033-3.9309-0.86061 0.14938-0.95065 0.47033-1.6808 0.18004-0.55003-0.23092-0.72033-0.93999-1.3004-1.2009-1.4113-0.63928-2.221 0.10959-2.7019 1.3203-0.8704 2.261-0.53046 4.8318-0.65052 7.3119-0.97023 0.0502-2.1212-0.18004-2.9414 0.39988-1.0714 0.76061-1.271 2.5408-1.6919 3.6413-0.39018 0.99936-1.2201 1.9498-1.8902 2.7711-1.8315 2.2499-3.1123 4.3216-6.4543 3.1807-1.4511-0.48989-2.0305-0.80105-3.8424-0.80105-1.2508 0-2.9714 0.32029-4.1726 0.0111-0.3308-0.0802-0.63094-0.21005-0.91085-0.36987-1.8608-1.0104-2.9113-3.3608-5.0625-3.621 0.0803 0.38031-0.12984 0.91064-0.0502 1.2903-0.63943 0.03-1.3108 0.03-1.9509 0-0.0196-1.0405-0.47043-2.1605-0.36016-3.1403 0.0998-0.91064 0.95065-1.5101 1.0302-2.471 0.30014-0.29029 0.1703-0.0502 0.28057-0.51012-1.8902 0.44032-1.6801-1.4103-2.2706-2.5604-0.66096-1.291-1.331-1.3007-1.2404-3.1012-1.301-0.44097-2.5616-0.20091-3.9723-0.36073-1.301-0.14938-2.1616-0.61971-3.3022-1.2003 0.0692-0.3105-0.12984-0.78996-0.0607-1.1102-0.6603 0.15003-1.2404 0.0202-1.331-0.66015-1.0707-0.43967-2.3809 0.0202-3.1019-1.2303-0.61007-1.0711-0.20945-2.8011-0.69946-3.9714-0.43063-1.0007-1.0805-1.6908-1.5013-2.8409-0.42932-1.1703-0.45999-2.1103-0.54024-3.4612-0.0796-0.0411-0.15921-0.0802-0.23946-0.11024-0.60028-1.2303-2.0612-0.78018-3.0614-1.5206-0.55069-0.40053-0.86061-0.63993-1.5007-0.84019-0.60027-0.18004-0.96044-0.33008-1.4811-0.67059 0.33015-0.12003 0.64008-0.25897 0.92064-0.45989 0.50045-0.3803 0.48022-0.58057 0.6205-1.1005 0.11027-0.4501 0.26034-0.72995 0.46065-1.1305 0.15007-0.30985 0.17029-0.8004 0.48022-0.99022-0.06 0.57013-0.0196 1.3999 0.06 1.9811 0.12005 0.7704 0.67987 0.90021 0.88018 0.12003 0.15007-0.57991-0.20031-1.4606 0.44042-1.6902 0.51024-0.18004 1.4217 0.21983 1.9209 0.30985 0.14029-0.57013 0.0502-1.0404 0.0803-1.6197 0.0202-0.56034 0.16051-1.1213 0.17029-1.6804-0.33994-0.0698-0.53046 0.27006-0.72033 0.51012-0.44042 0.55056-0.32036 0.50033-0.90041 0.44031-0.87562-0.10437-0.94609 0.2655-1.2958 1.0359z",
+                Yilan:"m393.17 81.6c0.64987 0.54012 1.0505 1.2003 1.0002 2.0405-0.0404 0.04044-0.0692 0.0698-0.12005 0.12068-1.1014 0.06915-3.342 0.46054-3.2519-1.1011-0.20031-0.06001-0.4104-0.12981-0.60027-0.21005-0.0104-0.03979-0.0104-0.06915-0.0104-0.10959h0.0196c0.36995 0.06067 0.81037 0.12981 1.2103 0.10959 0.18987-0.39922 0.11027-0.87998 0.53046-1.12 0.4613-0.25962 0.89193 0 1.2221 0.27006zm-72.209 76.407c-0.0692-0.17938-0.12006-0.36008-0.14942-0.55969-0.0907-0.55056-0.21009-0.97-0.79014-1.1709-0.35038-0.12003-0.36995 0.0104-0.61072-0.30007-0.43063-0.55056-0.55068-0.72995-1.2808-0.76061-0.48022-0.03-1.0505-0.03-1.5307 0.0998-0.20096 0.06-0.30013 0.23092-0.46064 0.33986-0.2499 0.15982-0.30014 0.15982-0.65052 0.15982-0.55003 0-1.0603 0.0196-1.5614 0.12002-0.45999 0.09-0.73011 0.0692-1.1412 0.30986-0.33015 0.20091-0.63943 0.29028-0.88998 0.58122-0.30013 0.3503-0.36016 0.5897-0.85082 0.66015-0.42019 0.06-0.93956 0.0202-1.32-0.12003-0.85017-0.32029-0.82994-1.1905-0.82994-2.0111 0-0.2805 0.0698-0.81019-0.0992-1.0411-0.21009-0.28898-0.80123-0.39922-1.1216-0.57992-0.69032-0.36986-1.87-0.17025-2.7012-0.17025-0.44042 0-0.58005 0.03-0.8704-0.29029-0.24011-0.25962-0.39996-0.57013-0.68053-0.78018-0.2499-0.17938-0.63029-0.33986-0.74056-0.63927-0.10961-0.26028 0.0104-0.75018 0.0692-1.0007 0.0803-0.30007 0.28056-0.5199 0.43063-0.78018 0.15986-0.27006 0.20096-0.57078 0.2101-0.92043 0-0.67972 0.12005-1.2505-0.2101-1.8506-0.16051-0.27984-0.23032-0.62036-0.43063-0.87998-0.19053-0.23092-0.44956-0.36008-0.69945-0.5199 0.39017-0.73061 0.31971-1.8311 0.79014-2.5708 0.27012-0.41031 0.77057-0.36922 1.0107-0.66015 0.2101-0.24984 0.24011-0.80106 0.39018-1.1305 0.24011-0.57013 0.73012-1.7404 1.2103-2.06 0.47043-0.32029 0.90041-0.0698 1.3904-0.25114 0.63942-0.23027 0.29035-0.5199 0.74056-0.84998 0.0998-0.71038 0.53046-0.62036 1.0107-0.81997 0.75034-0.31116 0.5807-0.17026 0.75034-1.0007 0.30014-1.4103 1.0107-0.84997 2.1616-1.2603 0.31057-1.1011-0.23033-1.7515 0.93108-2.2505 0.91998-0.40966 1.2508-0.33986 1.0798-1.4906-0.15986-1.1103-1.1301-3.7313-0.34973-4.6915 0.39018-0.47946 1.1705-0.44032 1.6312-0.95044 0.74969-0.85911 0.0692-0.95043-0.35038-1.6902-0.16051-0.28963-0.24011-0.66928-0.24011-1.0705-0.0104-1.06 0.50045-2.3105 1.3708-2.6217 0.71054-0.24984 1.1608-0.01 1.7114-0.72017 0.46-0.60013 0.44042-1.3001 0.65052-2.0105 0.41041-1.4208 1.4609-1.8709 2.5714-2.681 0.21988-0.66928 0.57026-1.9009 0.27991-2.5004-0.30993-0.66015-0.72033-0.46054-0.45999-1.2394 0.12005-0.33008 0.47043-0.77105 0.71054-1.0307 0.67009-0.74039 2.3411-0.88129 3.5618-0.95044 0.2101 0 0.39997-0.0111 0.57026-0.0202 0.88149-0.0404 1.2704-0.06 2.0011-0.43053 0.58005-0.28898 1.0805-0.77953 1.7708-0.92043 0.70989-0.14025 1.5307 0.0607 2.1812-0.20026 0.35038-0.14025 0.63029-0.4201 0.98067-0.54991 0.2897-0.0998 0.67988-0.0802 0.92064-0.23093 0.86061-0.50033 0.54025-1.7802 1.0714-2.5108 0.53959-0.76061 2.4905-0.91064 3.432-0.90021 1.2208 0 1.5907-0.40966 1.5098-1.6602 2.7026 0.12003 2.7326-2.0705 1.9711-4.0712-0.33016-0.87998-0.44042-1.7508 0-2.6908 0.33015-0.69016 1.2097-1.8304-0.0503-2.2603 0-0.12068 0.0405-0.26028 0.0503-0.33986 0.0692-1.4299 2.3613-1.6197 3.3518-1.6497 1.1105-0.04045 0.85017-0.20092 1.0002-1.1709 0.0998-0.60014 0.36017-1.1096 0.85083-1.4808 1.0302-0.76061 2.7913-0.69016 4.0721-0.77039 1.3806-0.08024 2.7515-0.02022 4.1524-0.09067 0.0398-0.69016-0.12071-1.5506 0.33015-2.1005 0.36995-0.44945 1.151-0.63014 1.6012-0.97 0.49-0.36922 0.81037-1 1.1705-1.4299 0.65052-0.78018 2.3006-1.7306 3.312-1.9302 1.3408-0.26028 2.7404 0.21983 3.9416-0.48011 1.1601-0.66015 1.6116-1.6106 2.9009-2.0105 0.29035-0.56035 0.86061-0.66994 0.75034-1.3007-0.0998-0.57992-0.7001-0.62036-0.38039-1.4208 1.4009-0.0098 0.94021-1.7202 1.4106-2.5004 1.2097-0.24984 2.3913-0.3503 3.6525-0.3503 0.53047 0 1.2808 0.0698 1.7004-0.23027 0.3693-0.26028 0.68053-0.72016 1.1405-1.0202 0.58071-0.36987 2.0801-1.2003 2.2315-1.9107 0.21989-1.06-1.0805-1.9805-2.1414-1.9413-0.42998-1.4403 0.26033-2.0796 1.1712-3.0711 1.1014-1.1703 2.2608-0.84019 3.8215-0.91064 0.6603-0.04044 1.4296-0.02022 2.0801-0.15004 0.82081-0.14938 1.0805-0.60014 1.5705-1.12 0.84039-0.91064 2.0912-1.5206 3.2722-1.6504 0.46-0.04958 1.4309-0.01957 1.8517-0.23027 0.56961-0.2805 0.60028-0.88064 1.2312-1.1305 1.2006-0.47033 2.2008 0.42988 3.3916 0.36987-0.11027 0.30007-0.15007 0.66015-0.0998 1.1103-1.4106-0.05023-2.882 0.66015-4.1432 1.2094-0.39931 0.17091-1.181 0.32029-1.3708 0.69081-0.19053 0.39009 0.15985 1.0796-0.44042 1.2394-0.0202 0.03001 0 0.0698-0.0104 0.10959-0.4215 0.28115-0.64008 0.6608-1.0303 0.97066-0.36995 0.31051-0.71054 0.91064-1.2103 0.96022-0.42084 0.4899-0.93108 1.0202-1.6312 1.1605-0.39018 0.08024-0.50045 0.08024-0.82929 0.33008-0.25969 0.20092-0.68053 0.42988-0.8306 0.75017-0.2897 0.63014 0.16051 1.4808 0.16051 2.1311-0.0104 0.6608-0.65052 1.3203-1.1705 1.6602-0.24011 0.17091-0.52067 0.30007-0.72033 0.50098-0.18987 0.19048-0.49001 0.41031-0.68053 0.63014-0.4489 0.53034-0.84039 1.1298-1.3604 1.5701-0.47957 0.41031-1.0107 0.98044-1.4413 1.4403-0.47892 0.53034-0.88932 0.8291-1.0407 1.5604-0.12984 0.63014-0.49 1.1103-0.76013 1.6902-0.31058 0.6608-0.53046 1.4103-0.82081 2.0907-0.60028 1.3901-0.47043 2.9811-0.58984 4.5219-0.0502 0.61058-0.09 1.2805-0.25903 1.8402-0.12984 0.45989-0.2512 0.85063-0.3308 1.3301-0.0796 0.50098-0.18987 0.97066-0.28057 1.4305-0.27012 1.3307-0.0502 2.7906-0.0502 4.1514 0 1.2303 0.2101 2.5702 0.51024 3.7509 0.27012 1.0705 1.1014 2.1703 1.6312 3.0901 0.27991 0.46054 0.40976 0.69081 0.44042 1.2101 0.03 0.44945 0.0796 0.85976 0.1703 1.291 0.12984 0.69081 0.36995 1.3999 0.3308 2.1207-0.03 0.60014-0.0411 1.2205-0.0411 1.8402 0 0.60013 0.0496 1.1814 0.0802 1.7802 0.0196 0.48989 0.26947 0.93021 0.31971 1.4208 0.0405 0.36008-0.0998 0.67972-0.0411 1.0496 0.12136 0.74104 0.72033 1.2909 0.93173 1.9915 0.28904 0.93021 0.17878 1.7 0.79014 2.4899 0.47044 0.61057 0.68053 1.501 1.3708 1.9009 0.65052 0.38031 1.1014 0.5199 1.8413 0.66081 0.20879 0.0404 0.39997 0.14024 0.61985 0.17025-0.0111 0.31051 0.23946 1.2205-0.36995 1.1207-0.2101-0.0404-0.33015-0.35029-0.50045-0.47032-0.2101-0.15004-0.30014-0.15004-0.58135-0.16047-0.49001-0.01-1.0407-0.0998-1.4106 0.24984-0.34973 0.33007-0.28057 0.8702-0.2499 1.3307 0.25969 0.12981 0.45999 0.36986 0.74056 0.47032 0.20944 0.0698 0.44107 0.0698 0.66095 0.17091 0.0992 0.15982 0.21989 0.33986 0.30014 0.50033 0.12006-0.0998 0.21989-0.21004 0.30014-0.33986 0.18987-0.0196 0.39083 0.0196 0.57026 0.0907 0.0104 0.28049-0.17943 1.1403 0.12071 1.2094 0.18987 0.32029-0.14028 0.36987-0.3693 0.43054-0.48022 0.12068-0.51024 0.03-0.56048 0.61057-0.0998 1.09-0.03 2.1898 0.03 3.2805 0.68053-0.17026 0.4502 1.4005 0.4502 1.8011 0 0.68038 0.28057 1.7097-0.50109 1.9602-0.72034 0.21983-1.4511 0.06-2.1212 0.57078-0.28904 0.2094-0.52067 0.40966-0.88084 0.47032-0.54024 0.09-1.0407 0.0196-1.3715 0.57992-0.25055 0.42075-0.22054 1.0307-0.1703 1.5101 0.0411 0.33986 0.0998 0.66994 0.30014 0.93935 0.25968 0.35029 0.68053 0.29028 0.95065 0.55121 0.25969 0.24005 0.1703 0.63014 0.25969 0.96022 0.14028 0.53034 0.39018 0.78018 0.82081 1.1207 0.17943 0.14025 0.82016 0.72995 0.84038 0.92043 0.0398 0.31116-0.73077 0.32029-0.99176 0.33008-1.4707 0.0698-2.3606 1.2407-3.4411 2.1318-0.31971 0.25897-0.88084 0.57992-1.0714 0.95044-0.20031 0.3803-0.1703 1.0104-0.30014 1.4208-0.63942 0.06-1.181 1.1807-1.6305 1.6308-0.35038 0.33986-0.63094 0.66993-0.90107 1.0802-0.20031 0.30986-0.53046 0.60014-0.70989 0.91-0.17029 0.32029-0.25968 0.74038-0.39083 1.0907-0.14028 0.36987-0.2101 0.81997-0.24011 1.2101-0.0796 0.96022-0.06 1.9504-0.25968 2.8702-0.18987 0.8702-0.27013 1.7306-0.31058 2.6308-0.0411 0.75017-0.31971 1.3105-0.73012 1.9204-0.49001 0.71038-0.82081 1.3503-0.8704 2.2505-0.0405 0.8702-0.25055 1.6706-0.25055 2.5512 0 0.63015-0.0411 1.2505-0.0496 1.8696-0.0104 0.36074 0.15986 1.0502-0.0998 1.3307 0 0.0202-0.0196 0.0411-0.0405 0.0502-0.48022 0.38031-1.5314-0.24984-2.0214-0.3803-0.31971-0.0802-0.61137-0.14025-0.90107-0.31051-0.33015-0.18983-0.58983-0.54012-0.93108-0.72995-0.58005-0.32029-1.4302-0.15003-2.0514-0.33986-0.49001-0.16047-0.88084-0.30007-1.4106-0.28963-0.49001 0-0.96109 0.03-1.4204-0.12068-0.59048-0.17939-1.0505-0.50033-1.5816-0.78997-0.27991-0.15982-0.58005-0.40966-0.8704-0.5199-0.42933-0.15982-0.99045 0.09-1.3904-0.12003-0.3693-0.18982-0.44042-0.42988-0.90041-0.50098-0.4202-0.06-0.73012 0-1.0805-0.24984-0.44955-0.31051-0.74969-0.75017-1.1099-1.1605-0.36082-0.41032-0.88084-0.54013-1.2612-0.92043-0.18987-0.19048-0.30992-0.55056-0.55003-0.63015-1.1203-0.33986-0.0502 1.9113-1.2006 0.76061-0.33994-0.33986-0.65052-0.69016-0.98067-1.0404-0.27013-0.27985-0.63029-0.74039-0.95066-0.96022-0.75034-0.50099-1.4407 0.3803-1.2404 1.1298 0.0998 0.3803 0.46065 0.48989 0.6603 0.77105 0.15007 0.21983 0.15007 0.47032 0.33994 0.67972 0.2897 0.31964 0.63029 0.23027 0.74056 0.66015 0.0698 0.25962 0.0196 0.69016-0.0104 0.96022-0.0202 0.20092-0.0202 0.69994-0.18987 0.81019-0.30014 0.20026-0.43063-0.38031-0.59049-0.58057-0.30013-0.36987-0.29035-0.12068-0.71054-0.23093-0.23098-0.0502-0.41041-0.28963-0.46065-0.53033-0.24011 0.13959-0.4502 0.39922-0.54024 0.66928-0.0692 0.21983-0.0503 0.74104-0.2897 0.85063-0.23033 0.11024-0.33015-0.19048-0.61985-0.10959-0.29035 0.0802-0.5011 0.53034-0.70076 0.7293-0.12984 0.12068-0.24011 0.30007-0.42998 0.31116-0.17029 0.01-0.19052-0.15004-0.32036-0.17026-0.19053-0.0104-0.16051-0.15004-0.21989 0.14025-0.06 0.27006 0.0907 0.39009 0.27013 0.55904 0.36995 0.3503 0.55003 0.33008 0.60027 0.81019 0.0411 0.29028-0.0202 0.57013 0.0803 0.81997-0.2499 0.03-0.42998-0.09-0.66944-0.12003-0.27013-0.0404-0.48022 0.06-0.74121 0.09-0.42019 0.0411-0.85017-0.12003-1.2397-0.21983-0.78036-0.20027-1.5509-0.0998-2.3613-0.21005-0.98002-0.12981-1.1908-0.81997-1.8106-1.4599-0.61071-0.6308-0.7797-1.7215-1.761-1.8206-0.41041-0.0502-0.83973-0.0111-1.2508-0.0502-0.63943-0.06-1.181-0.24005-1.7904-0.36986-0.44107-0.0992-0.92064-0.11025-1.3715-0.0405-0.2101 0.03-0.33994 0.0992-0.59049 0.0802-0.30992-0.03-0.33994-0.18004-0.58005-0.25049-0.56047-0.15917-0.67009 0.31115-1.0407 0.50098-0.21988 0.12003-0.12071 0.09-0.41041-0.0998-0.18008-0.13047-0.33994-0.24006-0.5011-0.39009-0.36016-0.33986-0.63942-0.66016-1.0798-0.93022-0.42998-0.27006-0.97023-0.33007-1.4309-0.54012-0.71055-0.32029-1.1405-0.97001-1.8811-1.2003-0.63094-0.20091-1.1608 0.01-1.5712-0.59035-0.0574-0.0855-0.10701-0.17548-0.14746-0.2655z",
+                HsinchuCounty:"m293.48 147.63c0.0196-0.71104-0.09-1.4514-0.0502-2.1514 0.03-0.55969 0.18987-1.1807 0.0698-1.73-0.12005-0.56034-0.58005-0.84019-0.91085-1.2707-0.2897-0.38031-0.67009-0.63015-1.0002-0.96023-0.67988-0.71103-1.2312-1.5812-1.9118-2.2805-0.60027-0.61123-1.2704-1.1102-1.7604-1.8011-0.55982-0.80041 0.47043-1.3705 0.19052-2.1403-0.25968-0.66993-1.0002-1.1703-1.5705-0.70973-0.69097 0.57013-1.5509 0.16961-2.2315 0.69016-0.30014 0.23027-0.52002 0.57079-0.88084 0.66015-0.36017 0.0907-0.88997 0.0111-1.2508 0-0.35038-0.01-0.66944-0.03-1.0002 0-0.39997 0.0411-0.58071 0.24006-0.93108 0.32029-0.47044 0.12003-0.61072-0.12981-0.95066-0.30985-0.34972-0.19048-0.72946-0.12068-1.1203-0.14025-0.69032-0.0307-1.0498-0.93086-1.7108-0.48011-0.25968 0.16961-0.38039 0.62036-0.61072 0.73974-0.18008 0.10045-0.82015 0.0502-1.0205 0-0.39018-0.10959-0.43064-0.51012-0.76079-0.69995-0.30014-0.19048-0.6205-0.06-0.90041 0.11025-0.21988 0.12981-0.3693 0.28963-0.55004 0.48011-0.24011 0.26027-0.47043 0.35029-0.79014 0.53033-0.30014 0.16961-0.44042 0.24984-0.67988 0.4899-0.24011 0.23027-0.33015 0.33986-0.6603 0.3803-0.69097 0.0692-1.3604-0.0607-1.8615-0.39074-0.52067-0.3503-1.1705-0.0691-1.791-0.24984-0.15985-0.2805-0.44955-0.47032-0.58005-0.78996-0.14028-0.3503-0.0802-0.75017-0.13049-1.1207-0.0998-0.66994-0.74056-1.3901-0.2499-2.0516 0.23032-0.32029 0.54025-0.36008 0.91085-0.43967 0.53047-0.0998 0.36996-0.18004 0.60093-0.57013 0.20945-0.3503 0.58984-0.55056 0.66031-1.0104 0.0692-0.42009-0.24011-0.4501-0.5011-0.62036-0.2897-0.20026-0.61072-0.48989-0.84039-0.77039-0.23946-0.2805-0.50958-0.5199-0.80058-0.75996-0.3804-0.32029-0.89063-0.74039-1.3604-0.95043-0.0803-0.47033 0.76078-0.33987 1.0407-0.44032 0.32037-0.12068 0.53046-0.36074 0.58136-0.72017 0.10961-0.78018 0.3693-1.5003 0.85996-2.1305 0.35038-0.46054 0.39083-0.9002 0.70989-1.3307 0.27012-0.36008 0.65051-0.66015 0.55134-1.1703-0.15007-0.78018-1.0414-1.0502-1.2808-1.711-0.17095-0.47033 0.12919-0.69994-0.33994-1.0405-0.39018-0.27006-0.73011-0.25049-0.99045-0.66993-0.23098-0.36009-0.29035-0.74039-0.81037-0.59036-0.30014 0.09-0.99111 0.48011-1.0407 0.76061-0.22053-0.0802-0.39996-0.41031-0.55069-0.58057-0.24011-0.27006-0.52002-0.48989-0.7797-0.74038-0.65052-0.6308-1.3115-1.0104-2.2119-1.3301-0.58983-0.21005-0.81037-0.78996-1.4106-1.0111-0.14942-0.0496-0.3693-0.03-0.50045-0.0802-0.2101-0.0991-0.12984-0.0691-0.25968-0.30007-0.19053-0.31964-0.20031-0.39009-0.57027-0.50033-0.19052-0.41031 0-0.89042-0.09-1.3307-0.10961-0.50033-0.60027-0.3503-1.0805-0.36987-0.80059-0.0496-1.1099-0.69016-1.5607-1.2394-0.23098-0.27985-0.54025-0.47033-0.76078-0.76061-0.30993-0.39009-0.43977-0.88129-0.78036-1.2505-0.21989-0.23092-0.54025-0.3105-0.77971-0.51011-0.25968-0.21984-0.35038-0.54013-0.64007-0.69016-0.54025-0.2805-0.91086-0.0411-0.66031-0.81019 0.12984-0.39987 0.50045-0.62036 0.76013-0.96022 0.33016-0.44097 1.2508-1.4814 0.82995-2.1612-0.27012-0.44945-1.4811-0.43053-1.9111-0.29028-0.64008 0.21005-0.33994 1-1.1705 0.8702-0.78036-0.12003-0.76079-1.0104-1.5907-0.5897-0.2897 0.14025-0.39018 0.3105-0.70011 0.0991-0.18008-0.10959-0.39083-0.47946-0.42084-0.66015-0.0196-0.0202-0.0502-0.0404-0.0803-0.06 1.2612-1.0104 0.11027-3.2212 0.85148-4.5213 0.8293-0.29028 1.8008-0.15003 2.7215-0.20092 0.0496-0.97001-0.15007-2.1207 0.65051-2.8206 0.76079-0.66015 2.1408 0.02022 2.6112-0.91064 0.2499-0.4899 0.13963-0.93021 0.47957-1.4403 0.30014-0.4501 0.41041-0.63014 0.94022-0.7306 0.74055-0.15004 1.9711 0.66015 2.1812 1.3203 0.2897 0.01044 0.60028 0.01957 0.89063 0.03001 0.0398 0.20026 0.18987 0.31964 0.18987 0.54991 0.5807 0.46054 0.28056 1.0307 0.49001 1.6804 0.33015 1.0307 0.63029 0.27985 1.2397 0.08024 0.90106-0.28963 1.1712 0.09915 0.91085-1.1403-0.10962-0.53034-0.15986-1.3601-0.33994-1.9204-0.19052-0.60014-0.64986-0.91064-0.98067-1.4305-0.38039-0.60014-0.33015-1.1096-0.33015-1.8396 0-1.5101-0.65051-1.9909-1.84-2.7508-0.64008-0.41031-1.0603-1.0104-1.7519-1.2401-0.89063-0.30007-1.3708-0.0698-1.8406-0.99023-0.88084-0.06067-1.4602-0.21005-2.2204-0.45989-0.73077-0.23092-1.6207 0.0098-2.2921-0.36987-1.35-0.76061-1.4211-2.651-3.0216-2.8311 0.0404-0.06001 0.0698-0.11024 0.0404-0.19048 0.0992-2.471 1.9202-1.6008 2.9218-3.1709 0.4502-0.71038-0.03-1.9107 0.14028-2.7508 0.26034-1.2401 1.0205-2.3105 1.6312-3.3908 0.5011-0.85976 0.66096-1.9805 1.3115-2.6908 0.4202-0.44945 0.93043-0.78996 1.4407-1.12 0.47956 0.12981 1.1705 0.12981 1.5607 0.03979 0.61006-0.1396 0.82995-0.7293 1.4407-0.90021 0.63029-0.17939 1.1908 0.2805 1.8106 0.3803 0.8704 0.13046 1.35-0.24006 2.0807-0.39922 0.61072-0.12981 1.4707-0.01044 1.9907 0.27006 0.41041 0.21983 1.3806 0.8702 1.6606 1.1703 0.81037 0.88977 0.0202 2.9713 0.27012 4.1416 0.26034 1.2205 2.4716 1.09 3.5925 1.5708 0.66944 0.28898 1.0107 0.54991 1.8308 0.5199 0.69032-0.03001 1.3506-0.11024 2.071-0.0698-0.11027 0.54012-0.06 1.2003-0.23032 1.7404 0.0992-0.33008 1.4511 0.63993 1.4602 0.65037 0.70011 0.24006 1.9509 0.01044 2.7019 0.01044 0.71055 0 2.2204 0.33986 2.4213 1 0.0405 0.14025-0.24011 0.36074-0.17029 0.58057 0.0992 0.36008 0.3693 0.19048 0.47957 0.44032 0.15006 0.33986 0.15985 1.12 0.16964 1.5003 0.0111 0.66994-0.0496 0.84998-0.47957 1.3307-0.36995 0.40966-0.82016 0.42075-0.6603 1.1403 0.30014-0.03001 0.47957 0.0698 0.72033 0.19048 0.20031 0.09981 0.52002 0.67972 0.78036 0.85976 0.28969 0.20026 0.74969 0.39987 1.0798 0.5199 0.55069 0.19048 1.7108 0.14938 1.5907 1.0104 0.86061-0.1396 1.181 0.56035 1.331 1.2505 1.0407 0.33008 1.6808 1.5708 2.8918 1.3307 0-0.18004 0.14028-0.33986 0.11027-0.54991 0.53046-0.08024 1.0413 0.09915 1.5614 0.08024 0.03 0.66928-0.26034 1.6706 0.51023 1.8206 0.63942 0.12003 1.2606-0.72016 1.8308-0.75017 0.91085-0.03979 0.57091 0.92043 1.1705 1.3405 0.39018 0.27006 1.4002 0.43053 1.9013 0.51012-0.03 0.59035 0.01 1.3412 0.3693 1.8206 0.45021 0.60014 0.99111 0.29028 1.6312 0.67972 0.0998 0.06001 0.31058 0.3803 0.5011 0.50098 0.30014 0.20026 0.6205 0.33008 0.85082 0.4899 0.65052 0.44945 0.78036 0.55969 1.581 0.74039 1.3004 0.30007 2.2014 1.6706 1.9209 3.0914-0.12984 0.66015-0.67988 0.93021-0.82995 1.5003-0.15985 0.55969 0.0104 1.3803 0.18008 1.9009 0.21989 0.0502 0.12071 0.0802 0.2499 0.17026 0.11027-0.0202 0.27013 0.0202 0.39083 0.0202 0.41041 1.8004-1.3911 2.9707-0.72033 4.8115 0.12984 0 0.2499 0.03 0.38039 0 0.44042-0.48011 1.5509-0.51012 2.2713-0.39988 0.93957 0.1396 0.80059 0.50034 1.3108 1.1905 0.33994 0.45989 0.88084 0.76061 1.0198 1.3901 0.16051 0.71038 0 1.4703 0.18008 2.1507 0.39018 0.0202 1.6312-0.17939 1.9209 0.0802 0.31906 0.2805 0.17943 1.411 0.14942 1.8506-0.03 0.61123-0.14942 1.0502 0.2499 1.5708 0.45999 0.61057 0.80124 0.66994 0.76013 1.5904 1.4609-0.28898 0.30014 3.2812 0.33994 4.002 0.86061 0.50033 0.74056 1.7508 1.5809 2.2512 0.76079 0.01 1.2508 0.77039 1.8413 0.99023 0.73012 0.27984 1.8902 0.0502 2.6712-0.0502 0 0.39987 0.0802 0.78018 0.24011 1.0711 0.42019 0.74039 1.1007 0.82976 0.35038 1.6902-0.46065 0.50947-1.2404 0.47033-1.6312 0.95044-0.78036 0.96022 0.19052 3.5806 0.35038 4.6909 0.1703 1.1507-0.15986 1.0802-1.0805 1.4906-1.1608 0.50098-0.6205 1.1507-0.93042 2.2505-1.1516 0.41031-1.8622-0.15004-2.1616 1.2603-0.17029 0.8304 0 0.69081-0.74969 1.0007-0.48022 0.20026-0.91085 0.10959-1.0113 0.81997-0.44956 0.33008-0.0992 0.62036-0.74056 0.85063-0.49001 0.17939-0.92064-0.0698-1.3904 0.25049-0.48022 0.32029-0.97088 1.4906-1.2103 2.0607-0.14942 0.33008-0.17943 0.88064-0.39018 1.1298-0.24011 0.29028-0.74056 0.24984-1.0107 0.66015-0.47043 0.74104-0.39997 1.8402-0.79015 2.5708-0.0411-0.0202-0.0802-0.0404-0.1207-0.0698-0.91999 0.94-2.0905 1.5812-3.4118 1.7802-1.5809 0.24005-3.4222 0.24005-5.043 0.15982 6.5e-4 -0.0437 6.5e-4 -0.0939 6.5e-4 -0.14351z",
+                HsinchuCity:"m239.48 98.926c0.2101-0.57078 0.27012-0.55121 0.82995-0.91064 0.30013-0.19048 0.85996-0.51012 1.1209-0.81019 0.25904-0.30007 0.20031-0.63014 0.30993-0.98044 0.0803-0.27006 0.24011-0.77953 0.11027-1.0802-0.14942-0.36008-0.63029-0.4201-0.91086-0.60014-0.24989-0.14025-0.58135-0.4899-0.42084-0.8291 0.0998-0.20092 0.28056-0.12068 0.39083-0.29028 0.09-0.14938 0.03-0.46054 0.03-0.63014 0-0.71038-0.0502-1.4501 0-2.1611 0.0196-0.34965 0.10962-0.5897 0.24011-0.8702 0.12006-0.26941 0.39018-0.4201 0.55069-0.66015 0.18987-0.31051 0.21989-0.7006 0.40976-1.0196 0.21988-0.3803 0.47956-0.4501 0.51023-0.91064 0.0196-0.33986-0.03-0.68037 0.0803-1.0007 0.11027-0.30985 0.3693-0.5199 0.5396-0.78996 0.20096-0.30985 0.41106-0.4899 0.64008-0.74039 0.23032-0.24006 0.42019-0.53034 0.6205-0.84019 0.38039-0.55969 0.42019-1.4103-0.25969-1.7306-0.30013-0.14025-0.63029-0.21983-0.95065-0.24984 0.06-0.4899 2.5616-0.16047 3.0314-0.27985 0.03-0.06001 0.0692-0.0998 0.09-0.14025 1.6005 0.17939 1.6716 2.0705 3.0216 2.8311 0.67009 0.3803 1.5614 0.1396 2.2921 0.36987 0.75948 0.24984 1.3408 0.39922 2.2204 0.45989 0.47109 0.91978 0.95066 0.69016 1.8406 0.99023 0.69032 0.23027 1.1105 0.83041 1.7512 1.2401 1.1908 0.76061 1.8406 1.2401 1.8406 2.7508 0 0.72995-0.0502 1.2394 0.33015 1.8396 0.33015 0.52055 0.79014 0.83041 0.98067 1.4305 0.18008 0.56035 0.23097 1.3908 0.33993 1.9204 0.25969 1.2394-0.0104 0.85063-0.91085 1.1403-0.61006 0.20026-0.9102 0.95044-1.2397-0.08024-0.21009-0.65037 0.09-1.2205-0.49001-1.6804 0-0.23092-0.15006-0.3503-0.18986-0.54991-0.29036-0.01109-0.60028-0.02022-0.89063-0.03001-0.2101-0.6608-1.4407-1.4703-2.1812-1.3203-0.53046 0.0998-0.64008 0.27985-0.94021 0.7306-0.33994 0.51012-0.23033 0.95044-0.48022 1.4403-0.47044 0.93021-1.8511 0.24984-2.6112 0.91064-0.80059 0.69994-0.60028 1.8506-0.65052 2.8206-0.91999 0.05023-1.8902-0.09002-2.7215 0.20092-0.74055 1.3001 0.40976 3.5108-0.85082 4.5212-0.42019-0.29028-1.1608-0.33007-1.7206-0.33007-0.8306 0-1.2912-0.14025-1.2808-1.0411 0-0.63928-0.03-1.1298-0.4104-1.6197-0.14094-0.18004-0.41106-0.36986-0.51024-0.54991-0.12984-0.21983-0.0907-0.50098-0.16964-0.74104-0.69097-0.19048-1.1105 1.4103-1.791 1.5401-0.31123 0.06-1.0903 0.03-1.3715-0.09-0.40062-0.15004-0.44955-0.44032-0.91085-0.46054-0.0111-0.06002-0.0202-0.11024 0-0.15004 0.0189-0.20026 0.20944-0.2805 0.3693-0.4201 0.24272-0.2094 0.27273-0.28963 0.37256-0.54926z",
+                Miaoli:"m246.9 103.34c0.03 0.0202 0.06 0.0404 0.0803 0.06 0.03 0.18004 0.24011 0.54991 0.42019 0.66015 0.31123 0.21005 0.41106 0.0411 0.70076-0.0992 0.82994-0.42075 0.81037 0.47032 1.5907 0.5897 0.82994 0.12981 0.53046-0.66015 1.1705-0.8702 0.42998-0.14025 1.641-0.16047 1.9111 0.29028 0.42084 0.67973-0.50045 1.7202-0.82995 2.1612-0.25968 0.33986-0.63094 0.5597-0.76013 0.96022-0.2512 0.7704 0.12005 0.53034 0.6603 0.81019 0.29035 0.14938 0.38039 0.47032 0.63943 0.69016 0.24011 0.20026 0.56047 0.27984 0.78036 0.51011 0.33993 0.36922 0.47043 0.86042 0.78035 1.2505 0.21989 0.29028 0.53046 0.48011 0.76079 0.76061 0.44955 0.54991 0.76078 1.1905 1.5607 1.2394 0.48022 0.0202 0.97088-0.12916 1.0805 0.36987 0.09 0.44032-0.0998 0.92043 0.09 1.3307 0.36995 0.10959 0.38039 0.18004 0.57026 0.50033 0.12985 0.23093 0.0502 0.20092 0.25969 0.30072 0.13049 0.0496 0.35038 0.03 0.50044 0.0796 0.60028 0.22048 0.82016 0.80105 1.4106 1.0111 0.90042 0.31964 1.5607 0.69929 2.2112 1.3301 0.26034 0.25049 0.54025 0.47032 0.78036 0.74039 0.15007 0.17025 0.33015 0.50033 0.55004 0.58056 0.0502-0.27984 0.74121-0.66928 1.0414-0.76061 0.52002-0.14938 0.5807 0.23093 0.80971 0.59036 0.26034 0.42009 0.60093 0.39987 0.99111 0.66993 0.47044 0.33986 0.1703 0.57013 0.33994 1.0405 0.24011 0.66015 1.1307 0.93021 1.2815 1.711 0.0992 0.51012-0.28122 0.81019-0.55134 1.1703-0.31906 0.42988-0.36017 0.8702-0.70989 1.3307-0.49001 0.63015-0.74969 1.3497-0.86062 2.1305-0.0496 0.36009-0.25968 0.60014-0.5807 0.72017-0.27991 0.0991-1.1203-0.03-1.0407 0.44032 0.47043 0.21004 0.98067 0.63014 1.3604 0.95043 0.29035 0.24006 0.55982 0.48011 0.80058 0.75996 0.23098 0.2805 0.55004 0.57013 0.84039 0.77039 0.25968 0.17026 0.57026 0.20092 0.5011 0.62036-0.0698 0.45989-0.45021 0.66015-0.66096 1.0104-0.23032 0.39074-0.0692 0.47033-0.60028 0.57013-0.3693 0.0802-0.68053 0.12068-0.91085 0.43967-0.49001 0.6608 0.14942 1.3803 0.2499 2.0516 0.0502 0.36921-0.01 0.77039 0.13049 1.1207 0.12919 0.32029 0.4202 0.51012 0.58005 0.78996 0.6205 0.18004 1.2704-0.0998 1.791 0.24984 0.50045 0.33008 1.1705 0.46054 1.8609 0.39075 0.3308-0.0411 0.42084-0.15004 0.66095-0.38031 0.24011-0.24005 0.38039-0.32029 0.67988-0.48989 0.31971-0.18005 0.55003-0.27007 0.79014-0.53034 0.17943-0.19048 0.33016-0.3503 0.55004-0.48011 0.28056-0.17026 0.60027-0.30007 0.90041-0.11025 0.33015 0.19048 0.36996 0.59036 0.76079 0.69995 0.20031 0.0502 0.84038 0.10045 1.0205 0 0.23032-0.12003 0.34972-0.57013 0.61071-0.73974 0.6603-0.4501 1.0205 0.44945 1.7108 0.48011 0.39017 0.0196 0.77057-0.0502 1.1203 0.14025 0.33994 0.17939 0.48022 0.42923 0.95066 0.30986 0.35037-0.0802 0.53046-0.27985 0.93042-0.3203 0.33081-0.03 0.65052-0.01 1.0009 0 0.36016 0.0111 0.89062 0.0907 1.2508 0 0.36016-0.09 0.5807-0.42988 0.88084-0.66015 0.68053-0.5199 1.5405-0.12002 2.2315-0.69016 0.57026-0.46054 1.3108 0.0398 1.5698 0.70973 0.28121 0.7704-0.74969 1.3405-0.19052 2.1409 0.49 0.69016 1.1608 1.1898 1.761 1.8004 0.67988 0.69929 1.2306 1.5702 1.9118 2.2805 0.33015 0.33007 0.71054 0.58056 1.0002 0.96022 0.33015 0.43053 0.79015 0.71038 0.91085 1.2707 0.12006 0.54991-0.0404 1.1703-0.0698 1.73-0.0405 0.69995 0.0698 1.4403 0.0502 2.1514-0.53046 0.47946-1.1307 0.91977-1.9411 0.87998-0.47108 1.1703 0.0803 2.6106-0.39083 3.7809-1.5007 0.53034-1.5398 1.8311-2.6412 2.561-1.8211 1.1814-2.2112-0.17939-2.5212-1.6804-0.6603-0.17939-1.4302-0.27985-2.1212-0.15917-0.10962 2.1005 0.0607 2.7704-2.161 3.1703-1.0505 2.0516-1.9013 2.8311-4.2019 3.3021-1.3904 0.28898-1.6501 0.0991-2.5414 1.1292-0.30013 0.33986-0.24989 0.83041-0.63029 1.2101-0.36081 0.36008-1.0903 0.19048-1.4609 0.69016-0.81038 1.0907-0.0502 1.3503-1.3715 2.1409-0.28057 0.16048-1.9914 1.12-2.3306 1.1703-1.1014 0.15982-1.4407-1.0907-2.6719-0.68037-0.93956 0.32029-0.88997 1.6706-2.4814 1.7-0.2499 0.6308-0.74056 1.0802-0.88084 1.7802-1.7519 0.14025-1.9607-0.39988-3.1926-1.4306-0.31058-0.25962-1.0002-0.39009-1.2508-0.74039-0.3693-0.5199-0.17943-1.2401-0.53046-1.7704-1.4407-2.1709-4.9627-1.5101-7.1739-1.8702-1.7408-0.2805-4.9425-2.4899-6.3832-0.3803-1.5209 2.261 1.5809 5.6615-1.6201 6.882-2.191 0.8402-5.2224-0.0404-7.6744 0.33073-1.3911 0.2094-2.3711 0.58057-3.4522-0.20091-0.96958-0.71038-1.5509-1.8709-2.4311-2.5806-1.8511-1.4808-4.7128-0.85976-6.834-2.1807-1.9613-1.2205-3.3824-3.1507-5.163-4.4912-1.0805-0.81019-1.7108-0.39074-2.8017-0.8702-0.95065-0.40966-1.2404-1.3001-1.9913-1.9602-1.4002-1.2401-2.3411-2.0907-3.462-3.5917-1.2208-1.6497-3.0216-2.1696-4.0917-3.621-1.0414-1.4299-1.1405-3.0809-2.5512-4.2114 0.58984-0.96935 1.6312-1.7202 2.5414-2.4599 0.47044-0.39074 1.1908-0.75017 1.5614-1.2003 0.38039-0.46054 0.17943-0.91064 0.33994-1.4305 0.2897-0.92043 1.1705-1.4906 1.5607-2.3608 0.4502-1.0007 0.91085-1.6908 1.5614-2.6008 0.30013-0.42923 0.49-1.15 0.55982-1.6602 0.11027-0.84019 0.11027-1.1403 0.69097-1.8096 0.54025-0.63993 0.63942-0.99088 0.67988-1.8004 0.06-1.2309 0.5807-2.5617 0.88083-3.762 0.36996-1.4703 1.6312-2.1005 2.4109-3.381 0.50045-0.83041 0.61072-1.7906 1.1705-2.651 0.36995-0.55904 0.92064-1.5206 1.5607-1.6602 1.0413-0.24006 4.1928 1 3.7824-1.2394-0.54025-0.22048-0.92064 0.12916-1.4106 0.0992-0.0411-0.23027 0.5807-1.1298 0.74056-1.4103 0.30013-0.53034 0.68053-0.92043 0.86061-1.5304 0.33994-1.1305 0.65051-1.9407 1.6201-2.6706 0.70076-0.53034 1.562-1.3007 2.5218-1.4403 1.1803-0.18004 2.3802-0.39988 3.5618-0.50099 0.59049-0.06 1.2103 0.0202 1.8008-0.01 0.2499-1.3503 1.2208-2.621 2.5009-3.1312 0.0907-0.98045 1.0505-1.1103 1.5809-1.7802 0.49001-0.6197 0.44107-1.2805 0.49001-2.0803 0.0607-0.81997 0.53046-1.4703 1.0805-2.0307 0.44042-0.44032 0.97088-1.3307 1.562-1.5401-0.0202 0.04044-0.0111 0.09067 0 0.15004 0.45999 0.0202 0.50958 0.30985 0.91085 0.46054 0.27991 0.12003 1.0603 0.14938 1.3715 0.09 0.68053-0.12981 1.1007-1.7306 1.7904-1.5401 0.0803 0.24006 0.0404 0.52056 0.17029 0.74104 0.0992 0.17939 0.3693 0.36922 0.50958 0.54991 0.3804 0.4899 0.41106 0.98044 0.41106 1.6204-0.0111 0.90021 0.44956 1.0405 1.2808 1.0405 0.56112-5e-3 1.301 0.0346 1.7212 0.32486z",
+                Taipei:"m351.36 53.383c0.0104 0.32029 0.0104 0.65037 0 0.97066-0.52002-0.02022-1.0407 0.06915-1.5705 0.09915-0.25968 0.01044-0.5807-0.06001-0.82994 0.02022-0.20031 0.0698-0.4202 0.36008-0.56048 0.39987-0.50045 0.14938-0.96044-0.11024-1.5307-0.09067-0.63029 0.03066-0.92064 0.32029-1.4909 0.44097-0.90042 0.19048-2.3313-0.39987-3.141 0.17026-0.20096 0.1396-0.10962 0.44032-0.28056 0.63014-0.15986 0.17026-0.42933-0.05023-0.58984 0.26028-0.35038 0.66928 0.3693 0.87998 0.82016 1.0196 0.0692 1.2805-1.0303 5.092 1.0909 4.8318 0.06 0.3503 1.3004 0.54991 1.6605 0.66994 0.25968 0.96935-0.47043 0.77953-1.151 0.81997-0.82995 0.05023-0.77123 0.41031-1.4106 0.66928-0.59049 0.22048-1.2208-0.2394-1.761-0.31964-0.61071-0.09981-1.3708 0.23027-1.5098-0.59035-0.67009 0.13046-1.0414 0.65037-1.7414 0.57013-0.55004-0.06001-0.85996-0.47032-1.1601-0.92043-0.47108-0.67972-1.3506-1.6804-1.2704-2.5708-0.3804 0.02022-0.8704-0.03001-1.1705-0.2394-0.39997-0.2805-0.25969-0.74104-0.47044-0.94-0.72033-0.66994-1.4609 0.47032-1.9117 0.83041-0.01-1.2009 1.791-2.1905 0.74121-3.3412-0.44107-0.48011-0.97023-0.68037-1.4009-1.1703-0.44042-0.50098-0.60028-0.96087-1.3604-0.90021-0.82016 0.06001-1.0505 0.72016-1.4909 1.2505-0.61072 0.74039-0.79015 0.88977-1.3604 0.09981-0.46065-0.63928-0.42019-0.95044-0.55982-1.681-0.0907-0.43967-0.61137-1.1801-0.59049-1.5904 0.06-1.06 2.2308-1.06 2.8115-2.0209 0.59049-0.94 0.61137-2.8011 0.61137-3.9818 0-1.2205-0.73077-2.1507-1.5816-2.9811-0.41041-0.39922-0.69032-0.8004-1.2501-1.0196-0.57091-0.21983-1.2404-0.10959-1.8315-0.24984-0.52002-0.12981-1.0603-0.20092-1.5607-0.39987-0.84038-0.32029-0.75034-0.42075-0.79014-1.1905-0.0202-0.54991-0.19053-1.2903 0.03-1.8095 0.0992-0.23092 1.2306-1.0202 1.2208-0.69081 0.0405-0.8004-0.2101-1.7606 0.42998-2.2407 0.7001-0.53034 1.331-0.10959 1.2612-1.3999 1.0309-0.06001 1.2097 0.12981 1.4909-0.85063 0.16051-0.57992 0.28056-0.97 0.65052-1.5003 0.28904-0.42075 0.67987-1.1011 1.1803-1.2609 0.54025-0.17026 1.4211 0.01957 1.9914 0 0.19052-1.1703-0.0802-1.8102 1.3415-1.8206 0.5807-0.01044 1.0002-0.06915 1.4902-0.25962 0.24011-0.09067 0.89062-0.3803 1.0205-0.57013 0.2101-0.36008-0.1605-1.06 0.0502-1.4403 0.21989-0.39074 0.89063-0.4899 1.1301-0.80105 0.18008-0.23027 0.36082-1.03 0.64007-1.1703 0.58005-0.28963 0.96045 0.42075 1.3904 0.65037-0.33994 1.6308 0.90041 1.8617 2.191 1.9309 0.60028 1.5003-0.03 3.3308 0.76013 4.822 0.14942 0.27006 0.50958 0.50033 0.61072 0.7293 0.15007 0.36987 0.0202 0.86042 0.06 1.2707 0.0698 0.85063 0.53046 1.2401 1.151 1.7704 0.20944 0.77105 0.85996 0.80105 0.85082 1.8206-0.0111 1.1011-0.69097 0.98044-1.0909 1.8311-0.10962 0.21983-0.13963 0.82976-0.0803 1.0907 0.14029 0.51012 0.0104 0.30007 0.66944 0.40966 0.78036 0.12981 1.3917 0.60014 2.1512 0.68037 0.0307 1.0405 1.1908 0.69994 1.4309 1.6504 0.2499 0.93935-0.48022 2.9707-1.0002 3.6706-0.85083 1.1507-0.63029 1.0705-0.33015 2.4208 0.32036 1.4808 2.0011 2.8011 3.2519 3.3301 0.53047 0.23092 1.1007 0.3803 1.7512 0.42075 0.76666 0.04175 1.1966-0.49838 1.8974-0.23875z",
+                Newtaipei:"m400.14 55.204c1.2012 4.4117-4.7722 2.1905-5.6935 4.7613-1.1901 0.06001-2.1904-0.84019-3.3909-0.36987-0.6316 0.25049-0.66161 0.85063-1.2319 1.1305-0.4202 0.21005-1.3911 0.18004-1.8511 0.23092-1.181 0.12916-2.4318 0.74039-3.2722 1.6497-0.49001 0.5199-0.7497 0.97001-1.5705 1.12-0.65051 0.12981-1.4211 0.1109-2.0801 0.15003-1.562 0.0698-2.7221-0.25962-3.8215 0.91064-0.91085 0.99023-1.6012 1.6308-1.1712 3.0711 1.0609-0.04044 2.3613 0.88064 2.1414 1.9407-0.15007 0.71038-1.6508 1.5401-2.2315 1.9107-0.46 0.30007-0.77122 0.76061-1.1405 1.0202-0.42085 0.30007-1.1705 0.23027-1.7004 0.23027-1.2612 0-2.4416 0.09981-3.6526 0.3503-0.47043 0.78018-0.0104 2.4906-1.4106 2.5004-0.31972 0.80105 0.28056 0.84084 0.38039 1.4208 0.11027 0.6308-0.46 0.74104-0.75035 1.3007-1.2906 0.39988-1.7408 1.3503-2.9009 2.0105-1.2012 0.69994-2.6008 0.21983-3.9416 0.48011-1.0113 0.20026-2.6614 1.15-3.312 1.9302-0.36082 0.42988-0.67988 1.06-1.1705 1.4305-0.4502 0.33986-1.2312 0.5199-1.6012 0.96935-0.4502 0.54991-0.29035 1.4103-0.33015 2.1005-1.4009 0.0698-2.7717 0.01044-4.1523 0.09067-1.2808 0.08024-3.0418 0.0098-4.0721 0.77039-0.49 0.36987-0.75034 0.88064-0.85082 1.4814-0.15007 0.96935 0.11027 1.1298-1.0002 1.1703-0.99046 0.03001-3.282 0.21983-3.3518 1.6497-0.0104 0.08024-0.0502 0.21983-0.0502 0.33986 1.2606 0.42988 0.38039 1.5701 0.0502 2.2603-0.44042 0.94-0.33015 1.8108 0 2.6908 0.76078 2.0007 0.73077 4.1912-1.9711 4.0712 0.0803 1.2505-0.28905 1.6602-1.5098 1.6602-0.94021-0.01-2.8924 0.14025-3.4327 0.9002-0.53046 0.72995-0.20944 2.0105-1.0707 2.5108-0.24011 0.15003-0.63029 0.13046-0.92064 0.23092-0.35038 0.12981-0.63029 0.40966-0.98066 0.54991-0.65052 0.26027-1.4707 0.06-2.1812 0.20026-0.69097 0.1409-1.1908 0.6308-1.7708 0.92043-0.73077 0.36987-1.1203 0.39074-2.0011 0.43053-0.1703 0.0104-0.36017 0.0202-0.57026 0.0202 0.01-0.92043 0.0398-1.8409-0.0104-2.7508-0.94022 0.11024-0.91086-0.74039-1.6312-1.1814-0.42084-0.24984-0.54024-0.33986-1.0205-0.4201-0.36016-0.0502-0.85017 0.11024-1.151-0.0998-0.64007-0.42989-0.21988-1.3301-0.54025-1.9602-0.26033-0.51011-0.72033-1.0307-1.0407-1.5206-0.75035-1.15-1.4511-2.1605-1.8615-3.501-0.17029-0.57013-0.21988-1.3197-0.33015-1.9198-0.20031-0.98044-0.14028-1.2009 0.60028-1.6412 1.0603-0.63014 1.3715-1.9302 2.7215-2.1201 0.31123-0.2805 0.29035-0.76061 0.2499-1.2205-2.3411 0.1409-0.99959-2.6504-1.7304-3.6811-0.39997-0.57013-1.3004-0.06001-1.6906-0.99023-1.1105 0.12003-1.6612-1.8709-2.2315-2.4514-0.68053-0.69016-2.7019-1.5806-3.5919-0.7306-0.44956 0.43053-0.30014 1.0711-1.1601 1.2505-0.81037 0.17091-1.331-0.58057-1.9209-0.91978-1.3108-0.74104-2.5009-0.59035-3.9918-0.68037-0.21988-1.0502 2.0612-1.3007 2.7319-1.3307 0.03-0.44097 0.0803-0.82976-0.21988-1.1814-0.2101-0.24984-0.91086-0.21983-1.0805-0.57992-0.43063-0.89042 1.6808-1.1403 1.3408-1.9909-0.24989-0.61058-1.1705 0.08024-1.6207-0.23092-0.36017-0.25962-0.38039-1.2303-0.33994-1.6602-0.12005 0-0.28056-0.04044-0.39018-0.03001-0.35038-0.30007-0.39083-1.0007-0.76078-1.2407-0.31123-0.20026-1.0205 0.01109-1.3415-0.24006-0.69031-0.53034 0.0405-1.4808-0.0104-2.4103-0.30992-0.01044-0.63029-0.01044-0.91085-0.0698 0.0202-0.14025 0.0411-0.90021 0.11092-0.93021 0.23946-0.09981 0.44956-0.23092 0.72033-0.27006 0.15007-0.3803 0.19052-1.1807 0.01-1.4906-0.30993-0.54012-0.72033-0.14025-1.0707-0.4899-0.42998-0.42988 0-1.1005 0.39997-1.2603 0.36016-0.15003 1.1007 0.01044 1.4909-0.01044 0.12005-0.77953-0.33994-1.2805-0.49001-1.9909-0.14093-0.71038-0.19052-1.5095-0.16051-2.2505 0.0104-0.33986-0.0802-1.0705 0.0992-1.3405 0.30014-0.4501 0.44107-0.21005 0.90041-0.33008 0.74121-0.18983 1.3115-0.30007 2.1016-0.1396 1.1301 0.23027 3.0118 0.57013 4.1523 0.14938 1.1301-0.43053 0.74056-2 2.4011-1.9407 0.19052-0.39987 0.77057-0.82976 1.1705-1 0.0398-0.54012 0.03-0.8702-0.30014-1.2603-0.18987-0.21983-0.72033-0.21005-0.84039-0.57013-0.32036-0.96087 1.3604-1.0307 1.9711-1.0007-0.03-0.92043-0.58984-1.0405-0.88019-1.7606-0.31058-0.74039-0.09-1.8004 0.12984-2.4599-0.0411-0.01044-0.09-0.02022-0.14028-0.03001-0.0405-0.2805-0.0998-0.55056-0.19052-0.81019-0.99111-0.24006-0.94022-0.55969-1.0002-1.5003-0.31123-0.0698-0.54025-0.2805-0.5807-0.58057-1.1712-0.12003-2.052-0.54991-3.2422-0.60014-0.76078-0.02022-1.6012-0.44032-2.071-0.93021-0.30992-0.32029-0.33015-0.63993-0.53046-0.98044-0.32036-0.53034-0.5011-0.44032-0.90041-0.75017-0.68053-0.51012-1.3611-0.90021-1.6808-1.6602-1.0303-0.02022-2.0912-0.05023-3.1417-0.11024-0.0692-0.20026-0.18008-0.24984-0.20031-0.47033-0.36995-0.29028-0.5807-0.67972-1.0714-0.8702-0.47957-0.19048-1.0002-0.0411-1.4407-0.36987-0.66031-0.5199-0.42933-1.9107-0.39932-2.8109 0.21989-0.01044 0.39018-0.02022 0.46065-0.05023 0.42933-0.15003 1.7512-0.15982 2.5505-0.33008 1.8817-0.39074 3.5729-0.15003 5.5128-0.24006 0.86061-0.0411 1.5007-0.17026 2.2419-0.76061 1.0198-0.81019 1.32-1.3705 2.7515-2.0007 0.0404-0.21983 0.90041-0.28963 1.0009-0.50033 1.9809-1.1011 6.8738-4.0509 2.7815-5.702 1.5307-0.33986 0.9102-1.3105 1.4609-2.3105 0.47043-0.86042 1.7512-1.6106 2.2112-2.3007 0.94022-1.4299 1.9509-3.2603 1.8413-5.4006 0-0.13046 2.4311-0.0698 2.6712-0.18004 1.2103-0.60014 1.0002-1.3601 1.7806-2.2603 1.3408-1.5604 3.402-2.561 4.5523-4.3112 1.2508 0.01109 4.703 0.96087 3.4816-1.4899 0.67009 0.33986 0.53046-0.05023 1.0205 0.66015 1.38 0.08024 3.8418 0.53034 4.6521-0.62036 0.80058 0.63014 1.0407 0.69016 2.0214 0.4501 0.12071 0.21983-0.0202 0.44032 0.0803 0.66928 1.2006 0.20092 1.7408 1.0202 2.7117 1.5401 1.2606 0.66994 0.59048 0.66015 2.251 0.74952 0.06 0.97 1.3708 1.6804 1.7003 2.5917 0.42085 1.1801 0.12985 2.8604 0.33994 4.1201 0.55917-0.12003 1.3604 0.20092 1.9202 0.08024-0.25903 2.2805 1.5712 2.6308 1.581 4.6713 0.96109 0.04044 1.962 0.04044 2.9224 0 0.69032-1.0007 2.071-0.93021 2.9916-1.9302 0.1703 2.2603-1.9613 3.1709-2.1616 4.9322 0.0502-0.4899 1.5105 0.7704 2.4716 1.6308-1.1399 0.53034-1.9307 1.0796-2.9505 1.7208-0.47043 0.29028-0.43063 1.2094-1.0505 1.4508-0.66944 0.25962-1.9907-0.01044-2.7215 0.03001-0.65052 1.8409-2.3913 1.4103-4.0023 1.501-0.12984 0.40966-0.12984 1.2603 0 1.6706 0.58071-0.14938 1.3708 0.0411 1.9209-0.17026 0.09 1.711-0.26034 6.0209 2.0005 6.002 0.03 0.27985-0.03 0.65037 0.0802 0.92043 0.42998-0.02022 1.0009 0.14938 1.4211 0.07958 0.42085 1.1403 1.4511 1.5708 2.5512 0.81019-0.21009 0.15982-0.43063 0.55056-0.7797 0.78018 0-0.01957 0.0796 0.55056 0.06 0.58057 1.4504-0.30007 2.5708 0.5199 2.5009 2.0007 2.0801 0.12003 3.5619 1.0405 5.5323 1.2205 0.47108 0.05023 1.0107 0.44945 1.6912 0.33008 0.60027-0.09981 0.48022-1.06 1.0414-1.2101 1.2697-0.34965 2.7515 0.58057 3.2121-1.0405 0.36017-1.2603-0.95065-2.1709-1.9711-2.3001 0.0998-1.8311-0.13963-3.1312-1.4504-4.2218 1.0498-0.24006 1.8406-1.1103 2.9009-1.2505 1.2012-0.16047 2.0605 0.78996 3.4712 0.47098-0.09-0.63993 0.33994-1.1103 0.33015-1.6713 0.3308 0.0698 0.84038-0.12003 1.1705-0.08024 0.0613-0.32029 0.39148-1.09 0.42149-1.4208v-0.03001c0.36017 0.01044 0.73012 0.01957 1.0805 0.03001-0.12136 0.55969 0.20031 1.3607 0.0796 1.9204 1.1099 0.07958 1.6612-0.84019 2.2504-0.92043 1.271-0.15982 1.8622 0.33008 2.7117 0.46054 1.4211 0.23027 4.7526-0.42075 5.043 1.2094 1.1405 0.18983 2.6216 0.39009 2.7515-0.92043 0.53046 0.06001 1.4811-0.28898 1.7108-0.28898-0.42084 0.74039-0.33015 1.5695-0.21009 2.4599 0.23097 0.0698 0.44042 0 0.67074 0.08024 0.36017 1.4299-2.5714 5.9316 0.2499 6.002 0.24011 1.1801 0.7908 1.7202 0.98067 2.9009 0.14028 0.85976-0.2101 2.4899-0.15007 3.5206 2.4115 1.5701 4.2535 0.91064 7.1739 1.0802 0.41106 1.1507 2.512 0.84084 3.6225 0.71038zm-48.785-0.84998c0.0104-0.32029 0.0104-0.65037 0-0.97066-0.69946-0.25962-1.1301 0.2805-1.9013 0.24006-0.65052-0.0411-1.2201-0.19048-1.7512-0.42075-1.2508-0.53034-2.9316-1.8506-3.2519-3.3301-0.30014-1.3503-0.52002-1.2701 0.33015-2.4208 0.52068-0.69994 1.2508-2.7313 1.0002-3.6706-0.24011-0.95044-1.4002-0.61123-1.4302-1.6504-0.76013-0.08024-1.3715-0.55056-2.1512-0.68037-0.66096-0.10959-0.53046 0.09981-0.67009-0.40966-0.06-0.26028-0.03-0.8702 0.0802-1.0907 0.40062-0.85063 1.0805-0.72995 1.0909-1.8311 0.01-1.0196-0.64008-1.0496-0.85083-1.8206-0.6205-0.53034-1.0805-0.91978-1.151-1.7704-0.0405-0.41031 0.0907-0.90021-0.06-1.2707-0.0998-0.23027-0.46064-0.45924-0.61071-0.7293-0.79015-1.4906-0.15986-3.3216-0.76013-4.822-1.2912-0.06915-2.5316-0.30007-2.191-1.9309-0.43063-0.23027-0.81037-0.93935-1.3904-0.65037-0.28056 0.14025-0.46065 0.94-0.64008 1.1703-0.23945 0.31116-0.91085 0.41031-1.1301 0.80105-0.2101 0.3803 0.15986 1.0802-0.0502 1.4403-0.12984 0.19048-0.78036 0.47946-1.0198 0.57013-0.49066 0.19048-0.91085 0.24984-1.4909 0.25962-1.4211 0.01044-1.151 0.65037-1.3415 1.8206-0.57027 0.01957-1.4511-0.17026-1.9914 0-0.50045 0.15982-0.89063 0.84019-1.1803 1.2609-0.36995 0.53034-0.49001 0.92043-0.65051 1.5003-0.28057 0.98044-0.46 0.78996-1.4909 0.85063 0.0692 1.2909-0.56047 0.8702-1.2606 1.3999-0.64008 0.47946-0.39084 1.4403-0.43064 2.2407 0.0104-0.33008-1.1203 0.46054-1.2208 0.69081-0.21989 0.5199-0.0502 1.2603-0.03 1.8095 0.0398 0.77039-0.0502 0.8702 0.79015 1.1905 0.50044 0.20026 1.0407 0.27006 1.5607 0.39988 0.59049 0.14025 1.2612 0.03001 1.8315 0.24984 0.55982 0.21983 0.84038 0.62036 1.2508 1.0196 0.85017 0.83041 1.5809 1.7606 1.5809 2.9811 0 1.1807-0.0202 3.0411-0.61137 3.9818-0.5807 0.96022-2.7515 0.96022-2.8115 2.0209-0.0202 0.41031 0.50044 1.1507 0.59048 1.5904 0.14029 0.7306 0.0992 1.0411 0.55983 1.681 0.57026 0.78996 0.75034 0.63993 1.3604-0.0998 0.44042-0.53034 0.67009-1.1905 1.4909-1.2505 0.76078-0.06067 0.92064 0.39922 1.3604 0.90021 0.43063 0.4899 0.9611 0.69016 1.4009 1.1703 1.0498 1.15-0.75034 2.1396-0.74121 3.3412 0.45021-0.36074 1.1908-1.501 1.9118-0.83041 0.2101 0.20026 0.0692 0.66015 0.47043 0.94 0.30014 0.2094 0.79015 0.25962 1.1705 0.2394-0.0803 0.89042 0.80124 1.8904 1.2704 2.5708 0.30013 0.4501 0.61071 0.86042 1.1608 0.92043 0.7001 0.08024 1.0707-0.43967 1.7408-0.57013 0.13963 0.82062 0.90041 0.4899 1.5098 0.59035 0.54025 0.08024 1.1705 0.54012 1.761 0.31964 0.64008-0.25897 0.58071-0.61971 1.4106-0.66928 0.68053-0.04044 1.4106 0.14938 1.151-0.81997-0.36017-0.12068-1.6012-0.32029-1.6606-0.66994-2.1212 0.25962-1.0198-3.5512-1.0909-4.8318-0.45021-0.14025-1.1705-0.3503-0.82016-1.0196 0.1605-0.31116 0.43063-0.09067 0.58983-0.26028 0.17095-0.18983 0.0803-0.4899 0.28057-0.63014 0.81037-0.57013 2.2412 0.02022 3.141-0.17026 0.57026-0.12068 0.85996-0.41031 1.4909-0.44097 0.57027-0.01957 1.0309 0.24006 1.5307 0.09067 0.14093-0.0411 0.36081-0.33008 0.56047-0.39988 0.2499-0.08024 0.57026-0.01044 0.82995-0.02022 0.53372-0.03066 1.0537-0.12068 1.5744-0.10046z",
+                Taoyuan:"m324.59 106.65c0.0502 0.91065 0.0202 1.8304 0.0104 2.7508-1.2208 0.0691-2.8918 0.21005-3.5619 0.95044-0.24011 0.25962-0.59048 0.69994-0.71054 1.0307-0.26034 0.78018 0.15007 0.57991 0.45999 1.2394 0.29035 0.60079-0.06 1.8311-0.27991 2.5004-1.1105 0.81019-2.1616 1.2609-2.5714 2.681-0.2101 0.71038-0.19053 1.4103-0.65052 2.0105-0.55069 0.71038-1.0009 0.47033-1.7114 0.72017-0.8704 0.3105-1.3806 1.561-1.3708 2.621-0.78035 0.0998-1.9418 0.33008-2.6719 0.0502-0.58984-0.21983-1.0798-0.98044-1.8406-0.99088-0.84039-0.50033-0.72033-1.7508-1.5809-2.2505-0.0405-0.72017 1.1209-4.291-0.33994-4.002 0.0411-0.92043-0.30014-0.97979-0.76013-1.5904-0.39997-0.5199-0.28057-0.96087-0.2499-1.5708 0.03-0.43967 0.16964-1.5701-0.15007-1.8506-0.2897-0.25963-1.5307-0.06-1.9202-0.0802-0.18008-0.67972-0.0202-1.4403-0.18008-2.1507-0.13963-0.63014-0.67988-0.93021-1.0198-1.3901-0.51023-0.69081-0.36995-1.0502-1.3115-1.1905-0.72033-0.11025-1.8308-0.0802-2.2706 0.39987-0.12984 0.03-0.2499 0-0.38039 0-0.67009-1.8409 1.1301-3.0111 0.72033-4.8115-0.12005 0-0.27991-0.0411-0.39018-0.0202-0.12984-0.09-0.03-0.12068-0.2499-0.17026-0.17029-0.52055-0.33993-1.3412-0.18008-1.9009 0.15007-0.57013 0.70011-0.84019 0.82995-1.501 0.28056-1.4208-0.6205-2.79-1.9209-3.0907-0.80059-0.18004-0.93043-0.28963-1.581-0.74104-0.23097-0.15917-0.55068-0.28898-0.85082-0.4899-0.19052-0.12003-0.39997-0.44032-0.5011-0.50033-0.63943-0.39009-1.181-0.08024-1.6312-0.67972-0.36016-0.48011-0.39931-1.2303-0.3693-1.8206-0.50109-0.08024-1.5105-0.24006-1.9013-0.51012-0.60028-0.4201-0.26034-1.3803-1.1705-1.3405-0.57026 0.03001-1.1908 0.8702-1.8315 0.75017-0.77057-0.15004-0.47957-1.1514-0.50958-1.8206-0.52068 0.01957-1.0309-0.16047-1.5614-0.08024 0.03 0.2094-0.11027 0.36922-0.11027 0.54991-1.2097 0.24006-1.8511-1.0007-2.8918-1.3307-0.15007-0.69081-0.47109-1.3901-1.331-1.2505 0.12006-0.86042-1.0414-0.81997-1.5907-1.0104-0.33015-0.12068-0.79015-0.32029-1.0805-0.5199-0.25968-0.18004-0.5807-0.75996-0.7797-0.85976-0.24011-0.12003-0.42085-0.21983-0.72033-0.19048-0.15986-0.72016 0.29035-0.7306 0.66095-1.1403 0.42933-0.48011 0.49001-0.66015 0.47957-1.3307-0.01-0.3803-0.0196-1.1605-0.16964-1.5003-0.11027-0.24984-0.38039-0.08024-0.48022-0.44032-0.0692-0.21983 0.21009-0.44097 0.17095-0.58057-0.20097-0.66015-1.7108-1.0007-2.422-1.0007-0.74969 0-2.0005 0.23092-2.7012-0.0098-0.0104-0.01044-1.3611-0.98044-1.4609-0.65037 0.17094-0.54012 0.1207-1.2003 0.23097-1.7404-0.72033-0.04044-1.3806 0.0411-2.071 0.0698-0.82081 0.03001-1.1608-0.23092-1.8315-0.5199-1.121-0.48011-3.3309-0.3503-3.5919-1.5708-0.2499-1.1703 0.54025-3.2505-0.27012-4.1423-0.27991-0.30007-1.2508-0.95044-1.6606-1.1703-0.52002-0.27985-1.3806-0.39922-1.9907-0.27006-0.73077 0.16047-1.2103 0.53034-2.0814 0.39987-0.61985-0.09981-1.1803-0.55904-1.81-0.3803-0.61137 0.17026-0.8306 0.76061-1.4407 0.90021-0.39083 0.09067-1.0805 0.09067-1.5614-0.03979 0.45999-0.30007 0.92064-0.60014 1.2704-0.99088 0.60028-0.66015 1.9307-2.561 2.2308-3.4514 0.47043-1.3901-0.39018-4.4208 1.271-4.7313 0.49-2.7411 2.2608-4.6909 4.6326-6.002 2.1714-1.2003 5.133-1.0104 5.9532-3.6706 0.66096-0.04958 0.82016-0.44945 1.4217-0.58057 0.0692-4.3014 8.9037-0.39009 9.8347-3.9211 2.512-0.54012 4.6221-2.5708 6.9534-3.6113 3.0118-1.3405 4.6025-0.98044 7.5145-1.9302 0.35038-0.10959 1.3806-0.0998 1.9914-0.12003-0.03 0.90021-0.25968 2.291 0.39931 2.8109 0.44108 0.33008 0.9611 0.18004 1.4407 0.36987 0.49 0.19048 0.7001 0.57992 1.0714 0.8702 0.0202 0.21983 0.12984 0.27006 0.20031 0.47032 1.0505 0.06001 2.1114 0.09002 3.1417 0.11024 0.32036 0.75996 1.0009 1.15 1.6808 1.6602 0.39996 0.30985 0.5807 0.21983 0.90041 0.75017 0.20031 0.33986 0.21988 0.66015 0.53046 0.98044 0.47044 0.4899 1.3108 0.91064 2.071 0.93021 1.1908 0.05023 2.0716 0.48011 3.2421 0.60014 0.0405 0.30007 0.27013 0.51012 0.5807 0.57992 0.06 0.94065 0.01 1.2609 1.0002 1.501 0.09 0.25962 0.14941 0.53034 0.19052 0.80953 0.0502 0.01044 0.0992 0.02022 0.14028 0.03001-0.21988 0.6608-0.44042 1.7215-0.12984 2.4606 0.2897 0.72017 0.85017 0.84019 0.88084 1.7606-0.61137-0.03001-2.2921 0.04044-1.9711 1.0007 0.12006 0.36008 0.65052 0.34965 0.84039 0.57013 0.33015 0.39009 0.33994 0.72017 0.30014 1.2603-0.40062 0.17026-0.98067 0.60014-1.1705 1-1.6605-0.06067-1.2704 1.5095-2.4011 1.9407-1.1405 0.42075-3.0223 0.08024-4.1523-0.14938-0.79015-0.16047-1.3604-0.05023-2.101 0.1396-0.46064 0.12003-0.60092-0.12068-0.90106 0.33008-0.17943 0.27006-0.09 1-0.0992 1.3405-0.03 0.74039 0.0196 1.5401 0.16051 2.2505 0.14942 0.71038 0.61072 1.2094 0.49001 1.9909-0.39083 0.02022-1.1307-0.14025-1.4909 0.01044-0.39997 0.15982-0.82995 0.82976-0.39997 1.2603 0.35038 0.3503 0.76078-0.05023 1.0707 0.4899 0.18008 0.31051 0.14093 1.1103-0.01 1.4906-0.27012 0.03979-0.48022 0.1696-0.72033 0.27006-0.0698 0.03001-0.0907 0.78996-0.11027 0.93021 0.28057 0.06001 0.60028 0.06001 0.91086 0.0698 0.0502 0.93021-0.67988 1.8806 0.0104 2.4103 0.32036 0.24984 1.0302 0.04044 1.3415 0.24006 0.3693 0.24006 0.41041 0.94 0.76078 1.2407 0.10962-0.01109 0.27013 0.03001 0.39018 0.03001-0.0404 0.42988-0.0202 1.3999 0.33994 1.6602 0.44956 0.31051 1.3708-0.3803 1.6201 0.23027 0.33994 0.85128-1.7708 1.1011-1.3408 1.9915 0.1703 0.36008 0.8704 0.33008 1.0805 0.57992 0.30013 0.3503 0.25055 0.74039 0.21988 1.1807-0.67009 0.03001-2.9511 0.28115-2.7319 1.3307 1.4909 0.09067 2.681-0.06001 3.9918 0.68037 0.59049 0.33986 1.1105 1.09 1.9209 0.92043 0.85996-0.17939 0.71054-0.81997 1.1601-1.2505 0.89062-0.84998 2.912 0.0411 3.5925 0.7306 0.56961 0.57992 1.1203 2.5708 2.2308 2.4508 0.39018 0.93021 1.2906 0.42075 1.6906 0.99088 0.73077 1.0307-0.61072 3.8207 1.7304 3.6811 0.0411 0.46054 0.0607 0.94-0.2499 1.2205-1.35 0.18983-1.6605 1.4906-2.7215 2.1201-0.74056 0.44032-0.80059 0.66015-0.60028 1.6406 0.10962 0.60014 0.15986 1.3503 0.33015 1.9204 0.41041 1.3405 1.1105 2.351 1.8615 3.501 0.31971 0.4899 0.7797 1.0104 1.0407 1.5206 0.32037 0.63014-0.0998 1.5304 0.54025 1.9602 0.30014 0.21005 0.79015 0.0502 1.151 0.0998 0.48022 0.0802 0.60028 0.17025 1.0205 0.42009 0.71577 0.44684 0.6851 1.2975 1.626 1.1872z",
+                Keelung:"m354.05 44.801c-1.1007 0.76061-2.131 0.33008-2.5505-0.81019-0.42085 0.0698-0.99176-0.09915-1.4217-0.08024-0.10962-0.26941-0.0502-0.63928-0.0803-0.91978-2.2615 0.01892-1.9111-4.2916-2.0005-6.002-0.55069 0.2094-1.3415 0.01957-1.9209 0.17026-0.12984-0.40966-0.12984-1.2603 0-1.6706 1.611-0.09067 3.3518 0.33986 4.0023-1.501 0.73077-0.04044 2.052 0.23092 2.7215-0.03001 0.6205-0.24006 0.58135-1.1598 1.0505-1.4508 1.0205-0.63993 1.8106-1.1905 2.9511-1.7208 0.46064 0.42988 0.80972 0.76061 0.82016 0.77039 1.4811 1.0502 2.6621 1.0705 4.6326 1.1801 0.4502 1.8617-0.28057 2.7906-0.14942 4.4423 0.68053-0.86042 1.7004-1.4005 1.7304-2.6908 2.4611-1.3203 4.0525 1.6706 6.6742 0.7306-0.11027 0.4899 0.17878 1.2003 0.0796 1.6902 0.52068 0.02022 1.0498 0.03001 1.5907 0.05023v0.03001c-0.03 0.33008-0.36016 1.1005-0.42084 1.4208-0.33015-0.04044-0.84039 0.15004-1.1705 0.08024 0.0104 0.56035-0.42084 1.0307-0.33015 1.6706-1.4106 0.32029-2.2706-0.63014-3.4718-0.47032-1.0603 0.14025-1.8511 1.0104-2.9009 1.2505 1.3108 1.0907 1.5503 2.3908 1.4511 4.2212 1.0198 0.13046 2.3306 1.0411 1.9711 2.3007-0.46064 1.6204-1.9418 0.69016-3.2121 1.0405-0.55982 0.15003-0.44042 1.1103-1.0407 1.2101-0.68053 0.12003-1.2208-0.2805-1.6912-0.33008-1.9711-0.18004-3.4516-1.1011-5.5323-1.2205 0.0698-1.4814-1.0505-2.3007-2.5009-2.0007 0.0196-0.03001-0.06-0.60014-0.06-0.58057 0.34907-0.23027 0.56896-0.62036 0.77971-0.78018z",
+                Kinmen:"m41.675 107.89c-0.0762 4e-3 -0.14595 0.0243-0.18718 0.0468-0.0375 0.0225-0.0711 0.0402-0.0936 0.0702l-0.0468 0.0936c-0.05235 0.16473-0.0159 0.38094-0.0234 0.53817-0.77124 0.0375-1.3965-0.23867-2.1526-0.16379-0.17222 0.015-0.27516 0.0412-0.32758 0.0936-0.015 8e-3 -9e-3 9e-3 -0.0234 0.0234-0.09735 0.11235-0.102 0.2967-0.30418 0.49137-0.21714 0.20217-0.453 0.4034-0.46797 0.72537-0.0075 0.41931 0.2527 0.74409 0.1404 1.1933-0.09735 0.34443-0.40246 0.4268-0.51478 0.74877-0.08985 0.2471 0.015 0.66641 0 0.93596-0.0225 0.3669-0.1095 0.46984-0.49137 0.51477-0.15724 0.0225-0.32666 0.0524-0.49138 0-0.09735-0.0225-0.24522-0.1563-0.32757-0.16379-0.75626-0.0973-0.35661 1.154-0.3042 1.521 0.045 0.34443-0.0135 0.56532-0.1404 0.84236-0.1422 0.32946-0.03375 0.42867-0.0936 0.79557-0.045-7e-3 -0.0795 0-0.117 0-0.03 0.10485-0.1011 0.16098-0.0936 0.28078-0.38936 0.0748-0.53722-0.27891-0.88916-0.23398-0.0225 0.11235 0.07485 0.23959 0.1872 0.37438 0.03 0.0375 0.072 0.0795 0.117 0.117 0.15723 0.1497 0.32384 0.27611 0.42117 0.35097 0.0375 0.0225 0.087 0.0552 0.117 0.0702 0.1422 0.0599 0.26301 0.0468 0.39778 0.0468 0.09735 8e-3 0.20778 0.0328 0.32758 0.0702 0.11235 0.0375 0.21434 0.10485 0.30418 0.1872 0.05235 0.0375 0.1029 0.0954 0.1404 0.1404 0.0375 0.0448 0.0795 0.0954 0.117 0.1404l0.0702 0.0468 0.0468 0.0702c0.1797 0.1797 0.39498 0.30699 0.70197 0.18719 0.35192-0.1347 0.1161-0.47265 0.28078-0.77216 0.22462-0.41182 0.906-0.78433 1.3103-0.88917 0.21789-0.0598 0.66546-0.25176 0.91256-0.117 0.23211 0.1497 0.1104 0.43898 0.1404 0.67857 0.0075 0.0748 0.0411 0.1347 0.0936 0.1872 0.015-0.0225 0.0243-0.0318 0.0468-0.0468 0.1497-0.1497 0.41368-0.27705 0.60837-0.37438 0.25458-0.1347 0.5026-0.33975 0.77217-0.44459 0.07485-0.26206-0.10395-0.43615-0.35098-0.42117-0.11235-0.45675-0.0468-0.63364 0.32758-0.86577 0.31448-0.20965 0.58497-0.3697 0.95936-0.44457 0.36688-0.0823 0.69354-0.0795 1.0529 0.0702 0.2995 0.11985 0.55222 0.34349 0.88916 0.35099 0.1497-0.20966 0.0486-0.47079 0.0936-0.72537 0.015-0.12735-0.04215-0.20685 0.0702-0.30419 0.09735-0.0898 0.25272 0.0206 0.32758-0.0468 0.26208-0.20965 0.045-0.94999 0.1872-1.2869 0.0225-0.0448 0.0243-0.072 0.0468-0.117 0.0375-0.0899 0.0795-0.19842 0.117-0.28078 0.0225-0.0448 0.0477-0.0795 0.0702-0.117 0.03-0.0523 0.072-0.0795 0.117-0.117 0.11985-0.11235 0.24615-0.19374 0.35098-0.35099 0.22462-0.37438 0.0543-1.0389 0.0468-1.4507-0.2471-0.0225-0.57 0.0263-0.77217-0.0936-0.05235-0.03-0.1188-0.072-0.16378-0.117-0.03-0.03-0.0636-0.0561-0.0936-0.0936-0.05985-0.0748-0.09645-0.1591-0.1638-0.23398-0.03-0.0375-0.0795-0.0795-0.117-0.117-0.4268-0.3594-0.98836-0.45674-1.3103-0.93596-0.0225-0.0375-0.0243-0.0881-0.0468-0.1404-0.0225-0.0524-0.0636-0.10395-0.0936-0.16378-0.0375-0.0824-0.0645-0.18158-0.117-0.23399-0.0225-0.0225-0.0477-0.0318-0.0702-0.0468-0.18718-0.11235-0.59433-0.0468-0.81896-0.0468-0.15162 0-0.47348-0.0594-0.70197-0.0468zm32.666-14.206c-0.71882-0.05985 0.19842 0.96028 0.28078 1.1699v0.0234c0.03 0.07485 0.0468 0.17596 0.0468 0.28078 0 0.21714-0.0468 0.45114-0.0468 0.60837 0 0.3669 0.0402 0.51946-0.30418 0.63177-0.20217 0.06735-0.3332 0.08805-0.46798 0.1404-0.05235 0.0225-0.10395 0.0327-0.16378 0.0702-0.03 0.015-0.0561 0.0477-0.0936 0.0702-0.10485 0.06735-0.21526 0.13575-0.32758 0.2106-0.11235 0.08235-0.22276 0.15818-0.32758 0.21058-0.1422 0.06735-0.29482 0.0702-0.44458 0.0702-0.05235 0.0075-0.11145 0-0.16378 0-0.06735 0-0.14325 9e-3 -0.21058 0.0234-0.0375 0.0075-0.0795 9e-3 -0.117 0.0234-0.25458 0.07485-0.44085 0.21058-0.72537 0.21058-0.07485 0.12735-0.1338 0.30513-0.1638 0.51478-0.04485 0.45675 0.06645 1.0408 0.35098 1.3103 0.0375 0.0375 0.072 0.0711 0.117 0.0936 0.0075 0.0075 0.0159 0 0.0234 0 0.04485 0.015 0.0954 0.0393 0.1404 0.0468v-0.117c0-0.015-0.0075-0.0318 0-0.0468v-0.0234c-0.0075-0.0075 0.0075-0.0159 0.0234-0.0234-0.0075-0.0075-0.0075-0.0159 0-0.0234-0.0075-0.0225-0.01515-0.0318 0-0.0468-0.0075-0.03 9e-3 -0.0711 0.0234-0.0936 0.0075-0.03-0.0075-0.0402 0-0.0702 0-0.015 0.01605-0.0234 0.0234-0.0234v-0.0468c0.0225-0.07485 0.04035-0.14325 0.0702-0.2106 0.0225-0.06735 0.0477-0.12735 0.0702-0.18718 0.015-0.0225 0.0159-0.0711 0.0234-0.0936 0.08235-0.0075 0.19281-0.0075 0.32758 0 0.05985 0 0.13575-0.0075 0.2106 0 0.0375 0 0.072 0.0234 0.117 0.0234 0.0225 0 0.0318-0.0075 0.0468 0 0.0375 0 0.0795-0.0075 0.117 0 0.08985 0.0075 0.19936 0.0318 0.30418 0.0468l0.0936 0.0234h0.0234c0.05985 0.0075 0.10395 9e-3 0.16378 0.0234 0.05985 0.015 0.1347 0.0318 0.18718 0.0468 0.05235 0.0225 0.08805 0.0552 0.1404 0.0702 0.04485 0.015 0.1029 0.0402 0.1404 0.0702 0.05985 0.0225 0.0954 0.0561 0.1404 0.0936 0.045 0.03 0.0945 0.07215 0.117 0.117 0.045 0.06735 0.0777 0.12825 0.0702 0.21058v0.0234c-0.0075 0-0.0318-0.0159-0.0468-0.0234h-0.0231c-0.18718-0.015-0.42117 0.0216-0.60837-0.0234-0.22462-0.04485-0.33694-0.19467-0.56157-0.18718h-0.0702c-0.0375 0-0.0795 0.0159-0.117 0.0234-0.015 0.0075-0.0318 0.0234-0.0468 0.0234-0.0375 0.015-0.0636 0.0243-0.0936 0.0468-0.06735 0.05985-0.09735 0.1535 0 0.28078 0.0075 0.015 0.0318 9e-3 0.0468 0.0234 0.08235 0.05985 0.19188 0.0543 0.30418 0.0468 0.10485 0 0.21246 0.0135 0.25738 0.1404 0.0225 0 0.0477 0.01575 0.0702 0.0234 0.0225-0.0075 0.0318-0.0075 0.0468 0 0.10485 0.31448 0.12825 0.45861 0.0234 0.79556l-0.0234 0.0936c-0.03 0.0973-0.04965 0.18345-0.117 0.28079-0.05985 0.0823-0.18999 0.12075-0.25738 0.2106l-0.0468 0.0468c-0.0075 0.015 0 0.0243 0 0.0468-0.0075 0.0448-0.0075 0.0881 0 0.1404 0.04485 0.16473 0.19094 0.32571 0.28078 0.46797 0.11235 0.17221 0.19188 0.46705 0.30418 0.63177l0.0468 0.0468c-0.03-7e-3 -0.0402-0.0159-0.0702-0.0234-0.0375-8e-3 -0.087-9e-3 -0.117-0.0234-0.05985-0.0225-0.11145-0.0561-0.16378-0.0936-0.0375-0.015-0.0636-0.0243-0.0936-0.0468-0.35193-0.25458-0.44178-0.67482-0.56158-1.1465-0.22462-0.0974-0.14595-0.27237-0.28078-0.44459l-0.0702-0.0702-0.0234-0.0468c-0.0375-0.03-0.1029-0.0477-0.1404-0.0702-0.08235-0.0375-0.17595-0.0636-0.28078-0.0936-0.1422-0.0375-0.263-0.0486-0.39778-0.0936-0.04485-0.015-0.08805-0.0243-0.1404-0.0468 0 0-0.0234-0.0157-0.0234-0.0234-0.0225-0.015-0.0477-0.0168-0.0702-0.0468-0.015-0.0075-9e-3 -0.0318-0.0234-0.0468-0.0225-0.03-0.0477-0.04785-0.0702-0.0702-0.015-0.015-0.0318-0.0393-0.0468-0.0468-0.07485-0.04485-0.1769-0.04305-0.30418 0.0468-0.21039 0.1422-0.22725 0.48951-0.0468 0.63177 0.1497 0.11235 0.26114 0.0561 0.35098 0.0936l0.0468 0.0234c0.03 0.03 0.0561 0.058 0.0936 0.1404 0.1422 0.26957 0.2705 0.74034 0.2106 1.0998-0.015 0.0749-0.0477 0.12735-0.0702 0.18718-0.15724 0.015-0.30232 0.0402-0.44458 0.0702-0.1497 0.03-0.29482 0.0795-0.44458 0.117-0.08985 0.03-0.17595 0.0478-0.28078 0.0702-0.05235 8e-3 -0.1029 0.0318-0.1404 0.0468s-0.0636 0.0243-0.0936 0.0468c-0.0375 0.0225-0.0711 0.0402-0.0936 0.0702-0.015 0.0225-0.0318 0.0636-0.0468 0.0936-0.015 0.0448-0.0234 0.10395-0.0234 0.1638-0.0075 0.0748-7.5e-4 0.15255-0.0234 0.25739-0.0075 0.0449-0.0243 0.10395-0.0468 0.16378-0.07485 0-0.16004 8e-3 -0.25738 0h-0.1404c-0.0225 0-0.0552-7e-3 -0.0702 0-0.10485 8e-3 -0.18999 0.0252-0.25738 0.0702-0.03 0.015-0.0552 0.0402-0.0702 0.0702-0.1872 0.29951 0.1011 0.6168 0.28078 0.81897 0.0225 0.015 0.0552 0.0318 0.0702 0.0468 0.37438 0.4268 0.41182 0.96872 0.37438 1.5678-0.0075 0.0973-0.0075 0.18251-0.0234 0.25739-0.0075 0.0748-0.0243 0.14325-0.0468 0.21058-0.045 0.11985-0.11415 0.24803-0.23398 0.39779-0.0375 0.045-0.0795 0.087-0.117 0.117-0.03 0.0375-0.0636 0.0478-0.0936 0.0702-0.03 0.0225-0.0402 0.0552-0.0702 0.0702s-0.07965 0.0159-0.117 0.0234c-0.08235 0.0225-0.20124 0.0234-0.35098 0.0234-0.31448 1e-5 -0.66734-5e-3 -0.95936 0.0702-0.2995 0.0748-0.44739 0.22557-0.70197 0.39778-0.27704 0.19467-0.3126 0.25646-0.70197 0.23399-0.21714-0.32946-0.52881-0.25083-0.86576-0.28079-0.40432-0.03-0.4998-0.33132-0.88916-0.42118-0.08985-0.0225-0.18345-0.0393-0.28078-0.0468-0.23961-0.015-0.49324-1e-3 -0.72537-0.0468-0.61398-0.10485-1.0988-0.2499-1.638-0.63177-0.89103-0.62897-1.5668-1.5612-2.4802-2.1526-0.48669-0.32198-0.94156-0.32384-1.2635-0.79556-0.26206-0.41182-0.46518-0.85921-0.77216-1.2635-0.29952-0.40434-0.69356-0.92566-1.053-1.2402-0.55408-0.47172-0.87138-0.13755-1.0062 0.49138-0.614 0.03-1.1194-0.1236-1.5912 0.28079-0.44176 0.37438-0.8199 0.74782-1.4039 0.91255-0.89852 0.23961-1.856 1.7043-1.4741 2.7376 0.19468 0.48669 0.6065 0.32945 0.93596 0.56157 0.1347 0.0898 0.18532 0.19842 0.32758 0.28079 0.0225 8e-3 0.0477 0.0393 0.0702 0.0468 0.045 0.0225 0.0954 0.0318 0.1404 0.0468 0.045 0.0225 0.08805 0.0318 0.1404 0.0468 0.11235 0.03 0.22276 0.0542 0.32758 0.0468 0.0375-0.20217 6e-3 -0.3566-0.0702-0.49139-0.05235-0.10485-0.1422-0.20778-0.18718-0.32758-0.0075-0.0225-0.0159-0.0402-0.0234-0.0702l-0.0468-0.0936c-0.10485-0.19467-0.27237-0.47358-0.25738-0.60837 0.24708-0.0449 0.44644 0.0786 0.67856 0.0936 0.25458 0.03 0.36783-0.1329 0.58498-0.1404 0.38936-0.015 0.88728 0.73095 0.84236-0.0702h0.21058c0.22464 7e-3 0.44178 0.015 0.56158-0.18719 0.10485-0.1797-0.11235-0.57936 0.18718-0.63177 0.32198-0.0524 0.23025 0.44364 0.32758 0.60837 0.07485 0.11985 0.61866 0.4764 0.117 0.49137-0.18718 0.29202-0.25738 0.30606-0.25738 0.72537 0 0.41183 0.08985 0.68138-0.37438 0.74877h-0.0702c-0.12735 0.0225-0.32384 0.03-0.42118 0-0.1422-0.0524-0.27048-0.32853-0.39777-0.35098-0.1422-0.0225-0.21996 0.0272-0.2574 0.117-0.0075 0.015-0.0234 0.0243-0.0234 0.0468-0.0075 0.015-0.0234 0.0477-0.0234 0.0702-0.0225 0.1347-0.0168 0.28546-0.0468 0.39778-0.25458 0.015-0.51758 8e-3 -0.77216 0.0234-0.015 0.20966 0.16566 0.14505 0.21058 0.25739 0.015 0.03 0.0234 0.0636 0.0234 0.0936 0.0075 0.0225 0.0234 0.0477 0.0234 0.0702 0.0075 0.0523 0.0075 0.10395 0 0.16378v0.117c0 8e-3 0.0075 0.0159 0 0.0234 0.0075 0.0375-0.01575 0.0636-0.0234 0.0936-0.0225 0.23961-0.0711 0.45395-0.0936 0.67857-0.0375 0.5466 0.39966 1.0314 0.63177 1.4507 0.21714 0.39684 0.34443 0.58029 0.37438 1.0296 0.03 0.32196 0.117 0.58309 0.117 0.91255 0 0.26955 0.0162 0.54098 0.0234 0.79556 0.0075 0.35941 0.0234 0.69261 0.0234 1.0296 0 0.20966 0.0972 0.76374 0 0.93596-0.11235 0.19468-0.55408 0.26767-0.74877 0.32758-0.08235 0.0225-0.18344 0.0477-0.28078 0.0702-0.06735 0.015-0.11985 9e-3 -0.18718 0.0234-0.09735 0.0225-0.21434 0.0402-0.30418 0.0702-0.12735 0.0448-0.24522 0.11235-0.32758 0.18719-0.11235 0.11235-0.16098 0.27517-0.0936 0.51478 0.05985 0.23211 0.25458 0.47172 0.18718 0.74876 0 0.015 0.0075 0.0159 0 0.0234 0 0.03-0.0075 0.0477-0.0234 0.0702-0.0225 0.0448-0.07215 0.0954-0.117 0.1404-0.03 0.0225-0.0636 0.0552-0.0936 0.0702-0.0375 0.0225-0.072 0.0477-0.117 0.0702-0.06735 0.0448-0.12735 0.0795-0.18718 0.117-0.03 0.0225-0.0711 0.0477-0.0936 0.0702-0.29202 0.23212-0.33507 0.23961-0.70197 0.1872-0.08235-7e-3 -0.26206-9e-3 -0.37438-0.0234-0.0225 0-0.0318 7e-3 -0.0468 0-0.015-2e-5 -0.0318-0.0157-0.0468-0.0234-0.03-0.015-0.0552-0.0168-0.0702-0.0468-0.0075 7e-3 0-0.0157 0-0.0234-0.05985-0.0599-0.06555-0.11985-0.1404-0.1872-0.20216-0.18719-0.36128-0.27891-0.60837-0.23399-0.04485 8e-3 -0.08805 0.0318-0.1404 0.0468-0.0375 0.0973-0.09645 0.18158-0.16378 0.23399-0.0225 0.0225-0.0402 0.0318-0.0702 0.0468-0.12735 0.0898-0.28827 0.0918-0.46798 0.0468-0.08235-0.015-0.17502-0.0243-0.25738-0.0468-0.0225 0-0.0318-0.0162-0.0468-0.0234-0.08235-0.0225-0.17502-0.0552-0.25738-0.0702h-0.0234c-0.1422-0.0225-0.2939-0.0135-0.42118 0.0234-0.0375 0.015-0.0561 0.0318-0.0936 0.0468-0.0375 0.0225-0.0636 0.0168-0.0936 0.0468-0.04485 0.0375-0.1029 0.0879-0.1404 0.1404-0.15723 0.21715-0.14505 0.33882-0.0702 0.42118 0.05235 0.0524 0.14415 0.1029 0.234 0.1404 0.08985 0.03 0.19094 0.0561 0.28078 0.0936 0.24708 0.11235 0.59994 0.50636 0.77216 0.67857 0.0375 0.015 0.0795 0.0168 0.117 0.0468 0.045 0.03 0.0954 0.072 0.1404 0.117 0.26956 0.23961 0.5438 0.68699 0.67857 0.88916 0.05235 0.0748 0.0636 0.10395 0.0936 0.1638 0.015 0.015 0.0318 0.0402 0.0468 0.0702 0.0225 0.0599 9e-3 0.22836 0.0468 0.28078 0.03 0.03 0.0486 0.0627 0.0936 0.0702 0.04485 0.015 0.11145 0.0159 0.1638 0.0234h0.0234c0.04485 8e-3 0.0954 9e-3 0.1404 0.0234 0.03 7e-3 0.0477 0.0159 0.0702 0.0234 0.0225 7e-3 0.0318 0.0318 0.0468 0.0468 0.10485 0.0973 0.17408 0.23211 0.23398 0.37437 0.0375 0.0898 0.0636 0.20685 0.0936 0.3042 0.045 0.1422 0.08895 0.27704 0.16378 0.37437 0.05985 0.0824 0.16848 0.13485 0.28078 0.1872 0.11985 0.0448 0.23212 0.087 0.37438 0.117 0.13485 0.03 0.28641 0.0552 0.42118 0.0702 0.12735 0.015 0.26114 0.0318 0.35098 0.0468 0.03 0.12735 0.09735 0.23772 0.18718 0.32759 0.07485 8e-3 0.12735 0 0.1872 0 0.06735 0 0.1422 9e-3 0.18718 0.0234 0.0375 8e-3 0.0636-6e-3 0.0936 0.0234 0.05235 0.0375 0.0954 0.10485 0.1404 0.18718 0.0225 0.0448 0.0477 0.088 0.0702 0.1404 0.045 0.10485 0.0795 0.22277 0.117 0.32759 0.015 0.0524 0.0477 0.0954 0.0702 0.1404 0.05235 7e-3 0.087 0.0486 0.117 0.0936 0.09735 0.11985 0.16098 0.34723 0.28078 0.44458 0.25458 0.2396 0.2939 0.1694 0.60837 0.117 0.32946-0.0448 0.86109-0.20122 1.1232 0.0234 0.0225 0.015 0.0552 0.0402 0.0702 0.0702 0.0375 0.0524 0.0552 0.11235 0.0702 0.18719 0.15723 0.11985 0.43054 0.19749 0.65517 0.25738 0.03 0.015 0.0402 0.0159 0.0702 0.0234 0.03 7e-3 0.0711 0.0234 0.0936 0.0234 0.1347 0.03 0.2293 0.03 0.30418 0 0.015 0 0.0393-8e-3 0.0468-0.0234 0.0225-8e-3 0.0318-0.0243 0.0468-0.0468 0.05235-0.0674 0.0795-0.17782 0.117-0.32758 0.0375-0.015 0.0954-0.0234 0.1404-0.0234 0.10485-0.0225 0.19935-0.0309 0.30418-0.0234 0.10485 0 0.20684-7.5e-4 0.30418-0.0234 0.0225 0 0.0477 7e-3 0.0702 0 0.03-8e-3 0.0477-0.0161 0.0702-0.0234 0.0375-0.015 0.0795-0.0477 0.117-0.0702s0.0711-0.0402 0.0936-0.0702c0.20217-0.20216 0.26768-0.51758 0.32758-0.77216 0.15723-0.6664 0.14415-1.0436 0.60837-1.5678 0.39684-0.45675 0.52881-1.096 0.86576-1.5678 0.1497-0.20965 0.23118-0.4839 0.35098-0.67857 0.0375-0.0524 0.0795-0.0954 0.117-0.1404 0.08235-0.0824 0.1591-0.15163 0.23398-0.234 0.04485-0.0375 0.087-0.088 0.117-0.1404 0.0225-0.015 9e-3 -0.0477 0.0234-0.0702 0.1872-0.45673-0.0318-0.7029 0.51478-0.91255 0.23211-0.0974 0.30324-0.1161 0.46797-0.28079 0.43428-0.44176 0.58592-0.64113 1.1699-0.86575 0.32198-0.12735 0.5569-0.31167 0.81897-0.49139 0.17222-0.1347 0.35847-0.23772 0.53817-0.32758 0.35192-0.18719 0.73378-0.34161 1.1232-0.49137 0.61398-0.23961 1.082-0.4764 1.7782-0.49137 0.68138 0 1.3534-0.0748 2.0122-0.1872 0.63645-0.11235 1.183-0.23399 1.8718-0.23399 0.16473 0 0.31072 9e-3 0.46797 0.0234 0.1497 8e-3 0.31822 0.0168 0.46798 0.0468 0.07485 0.015 0.1347 0.0477 0.18718 0.0702 0.17222 0.0598 0.26582 0.13665 0.46798 0.23399 0.32944 0.1497 0.50634 0.1086 0.67856 0.46798 0.09735 0.1797 0.12825 0.41369 0.2106 0.60837 0.03 0.0598 0.0486 0.11145 0.0936 0.16379 0.04485 0.0523 0.10395 0.0795 0.16378 0.117 0.19468 0.0974 0.453 0.1179 0.65517 0.1404 0.15724 0.0225 0.34162-4e-3 0.49138 0.0468 0.1497 0.0598 0.2396 0.20497 0.37437 0.2574 0.15724 0.0523 0.32666 7.3e-4 0.49138 0.0234 0.03 0 0.0636 0.0159 0.0936 0.0234 0.0375 0.015 0.0636 0.0243 0.0936 0.0468 0.06735 0.0448 0.11985 0.0956 0.18718 0.1404 0.03 0.0225 0.0561 0.0552 0.0936 0.0702 0.15724 0.0898 0.31917 0.0824 0.49138 0.18718 0.1497 0.0824 0.20122 0.19749 0.35098 0.25739h0.0234l0.0234 0.1404c0.0075 0.0448 0.01605 0.0795 0.0234 0.117 0.015 0.0824 0.04875 0.17502 0.0936 0.25738 0.11985 0.23961 0.24522 0.36878 0.32758 0.60837 0.11235 0.28454 0.18063 0.52602 0.21058 0.79557 0.0075 0.0448 0.0234 0.0954 0.0234 0.1404 0.015 0.0898 0.0075 0.17595 0 0.28079-0.57656 0.20217-1.8064-0.30699-1.7316 0.56157 0.49419 0.0225 0.97246-0.0459 1.4741-0.0234 0.05985 0.41931-1.0333 0.20685-1.3103 0.30418-0.05235 0.20217 0.1245 0.28266 0.30418 0.32759 0.045 0.1347 0.0702 0.30231 0.0702 0.44458 0.30699-0.0375 0.57374-0.24241 0.86576-0.25738 0.26206-0.015 0.58965 0.1077 0.88916 0.0702 0.55334-0.0524 0.37083-0.1422 0.49138-0.56159 0.11985-0.42679 0.41276-0.29763 0.77216-0.32758 0.60651-0.0448 0.81054-0.70383 1.3571-0.93596 0.29202-0.11985 0.68325-0.0411 0.98276-0.0936 0.05985-8e-3 0.13485-0.0477 0.18718-0.0702 0.1497-0.0749 0.24054-0.19935 0.2106-0.49137-0.0225-0.20965-0.06555-0.30138-0.1404-0.42118-0.03-0.0448-0.0402-0.0647-0.0702-0.117l-0.0234-0.0234c-0.0225-0.0375-0.0318-0.0636-0.0468-0.0936-0.10485-0.16473-0.11235-0.18533 0-0.32759 0.015-0.0225 0.0243-0.0636 0.0468-0.0936 0.03-0.0449 0.0879-0.0954 0.1404-0.1404 0.2396-0.24709 0.61586-0.48201 0.79556-0.0702 0.33694 0.0973 0.57 0.15537 0.95936 0.1404 0.20966-0.24709 0.57375-0.61678 0.49138-1.0062-0.1497-0.0898-0.27986-0.20498-0.44458-0.25739-0.05235-0.12735-0.0375-0.27798 0-0.39778-0.16473-0.12735-0.53444-0.31355-0.63177-0.53817-0.08235-0.19467 7.5e-4 -0.64862 0.0234-0.86576 0.08985-0.74128 0.6636-0.80211 1.2401-0.58497-0.0225 0.22463 0.49138 0.27143 0.67857 0.23399 0.40434-0.0974 0.2527-0.40434 0.32758-0.74877 0.05985-0.25458 0.18158-0.48669 0.23398-0.74876 0.0075-0.03 0-0.0636 0-0.0936 0.0075-0.0748 0.0318-0.15912 0.0468-0.234 0.0075-0.03 9e-3 -0.0636 0.0234-0.0936 0.0075-0.015 0.0159-9e-3 0.0234-0.0234 0.05985-0.0898 0.2106-0.21432 0.2106-0.30418 0-0.45674-1.0923-0.1254-1.4741-0.51477-0.03-0.03-0.0786-0.072-0.0936-0.117-0.09735-0.2471 0.1125-0.54192 0-0.81896-0.09735-0.25458-0.41649-0.4165-0.49137-0.67857-0.1497-0.50916-0.05235-1.4732 0-2.0122 0.045-0.43428 0.28452-1.534 0.74876-1.6614 0.10485-0.23211 0.43522-0.34068 0.39778-0.65517-0.0075-0.10485-0.13005-0.24615-0.25738-0.35097-0.05235-0.0375-0.08805-0.0711-0.1404-0.0936-0.0225-8e-3 -0.0711-0.0159-0.0936-0.0234-0.05985-0.015-0.10395-0.0234-0.16378-0.0234-0.05985 0-0.11145 7e-3 -0.1638 0.0234-0.0225 8e-3 -0.0477 8e-3 -0.0702 0.0234-0.0225 0-0.0477 0.0159-0.0702 0.0234-0.05235 0.0225-0.1188 0.0477-0.16378 0.0702-0.1497 0.0748-0.263 0.1404-0.39778 0.1404-0.11985 0-0.25552-0.0459-0.39778-0.2106-0.06735-0.0824-0.12735-0.16659-0.18718-0.23398-0.05985-0.0824-0.1188-0.15911-0.1638-0.23399-0.05985-0.10485-0.1263-0.21528-0.16378-0.32758-0.03-0.10485-0.0318-0.2237-0.0468-0.35099-0.015-0.10485-0.03075-0.20029-0.0234-0.32758 0.03-0.614 0.25364-1.3272-0.39778-1.5444-0.05235-0.015-0.0954-0.0477-0.1404-0.0702-0.08235-0.0375-0.1422-0.0645-0.18718-0.117-0.20966-0.1872-0.19376-0.46611-0.1638-0.79557l0.0234-0.16379v-0.1872c0.0075-0.20216-0.0075-0.453 0.0234-0.65517 0.0075-0.06735 7.5e-4 -0.10395 0.0234-0.16378 0.11235-0.2995 0.3566-0.3828 0.30418-0.77217-0.05235-0.0075-0.1188-0.0159-0.16378-0.0234-0.0225 0-0.0318-0.0234-0.0468-0.0234-0.26956-0.015-0.51759 0.01785-0.77217 0.0702-0.16473 0.0375-0.31822 0.08055-0.46798 0.1404-0.03 0.015-0.0636 0.0393-0.0936 0.0468-0.05985 0.0225-0.12735 0.0402-0.18718 0.0702l-0.0702 0.0468c-0.11985 0.07485-9e-3 0.23306-0.23398 0.2106-0.1797-0.0075-0.36034-0.39591-0.39778-0.53817-0.03-0.0375-0.0327-0.0411-0.0702-0.0936-0.12735-0.0075-0.26206-0.0159-0.37438-0.0234-0.23211 0-0.43521-0.0135-0.58497-0.1404-0.08235-0.06735-0.1347-0.15351-0.18718-0.2808-0.04485-0.11985-0.0627-0.24708-0.0702-0.37437 0-0.06735 0.0075-0.12735 0-0.1872-0.015-0.06735-0.0318-0.12735-0.0468-0.18718-0.08985-0.28454-0.20498-0.497-0.2574-0.81897-0.0375-0.1797-0.1188-0.3828-0.16378-0.58497-0.015-0.05235-0.0159-0.11145-0.0234-0.16378-0.0075-0.07485-0.0075-0.15912 0-0.234v-0.1404c0.0075-0.11985 0.02265-0.26206 0-0.37437-0.0075-0.04485-0.01605-0.07215-0.0234-0.117-0.0375-0.1347-0.11415-0.26674-0.23398-0.30418-0.03-0.0075-0.072-0.015-0.117 0-0.015-0.0075-0.0318 0.0159-0.0468 0.0234l-0.0702 0.0234c-0.13485 0.08235-0.16473 0.30512-0.37438 0.32758-0.06735-0.16473-0.0243-0.35098-0.0468-0.53818-0.38187-0.1797-1.257 0.09825-1.6614 0.2106h-0.0234c-0.05985 0.0225-0.1029 0.0393-0.1404 0.0468h-0.0234c-0.16473 0.0375-0.24802 0.01785-0.39778-0.117-0.0375-0.03-0.072-0.0645-0.117-0.117h-0.0234c-0.16473-0.1497-0.36876-0.42962-0.60837-0.44458z",
+                Matsu:"m47.89 49.587c-0.5391 0.81864-0.3307 2.5646-0.0312 3.463-0.75874 0.08984-1.3228 0.52164-1.8719 1.0607 0.87854 1.6672-0.22714 1.5961-0.68638 2.9638-0.56906 1.6672 0.4917 2.5258 1.5599 3.2446 0.40934 0.27954 0.76624 0.68512 1.1856 0.90476 1.0383 0.46922 0.98962 0.07608 1.7783-0.09354 0.7288-0.18968 0.60276-0.31948 1.5911-0.24958 0.62896 0.02994 1.2292 0.46298 2.028 0.34318 0.39934-0.75874 1.4738-2.1078 2.4022-2.028 0.51914 1.6772 2.6594-0.27828 3.3382-0.71756 1.4876-0.98836 2.26-1.5712 2.0904-3.5878-1.797 0.08986-3.4904-0.45424-5.3974-0.37438-1.1381 0.04992-1.7571-0.1273-2.2464 0.81116-0.1198 0.22962-0.1572 0.47672-0.1872 0.68636l-0.0312 0.28078c0 0.03994-0.0212 0.08486-0.0312 0.1248-0.01 0.08986-0.012 0.1797-0.0312 0.24958-0.01 0.03994-0.012 0.09484-0.0312 0.1248-0.03 0.0599-0.065 0.10608-0.1248 0.156-0.1798 0.12978-0.52538 0.19468-1.1543 0.1248-0.1398-1.6972-0.2683-4.0908-2.7142-3.6814 0.32944-0.609 0.76498-1.0795 1.4039-1.2791 0.1598-0.16972 0.40708-0.72506 0.46798-0.90476 0.1598-0.32946-2.9376-1.4726-3.307-1.6223zm23.56-17.784c-0.38328 0.04264-0.8218 0.14792-1.2479 0.24958-0.21306 0.05082-0.42916 0.11702-0.62396 0.156-0.1948 0.03894-0.37314 0.05302-0.53038 0.0624-0.34942 0.02-0.85984-0.07238-1.2791-0.0624h-0.0312c-0.1698 0-0.31698 2e-3 -0.43678 0.0624-0.70882 0.26956-0.46922 0.52664-0.99836 0.93596-0.34442 0.24958-0.7213 0.5831-1.1231 0.87356s-0.82864 0.53786-1.2479 0.59278c-1.228 0.13978-1.807-0.80616-2.7454 0.31198-1.0882 1.2679 0.1548 1.9006 0.37438 3.0886 0.1198 0.6689-0.0212 0.95716-0.2808 1.2167-0.0698 0.0599-0.1386 0.12728-0.21838 0.18718-0.31948 0.24958-0.74252 0.54536-1.092 1.1543-0.1398 0.25958-0.2421 0.56532-0.31198 0.90476-0.02 0.1198-0.0524 0.25458-0.0624 0.37438-0.0598 0.58902 8e-3 1.2068 0.1872 1.7159 0.1598 0.04992 0.1872-0.04492 0.1872 0.1248 0.20966-0.02996 0.52914 0.09234 0.74876 0.0624-0.1572 0.84736 0.41046 1.3996 1.1232 1.2167 0.1018-0.02616 0.2059-0.06738 0.31198-0.1248-0.0486-0.1872-0.091-0.41458-0.1248-0.65516-0.23696-1.6842-0.0236-4.4052 1.8719-4.4926-0.0224-0.5441 0.0872-0.94332 0.28078-1.2479 0.0968-0.1523 0.20398-0.30146 0.34318-0.40558 0.69598-0.5206 1.8782-0.47422 3.0574-0.37438-0.0798 0.49918 0.1884 0.94468 0.21838 1.4039 1.797-0.7887 2.9938-1.7147 5.2102-0.93596 0.1872 0.38936-0.093 2.9332 0.49918 3.5254 0.0494 0.04932 0.125 0.07348 0.1872 0.09354s0.1106 0.0138 0.1872 0c0.153-0.02786 0.34192-0.1198 0.56156-0.31198 0.0674-0.0587 0.1122-0.13966 0.156-0.2184 0.0438-0.07876 0.1006-0.1542 0.1248-0.2496 0.1936-0.76316-0.191-2.0002-0.1248-2.839 8e-3 -0.10486 8e-3 -0.22142 0.0312-0.31198 0.024-0.09056 0.0812-0.14556 0.1248-0.2184 0.0436-0.07288 0.089-0.13552 0.156-0.1872 0.20096-0.15502 0.5154-0.22214 0.99836-0.1248 0.0798-0.45924 0.0798-1.1107 0-1.5599-0.76874-0.04992-3.01 0.68512-2.8702-0.34318 0.1598-0.99836 1.6186-0.7238 1.2791-2.371-1.1381 0.24958-1.1656-0.99836-2.184-1.2479-0.1798-0.04742-0.43086-0.0596-0.68636-0.03114z"
+                };
+            var i = {};
+            for (var s in r) {
+                i = {};
+                if (this.options.stateSpecificStyles[s]) {
+                    e.extend(i, t, this.options.stateSpecificStyles[s])
+                } else {
+                    i = t
+                }
+                this.stateShapes[s] = n.path(r[s]).attr(i);
+                this.topShape = this.stateShapes[s];
+                this.stateHitAreas[s] = n.path(r[s]).attr({
+                    fill: "#000",
+                    "stroke-width": 0,
+                    opacity: 0,
+                    cursor: "pointer"
+                });
+                this.stateHitAreas[s].node.dataState = s
+            }
+            this._onClickProxy = e.proxy(this, "_onClick");
+            this._onMouseOverProxy = e.proxy(this, "_onMouseOver"),
+            this._onMouseOutProxy = e.proxy(this, "_onMouseOut");
+            for (var s in this.stateHitAreas) {
+                this.stateHitAreas[s].toFront();
+                e(this.stateHitAreas[s].node).bind("mouseout", this._onMouseOutProxy);
+                e(this.stateHitAreas[s].node).bind("click", this._onClickProxy);
+                e(this.stateHitAreas[s].node).bind("mouseover", this._onMouseOverProxy)
+            }
+        },
+        _initCreateLabels: function() {
+            var t = this.paper;
+            var n = [];
+            var r = 860;
+            var i = 220;
+            var s = this.options.labelWidth;
+            var o = this.options.labelHeight;
+            var u = this.options.labelGap;
+            var a = this.options.labelRadius;
+            var f = s / this.scale;
+            var l = o / this.scale;
+            var c = (s + u) / this.scale;
+            var h = (o + u) / this.scale * .5;
+            var p = a / this.scale;
+            var d = this.options.labelBackingStyles;
+            var v = this.options.labelTextStyles;
+            var m = {};
+            for (var g = 0, y, b, w; g < n.length; ++g) {
+                w = n[g];
+                y = (g + 1) % 2 * c + r;
+                b = g * h + i;
+                m = {};
+                if (this.options.stateSpecificLabelBackingStyles[w]) {
+                    e.extend(m, d, this.options.stateSpecificLabelBackingStyles[w])
+                } else {
+                    m = d
+                }
+                this.labelShapes[w] = t.rect(y, b, f, l, p).attr(m);
+                m = {};
+                if (this.options.stateSpecificLabelTextStyles[w]) {
+                    e.extend(m, v, this.options.stateSpecificLabelTextStyles[w])
+                } else {
+                    e.extend(m, v)
+                }
+                if (m["font-size"]) {
+                    m["font-size"] = parseInt(m["font-size"]) / this.scale + "px"
+                }
+                this.labelTexts[w] = t.text(y + f / 2, b + l / 2, w).attr(m);
+                this.labelHitAreas[w] = t.rect(y, b, f, l, p).attr({
+                    fill: "#000",
+                    "stroke-width": 0,
+                    opacity: 0,
+                    cursor: "pointer"
+                });
+                this.labelHitAreas[w].node.dataState = w
+            }
+            for (var w in this.labelHitAreas) {
+                this.labelHitAreas[w].toFront();
+                e(this.labelHitAreas[w].node).bind("mouseout", this._onMouseOutProxy);
+                e(this.labelHitAreas[w].node).bind("click", this._onClickProxy);
+                e(this.labelHitAreas[w].node).bind("mouseover", this._onMouseOverProxy)
+            }
+        },
+        _getStateFromEvent: function(e) {
+            var t = e.target && e.target.dataState || e.dataState;
+            return this._getState(t)
+        },
+        _getState: function(e) {
+            var t = this.stateShapes[e];
+            var n = this.stateHitAreas[e];
+            var r = this.labelShapes[e];
+            var i = this.labelTexts[e];
+            var s = this.labelHitAreas[e];
+            return {
+                shape: t,
+                hitArea: n,
+                name: e,
+                labelBacking: r,
+                labelText: i,
+                labelHitArea: s
+            }
+        },
+        _onMouseOut: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("mouseout", e, t)
+        },
+        _defaultMouseOutAction: function(t) {
+            var n = {};
+            if (this.options.stateSpecificStyles[t.name]) {
+                e.extend(n, this.options.stateStyles, this.options.stateSpecificStyles[t.name])
+            } else {
+                n = this.options.stateStyles
+            }
+            t.shape.animate(n, this.options.stateHoverAnimation);
+            if (t.labelBacking) {
+                var n = {};
+                if (this.options.stateSpecificLabelBackingStyles[t.name]) {
+                    e.extend(n, this.options.labelBackingStyles, this.options.stateSpecificLabelBackingStyles[t.name])
+                } else {
+                    n = this.options.labelBackingStyles
+                }
+                t.labelBacking.animate(n, this.options.stateHoverAnimation)
+            }
+        },
+        _onClick: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("click", e, t)
+        },
+        _onMouseOver: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("mouseover", e, t)
+        },
+        _defaultMouseOverAction: function(t) {
+            this.bringShapeToFront(t.shape);
+            this.paper.safari();
+            var n = {};
+            if (this.options.stateSpecificHoverStyles[t.name]) {
+                e.extend(n, this.options.stateHoverStyles, this.options.stateSpecificHoverStyles[t.name])
+            } else {
+                n = this.options.stateHoverStyles
+            }
+            t.shape.animate(n, this.options.stateHoverAnimation);
+            if (t.labelBacking) {
+                var n = {};
+                if (this.options.stateSpecificLabelBackingHoverStyles[t.name]) {
+                    e.extend(n, this.options.labelBackingHoverStyles, this.options.stateSpecificLabelBackingHoverStyles[t.name])
+                } else {
+                    n = this.options.labelBackingHoverStyles
+                }
+                t.labelBacking.animate(n, this.options.stateHoverAnimation)
+            }
+        },
+        _triggerEvent: function(t, n, r) {
+            var i = r.name;
+            var s = false;
+            var o = e.Event("usmap" + t + i);
+            o.originalEvent = n;
+            if (this.options[t + "State"][i]) {
+                s = this.options[t + "State"][i](o, r) === false
+            }
+            if (o.isPropagationStopped()) {
+                this.element.trigger(o, [r]);
+                s = s || o.isDefaultPrevented()
+            }
+            if (!o.isPropagationStopped()) {
+                var u = e.Event("usmap" + t);
+                u.originalEvent = n;
+                if (this.options[t]) {
+                    s = this.options[t](u, r) === false || s
+                }
+                if (!u.isPropagationStopped()) {
+                    this.element.trigger(u, [r]);
+                    s = s || u.isDefaultPrevented()
+                }
+            }
+            if (!s) {
+                switch (t) {
+                case "mouseover":
+                    this._defaultMouseOverAction(r);
+                    break;
+                case "mouseout":
+                    this._defaultMouseOutAction(r);
+                    break
+                }
+            }
+            return !s
+        },
+        trigger: function(e, t, n) {
+            t = t.replace("usmap", "");
+            e = e.toUpperCase();
+            var r = this._getState(e);
+            this._triggerEvent(t, n, r)
+        },
+        bringShapeToFront: function(e) {
+            if (this.topShape) {
+                e.insertAfter(this.topShape)
+            }
+            this.topShape = e
+        }
+    };
+    var c = [];
+    s(e, "usmap", l, c)
+})(jQuery, document, window, Raphael)
+
+
+
+endingPicker = (out, totv, aa, quickstats) => {
+    
+    //out = "win", "loss", or "tie" for your candidate
+    //totv = total votes in entire election
+    //aa = all final overall results data
+    //quickstat = relevant data on candidate performance (format: your candidate's electoral vote count, your candidate's popular vote share, your candidate's raw vote total)
+  
+    /*
+    e.header = "<h2></h2>"
+    e.pages = ["<p></p>",
+               "<p></p>"]
+    */
+  
+    // NORMAL ENDINGS
+  e.final_overall_results.sort((a, b) => b.popular_votes - a.popular_votes);
+  map = document.getElementById("map_container");
+          ///柯文哲结局，以自身得票率和胜利者分结局
+          if (aa[0].candidate === 2001557 && quickstats[1] > 20.0 && quickstats[1] < 25.0) {
+            used=false
+            if (used != true) {
+                        setInterval(function () {
+                            used = true;
+                            imgg = document.getElementsByClassName("person_image")[0];
+                            if (imgg != null) {
+                                imgg.src =  "https://i.ntdtv.com/assets/uploads/2024/01/id103843225-GettyImages-1929871502.jpg";
+                            }
+                        }, 100);
+                    }
+            return "<div style='overflow-y:scroll;height:250px;'><p>On November 24th, when KMT and TPP registered as presidential candidates, many observers and commentators believed that the DPP would secure its third term. However, the young supporters dedicated to you still believed that Ko Wen-je would become the next president, bringing new politics to Taiwan. On January 13th, when the election results were announced, they could hardly believe their eyes. Ko Wen-je, who had surpassed both Hou Yu-ih and Lai Ching-te in previous polls, only received less than 25% of the votes. The reality was harsh, and that night, these young individuals grew up, realizing that strength in their own world did not necessarily translate to strength in the broader political arena...</p><p>Of course, it was expected that TPP wouldn't win the presidency in this election. On the spot, you announced your intention to participate in the next presidential election in 2028, indicating that there's still a political future for you. Your party gained significant visibility in this election, along with government subsidies, where each vote translates to a subsidy of 30 NTD. TPP secured 8 legislator-at-large seats in the Legislative Yuan. Unfortunately, none of your regional legislative candidates won, but at least your influence in the parliament has expanded, which is a positive outcome.</p><p>In the future, you won't be the mayor anymore or the high-profile presidential candidate, but rather the party chairman. It will be crucial for your party to consider how to increase exposure and secure more regional governing power in 2026. Best of luck to you, Chairman Ko Wen-je, in 2026 and 2028!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div> "  
+            
+              } 
+              if (aa[0].candidate === 2001557 && quickstats[1] > 25.0 && quickstats[1] < 30.0) {
+                used=false
+                if (used != true) {
+                            setInterval(function () {
+                                used = true;
+                                imgg = document.getElementsByClassName("person_image")[0];
+                                if (imgg != null) {
+                                    imgg.src =  "https://image.cache.storm.mg/styles/smg-800x533-fp-wm/s3/media/image/2023/12/09/20231209-052001_U29087_M914746_2cdf.jpeg?itok=QD-9_lDY";
+                                }
+                            }, 100);
+                        }
+                return "<div style='overflow-y:scroll;height:250px;'>  <h3>TPP Shakes the Foundation of Two-Party System: Lai Ching-te's Victory, Ko Wen-je Stirs the Nation</h3> <p>On November 24th, when both the KMT and TPP registered as presidential candidates, many observers and commentators believed that the DPP would secure a third term. As the final stage of the election passed, the steadfast support of the youth who remained loyal to you persisted, with the belief that Ko Wen-je would become the next president, bringing a new era of politics to Taiwan. On January 13th, when the election results were revealed, they were astonished that a party established only a few years ago could garner support from over a quarter of Taiwan's voters. Although you faced defeat, such an achievement was enough to shake the two-party system and strengthen your support. Despite Lai Ching-te's victory, the youth realized that following you was a decision they didn't regret. On that night, they understood that they had bravely stood by you, striving for the hope of overturning the monopoly of the two-party system in Taiwan.</p><p>Even though winning the presidency for TPP was expected to be challenging, given your already high popularity, you announced on the spot that you would participate in the next presidential election in 2028. This implies that you still have a role to play, and your party gained significant visibility and government subsidies in this election, with each vote equivalent to a subsidy of 30 NTD. In the Legislative Yuan, you secured 8 at-large legislators, though unfortunately, none were elected in specific constituencies. Nevertheless, your influence in the parliament has expanded, which is a positive development.</p><p>Looking ahead, without the position of mayor or the spotlight of a presidential candidate, you are now just a party chairman. Figuring out how to increase exposure and help the TPP gain more local governance in 2026 is a crucial consideration for your party. Best of luck to you, Chairman Ko, in 2026 and 2028!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div>"   
+                  } 
+                  if (aa[0].candidate === 2001557 && quickstats[1] > 30.0) {
+                    used=false
+                    if (used != true) {
+                                setInterval(function () {
+                                    used = true;
+                                    imgg = document.getElementsByClassName("person_image")[0];
+                                    if (imgg != null) {
+                                        imgg.src =  "https://d1b8dyiuti31bx.cloudfront.net/NewsPhotos/20240113/105_134341361554.jpg";
+                                    }
+                                }, 100);
+                            }
+                    return "<div style='overflow-y:scroll;height:250px;'><h3>Ko Wen-je Gains 30% Voter Trust: A New Major Party Rising</h3> <p>On November 24th, when both the KMT and TPP registered as presidential candidates, many observers and commentators believed that the DPP would secure a third term. As the final stage of the election passed, the steadfast support of the youth who remained loyal to you persisted, with the belief that Ko Wen-je would become the next president, bringing a new era of politics to Taiwan. On January 13th, when the election results were revealed, they and you were not disappointed. Ko Wen-je's TPP, established only a few years ago, gained over 30% of the votes. If it had been a bit higher, you might have even won the presidential position. Unfortunately, the KMT and DPP's electoral base was too strong, and you fell short. Despite the defeat, such an achievement was enough to shake the two-party system and strengthen your support. Although Lai Ching-te still emerged victorious, the youth realized that following you that night was a decision they didn't regret. They braved it with you once, striving for the hope of overturning the monopoly of the two-party system in Taiwan. The Taiwan People's Party is likely to become another major political party in Taiwan, forming a stable tripartite competition with the DPP and KMT.</p> <p>Even though winning the presidency for TPP was expected to be challenging, given your already high popularity, you announced on the spot that you would participate in the next presidential election in 2028. This implies that you still have a role to play. The young audience below passionately chanted for another chance. Your party gained significant visibility and government subsidies in this election, with each vote equivalent to a subsidy of 30 NTD. In the Legislative Yuan, you secured 8 at-large legislators. Unfortunately, none were elected in specific constituencies. Nevertheless, your influence in the parliament has expanded, which is a positive development.</p> <p>Looking ahead, without the position of mayor or the spotlight of a presidential candidate, you are now just a party chairman. Figuring out how to increase exposure and help the TPP gain more local governance in 2026 is a crucial consideration for your party. Best of luck to you, Chairman Ko, in 2026 and 2028!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div>"  
+                      } 
+                      if (aa[0].candidate === 2001557 && quickstats[1] < 20.0) {
+                        used=false
+                        if (used != true) {
+                                    setInterval(function () {
+                                        used = true;
+                                        imgg = document.getElementsByClassName("person_image")[0];
+                                        if (imgg != null) {
+                                            imgg.src =  "https://static.rti.org.tw/assets/thumbnails/2024/01/07/031ee53a27a76779d79707bf5c48ca56.jpg";
+                                        }
+                                    }, 100);
+                                }
+                        return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Enters Third Term, TPP Becomes a Historical Footnote</h3> <p>On November 24th, when both the KMT and TPP registered as presidential candidates, many observers and commentators believed that the DPP would secure a third term. As the final stage of the election passed, the steadfast support of the youth who remained loyal to you persisted, with the belief that Ko Wen-je would become the next president, bringing a new era of politics to Taiwan. On January 13th, when the election results were revealed, the youth couldn't believe their eyes; you received a vote percentage even below 20%. What happened? With such a low vote percentage, the survival of TPP to the next election is uncertain, as your supporters might dwindle. Lai Ching-te secured the presidency, but your low vote percentage indicates that TPP might not have sustained viability. Your vote percentage wasn't much better than James Soong's in 2016. Winning the presidency is still a distant dream. The eyes of the youth were filled with tears that night; they grew up, matured, becoming adults in the political world. They realized how cruel reality could be, not just in their own strong world, but also outside...</p><p>Although your vote percentage wasn't high, no one expected a victory in this election. On the spot, you announced your participation in the next 2028 presidential election, signaling that there's still a role for you to play. Your party gained significant visibility and government subsidies in this election, with each vote equivalent to a subsidy of 30 NTD. In the Legislative Yuan, you secured 7 at-large legislators. Unfortunately, none were elected in specific constituencies. Nevertheless, your influence in the parliament has expanded, which is a positive development.</p><p>Looking ahead, without the position of mayor or the spotlight of a presidential candidate, you are now just a party chairman. Figuring out how to increase exposure and help the TPP gain more local governance in 2026 is a crucial consideration for your party. Best of luck to you, Chairman Ko, in 2026 and 2028!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div>"  
+                          } 
+                      if (aa[0].candidate === 2001591 && quickstats[1] > 20.0 && quickstats[1] < 25.0) {
+                        used=false
+                        if (used != true) {
+                                    setInterval(function () {
+                                        used = true;
+                                        imgg = document.getElementsByClassName("person_image")[0];
+                                        if (imgg != null) {
+                                            imgg.src =  "https://i.epochtimes.com/assets/uploads/2023/12/id14132681-652212-600x400.jpg";
+                                        }
+                                    }, 100);
+                                }
+                        return "<div style='overflow-y:scroll;height:250px;'> <h3>Party Alternation Again, DPP Fades: KMT Secures Victory in 2024!</h3> <p>On November 24th, when both the KMT and TPP registered as presidential candidates, many observers and commentators believed that the DPP would secure a third term. As the final stage of the election passed, the steadfast support of the youth who remained loyal to you persisted, with the belief that Ko Wen-je would become the next president, bringing a new era of politics to Taiwan. On January 13th, when the election results were revealed, the unexpected happened: Hou You-yi and the KMT surpassed both you and Lai Ching-te. What happened on November 23rd must have affected the current outcome, leading to your vote percentage being below 25%. Winning the presidency remains a distant dream. The KMT, once disdained by you, reclaimed the presidential position. The 8-year curse continues, and the eyes of the youth who supported you were filled with tears that night. They grew up and matured, becoming adults in the political world. They realized how cruel reality could be, not just in their own strong world, but also outside...</p> <p>Although your vote percentage wasn't very high, no one expected a victory in this election. At least it shook the future of the two-party system and the KMT government. On the spot, you announced your participation in the next 2028 presidential election, signaling that there's still a role for you to play. Your party gained significant visibility and government subsidies in this election, with each vote equivalent to a subsidy of 30 NTD. In the Legislative Yuan, you secured 8 at-large legislators. Unfortunately, none were elected in specific constituencies. Nevertheless, your influence in the parliament has expanded, which is a positive development.</p><p>Looking ahead, without the position of mayor or the spotlight of a presidential candidate, you are now just a party chairman. Figuring out how to increase exposure and help the TPP gain more local governance in 2026 is a crucial consideration for your party. Best of luck to you, Chairman Ko, in 2026 and 2028!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div>"  
+                        
+                          } 
+                          if (aa[0].candidate === 2001591 && quickstats[1] > 25.0 && quickstats[1] < 30.0) {
+                            used=false
+                            if (used != true) {
+                                        setInterval(function () {
+                                            used = true;
+                                            imgg = document.getElementsByClassName("person_image")[0];
+                                            if (imgg != null) {
+                                                imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/800/20240113/2000x1333_wmky_321863552021_0.jpg";
+                                            }
+                                        }, 100);
+                                    }
+                            return "<div style='overflow-y:scroll;height:250px;'><h3>Kuomintang Triumphs Over DPP: TPP Emerges as the New Force of the Third Party</h3> <p>On November 24, when both the KMT and TPP registered as presidential candidates, many observers and commentators predicted that the DPP would secure its third term. As the final stages of the campaign unfolded, the steadfast young supporters still believed that Ko Wen-je would become the next president, bringing a new era to Taiwan. However, on January 13, when the election results were revealed, the KMT, led by Hou You-yi, surpassed both you and Lai Ching-te. This surprising turn of events could be attributed to your performance on November 23. Although your vote share exceeded 25%, it was far from winning the presidency. Nevertheless, this marks the strongest performance of a third party since James Soong in 2000.</p> <p>Unfortunately, the once-dismissed KMT and Hou You-yi reclaimed the presidential position, leveraging their strong support base. The curse of eight years persisted, and the eyes of the young supporters who backed you were filled with tears. On that night, they matured, growing into adults in the political world. They realized that reality is cruel, and strength in their own bubble doesn't necessarily translate to strength in the wider world.</p><p>Your vote share, while impressive for a third party, was not enough to secure the presidency. Nonetheless, your participation in this election has shaken the future of the two-party system and the KMT government. You promptly announced your intention to participate in the next presidential election in 2028, indicating that you still have a role to play. Your party gained significant visibility and received government subsidies in this election, with each vote equivalent to a subsidy of 30 New Taiwan Dollars. You also secured eight at-large legislative seats, although none were won in regional constituencies. Nevertheless, your influence in the parliament has expanded, which is a positive development.</p><p>In the future, you may no longer be the mayor or the highly anticipated presidential candidate, but rather the party chairman. How to increase exposure and ensure that TPP gains more local governance in 2026 is a matter your party needs to carefully consider. Best of luck to you in 2026 and 2028, Chairman Ko Wen-je!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div>"  
+                              } 
+                              if (aa[0].candidate === 2001591 && quickstats[1] > 30.0) {
+                                used=false
+                                if (used != true) {
+                                            setInterval(function () {
+                                                used = true;
+                                                imgg = document.getElementsByClassName("person_image")[0];
+                                                if (imgg != null) {
+                                                    imgg.src =  "https://image1.thenewslens.com/2024/1/wx33finxgrblpxqsfigaxro95slkwi.jpeg?fm=jpg&format=crop&h=630&q=70&w=1200";
+                                                }
+                                            }, 100);
+                                        }
+                                return " <div style='overflow-y:scroll;height:250px;'><h3>Rise of the TPP: DPP Faces Complete Failure, KMT Secures Presidency</h3><p>On November 24, when both the KMT and TPP registered as presidential candidates, many observers and commentators predicted that the DPP would secure its third term. As the final stages of the campaign unfolded, the steadfast young supporters still believed that Ko Wen-je would become the next president, bringing a new era to Taiwan. However, on January 13, when the election results were revealed, the KMT, led by Hou You-yi, surpassed both you and Lai Ching-te. This surprising turn of events could be attributed to your performance on November 23. While it had some impact, your vote share reached nearly 30%. Although it was not enough to win the presidency, it made your young supporters extremely proud.</p> <p>This marks the most powerful performance of a third party since James Soong in 2000. Unfortunately, the once-dismissed KMT and Hou You-yi reclaimed the presidential position, leveraging their strong support base. The curse of eight years persisted, and on that night, the young people who supported you realized that following you was not a decision they regretted. They wholeheartedly joined you in the hope of overturning the duopoly of the two-party system in Taiwan. The Taiwan People's Party (TPP) is likely to become another major political party in Taiwan, creating a stable triangular competition with the DPP and KMT.</p> <p>Your vote share is exceptional for a third party, and if you can maintain this level of support and base in the next four years, winning the presidency is entirely possible. This has shaken Taiwan's two-party system, the current DPP government, and the future KMT government. You promptly announced your intention to participate in the next presidential election in 2028, indicating that you still have a role to play. The young people in the audience demanded you to give it another shot. Your party gained significant visibility and received government subsidies in this election, with each vote equivalent to a subsidy of 30 New Taiwan Dollars. You also secured eight at-large legislative seats, although none were won in regional constituencies. Nevertheless, your influence in the parliament has expanded, which is a positive development.</p><p>In the future, you may no longer be the mayor or the highly anticipated presidential candidate but rather the party chairman. How to increase exposure and ensure that TPP gains more local governance in 2026 is a matter your party needs to carefully consider. Best of luck to you in 2026 and 2028, Chairman Ko Wen-je!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div>"  
+                                  } 
+                                  if (aa[0].candidate === 2001591 && quickstats[1] < 20.0) {
+                                    used=false
+                                    if (used != true) {
+                                                setInterval(function () {
+                                                    used = true;
+                                                    imgg = document.getElementsByClassName("person_image")[0];
+                                                    if (imgg != null) {
+                                                        imgg.src =  "https://media.zenfs.com/ko/news_tvbs_com_tw_938/b1d97931cbbe610f15b2cd031f8176da";
+                                                    }
+                                                }, 100);
+                                            }
+                                    return "<div style='overflow-y:scroll;height:250px;'><h3>KMT Completes Party Alternation, TPP Becomes a Historical Footnote</h3><p>On November 24, when the KMT and TPP registered as presidential candidates, many observers and commentators believed the DPP would secure its third term. As the final campaign stage passed, the steadfast young supporters still believed Ko Wen-je would become the next president and bring a new era to Taiwan. However, on January 13, when the voting results were revealed, the young people couldn't believe their eyes – you received a vote share of less than 20%. What happened? With such a low vote share, it's unlikely you'll survive until the next election, and your supporters might vanish. Hou You-yi won the presidency, but your low vote share may hinder TPP's sustained viability, barely surpassing James Soong's performance in 2016. It's a long way from winning the presidency. Tears filled the eyes of the young people that night; they grew up, realizing the harsh reality that strength in their own world doesn't necessarily translate to strength outside...</p><p>Although your vote share isn't high, no one expected you to win in this election. You immediately announced your participation in the next presidential election in 2028, indicating there's still a role for you to play. Your party gained significant visibility and government subsidies in this election – each vote equivalent to 30 New Taiwan Dollars in subsidies. You secured 7 at-large legislative seats, unfortunately none in regional constituencies. However, your influence in the parliament has expanded, which is a positive development.</p><p>In the future, you may no longer be the mayor or the highly anticipated presidential candidate but rather the party chairman. How to increase exposure and ensure that TPP gains more local governance in 2026 is a matter your party needs to carefully consider. Best of luck to you in 2026 and 2028, Chairman Ko Wen-je!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div>"  
+                                      } 
+                                  //白莲教结局
+                                  if (aa[0].candidate === 2001622 && quickstats[1] < 35.0){
+                                    used=false
+                                    if (used != true) {
+                                                setInterval(function () {
+                                                    used = true;
+                                                    imgg = document.getElementsByClassName("person_image")[0];
+                                                    if (imgg != null) {
+                                                        imgg.src =  "https://image.cache.storm.mg/styles/smg-800x533-fp/s3/media/image/2023/12/30/20231230-105730_U28894_M921121_1023.jpg?itok=vd3ZzsLd";
+                                                    }
+                                                }, 100);
+                                            }
+                                    return "<div style='overflow-y:scroll;height:250px;'><h3>Miracles Are Always Possible: Ko Wen-je Breaks Taiwan's Two-Party System, Wins Presidency</h3><p>On November 24, after you and the KMT introduced your respective vice-presidential candidates, everyone believed it was a sure thing for Lai Ching-te to become the next president. However, reality proved them all wrong. Despite Hou You-yi and Zhao Shao-kang boosting the KMT's prospects, the erosion of Lai Ching-te's support base and your party's excellent early campaign operations allowed you to maintain around 30% support in the final month. On election day, it was almost unbelievable; Ko Wen-je and Lai Ching-te, Hou You-yi were neck-and-neck in the vote count. After two hours, Ko Wen-je established a stable lead, and the hearts of young people pounded with excitement. They knew they were witnessing a new history and a new politics in Taiwan. A five-year-old party defeated the two major parties, KMT and DPP, in the presidential election. In that moment, with tears in their eyes, they chose to believe in miracles, to believe in risking it all for once!</p><p>The victory of the TPP and Ko Wen-je in the presidential race marks a new era in Taiwanese politics. On May 20, you will form a new government, securing 10 at-large legislative seats in the Legislative Yuan, and even winning one regional seat in the first electoral district of Taichung. Unfortunately, other regional candidates did not succeed due to their limited local foundations. Nevertheless, your influence in the parliament has expanded, which is a positive development. However, Taiwan has never seen such a small majority in the presidency. You will need to collaborate with both blue and green camps to pass any legislation, signifying that your governance will be constrained. Nonetheless, it also provides an opportunity to realize your vision of a coalition government and a united cabinet!</p><p>Looking ahead, what image will you shape for Taiwan? How should relations progress among China, the United States, and Taiwan? Economic, domestic, and energy policies, defense, and diplomacy are all challenges that the young TPP must confront. Winning the election is only the first step; governing the country is a more difficult task. How to secure more regional governance for the TPP in 2026 is something you and your party need to carefully consider. If you succeed, you might attempt re-election in 2028. Wishing you the best of luck in 2026 and 2028, President Ko Wen-je!</p></div>"  
+                                      } 
+                                      if (aa[0].candidate === 2001622 && quickstats[1] > 35.0  && quickstats[1] < 41.0){
+                                        used=false
+                                        if (used != true) {
+                                                    setInterval(function () {
+                                                        used = true;
+                                                        imgg = document.getElementsByClassName("person_image")[0];
+                                                        if (imgg != null) {
+                                                            imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/800/20240114/1200x798_wmky_641658631642_202401120168000000.jpg";
+                                                        }
+                                                    }, 100);
+                                                }
+                                        return "<div style='overflow-y:scroll;height:250px;'><h3>TPP Overpowers the Bipartisan System: Ko Wen-je Secures Presidency with Over 35% of Votes</h3> <p>On November 24, after both you and the KMT introduced vice-presidential candidates, everyone believed it was a done deal for Lai Ching-te to become the next president. However, reality proved them wrong. Despite the efforts of Hou You-yi and Zhao Shao-kang to boost the blue camp's prospects, the erosion of Lai Ching-te's support base, your party's excellent early campaign operations, and nearly flawless performances in debates allowed you to maintain a support rate of around 35% in the last month. On election day, the results were almost unbelievable—Ko Wen-je consistently held a fragile but stable lead, always ranking first. The hearts of the younger generation pounded as they witnessed the new history and politics of Taiwan. A new party, only five years old, defeated the KMT and DPP in the presidential election. In this moment, tears welled up, yet they chose to believe in miracles, believing in going all out with no regrets!</p><p>The TPP and Ko Wen-je securing the presidency mark a new era in Taiwanese politics. On May 20, you will form a new government, having gained 13 at-large legislators in the Legislative Yuan, already on par with the blue and green parties. Additionally, you obtained one regional legislator, representing Taichung's first electoral district. Unfortunately, other regional candidates were not successful due to their limited local bases. Nevertheless, your influence in the parliament has expanded, which is a positive development. However, Taiwan has never seen such a minority president. To pass any bills, you must cooperate with both the blue and green camps, meaning your governance will face constraints. Yet, you can still realize your vision of a coalition government and a joint cabinet!</p> <p>Looking ahead, what image will you shape for Taiwan? How should the relationships between China, the United States, and Taiwan evolve? Economic, domestic, and energy policies, defense, and diplomacy are challenges the young TPP must confront. Winning the election is only the first step; governing the country is the more difficult task. How to ensure TPP gains more local governance power in 2026 is something you and your party need to carefully consider. Your current approval rating is sufficient for a re-election attempt in 2028, but it will depend on your ongoing support and the situation with the blue and green parties. Best of luck in 2026 and 2028, President Ko Wen-je!</p></div>"  
+                                          } 
+                                          if (aa[0].candidate === 2001622 && quickstats[1] > 41.0 ) {
+                                            used=false
+                                            if (used != true) {
+                                                        setInterval(function () {
+                                                            used = true;
+                                                            imgg = document.getElementsByClassName("person_image")[0];
+                                                            if (imgg != null) {
+                                                                imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/800/20231223/1200x968_wmky_132224609412_202312230197000000.jpg";
+                                                            }
+                                                        }, 100);
+                                                    }
+                                            return "<div style='overflow-y:scroll;height:250px;'><h3>Green-White Showdown: Lai Ching-te Upended, Ko Wen-je Triumphs as President!</h3><p>When the Blue-White Joint Ticket was formed, Lai Ching-te had to wake up from his dream and seriously face your campaign. However, with the erosion of Lai Ching-te's support base, your party's excellent early operations, nearly flawless performances in debates, and the full cooperation of the KMT, you maintained over 50% support in the last month. On election day, it was almost unbelievable—Ko Wen-je consistently held a fragile but stable lead, always ranking first. The hearts of the younger generation pounded as they witnessed the new history and politics of Taiwan. A new party, only five years old, defeated the corrupt and incompetent ruling party, the DPP, which had been in power for eight years. In this moment, tears welled up, yet they chose to believe in miracles, believing in going all out with no regrets!</p><p>The TPP and Ko Wen-je securing the presidency mark a new era in Taiwanese politics. On May 20, you will form a new government, having gained 13 at-large legislators in the Legislative Yuan, already on par with the blue and green parties. Additionally, you obtained one regional legislator, representing Taichung's first electoral district. Unfortunately, other regional candidates were not successful due to their limited local bases. Nevertheless, your influence in the parliament has expanded, which is a positive development. However, Taiwan has never seen such a minority president. To pass any bills, you must cooperate with both the blue and green camps, meaning your governance will face constraints. Yet, you can still realize your vision of a coalition government and a joint cabinet!</p><p>Looking ahead, what image will you shape for Taiwan? How should the relationships between China, the United States, and Taiwan evolve? Economic, domestic, and energy policies, defense, and diplomacy are challenges the young TPP must confront. Winning the election is only the first step; governing the country is the more difficult task. How to ensure TPP gains more local governance power in 2026 is something you and your party need to carefully consider. Your current approval rating is sufficient for a re-election attempt in 2028, but it will depend on your ongoing support and the situation with the blue and green parties. Best of luck in 2026 and 2028, President Ko Wen-je!</p></div>"  
+                                              } 
+                                              if (aa[1].candidate === 2001622 && quickstats[1] > 41.0 ) {
+                                                used=false
+                                                if (used != true) {
+                                                            setInterval(function () {
+                                                                used = true;
+                                                                imgg = document.getElementsByClassName("person_image")[0];
+                                                                if (imgg != null) {
+                                                                    imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/800/20240113/1152x768_wmky_0_C20240113000218.jpg";
+                                                                }
+                                                            }, 100);
+                                                        }
+                                                return "<div style='overflow-y:scroll;height:250px;'><h3>Bitter Defeat: Lai Ching-te and DPP Enter Third Term, Ko Wen-je Misses Presidency</h3><p>When the Blue-White Joint Ticket was formed, Lai Ching-te had to wake up from his dream and seriously face your campaign. However, your poor performance in the later stages of operations and debates negatively impacted your nationwide support, and by the end of the polling, you were trailing behind Lai Ching-te. On January 13, during the vote-counting program, the hearts of the younger generation pounded as they knew they were witnessing a new history and politics in Taiwan. Although Ko Wen-je and Lai Ching-te's rankings frequently exchanged places, a deathly silence shrouded your campaign headquarters a few hours later. Lai Ching-te still emerged victorious, leaving the young people in tears, wondering why things didn't turn out as they had hoped. You had to awkwardly deliver a concession speech, even though just a month ago, you were leading Lai Ching-te. Today proved that you were not the strongest.</p> <p>While the Joint Ticket didn't secure victory for you, it left 60% (perhaps less than 50%) of the people who hoped for a change in political parties disappointed. They questioned whether your capabilities were not as strong as you had previously claimed. However, you immediately announced your participation in the next presidential election in 2028, indicating that you still have a chance. Your party gained significant visibility in this election, along with government subsidies, where each vote is equivalent to a subsidy of NT$30. You also obtained 11 at-large legislators in the Legislative Yuan. Unfortunately, none of your regional legislators were successful, but your influence in the parliament has at least expanded, which is a positive development.</p><p>Looking ahead, with no mayoral position and not being the highly anticipated presidential candidate, but only the party chairman, how will you increase exposure and how the TPP can gain more local governance power in 2026 are crucial considerations for your party. Best of luck in 2026 and 2028, Chairman Ko Wen-je!</p></div>"  
+                                                  } 
+    }
+
+// in-game achievements
+
+setInterval(endingPicker, 250);
+
+//注释代码
+function getTooltips(str) {
+    let matches = [];
+
+    tooltipList.forEach((tooltip, index) => {
+        // Adjust the regex to match searchString potentially surrounded by “ and followed by optional punctuation
+       let regex = new RegExp(`(?<=\\b|\\s|^|“)${tooltip.searchString}(?=[.,;!?]?\\b|\\s|”|$)`, 'g');
+
+
+        let match;
+        while ((match = regex.exec(str)) !== null) {
+            matches.push({
+                start: match.index + (match[0].startsWith('“') ? 1 : 0), // Adjust for potential starting “
+                end: match.index + match[0].length - (match[0].endsWith('”') ? 1 : 0) - (match[2] ? 1 : 0), 
+                tooltipIndex: index
+            });
+        }
+    });
+
+    // Sort by starting position; if two start at the same position, longer match comes first
+    matches.sort((a, b) => a.start - b.start || b.end - b.start - (a.end - a.start));
+
+    // Filter out overlaps
+    for (let i = 0; i < matches.length - 1; ) {
+        if (matches[i + 1].start < matches[i].end) {
+            matches.splice(i + 1, 1); // Remove the next match since it overlaps
+        } else {
+            i++; // Move to next match
+        }
+    }
+
+    return matches;
+}
+function applyTooltips(str) {
+    const matches = getTooltips(str);
+    let result = '';
+    let lastIndex = 0;
+
+    matches.forEach(match => {
+        const tooltip = tooltipList[match.tooltipIndex];
+        result += str.slice(lastIndex, match.start);
+        result += `<span class='mytooltip'>${tooltip.searchString}<span class='mytooltiptext'>${tooltip.explanationText}</span></span>`;
+        lastIndex = match.end;
+    });
+
+    result += str.slice(lastIndex); // Add the remainder of the original string
+    return result;
+}
+
+function applyTooltipsToObject(obj) {
+    for (let key in obj) {
+        if (typeof obj[key] === 'string') {
+            obj[key] = applyTooltips(obj[key]);
+        } else if (typeof obj[key] === 'object') {
+            applyTooltipsToObject(obj[key]); // Recursive call
+        }
+    }
+}
+
+applyTooltipsToObject(campaignTrail_temp.questions_json);
+applyTooltipsToObject(campaignTrail_temp.answers_json);
+applyTooltipsToObject(campaignTrail_temp.answer_feedback_json);

--- a/static/mods/2024ROC_Ko-Wu.json
+++ b/static/mods/2024ROC_Ko-Wu.json
@@ -1,0 +1,10007 @@
+e=campaignTrail_temp // this is redundant, but Decstar uses this because it looks nicer in the code.and The final resul
+campaignTrail_temp.multiple_endings=true
+campaignTrail_temp.cyoa = true
+campaignTrail_temp.questions_json = [
+    {
+        "model": "campaign_trail.question",
+        "pk": 13004,
+        "fields": {
+            "priority": 0,
+            "description": "Happy New Year, Chairman Ko Wen-je! This year marks an election year, and it is destined to be a lengthy one. Currently, the most likely candidates for the 2024 election are DPP's Lai Ching-te and KMT's Hou You-yi. As a commemoration of your first presidential election campaign, what is your overall agenda for this election?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13005,
+        "fields": {
+            "priority": 0,
+            "description": "Unlike other candidates, you have been preparing for the 2024 presidential election very early, and the TPP is a party with limited political power and resources. However, your extraordinary charisma can compensate for this. In the early part of this year, what do you want to accomplish?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13006,
+        "fields": {
+            "priority": 0,
+            "description": "This April, you visited the United States, adding to your diplomatic experience. It contributes to your international image and builds trust among domestic voters. What is the most memorable thing during your trip?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13007,
+        "fields": {
+            "priority": 0,
+            "description": "May 17th, you were selected as the presidential candidate for the 2024 elections by the TPP Central Committee. On the same day, the KMT also chose Hou Youyi as their presidential candidate. In this thrilling moment, do you have anything you'd like to say?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13008,
+        "fields": {
+            "priority": 0,
+            "description": "Recently, there have been a series of scandals and incidents involving sexual harassment within the Democratic Progressive Party (DPP). This seems to be our best opportunity to criticize them. What statement should we make here?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13009,
+        "fields": {
+            "priority": 0,
+            "description": "As a small party, TPP faces challenges such as the lack of political celebrities, capital, and local presence. Another significant constraint is the empty wallet, as TPP is in dire need of campaign funds. To overcome this financial challenge, where do you plan to seek funding?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13010,
+        "fields": {
+            "priority": 0,
+            "description": "As our online followers continue to grow, it's time to translate the online momentum into offline support. Some grassroots internet celebrities who are close to us have obtained the right to organize a protest on Ketagalan Boulevard in front of the Presidential Office. It's time to turn the public's anger towards the DPP into a tangible movement. The event, named the \"716 Fair and Just Grand Parade,\" will serve as the starting point for our path to victory. Do you have any specific plans or actions you'd like to take for this event?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13011,
+        "fields": {
+            "priority": 0,
+            "description": "With Hou You-Yi's declining poll numbers due to the university speech and kindergarten incidents, we seem to be getting closer to Lai Ching-te. However, at the same time, Terry Gou appears to be restless, preparing for an independent run. He has yet to openly support Hou You-Yi, suggesting that his assistance may be merely verbal. what should we do to clarify our goals?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13012,
+        "fields": {
+            "priority": 0,
+            "description": "On August 28th, Terry Gou announced his independent candidacy for the presidency, dispelling rumors of a potential partnership with you as president and vice president. His insistence on running for the presidency was unacceptable to you and your supporters, as it would tarnish the new political image you've been cultivating. What is your assessment of Terry Gou's independent candidacy?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13013,
+        "fields": {
+            "priority": 0,
+            "description": "As the election enters its mid-stage, you need to emphasize specific policies to gain the trust of the people. TPP has many noteworthy policies. Which ones would you like to emphasize the most?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13014,
+        "fields": {
+            "priority": 0,
+            "description": "As a nationwide political party, the foundation of the TPP is still relatively weak. A lack of a strong presence in various regions could lead to lower vote counts. Therefore, it is essential for you to visit different areas to gain more support. In which regions do you plan to focus your efforts?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13015,
+        "fields": {
+            "priority": 0,
+            "description": "At this crucial moment in the election, with both Lai Ching-te and Hou You-yi making consecutive visits to the United States and Terry Gou steadily increasing his number of citizen signatures, Lai Ching-te still maintains a lead. At this juncture, what specific aspects do you intend to focus on to boost your popularity?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13016,
+        "fields": {
+            "priority": 0,
+            "description": "Entering October, there is significant discussion among opposition supporters about the possibility of a KMT-TPP joint ticket. Currently, Lai Ching-te still maintains a lead in the polls, leading many to believe that the only way to defeat the DPP is through a blue-white alliance. Polls indicate that such an alliance could effectively overcome Lai Ching-te's lead. What is your stance on this matter?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13017,
+        "fields": {
+            "priority": 0,
+            "description": "Chairman Ko, the KMT is boycotting this year's National Day celebration because they believe that the event's logo has lost the distinctive features and name of the Republic of China. They see it as another step by the DPP in diminishing the ROC's presence. As a response, they have decided to organize their own flag-raising ceremony and event. What are your thoughts on this matter?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13018,
+        "fields": {
+            "priority": 0,
+            "description": "In these Joint Tickets negotiations, opinion polls are a crucial issue. There is considerable controversy surrounding the polling methods, agencies, and approaches during the election season. Given the significance of determining the presidential and vice-presidential candidates, public opinion polls play a crucial role. Your supporters are not fond of the polls from Formosa and Ettoday as they consistently place you below Hou You-yi. What are your thoughts on this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13019,
+        "fields": {
+            "priority": 0,
+            "description": "While there's no agreement on joint presidential and vice-presidential tickets, we can find common ground in legislative and local elections. This year, TPP has local candidates running for legislative seats. Without KMT's support, they may struggle. What's your approach to cooperating with KMT at non-presidential levels?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13020,
+        "fields": {
+            "priority": 0,
+            "description": "Recent developments in Terry Gou's campaign have garnered attention. He has successfully surpassed the required number of citizen signatures, but still relies on substantial financial resources to boost signature numbers and drive his campaign momentum. However, his poll numbers have been steadily declining. What is your stance on his campaign?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13021,
+        "fields": {
+            "priority": 0,
+            "description": "As November approaches, it's time for your national campaign headquarters to make its debut. We still have the flexibility to choose the specific location. In which major city among the six municipalities would you prefer to establish your campaign headquarters?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13022,
+        "fields": {
+            "priority": 0,
+            "description": "On November 15th, you attended a secret meeting with Eric Chu, Ma Ying-jeou, and Hou You-yi, signing an agreement to determine the presidential candidate through nationwide polls. The terms, stating that if the Ko-Hou poll is within the margin of error, it would be considered a victory for Hou You-yi, have sparked widespread speculation that you might accept the role of vice president. In tonight's news program, when asked why you made this decision, you responded...",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13023,
+        "fields": {
+            "priority": 0,
+            "description": "On November 18th, after intensive calculations and investigations, the polling experts designated by TPP and KMT are in intense discussions regarding the polling outcomes and margin of error. The final results are:",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13024,
+        "fields": {
+            "priority": 0,
+            "description": "As you succeed and unbelievably surpass both the KMT and Mayor Hou Yu-yi, it is crucial to manage your relationship with the KMT. Meanwhile, many core supporters also have reservations about the KMT. In order to ensure the longevity of this alliance, what do you hope to say or do to eliminate internal divisions caused by the alliance?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13025,
+        "fields": {
+            "priority": 0,
+            "description": "As each party finalizes their running mates, the DPP has selected Hsiao Bi-khim as the vice president. This signifies that the current Green-White showdown has completely taken shape! How do you plan to balance your campaign strategy and policies in response to this development?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13492,
+        "fields": {
+            "priority": 0,
+            "description": "Mayor Hou You-yi proposes that, considering his limited authority and influence as vice president, he would like to actively campaign for you across Taiwan to strengthen the TPP-KMT alliance's presence and support in various regions. Where do you think he should focus his efforts?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13026,
+        "fields": {
+            "priority": 0,
+            "description": "Some of your aides suggest that, following the tradition of KMT candidates, you add a small Republic of China (ROC) flag emblem on top of your KP badge to increase appeal to blue-leaning voters. Will you consider this suggestion?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13027,
+        "fields": {
+            "priority": 0,
+            "description": "Chairman Ko, in a recent interview with a newspaper, you discussed various policy details. Certainly, the TPP has many comprehensive policy ideas and visions. Among these policies, what do you like the most and what would you like to emphasize the most?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13028,
+        "fields": {
+            "priority": 0,
+            "description": "As the presidential election enters its final stage, some of your former green supporters have become disappointed due to your cooperation with the Kuomintang (KMT) and have left your camp. At the same time, some elderly blue camp voters find it difficult to accept a candidate with a deep-green background and may choose not to vote. In light of this situation, how do you plan to respond?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13029,
+        "fields": {
+            "priority": 0,
+            "description": "Chairman Ko, the opportunity for an attack has arrived!As the presidential election enters its final stage, it has been discovered that Lai Ching-te's ancestral home is found to have violated building regulations. Although this issue has been known for quite some time, it has only recently been sensationalized. This could be our only opportunity to undermine Lai Ching-te before the election. Do you want to pursue this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13030,
+        "fields": {
+            "priority": 0,
+            "description": "It seems that the DPP has launched a counterattack against your campaign. It was revealed that agricultural land you own in Hsinchu City, designated for specific agricultural and husbandry purposes, has been exposed during the presidential election for not being used for farming but rather illegally converted into a parking lot. The DPP is using this to attack your personal integrity, similar to Lai Ching-te's building violation controversy. How do you plan to respond?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13031,
+        "fields": {
+            "priority": 0,
+            "description": "In this year's presidential election, you and Lai Ching-te will engage in a one-on-one debate on the stage, which could be the most crucial moment in your life. The outcome of the debate is likely to influence public perception and generate significant media coverage. What would you like to emphasize the most in this debate?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13032,
+        "fields": {
+            "priority": 0,
+            "description": "In the final week before the election, you have the opportunity to visit specific regions nationwide to boost local support. In which areas do you hope to campaign in a final effort?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13033,
+        "fields": {
+            "priority": 0,
+            "description": "On the night of November 18th, as the people of Taiwan slept, in a dark and windy evening, polling experts from the TPP and KMT were nervously discussing issues related to the margin of error in the polls and the number of victories for each party. and The final results are.....",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13350,
+        "fields": {
+            "priority": 0,
+            "description": "On November 18th, another shocking news rocked the political scene: the KMT and TPP were embroiled in disputes within the margin of error in the polls, leading to conflicting victory claims. The TPP insisted on a margin of error of 3%, with a range of plus or minus 1.5%, while the KMT argued that each poll should be calculated based on its own determined maximum margin of error. For example, Formosa Poll indicated a maximum sampling error of ±3.0% at a 95% confidence level, totaling 6%. Now, at this crucial moment deciding Taiwan's fate, how do you perceive the negotiations reaching a deadlock?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13509,
+        "fields": {
+            "priority": 0,
+            "description": "On November 23rd, you and Terry Gou invited Mayor Hou Yu-yi to the Taipei Grand Hyatt to discuss the last hope for Joint Tickets. However, Mayor Hou Yu-yi brought President Ma Ying-jeou and Chairman Eric Chu to the scene, causing dissatisfaction from Terry Gou. Chairman Ko Wen-je, what points do you need to emphasize during the meeting?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13510,
+        "fields": {
+            "priority": 0,
+            "description": "As Joints Tickets completely failed, on November 24th, you unexpectedly chose legislator Cynthia Wu as the vice president. She is the daughter of a major business tycoon, bringing an impressive background to your campaign. Additionally, being an American-born Chinese (ABC), what special qualities do you see in her that led to your choice of her as the vice president?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13511,
+        "fields": {
+            "priority": 0,
+            "description": "November 24th, after you registered as a presidential candidate at the CEC, Hou Youyi called you, but you ignored it. An hour later, he teamed up with Zhao Shaokang, the chairman of China Broadcasting Corporation, and other media figures to form the presidential and vice-presidential ticket. In the following days, many blue camp voters were emotionally stirred by this, and it seems that many blue voters who had temporarily supported you are returning to the KMT's base.....",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13512,
+        "fields": {
+            "priority": 0,
+            "description": "In this year's presidential election, there are three candidates on the stage: Hou from the KMT, you from the TPP, and Lai from the DPP. This will be your moment to showcase your debating skills in the presidential election. What do you want to emphasize during the debate?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13513,
+        "fields": {
+            "priority": 0,
+            "description": "Your vice president, Cynthia Wu, has many noteworthy qualities. Handing over the floor to her, what do you think she should say to attract voters?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13577,
+        "fields": {
+            "priority": 0,
+            "description": "This year's unprecedented presidential election features four candidates participating in a debate: yourself from the TPP, Hou from the KMT, Lai from the DPP, and the independent candidate Gou. Just a month ago, you suggested that Gou should withdraw from the election, but he did not consider this proposal and chose to run independently. In this debate, what main points would you like to emphasize?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13631,
+        "fields": {
+            "priority": 0,
+            "description": "In the final week before the election, you have the opportunity to visit specific regions nationwide to boost local support. In which areas do you hope to campaign in a final effort?",
+            "likelihood": 1
+        }
+    }
+]
+
+campaignTrail_temp.answers_json = [
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13034,
+        "fields": {
+            "question": 13004,
+            "description": "The Kuomintang (KMT) and the Democratic Progressive Party (DPP) are both mired in corruption. We must create a new chapter in Taiwan's political history. Please support the Taiwan People's Party (TPP) and let us write the records of Taiwan's history!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13035,
+        "fields": {
+            "question": 13004,
+            "description": "Nowadays, many young people cannot afford homes, the standard of living is declining, and prices and inflation are steadily rising. The DPP government has made their lives worse, but where is the accountability? The promises made in the past seem to have disappeared."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13036,
+        "fields": {
+            "question": 13004,
+            "description": "Ah, it's just that the two major parties have monopolized for too long, and the interest groups underneath have become deeply intertwined. The DPP has been in power for 8 years, and the rate of decay is even faster than the KMT. Taiwan cannot continue like this."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13037,
+        "fields": {
+            "question": 13004,
+            "description": "I guess that's how it is. Since the KMT doesn't have the ability to regain power and has given you two chances, but still can't defeat the DPP, what can be done? Only our TPP can do it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13047,
+        "fields": {
+            "question": 13005,
+            "description": "We plan to visit various regions of Taiwan to strengthen our visibility among voters. Many people in Taiwan have been dissatisfied with the political monopoly of the blue and green camps. We want to make them aware that there is a new choice this time!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13048,
+        "fields": {
+            "question": 13005,
+            "description": "We need to strengthen our online presence and ensure visibility on the internet. Let's focus on managing our YouTube channel effectively and create a buzz around supporting Ko Wen-je!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13049,
+        "fields": {
+            "question": 13005,
+            "description": "Strengthening our presence and offline organizations in major cities across the country is essential. Relying solely on online activities is virtual and misleading. Only by translating online supporters into real-life voters can we reap greater benefits."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13056,
+        "fields": {
+            "question": 13006,
+            "description": "Taiwan should act as a bridge for communication between the United States and China, rather than being a pawn. If I assume office, Taiwan can not only maintain a strong relationship with the United States but also work towards improving ties with China."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13057,
+        "fields": {
+            "question": 13006,
+            "description": "Do you know who I met? I met with Pompeo, Rosenberger, and Texas Governor Greg Abbott! This will bring me a lot of positive international coverage, letting Americans know that Taiwan's TPP is fighting for democracy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13058,
+        "fields": {
+            "question": 13006,
+            "description": "Of course, I held a banquet with Taiwanese students and young people in the United States to build connections. Every candidate comes to the U.S. for campaigning, so we must win the hearts and votes of young Taiwanese studying there."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13067,
+        "fields": {
+            "question": 13007,
+            "description": "My presence is aimed at breaking the blue-green barrier in Taiwan. Let's no longer be monopolized by the two major parties. Join me, Ko Wen-je, in moving towards a Taiwan characterized by integrity and clean new politics!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13068,
+        "fields": {
+            "question": 13007,
+            "description": "I have been collaborating and communicating with Hou You-yi. However, to be honest, his current poll numbers don't seem to be very promising, and it's uncertain what Guo Taiming's plans are for the future."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13076,
+        "fields": {
+            "question": 13006,
+            "description": "I visited major U.S. cities such as New York, San Francisco, Houston, etc., and connected with the local Taiwanese communities. I also had meetings with various congressmen and American political figures, undoubtedly enhancing my diplomatic experience."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13081,
+        "fields": {
+            "question": 13008,
+            "description": "Believe in the system, not individuals. When facing problems, think about how to address them within the system. The DPP should speed up their handling process. We have resolved similar issues quickly."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13083,
+        "fields": {
+            "question": 13008,
+            "description": "Our party has also had incidents of sexual harassment in the past, but we promptly addressed them. However, I do not support turning this issue into a political weapon!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13084,
+        "fields": {
+            "question": 13008,
+            "description": "The DPP claims every day that I harbor hatred towards women. Yet, their party is rife with sexual harassment cases. Do they really respect women? It's quite amusing. Before criticizing others, they should take a look at their own actions."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13097,
+        "fields": {
+            "question": 13009,
+            "description": "We will start selling some campaign-related merchandise, such as badges, flags, folders, and other accessories. This will provide us with a steady source of sales revenue."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13098,
+        "fields": {
+            "question": 13009,
+            "description": "I will ask my supporters for small donations, as little as 500 New Taiwan Dollars per person. The People's Party can make good use of these funds for an extended period because we are financially prudent and committed to preventing corruption."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13099,
+        "fields": {
+            "question": 13009,
+            "description": "Let's secretly reach out to some major corporations. We are the third party in Taiwan, but we have already surpassed the KMT in the polls. This is the best evidence that we might win. Let them know that we are a dark horse, and investing in us will be beneficial!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13100,
+        "fields": {
+            "question": 13009,
+            "description": "I have a great idea, let's organize a concert with Ko P singing personally. Set the ticket price at 8800 NTD, and this way, we can address a significant portion of our funding needs!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13113,
+        "fields": {
+            "question": 13010,
+            "description": "I heard that Lai Ching-te won't be coming here. It's truly laughable. If a governing party and its leader refuse to face the questions and challenges from the people, shouldn't they step down?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13114,
+        "fields": {
+            "question": 13010,
+            "description": "Arrange some people in the audience to boo when Hou You-yi speaks today. Let him know that young people don't appreciate the old-fashioned ways of the Kuomintang."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13115,
+        "fields": {
+            "question": 13010,
+            "description": "That's my place, and I will certainly give a speech. I'll strongly criticize the DPP and enhance my image. As long as I appear on stage, the enthusiasm among young people will soar."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13116,
+        "fields": {
+            "question": 13010,
+            "description": "Let's focus our attention on judicial reform and the pursuit of fairness and justice, avoiding turning it into a personal showcase. I don't want to be criticized for overly politicizing the parade."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13130,
+        "fields": {
+            "question": 13011,
+            "description": "We need to take over Lai Ching-te's light-green and moderate voters. The DPP government has been quite unpopular in recent years, as evident from the last local elections. My green background allows me to attract them."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13135,
+        "fields": {
+            "question": 13011,
+            "description": "I believe Chairman Guo has his own independence, but to secure victory, I must obtain his resources and supporters. This will ensure that I outperform Hou You-Yi and stand on equal footing with Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13136,
+        "fields": {
+            "question": 13011,
+            "description": "Of course, we choose to continue attracting Hou You-Yi's blue voters. Many deep-blue voters are dissatisfied with Hou You-Yi's relationship with Han Kuo-yu and even dislike his local Taiwanese image. Let me say something that resonates with deep-blue voters to draw them in."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13147,
+        "fields": {
+            "question": 13012,
+            "description": "Well, he insists on running for president? Haha, that makes Lai Ching-te even more secure, doesn't it? He's taking away votes from both me and Hou. Although everyone has the right to run in this society, we shouldn't be guaranteeing the DPP a third term, right?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13148,
+        "fields": {
+            "question": 13012,
+            "description": "I still have the highest and most powerful support in the current polls among the opposition candidates. We have a steady support base and continue to work hard. Let's focus on our own campaign strategy and not worry too much about Terry Gou for now."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13155,
+        "fields": {
+            "question": 13013,
+            "description": "TPP advocates for the establishment of an anti-media monopoly law to restore professionalism and independence to the media. It also calls for strict prohibition of political interference in public media. The fact is that the media has already been under the control of the blue and green camps, hasn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13156,
+        "fields": {
+            "question": 13013,
+            "description": "The alternation of parties should not result in a worse situation. This election is a showdown between corruption and integrity, old forces and new politics, and governing ability versus party interests. TPP is the strongest force transcending the blue and green camps!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13157,
+        "fields": {
+            "question": 13013,
+            "description": "I advocate for vigorously building social housing, reforming the tax system, and providing rent subsidies to tenants. The TPP has the ability and confidence to make housing affordable for young people, ensuring they can buy or rent a good place to live."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13158,
+        "fields": {
+            "question": 13013,
+            "description": "Lai Ching-te, do you dare to come out and declare that Taiwan will definitely be a non-nuclear homeland by 2025? Just saying this sentence guarantees you'll be criticized to death. Let's see if you dare to say it!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13170,
+        "fields": {
+            "question": 13014,
+            "description": "Certainly, I will focus on strengthening my presence in Taipei, where I served as mayor for eight years. Additionally, I will concentrate efforts in the neighboring New Taipei and Taoyuan. This region has a population of 5 million voters, and winning here is crucial for anyone aspiring to become president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13171,
+        "fields": {
+            "question": 13014,
+            "description": "I miss my mother. Let me go back to my hometown Hsinchu to take a look. We can also visit Miaoli. I believe I can gain many votes in this region, and there are also many young people here."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13172,
+        "fields": {
+            "question": 13014,
+            "description": "I think Tainan, Kaohsiung, Chiayi, and Pingtung are the most suitable places for me. I am also a local Taiwanese, so speaking Taiwanese is not a problem. Let's visit the southern region, which is the stronghold of the DPP, and see how we can gain support there!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13173,
+        "fields": {
+            "question": 13014,
+            "description": "The central region is an area where we need to strengthen our presence. Swing voters in places like Taichung, Changhua, Yunlin, and Nantou may find our platform appealing, so it's crucial for us to focus on strengthening our support in these areas."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13194,
+        "fields": {
+            "question": 13015,
+            "description": "Certainly, since they are visiting the United States, I will also make a trip there. I plan to make my second visit to the United States and participate in economic forums to increase my visibility."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13196,
+        "fields": {
+            "question": 13015,
+            "description": "let's engage with more senior citizens. I haven't been receiving much support from the elderly in the polls; the support rate among those aged 60-70 is almost zero. We can organize events at temples and market entrances, conducting on-site speeches to connect with them."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13197,
+        "fields": {
+            "question": 13015,
+            "description": "We should maximize our influence among the youth. I'll collaborate with online influencers and celebrities to add more vibrancy to my campaign."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13198,
+        "fields": {
+            "question": 13015,
+            "description": "Let's focus on the pan-blue voters dissatisfied with Hou and Terry Gou, as well as the swing voters. The DPP has performed poorly in recent years, and we should be able to welcome them into our camp, shouldn't we?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13213,
+        "fields": {
+            "question": 13016,
+            "description": "In fact, I don't want to form an alliance. It would damage my new political image, and I don't want any association with the KMT, okay? I intend to win the election on my own merits and strength!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13214,
+        "fields": {
+            "question": 13016,
+            "description": "Let's propose a demand to the KMT – let the victory or defeat be determined by the comprehensive results of various polls. Given our current advantage in the polls, this is advantageous for us and places the KMT in an embarrassing position."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13225,
+        "fields": {
+            "question": 13016,
+            "description": "Ah, Mayor Hou, with your low poll numbers, why don't you just withdraw from the election? Anyway, I'll give it to you, and you won't win!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13230,
+        "fields": {
+            "question": 13017,
+            "description": "Honestly, I don't want to associate with Lai Ching-te and Tsai Ing-wen. I won't attend this year's National Day celebration. How about organizing our own National Day event?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13231,
+        "fields": {
+            "question": 13017,
+            "description": "National Day should be a day of unity for the entire nation. However, the controversies surrounding Taiwan National Day have led many citizens to feel like outsiders in the national celebration. Taiwan is currently facing a severe crisis of identity, where right and wrong become blurred by political colors. When will such situations come to an end?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13232,
+        "fields": {
+            "question": 13017,
+            "description": "Alright, I'll go to the National Day celebration after all. After all, it's the country's birthday and commemoration day. However, I don't need to attack the KMT; they have their own autonomy."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13247,
+        "fields": {
+            "question": 13018,
+            "description": "We need to emphasize the stereotypical impression voters have. Young people are not fond of using landline phones anymore, yet Formosa's polls persist with 100% reliance on landline calls. When will they start adopting mobile survey methods? Landline polls are unreliable!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13248,
+        "fields": {
+            "question": 13018,
+            "description": "We respect these polls and the results they produce. However, some seem to be a bit outrageous, don't they? It's evident that I am the strongest opposition candidate, yet they place me below Hou You-yi. What's going on?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13249,
+        "fields": {
+            "question": 13018,
+            "description": "Hey, compared to those polls using both mobile and landline phones, street interviews with passersby are the most accurate and genuine, right? We record the entire process, asking voters for their most authentic opinions – much more accurate than any phone polls!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13262,
+        "fields": {
+            "question": 13019,
+            "description": "We can consider fielding candidates in deep-green constituencies where both KMT and TPP might lack sufficient strength. Areas like Luzhou, Sanchong in New Taipei City, and the coastal line of Taichung could be targeted for TPP candidates, enhancing our chances in opposition."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13263,
+        "fields": {
+            "question": 13019,
+            "description": "I hope KMT can support TPP in those challenging constituencies by endorsing our legislators and candidates. As it's widely known, their support can enhance our local campaign capabilities and visibility. Even if we don't secure a victory, it can help lay the groundwork for future endeavors."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13264,
+        "fields": {
+            "question": 13019,
+            "description": "I'd like to issue a warning to the KMT. I have the ability to divert pan-blue votes and potentially cause their legislators to lose. If each TPP candidate in every district takes away 5% of the KMT votes, how many KMT candidates would end up losing?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13277,
+        "fields": {
+            "question": 13020,
+            "description": "He has consistently insisted on becoming the president, pushing for me to step back as the vice president. This is, of course, impossible. The TPP is my party, right? I am the party chairman, while he doesn't even have party membership. In any case, I cannot be his deputy, as it would mean betrayal of my support base and political suicide."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13278,
+        "fields": {
+            "question": 13020,
+            "description": "Why bother about his campaign? Even if they present a decent vice presidential candidate, his polling numbers are barely reaching 10% in various polls. If he persists in continuing the election, there seems to be no hope, right? I think he will withdraw from the race."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13283,
+        "fields": {
+            "question": 13021,
+            "description": "Certainly, it will be in my home base, Taipei City. I've been the mayor here for so long, and being the capital, it holds significant importance."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13284,
+        "fields": {
+            "question": 13021,
+            "description": "I want to go to Taoyuan City, a place with many young people and emerging high-tech industries. I will be very popular here and let the people of Taoyuan know that Ko Wen-je has noticed them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13285,
+        "fields": {
+            "question": 13021,
+            "description": "I want to compete with Hou You-yi on his turf. Let's set up the campaign headquarters in New Taipei City, a battleground state. We aim to secure the most votes in this city with the largest population nationwide!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13286,
+        "fields": {
+            "question": 13021,
+            "description": "Let's go to Taichung, the famous swing state. This is a crucial city, and if we can't secure victories in the deep blue or deep green north and south, let's explore our opportunities in the central region!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13295,
+        "fields": {
+            "question": 13022,
+            "description": "I dislike the KMT, but I hate the DPP even more. It's as simple as that. I aim to bring down the DPP, complete Taiwan's democratic reform, and prevent one party from dominating indefinitely."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13296,
+        "fields": {
+            "question": 13022,
+            "description": "Let me tell you, under our supervision,KMT won't be as corrupt as before. Our primary role is oversight and checks and balances. In the future coalition government, we will monitor each other, preventing corruption from happening."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13298,
+        "fields": {
+            "question": 13022,
+            "description": "I often say that I make decisions in the last 30 seconds; it's a habit from my medical profession. Therefore, I won't make such decisions until the very last moment. I have thought about it extensively."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13302,
+        "fields": {
+            "question": 13023,
+            "description": "I have always claimed to be the strongest candidate in the opposition, and that's why I agreed to participate in this competition, isn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13303,
+        "fields": {
+            "question": 13023,
+            "description": "I have always claimed to be the strongest candidate in the opposition, and that's why I agreed to participate in this competition, isn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13304,
+        "fields": {
+            "question": 13023,
+            "description": "I have always claimed to be the strongest candidate in the opposition, and that's why I agreed to participate in this competition, isn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13305,
+        "fields": {
+            "question": 13023,
+            "description": "I have always claimed to be the strongest candidate in the opposition, and that's why I agreed to participate in this competition, isn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13322,
+        "fields": {
+            "question": 13033,
+            "description": "As long as Uncle Ko doesn't step back, we'll stand by him with unwavering support, okay? Let's not be disheartened, everyone."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13323,
+        "fields": {
+            "question": 13033,
+            "description": "As long as Uncle Ko doesn't step back, we'll stand by him with unwavering support, okay? Let's not be disheartened, everyone."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13324,
+        "fields": {
+            "question": 13033,
+            "description": "As long as Uncle Ko doesn't step back, we'll stand by him with unwavering support, okay? Let's not be disheartened, everyone."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13325,
+        "fields": {
+            "question": 13024,
+            "description": "I have long advocated that Taiwan should not be trapped in the quagmire of the blue-green political struggle. We need to unite the maximum and largest public opinion to jointly usher in a new era of politics and a coalition government, perhaps even under a cabinet system leadership. Currently, what we most need is to dismantle the dominance of a single party and the unchecked power of the DPP."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13326,
+        "fields": {
+            "question": 13024,
+            "description": "The DPP government has been deceiving the people, hasn't it? Tsai Ing-wen has not held a press conference for over 700 days and refuses to answer the people's questions. In Taiwan, being president seems more enjoyable than being an emperor. We didn't choose a president; we chose an emperor."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13327,
+        "fields": {
+            "question": 13024,
+            "description": "Hou You-yi is not a bad person, I believe he wouldn't engage in corruption. He just lacks a bit of personal charisma, that's all. Moreover, the position of vice president suits him well. He can help me gain more points on issues related to public safety and national security!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13341,
+        "fields": {
+            "question": 13033,
+            "description": "As long as Uncle Ko doesn't step back, we'll stand by him with unwavering support, okay? Let's not be disheartened, everyone."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13351,
+        "fields": {
+            "question": 13350,
+            "description": "KMT is quite amusing. Despite being a century-old party, they now need me to determine the margin of error. Let's make it clear: I've given you the opportunity to choose, and you still can't win!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13352,
+        "fields": {
+            "question": 13350,
+            "description": "Did you hear that? The Kuomintang wants me to concede a 6% margin in the polls. This could mean up to 800,000 votes. Mayor Hou, on January 13th, Lai Ching-te won't be conceding to you!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13353,
+        "fields": {
+            "question": 13350,
+            "description": "Well, it's probably best for us to go our own way and refrain from further negotiations. Due to the incessant disputes over the polls, we don't have the luxury of time for more disruptions. I've decided that I must independently run for election and defeat the DPP!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13361,
+        "fields": {
+            "question": 13022,
+            "description": "(On the show, I need to maintain the appearance that things are proceeding as usual. In reality, we only aim to run independently and secure a standalone victory. We don't need to be with the KMT!)"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13370,
+        "fields": {
+            "question": 13025,
+            "description": "To be honest, deep down, I am fundamentally pro-Green. However, the DPP has gone too far in recent years, causing even someone like me, who used to support the DPP, to leave. So, the DPP really needs to reflect on its actions!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13371,
+        "fields": {
+            "question": 13025,
+            "description": "I've made it clear that I will continue with Tsai Ing-wen's approach in diplomacy and national defense. Please note, that cross-strait relations are not included; there will be a shift from Tsai Ing-wen's approach in that regard."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13372,
+        "fields": {
+            "question": 13025,
+            "description": "We don't need to lean towards the Green camp; the DPP's base is around 40%, which we can't easily capture. Instead, let's focus on strengthening our core supporters, who may be somewhat disappointed due to my collaboration with the KMT. We'll launch an online TV channel called KPTV and encourage supporters to subscribe and watch!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13374,
+        "fields": {
+            "question": 13025,
+            "description": "I'll work on enhancing my appeal to the deep-blue and pro-unification voters. Many of them are dissatisfied with Hou You-yi but might support me. I'll make joint appearances with Chiu Yi in campaign events!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13388,
+        "fields": {
+            "question": 13026,
+            "description": "Of course, expressing love for our country is perfectly normal. I will continue to wear this small national flag emblem in future events."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13389,
+        "fields": {
+            "question": 13026,
+            "description": "No, I don't want that. I still want to maintain some distance from the KMT. I don't want to be perceived entirely as a KMT candidate, and I don't need to follow their trends. New politics belong to us, and there's no need to imitate the KMT."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13390,
+        "fields": {
+            "question": 13026,
+            "description": "Not only should we add the emblem, but let's also mobilize young people to hit the streets with flags for promotion. We'll prominently use national flags in our campaign rallies and events. Patriotism is nothing to be ashamed of!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13401,
+        "fields": {
+            "question": 13027,
+            "description": "I advocate maintaining an attitude of mutual understanding, mutual respect, cooperation, and mutual forgiveness in cross-strait relations. I am a candidate acceptable to both mainland China and the United States, rather than being overly pro-China or pro-America like the KMT and DPP."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13402,
+        "fields": {
+            "question": 13027,
+            "description": "Honestly, I opposed nuclear power ten years ago. Now I'm reconsidering due to the high electricity demand from our semiconductor industry. If there's no better solution, this less-than-ideal method may be the best choice for now. Extending the life of nuclear power plants is because renewable energy can't meet the demand."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13403,
+        "fields": {
+            "question": 13027,
+            "description": "I certainly support vigorously constructing social housing, changing the tax system, and altering tenant subsidies. I believe rental income should be taxed separately, so I think the policies of both the blue and green parties have issues! The problem lies in housing prices! It's pitiful not being able to afford a house, and it's even more pitiful after buying one. Becoming a homeowner for a lifetime means being a mortgage slave, constantly paying off the mortgage throughout one's life!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13414,
+        "fields": {
+            "question": 13028,
+            "description": "They can go wherever they want; we are now the largest force in Taiwan's mainstream public opinion. If someone is willing to give up the opportunity to overthrow the DPP government just because they won't vote, so be it! It will only purify my supporters even more!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13419,
+        "fields": {
+            "question": 13029,
+            "description": "Lai Ching-te, you truly are a candidate lacking integrity. I don't understand why so many people are still willing to support you. If you're unwilling to demolish an illegally constructed building, how can we expect you to bring any positive change to Taiwan?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13420,
+        "fields": {
+            "question": 13029,
+            "description": "Lai Ching-te's moral standards are really low. Many others have been involved in illegal constructions, and they've been demolished. My mother did it, Huang Kuo-chang did it, Su Jia-chyuan did it, Han Kuo-yu did it. Why are you the only one not willing to do so? Your attitude is arrogant, and this person is likely to become a dictator. Therefore, he is not suitable to be president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13421,
+        "fields": {
+            "question": 13029,
+            "description": "Lai Ching-te, can't you just demolish your own house? This issue will definitely be exploited, so it's better to bear the pain and take it down. Why shed tears? It's strange; I can't understand that."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13436,
+        "fields": {
+            "question": 13030,
+            "description": "Alright, alright, Lai Ching-te. You should hold yourself to the highest standards regarding your building violation. I will immediately arrange for an excavator to demolish my parking lot. Are you brave enough to take the same action for your building violation?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13437,
+        "fields": {
+            "question": 13030,
+            "description": "You're absolutely right, I made a mistake. I improperly used agricultural land, and I will immediately dismantle it. Moreover, I'll replant it with guava and bananas. That's the right way to handle it, isn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13438,
+        "fields": {
+            "question": 13030,
+            "description": "Alright, alright, not only will I dismantle the parking lot, but I'll also donate all the proceeds from this parking lot to charity. Is that satisfactory for you? Are you pleased now?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13449,
+        "fields": {
+            "question": 13031,
+            "description": "2024 election is a historic choice for the people of Taiwan. Do we want to choose a new political direction or stick with the old power structures? Are we opting for transparency, diligent governance, pragmatism, and a love for our homeland, or are we embracing ideology and governing through slogans?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13450,
+        "fields": {
+            "question": 13031,
+            "description": "Lai Ching-te and the DPP have once again demonstrated what deceit and smear tactics mean. They claim a fiscal surplus in their government, but in reality, it's because they treat loans as income and exclude special budget expenditures, creating a significant surplus. This is truly laughable – are they suggesting that these loans won't need to be repaid in the future?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13451,
+        "fields": {
+            "question": 13031,
+            "description": "Since 2000, Taiwan has witnessed a continuous change in political power, with the blue and green camps taking turns in office. Many believed that the DPP and the Tsai Ing-wen government would bring a humble administration. However, eight years have passed, and the issues left behind during the Ma Ying-jeou era remain unresolved. Moreover, the DPP government has been plagued by corruption. Is this an improvement?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13452,
+        "fields": {
+            "question": 13031,
+            "description": "Lai Ching-te, stop using double standards. When you want to utilize KMT county and city mayors, you praise them as local gentry and heroes. When you don't need them, you label them as members of black gold conglomerates. Let me tell you, your President Tsai Ing-wen has probably taken more photos with these county and city mayors than I have. What do you have to say about that?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13469,
+        "fields": {
+            "question": 13032,
+            "description": "We aim to strengthen our support in the traditional blue camp strongholds of the East Coast and outlying islands. While everyone is focused on the fierce battlegrounds in Taipei, Taichung, and the southern regions, where public opinion is unpredictable, let's secure stable support in Hualien, Taidong, Yilan, Penghu, Kinmen, and Matsu!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13470,
+        "fields": {
+            "question": 13032,
+            "description": "We need to strengthen our hold on Taipei City, where I served as mayor; I cannot afford to lose it. At the same time, we'll compete with Lai Ching-te in New Taipei!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13471,
+        "fields": {
+            "question": 13032,
+            "description": "Changhua, Taichung, and Nantou are the battlegrounds where we need to put in the most effort. Let's strive in these areas and secure a stable stronghold. Victory will be ours tomorrow!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13479,
+        "fields": {
+            "question": 13032,
+            "description": "Let's work hard to increase voter support in my hometown, Hsinchu. If there's one place where my support base is equivalent to both the blue and green camps nationwide, it's Hsinchu. I hope to achieve victory here!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13493,
+        "fields": {
+            "question": 13492,
+            "description": "Mayor Hou, spending a month in Chiayi is a great idea. I believe our support in Chiayi and Yunlin can increase significantly, especially considering that it's your hometown."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13494,
+        "fields": {
+            "question": 13492,
+            "description": "Kaohsiung and Tainan have a large population, so it makes sense to visit these two major cities. Your proficiency in Taiwanese will allow you to connect well with the locals!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13495,
+        "fields": {
+            "question": 13492,
+            "description": "Please help me increase support in your New Taipei City; you don't need to go anywhere else. New Taipei City is a crucial battleground, and we must win it!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13496,
+        "fields": {
+            "question": 13492,
+            "description": "Mayor Hou, please help me with some publicity in Pingtung and Yilan! These are areas with a significant number of Minnan people and strong support for the DPP. I entrust you to carry out the promotion in these regions!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13514,
+        "fields": {
+            "question": 13509,
+            "description": "Mayor Hou, I really didn't expect that you would bring two nannys with you for the election. What does this mean? Can't you make decisions on your own without Chairman Chu and President Ma?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13515,
+        "fields": {
+            "question": 13509,
+            "description": "As a leader, Mayor Hou should have the ability to face difficulties independently. The main purpose of the cooperation between the blue and white camps is to win the election. Do you insist that the Hou-Ko ticket is the strongest combination?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13516,
+        "fields": {
+            "question": 13509,
+            "description": "Chairman Guo, since you are unable to achieve integration now, why not simply withdraw from the election? Are you going to register tomorrow? We already have enough issues within the opposition camp."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13522,
+        "fields": {
+            "question": 13509,
+            "description": "Chairman Guo, since you are unable to achieve integration now, why not simply withdraw from the election? Are you going to register tomorrow? We already have enough issues within the opposition camp."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13533,
+        "fields": {
+            "question": 13510,
+            "description": "She possesses excellent manners and a very graceful image. She is also the candidate that our People's Party needs, capable of attracting more female voters for me. Together, we will have a perfect gender balance!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13534,
+        "fields": {
+            "question": 13510,
+            "description": "Of course, it's her international background and fluent English. She speaks English even better than native born Americans, which can be advantageous for TPP and Taiwan's participation in more international conferences, boosting our visibility. This is truly fantastic!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13535,
+        "fields": {
+            "question": 13510,
+            "description": "She is the daughter from the Shin Kong Financial Holding Co., Ltd., I know I can leverage her family connections to secure more campaign funds... which is currently scarce for us."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13548,
+        "fields": {
+            "question": 13511,
+            "description": "Oh, that old guy who ran for mayor in 1994? He's even older than me. Can he really mobilize so many blue camp voters? I find it hard to believe. Anyway, let's stabilize our own pace to secure an independent victory."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13550,
+        "fields": {
+            "question": 13511,
+            "description": "He chose to be the vice president. When is he going to resign from his position as chairman of the broadcasting company? It's embarrassing. Instead of focusing on media affairs, he's running to rescue Hou You-yi's campaign. No matter how you look at it, Zhao Shao-kang seems to be here to play the role of a nanny!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13558,
+        "fields": {
+            "question": 13512,
+            "description": "On the issue of the death penalty, I believe that since the time of Emperor Gaozu of Han, who established the Three Chapter Covenant with the people, the tradition in Chinese culture has been clear: those who commit murder shall face the penalty of death. If we are to abolish the death penalty, then we must introduce a system of life imprisonment, ensuring that criminals are not released after serving just a few years."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13559,
+        "fields": {
+            "question": 13512,
+            "description": "Since 2000, Taiwan has witnessed a continuous change in political power, with the blue and green camps taking turns in office. Many believed that the DPP and the Tsai Ing-wen government would bring a humble administration. However, eight years have passed, and the issues left behind during the Ma Ying-jeou era remain unresolved. Moreover, the DPP government has been plagued by corruption. Is this an improvement?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13560,
+        "fields": {
+            "question": 13512,
+            "description": "Lai Ching-te and the DPP have once again demonstrated what deceit and smear tactics mean. They claim a fiscal surplus in their government, but in reality, it's because they treat loans as income and exclude special budget expenditures, creating a significant surplus. This is truly laughable – are they suggesting that these loans won't need to be repaid in the future?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13561,
+        "fields": {
+            "question": 13512,
+            "description": "Mayor Hou, I would like to ask you, why is China conducting so many fake polls to boost your campaign? What is your relationship with China? What's going on?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13578,
+        "fields": {
+            "question": 13513,
+            "description": "Blackcurrant soda, beer, guava juice, and Johnny Walker are all common beverages at our Chinese banquets, especially Johnny Walker, representing the spirit of Taiwanese people looking forward and the determination that one must strive to win. Isn't that right?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13583,
+        "fields": {
+            "question": 13513,
+            "description": "She criticized that the ECFA and trade in services agreements were \"blocked by the green camp,\" leading to restrictions in Taiwan's youth job market. She expressed dissatisfaction with the blue and green camps' efforts to boost the economy but questioned why Taiwan's economy had not improved over the past eight years. She repeatedly challenged, \"Can't you (referring to the ruling party) even copy (policy proposals)?\""
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13587,
+        "fields": {
+            "question": 13513,
+            "description": "She will criticize the DPP and their policies, stating that wrong policies are as frightening as corruption. These policies have made it difficult for young people to earn money, buy houses, and have led to shortages in various aspects of life, such as money, electricity, eggs, and vaccines. \"Shortage\" has become a keyword for the year 2023."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13591,
+        "fields": {
+            "question": 13513,
+            "description": "The government must adhere to more rigorous fiscal discipline so that we don't leave debts for future generations. We also reject burdening Taiwan with debts and advocate for strengthening fiscal reforms to safeguard the hard-earned money of the people."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13602,
+        "fields": {
+            "question": 13577,
+            "description": "Lai Ching-te, not tearing down your illegal construction is truly hurting the hearts of the Taiwanese people. You are about to become the president, yet you still cherish your house so much. Where is the democracy and progressiveness in your party?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13603,
+        "fields": {
+            "question": 13577,
+            "description": "Mayor Hou, the rent for your building is so high, huh? The students living there have emptied their wallets because of you. Can't you lower the rent a bit?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13604,
+        "fields": {
+            "question": 13577,
+            "description": "Chairman Guo has been talking about forming an opposition alliance and bringing down the DPP together. Now, he's unexpectedly running independently. I really didn't expect Chairman Guo to be such an untrustworthy person."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13605,
+        "fields": {
+            "question": 13577,
+            "description": "I believe the facts are clear. I am the most capable and eloquent candidate in the opposition. Both Mayor Hou and Chairman Guo cannot match me. I am confident that in debates and future elections, I am the one who can defeat Lai Ching-te. Please support me!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13632,
+        "fields": {
+            "question": 13631,
+            "description": "We aim to strengthen our support in the traditional blue camp strongholds of the East Coast and outlying islands. While everyone is focused on the fierce battlegrounds in Taipei, Taichung, and the southern regions, where public opinion is unpredictable, let's secure stable support in Hualien, Taidong, Yilan, Penghu, Kinmen, and Matsu!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13633,
+        "fields": {
+            "question": 13631,
+            "description": "We need to strengthen our hold on Taipei City, where I served as mayor; I cannot afford to lose it. At the same time, we'll compete with Lai Ching-te in New Taipei!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13634,
+        "fields": {
+            "question": 13631,
+            "description": "Changhua, Taichung, and Nantou are the battlegrounds where we need to put in the most effort. Let's strive in these areas and secure a stable stronghold. Victory will be ours tomorrow!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13635,
+        "fields": {
+            "question": 13631,
+            "description": "Let's work hard to increase voter support in my hometown, Hsinchu. If there's one place where my support base is equivalent to both the blue and green camps nationwide, it's Hsinchu. I hope to achieve victory here!"
+        }
+    }
+]
+
+
+campaignTrail_temp.states_json = [
+    {
+        "model": "campaign_trail.state",
+        "pk": 251,
+        "fields": {
+            "name": "Tainan City",
+            "abbr": "Tainancity",
+            "electoral_votes": 1,
+            "popular_votes": 1120238,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 252,
+        "fields": {
+            "name": "Kaohsiung City",
+            "abbr": "Kaohsiungcity",
+            "electoral_votes": 1,
+            "popular_votes": 1636962,
+            "poll_closing_time": 180,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 253,
+        "fields": {
+            "name": "Pingtung County",
+            "abbr": "Pingtung",
+            "electoral_votes": 1,
+            "popular_votes": 475927,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 254,
+        "fields": {
+            "name": "Taidong County",
+            "abbr": "Taidong",
+            "electoral_votes": 1,
+            "popular_votes": 109941,
+            "poll_closing_time": 75,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 255,
+        "fields": {
+            "name": "Hualien County",
+            "abbr": "Hualien",
+            "electoral_votes": 1,
+            "popular_votes": 174157,
+            "poll_closing_time": 90,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 256,
+        "fields": {
+            "name": "Chiayi County",
+            "abbr": "ChiayiCounty",
+            "electoral_votes": 1,
+            "popular_votes": 292534,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 257,
+        "fields": {
+            "name": "Chiayi City",
+            "abbr": "ChiayiCity",
+            "electoral_votes": 1,
+            "popular_votes": 157656,
+            "poll_closing_time": 80,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 258,
+        "fields": {
+            "name": "Nantou Conuty",
+            "abbr": "Nantou",
+            "electoral_votes": 1,
+            "popular_votes": 287296,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 259,
+        "fields": {
+            "name": "Yunlin Conuty",
+            "abbr": "Yunlin",
+            "electoral_votes": 1,
+            "popular_votes": 380619,
+            "poll_closing_time": 130,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 260,
+        "fields": {
+            "name": "Changhua Conuty",
+            "abbr": "Changhua",
+            "electoral_votes": 1,
+            "popular_votes": 741368,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 261,
+        "fields": {
+            "name": "Penghu Conuty",
+            "abbr": "Penghu",
+            "electoral_votes": 1,
+            "popular_votes": 49277,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 262,
+        "fields": {
+            "name": "Taichung City",
+            "abbr": "Taichung",
+            "electoral_votes": 1,
+            "popular_votes": 1707203,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 263,
+        "fields": {
+            "name": "Yilan County",
+            "abbr": "Yilan",
+            "electoral_votes": 1,
+            "popular_votes": 267129,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 264,
+        "fields": {
+            "name": "Hsinchu County",
+            "abbr": "HsinchuCounty",
+            "electoral_votes": 1,
+            "popular_votes": 340310,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 265,
+        "fields": {
+            "name": "Hsinchu City",
+            "abbr": "HsinchuCity",
+            "electoral_votes": 1,
+            "popular_votes": 266389,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 266,
+        "fields": {
+            "name": "Miaoli County",
+            "abbr": "Miaoli",
+            "electoral_votes": 1,
+            "popular_votes": 318665,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 267,
+        "fields": {
+            "name": "New Taipei City",
+            "abbr": "Newtaipei",
+            "electoral_votes": 1,
+            "popular_votes": 2458480,
+            "poll_closing_time": 225,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 268,
+        "fields": {
+            "name": "Taipei City",
+            "abbr": "Taipei",
+            "electoral_votes": 1,
+            "popular_votes": 1542009,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 269,
+        "fields": {
+            "name": "Taoyuan City",
+            "abbr": "Taoyuan",
+            "electoral_votes": 1,
+            "popular_votes": 1350792,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 270,
+        "fields": {
+            "name": "Keelung City",
+            "abbr": "Keelung",
+            "electoral_votes": 1,
+            "popular_votes": 218781,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 271,
+        "fields": {
+            "name": "Kinmen County",
+            "abbr": "Kinmen",
+            "electoral_votes": 1,
+            "popular_votes": 45612,
+            "poll_closing_time": 70,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 272,
+        "fields": {
+            "name": "Lienchiang County",
+            "abbr": "Matsu",
+            "electoral_votes": 1,
+            "popular_votes": 6159,
+            "poll_closing_time": 50,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.issues_json = [
+    {
+        "model": "campaign_trail.issue",
+        "pk": 32,
+        "fields": {
+            "name": "Party coalition",
+            "description": 0,
+            "stance_1": "Deep Green",
+            "stance_desc_1": 0,
+            "stance_2": "Green",
+            "stance_desc_2": 0,
+            "stance_3": "Light Green",
+            "stance_desc_3": 0,
+            "stance_4": "Neutral",
+            "stance_desc_4": 0,
+            "stance_5": "Light Blue",
+            "stance_desc_5": 0,
+            "stance_6": "Blue",
+            "stance_desc_6": 0,
+            "stance_7": "Deep Blue",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 33,
+        "fields": {
+            "name": "Provincial differences",
+            "description": 0,
+            "stance_1": "Mostly Taiwanese",
+            "stance_desc_1": 0,
+            "stance_2": "Taiwanese and Hakka mixed",
+            "stance_desc_2": 0,
+            "stance_3": "Taiwanese,Hakka,Mainlanders mixed",
+            "stance_desc_3": 0,
+            "stance_4": "mixing of ethnic groups",
+            "stance_desc_4": 0,
+            "stance_5": "Aboriginal",
+            "stance_desc_5": 0,
+            "stance_6": "Taiwanese Hakka(Northern)",
+            "stance_desc_6": 0,
+            "stance_7": "Mostly Mainlanders",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 34,
+        "fields": {
+            "name": "Urban/rural differences",
+            "description": 0,
+            "stance_1": "Townships Rural",
+            "stance_desc_1": 0,
+            "stance_2": "Small towns and large towns",
+            "stance_desc_2": 0,
+            "stance_3": "Small cities and towns",
+            "stance_desc_3": 0,
+            "stance_4": "Medium-sized city",
+            "stance_desc_4": 0,
+            "stance_5": "Groups of Small Cities",
+            "stance_desc_5": 0,
+            "stance_6": "Large Cities",
+            "stance_desc_6": 0,
+            "stance_7": "Capitals",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 35,
+        "fields": {
+            "name": "Young population",
+            "description": 0,
+            "stance_1": "Very little",
+            "stance_desc_1": 0,
+            "stance_2": "Little",
+            "stance_desc_2": 0,
+            "stance_3": "Less",
+            "stance_desc_3": 0,
+            "stance_4": "Normal level",
+            "stance_desc_4": 0,
+            "stance_5": "Relatively much more",
+            "stance_desc_5": 0,
+            "stance_6": "Large young population",
+            "stance_desc_6": 0,
+            "stance_7": "Younger society",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 36,
+        "fields": {
+            "name": "Feelings about DPP Government",
+            "description": 0,
+            "stance_1": "DPP is the best!",
+            "stance_desc_1": 0,
+            "stance_2": "That's what we like!",
+            "stance_desc_2": 0,
+            "stance_3": "Pro-DPP",
+            "stance_desc_3": 0,
+            "stance_4": "no feelings for the DPP",
+            "stance_desc_4": 0,
+            "stance_5": "Hate green governance",
+            "stance_desc_5": 0,
+            "stance_6": "Mosquitoes, cockroaches, and the DPP",
+            "stance_desc_6": 0,
+            "stance_7": "Never support the Taiwan Independence Party!!",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.state_issue_score_json = [
+    //台北市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191111,
+        "fields": {
+            "state": 268,
+            "issue": 32,
+            "state_issue_score": 0.22,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191112,
+        "fields": {
+            "state": 268,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191113,
+        "fields": {
+            "state": 268,
+            "issue": 34,
+            "state_issue_score": 1,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191114,
+        "fields": {
+            "state": 268,
+            "issue": 35,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191115,
+        "fields": {
+            "state": 268,
+            "issue": 36,
+            "state_issue_score": 0.1,
+            "weight": 0.5
+        }
+    },
+    //新北市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191116,
+        "fields": {
+            "state": 267,
+            "issue": 32,
+            "state_issue_score": 0.15,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191117,
+        "fields": {
+            "state": 267,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191118,
+        "fields": {
+            "state": 267,
+            "issue": 34,
+            "state_issue_score": 0.65,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191119,
+        "fields": {
+            "state": 267,
+            "issue": 35,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191120,
+        "fields": {
+            "state": 267,
+            "issue": 36,
+            "state_issue_score": 0.0,
+            "weight": 0.5
+        }
+    },
+    //桃园市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191121,
+        "fields": {
+            "state": 269,
+            "issue": 32,
+            "state_issue_score": 0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191122,
+        "fields": {
+            "state": 269,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191122,
+        "fields": {
+            "state": 269,
+            "issue": 34,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191123,
+        "fields": {
+            "state": 269,
+            "issue": 35,
+            "state_issue_score": 0.75,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191124,
+        "fields": {
+            "state": 269,
+            "issue": 36,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    //新竹市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191125,
+        "fields": {
+            "state": 265,
+            "issue": 32,
+            "state_issue_score": 0.4,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191126,
+        "fields": {
+            "state": 265,
+            "issue": 33,
+            "state_issue_score": -0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191127,
+        "fields": {
+            "state": 265,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191128,
+        "fields": {
+            "state": 265,
+            "issue": 35,
+            "state_issue_score": 0.65,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191129,
+        "fields": {
+            "state": 265,
+            "issue": 36,
+            "state_issue_score": 0.35,
+            "weight": 0.5
+        }
+    },
+    //基隆市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191130,
+        "fields": {
+            "state": 270,
+            "issue": 32,
+            "state_issue_score": 0.5,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191131,
+        "fields": {
+            "state": 270,
+            "issue": 33,
+            "state_issue_score": 0.1,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191132,
+        "fields": {
+            "state": 270,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191133,
+        "fields": {
+            "state": 270,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191134,
+        "fields": {
+            "state": 270,
+            "issue": 36,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    //新竹县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191135,
+        "fields": {
+            "state": 264,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191136,
+        "fields": {
+            "state": 264,
+            "issue": 33,
+            "state_issue_score": 0.45,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191137,
+        "fields": {
+            "state": 264,
+            "issue": 34,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191138,
+        "fields": {
+            "state": 264,
+            "issue": 35,
+            "state_issue_score": 0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191139,
+        "fields": {
+            "state": 264,
+            "issue": 36,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    //苗栗縣
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191140,
+        "fields": {
+            "state": 266,
+            "issue": 32,
+            "state_issue_score": 0.85,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191141,
+        "fields": {
+            "state": 266,
+            "issue": 33,
+            "state_issue_score": 0.55,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191142,
+        "fields": {
+            "state": 266,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191143,
+        "fields": {
+            "state": 266,
+            "issue": 35,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191144,
+        "fields": {
+            "state": 266,
+            "issue": 36,
+            "state_issue_score": 0.85,
+            "weight": 0.5
+        }
+    },
+    //宜兰县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191145,
+        "fields": {
+            "state": 263,
+            "issue": 32,
+            "state_issue_score": -0.45,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191146,
+        "fields": {
+            "state": 263,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191147,
+        "fields": {
+            "state": 263,
+            "issue": 34,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191148,
+        "fields": {
+            "state": 263,
+            "issue": 35,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191149,
+        "fields": {
+            "state": 263,
+            "issue": 36,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    //台中市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191150,
+        "fields": {
+            "state": 262,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191151,
+        "fields": {
+            "state": 262,
+            "issue": 33,
+            "state_issue_score": 0,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191152,
+        "fields": {
+            "state": 262,
+            "issue": 34,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191154,
+        "fields": {
+            "state": 262,
+            "issue": 35,
+            "state_issue_score": 0.35,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191155,
+        "fields": {
+            "state": 262,
+            "issue": 36,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    //南投县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191156,
+        "fields": {
+            "state": 258,
+            "issue": 32,
+            "state_issue_score": 0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191157,
+        "fields": {
+            "state": 258,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191158,
+        "fields": {
+            "state": 258,
+            "issue": 34,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191159,
+        "fields": {
+            "state": 258,
+            "issue": 35,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191160,
+        "fields": {
+            "state": 258,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //花莲县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191161,
+        "fields": {
+            "state": 255,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191162,
+        "fields": {
+            "state": 255,
+            "issue": 33,
+            "state_issue_score": 0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191163,
+        "fields": {
+            "state": 255,
+            "issue": 34,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191164,
+        "fields": {
+            "state": 255,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191165,
+        "fields": {
+            "state": 255,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //台东县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191166,
+        "fields": {
+            "state": 254,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191167,
+        "fields": {
+            "state": 254,
+            "issue": 33,
+            "state_issue_score": 0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191168,
+        "fields": {
+            "state": 254,
+            "issue": 34,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191169,
+        "fields": {
+            "state": 254,
+            "issue": 35,
+            "state_issue_score": -0.33,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191170,
+        "fields": {
+            "state": 254,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //彰化县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191171,
+        "fields": {
+            "state": 260,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191172,
+        "fields": {
+            "state": 260,
+            "issue": 33,
+            "state_issue_score": -0.85,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191173,
+        "fields": {
+            "state": 260,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191174,
+        "fields": {
+            "state": 260,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191175,
+        "fields": {
+            "state": 260,
+            "issue": 36,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    //云林县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191176,
+        "fields": {
+            "state": 259,
+            "issue": 32,
+            "state_issue_score": -0.4,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191177,
+        "fields": {
+            "state": 259,
+            "issue": 33,
+            "state_issue_score": -0.85,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191178,
+        "fields": {
+            "state": 259,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191179,
+        "fields": {
+            "state": 259,
+            "issue": 35,
+            "state_issue_score": -0.85,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191180,
+        "fields": {
+            "state": 259,
+            "issue": 36,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    //澎湖
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191181,
+        "fields": {
+            "state": 261,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191182,
+        "fields": {
+            "state": 261,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191183,
+        "fields": {
+            "state": 261,
+            "issue": 34,
+            "state_issue_score": -0.9,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191184,
+        "fields": {
+            "state": 261,
+            "issue": 35,
+            "state_issue_score": -0.75,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191185,
+        "fields": {
+            "state": 261,
+            "issue": 36,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    //嘉义县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191186,
+        "fields": {
+            "state": 256,
+            "issue": 32,
+            "state_issue_score": -0.75,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191187,
+        "fields": {
+            "state": 256,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191188,
+        "fields": {
+            "state": 256,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191189,
+        "fields": {
+            "state": 256,
+            "issue": 35,
+            "state_issue_score": -0.9,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191190,
+        "fields": {
+            "state": 256,
+            "issue": 36,
+            "state_issue_score": -0.75,
+            "weight": 0.5
+        }
+    },
+    //嘉义市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191191,
+        "fields": {
+            "state": 257,
+            "issue": 32,
+            "state_issue_score": -0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191192,
+        "fields": {
+            "state": 257,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191193,
+        "fields": {
+            "state": 257,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191194,
+        "fields": {
+            "state": 257,
+            "issue": 35,
+            "state_issue_score": -0.6,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191195,
+        "fields": {
+            "state": 257,
+            "issue": 36,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+     //台南市
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191196,
+            "fields": {
+                "state": 251,
+                "issue": 32,
+                "state_issue_score": -0.85,
+                "weight": 1
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191197,
+            "fields": {
+                "state": 251,
+                "issue": 33,
+                "state_issue_score": -0.15,
+                "weight": 2
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191198,
+            "fields": {
+                "state": 251,
+                "issue": 34,
+                "state_issue_score": 0.55,
+                "weight": 0.5
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191199,
+            "fields": {
+                "state": 251,
+                "issue": 35,
+                "state_issue_score": 0.15,
+                "weight": 0.5
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191200,
+            "fields": {
+                "state": 251,
+                "issue": 36,
+                "state_issue_score": -0.75,
+                "weight": 0.5
+            }
+        },
+         //高雄市
+             {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191201,
+                "fields": {
+                    "state": 252,
+                    "issue": 32,
+                    "state_issue_score": -0.55,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191202,
+                "fields": {
+                    "state": 252,
+                    "issue": 33,
+                    "state_issue_score": -0.15,
+                    "weight": 2
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191203,
+                "fields": {
+                    "state": 252,
+                    "issue": 34,
+                    "state_issue_score": 0.65,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191204,
+                "fields": {
+                    "state": 252,
+                    "issue": 35,
+                    "state_issue_score": 0.15,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191205,
+                "fields": {
+                    "state": 252,
+                    "issue": 36,
+                    "state_issue_score": -0.75,
+                    "weight": 0.5
+                }
+            },
+            //屏东县
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191206,
+                "fields": {
+                    "state": 253,
+                    "issue": 32,
+                    "state_issue_score": -0.5,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191207,
+                "fields": {
+                    "state": 253,
+                    "issue": 33,
+                    "state_issue_score": -0.25,
+                    "weight": 2
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191208,
+                "fields": {
+                    "state": 253,
+                    "issue": 34,
+                    "state_issue_score": 0.25,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191209,
+                "fields": {
+                    "state": 253,
+                    "issue": 35,
+                    "state_issue_score": 0,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191210,
+                "fields": {
+                    "state": 253,
+                    "issue": 36,
+                    "state_issue_score": -0.55,
+                    "weight": 0.5
+                }
+            },
+              //金门县
+              {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191211,
+                "fields": {
+                    "state": 271,
+                    "issue": 32,
+                    "state_issue_score": 1,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191212,
+                "fields": {
+                    "state": 271,
+                    "issue": 33,
+                    "state_issue_score": 1,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191213,
+                "fields": {
+                    "state": 271,
+                    "issue": 34,
+                    "state_issue_score": -0.75,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191214,
+                "fields": {
+                    "state": 271,
+                    "issue": 35,
+                    "state_issue_score": -0.25,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191215,
+                "fields": {
+                    "state": 271,
+                    "issue": 36,
+                    "state_issue_score": 1,
+                    "weight": 0.5
+                }
+            },
+                //连江县
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191216,
+                    "fields": {
+                        "state": 272,
+                        "issue": 32,
+                        "state_issue_score": 1,
+                        "weight": 1
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191217,
+                    "fields": {
+                        "state": 272,
+                        "issue": 33,
+                        "state_issue_score": 1,
+                        "weight": 1
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191218,
+                    "fields": {
+                        "state": 272,
+                        "issue": 34,
+                        "state_issue_score": -1,
+                        "weight": 0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191219,
+                    "fields": {
+                        "state": 272,
+                        "issue": 35,
+                        "state_issue_score": 0.25,
+                        "weight": 0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191220,
+                    "fields": {
+                        "state": 272,
+                        "issue": 36,
+                        "state_issue_score": 1,
+                        "weight": 0.5
+                    }
+                },
+]
+campaignTrail_temp.candidate_issue_score_json = [
+    //赖清德
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 328,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 32,
+            "issue_score": -0.85 //深绿
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 329,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 33,
+            "issue_score": -0.75 //台湾本省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 330,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 34,
+            "issue_score": -0.35 //矿工之子
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 331,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 35,
+            "issue_score": 0.25 //年轻人支持度还行
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 332,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 36,
+            "issue_score": -1 //我就是现任副总统啊
+        }
+    },
+    //侯友谊
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 333,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 32,
+            "issue_score": 0.15 //浅蓝，甚至蓝皮绿谷
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 334,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 33,
+            "issue_score": -0.9 //比赖清德更本省
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 335,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 34,
+            "issue_score": -0.5 //嘉义乡下卖猪肉的
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 336,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 35,
+            "issue_score": -0.25 //年轻人不喜欢的老蓝男
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 337,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 36,
+            "issue_score": 0.25 //攻击性不强
+        }
+    },
+    //柯文哲
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 338,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 32,
+            "issue_score": -0.5 //我内心本质还是深绿的
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 339,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 33,
+            "issue_score": -0.75 //本省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 340,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 34,
+            "issue_score": 0.15 //家庭条件还可以
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 341,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 35,
+            "issue_score": 0.8 //阿北阿北我爱你
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 342,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 36,
+            "issue_score": 0.5 //攻击性很强，但并不把下架民进党当第一目标
+        }
+    },
+     //郭台铭
+     {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 343,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 32,
+            "issue_score": 0.7 //深蓝
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 344,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 33,
+            "issue_score": 0.75 //外省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 345,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 34,
+            "issue_score": 0.75 //城里人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 346,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 35,
+            "issue_score": -0.25 //老蓝男
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 347,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 36,
+            "issue_score": 0.4 //攻击性一般，下架民进党是说说听得口号
+        }
+    },
+]
+campaignTrail_temp.running_mate_issue_score_json = [
+  //萧美琴
+  {
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9343,
+    "fields": {
+        "candidate": 1002,
+        "issue": 32,
+        "issue_score": -0.7
+    }
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9344,
+    "fields": {
+        "candidate": 1002,
+        "issue": 33,
+        "issue_score": -0
+    }
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9345,
+    "fields": {
+        "candidate": 1002,
+        "issue": 34,
+        "issue_score": -0.25
+},
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9346,
+    "fields": {
+        "candidate": 1002,
+        "issue": 35,
+        "issue_score": 0.25 
+    }
+},
+    {
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9347,
+    "fields": {
+        "candidate": 1002,
+        "issue": 36,
+        "issue_score": -0.5
+    }
+    },
+    //蓝白联票
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9348,
+        "fields": {
+            "candidate": 50001,
+            "issue": 32,
+            "issue_score": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9349,
+        "fields": {
+            "candidate": 50001,
+            "issue": 33,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9350,
+        "fields": {
+            "candidate": 50001,
+            "issue": 34,
+            "issue_score": 0
+    },
+},
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9351,
+        "fields": {
+            "candidate": 50001,
+            "issue": 35,
+            "issue_score": 0.15 
+        }
+    },
+        {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9352,
+        "fields": {
+            "candidate": 50001,
+            "issue": 36,
+            "issue_score": 0.4
+        }
+        },
+        //赵少康
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93481,
+            "fields": {
+                "candidate": 50000,
+                "issue": 32,
+                "issue_score": 0.95
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93491,
+            "fields": {
+                "candidate": 50000,
+                "issue": 33,
+                "issue_score": 0.95
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93501,
+            "fields": {
+                "candidate": 50000,
+                "issue": 34,
+                "issue_score": 0.55
+        },
+    },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93511,
+            "fields": {
+                "candidate": 50000,
+                "issue": 35,
+                "issue_score": 0.1
+            }
+        },
+            {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93521,
+            "fields": {
+                "candidate": 50000,
+                "issue": 36,
+                "issue_score": 0.5
+            }
+            },
+            //韩国瑜
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 934812,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 32,
+                    "issue_score": 0.95
+                }
+            },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 934912,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 33,
+                    "issue_score": 0.95
+                }
+            },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935013,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 34,
+                    "issue_score": -0.25
+            },
+        },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935114,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 35,
+                    "issue_score": 0
+                }
+            },
+                {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935215,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 36,
+                    "issue_score": 0.65
+                }
+                },
+                //柯志恩
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9348121,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 32,
+                        "issue_score": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9349121,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 33,
+                        "issue_score": -0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9350131,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 34,
+                        "issue_score": -0.15
+                },
+            },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9351141,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 35,
+                        "issue_score": 0.55
+                    }
+                },
+                    {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9352151,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 36,
+                        "issue_score": 0.42
+                    }
+                    },
+                    //赖佩霞
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93481211,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 32,
+                            "issue_score": 0.1
+                        }
+                    },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93491211,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 33,
+                            "issue_score": 0
+                        }
+                    },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93501311,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 34,
+                            "issue_score": 0.25
+                    },
+                },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93511411,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 35,
+                            "issue_score": 0.15
+                        }
+                    },
+                        {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93521511,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 36,
+                            "issue_score": 0.15
+                        }
+                        },
+                        //白蓝联票
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410110,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 32,
+                                "issue_score": -0.1
+                            }
+                        },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410111,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 33,
+                                "issue_score": 0
+                            }
+                        },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410112,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 34,
+                                "issue_score": 0
+                        },
+                    },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410113,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 35,
+                                "issue_score": 0.75
+                            }
+                        },
+                            {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410114,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 36,
+                                "issue_score": 0.25
+                            }
+                            },
+                            //吴欣盈
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241000,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 32,
+                                    "issue_score": 0
+                                }
+                            },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241001,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 33,
+                                    "issue_score": 0
+                                }
+                            },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241002,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 34,
+                                    "issue_score": 0
+                            },
+                           },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241003,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 35,
+                                    "issue_score": 0.75
+                                }
+                            },
+                                {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241004,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 36,
+                                    "issue_score": 0.25
+                                }
+                        }
+    ]
+
+campaignTrail_temp.candidate_state_multiplier_json = [
+       //台南市
+       {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25191,
+        "fields": {
+            "candidate": 2001557,
+            "state": 251,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25192,
+        "fields": {
+            "candidate": 2001591,
+            "state": 251,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25693,
+        "fields": {
+            "candidate": 2001622,
+            "state": 251,
+            "state_multiplier": 0.17
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25694,
+        "fields": {
+            "candidate": 2001653,
+            "state": 251,
+            "state_multiplier": 0.07
+        }
+    },
+    //嘉义县
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25691,
+        "fields": {
+            "candidate": 2001557,
+            "state": 256,
+            "state_multiplier": 0.28
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25692,
+        "fields": {
+            "candidate": 2001591,
+            "state": 256,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25693,
+        "fields": {
+            "candidate": 2001622,
+            "state": 256,
+            "state_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25694,
+        "fields": {
+            "candidate": 2001653,
+            "state": 256,
+            "state_multiplier": 0.07
+        }
+    },
+      //花莲县
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25591,
+        "fields": {
+            "candidate": 2001557,
+            "state": 255,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25592,
+        "fields": {
+            "candidate": 2001591,
+            "state": 255,
+            "state_multiplier": 0.366
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25593,
+        "fields": {
+            "candidate": 2001622,
+            "state": 255,
+            "state_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25594,
+        "fields": {
+            "candidate": 2001653,
+            "state": 255,
+            "state_multiplier": 0.1
+        }
+    },
+      //屏东
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25391,
+        "fields": {
+            "candidate": 2001557,
+            "state": 253,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25392,
+        "fields": {
+            "candidate": 2001591,
+            "state": 253,
+            "state_multiplier": 0.27
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25393,
+        "fields": {
+            "candidate": 2001622,
+            "state": 253,
+            "state_multiplier": 0.14
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25294,
+        "fields": {
+            "candidate": 2001653,
+            "state": 253,
+            "state_multiplier": 0.07
+        }
+    },
+    //高雄
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25291,
+        "fields": {
+            "candidate": 2001557,
+            "state": 252,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25292,
+        "fields": {
+            "candidate": 2001591,
+            "state": 252,
+            "state_multiplier": 0.25
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25293,
+        "fields": {
+            "candidate": 2001622,
+            "state": 252,
+            "state_multiplier": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25294,
+        "fields": {
+            "candidate": 2001653,
+            "state": 252,
+            "state_multiplier": 0.07
+        }
+    },
+    //台东
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252912,
+        "fields": {
+            "candidate": 2001557,
+            "state": 254,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252922,
+        "fields": {
+            "candidate": 2001591,
+            "state": 254,
+            "state_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252932,
+        "fields": {
+            "candidate": 2001622,
+            "state": 254,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252942,
+        "fields": {
+            "candidate": 2001653,
+            "state": 254,
+            "state_multiplier": 0.1
+        }
+    },
+        //嘉义市
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114514,
+            "fields": {
+                "candidate": 2001557,
+                "state": 257,
+                "state_multiplier": 0.28
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114515,
+            "fields": {
+                "candidate": 2001591,
+                "state": 257,
+                "state_multiplier": 0.23
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114516,
+            "fields": {
+                "candidate": 2001622,
+                "state": 257,
+                "state_multiplier": 0.15
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114517,
+            "fields": {
+                "candidate": 2001653,
+                "state": 257,
+                "state_multiplier": 0.05
+            }
+        },
+        //南投
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 566666,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 258,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 666666,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 258,
+                        "state_multiplier": 0.31
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 6666666,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 258,
+                        "state_multiplier": 0.20
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 66666666,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 258,
+                        "state_multiplier": 0.08
+                    }
+                },
+                //彰化
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 114514123,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 260,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1145141234,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 260,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 11451414,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 260,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 21412412,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 260,
+                        "state_multiplier": 0.06
+                    }
+                },
+                //云林
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1111,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 259,
+                        "state_multiplier": 0.32
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2222,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 259,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 3333,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 259,
+                        "state_multiplier": 0.19
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 4444,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 259,
+                        "state_multiplier": 0.04
+                    }
+                },
+                //澎湖
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 5555,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 261,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 6666,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 261,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 7777,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 261,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 8888,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 261,
+                        "state_multiplier": 0.05
+                    }
+                },
+                //台中
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412241,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 262,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412411,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 262,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412412,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 262,
+                        "state_multiplier": 0.22
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412511,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 262,
+                        "state_multiplier": 0.05
+                    }
+                },
+                //新竹县
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101001,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 264,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101002,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 264,
+                        "state_multiplier": 0.29
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101003,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 264,
+                        "state_multiplier": 0.24
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101004,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 264,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //新竹市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010012,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 265,
+                        "state_multiplier": 0.29
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010022,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 265,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010032,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 265,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010042,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 265,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //苗栗
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2194,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 266,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2195,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 266,
+                        "state_multiplier": 0.35
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2196,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 266,
+                        "state_multiplier": 0.22
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2197,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 266,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //新北市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12194,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 267,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12195,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 267,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12196,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 267,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12197,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 267,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //台北市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 268,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 268,
+                        "state_multiplier": 0.34
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 268,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 268,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //桃园
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 269,
+                        "state_multiplier": 0.26
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 269,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 269,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 269,
+                        "state_multiplier": 0.13
+                    }
+                },
+                //基隆
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 270,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 270,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 270,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 270,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //金门
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19581,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 271,
+                        "state_multiplier": 0.05
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19582,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 271,
+                        "state_multiplier": 0.55
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19583,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 271,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19584,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 271,
+                        "state_multiplier": 0.15
+                    }
+                },         
+                 //宜兰
+                 {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195813,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 263,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195823,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 263,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195833,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 263,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195843,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 263,
+                        "state_multiplier": 0.08
+                    }
+                },       
+                  //连江
+                  {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195812,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 272,
+                        "state_multiplier": 0.05
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195822,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 272,
+                        "state_multiplier": 0.55
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195832,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 272,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195842,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 272,
+                        "state_multiplier": 0.15
+                    }
+                },      
+]
+
+
+
+campaignTrail_temp.answer_score_global_json = [
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13042,
+        "fields": {
+            "answer": 13034,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13043,
+        "fields": {
+            "answer": 13034,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13045,
+        "fields": {
+            "answer": 13036,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13046,
+        "fields": {
+            "answer": 13037,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13053,
+        "fields": {
+            "answer": 13047,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13064,
+        "fields": {
+            "answer": 13057,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13066,
+        "fields": {
+            "answer": 13056,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13071,
+        "fields": {
+            "answer": 13067,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13072,
+        "fields": {
+            "answer": 13067,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13073,
+        "fields": {
+            "answer": 13068,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.24
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13074,
+        "fields": {
+            "answer": 13067,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13075,
+        "fields": {
+            "answer": 13068,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -5
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13078,
+        "fields": {
+            "answer": 13076,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13087,
+        "fields": {
+            "answer": 13084,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13091,
+        "fields": {
+            "answer": 13083,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.008
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13094,
+        "fields": {
+            "answer": 13084,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13095,
+        "fields": {
+            "answer": 13083,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13096,
+        "fields": {
+            "answer": 13081,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13102,
+        "fields": {
+            "answer": 13100,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13107,
+        "fields": {
+            "answer": 13099,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13109,
+        "fields": {
+            "answer": 13098,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13112,
+        "fields": {
+            "answer": 13097,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13121,
+        "fields": {
+            "answer": 13115,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13125,
+        "fields": {
+            "answer": 13114,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13126,
+        "fields": {
+            "answer": 13113,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13129,
+        "fields": {
+            "answer": 13114,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13131,
+        "fields": {
+            "answer": 13113,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": 5.25
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13132,
+        "fields": {
+            "answer": 13114,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": 5.25
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13133,
+        "fields": {
+            "answer": 13115,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": 5.25
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13134,
+        "fields": {
+            "answer": 13116,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": 5.25
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13141,
+        "fields": {
+            "answer": 13135,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13144,
+        "fields": {
+            "answer": 13130,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13145,
+        "fields": {
+            "answer": 13135,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13146,
+        "fields": {
+            "answer": 13136,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13150,
+        "fields": {
+            "answer": 13148,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13151,
+        "fields": {
+            "answer": 13148,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13152,
+        "fields": {
+            "answer": 13147,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13153,
+        "fields": {
+            "answer": 13147,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13161,
+        "fields": {
+            "answer": 13158,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13166,
+        "fields": {
+            "answer": 13156,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13205,
+        "fields": {
+            "answer": 13196,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13206,
+        "fields": {
+            "answer": 13194,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13207,
+        "fields": {
+            "answer": 13194,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13208,
+        "fields": {
+            "answer": 13194,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13209,
+        "fields": {
+            "answer": 13194,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13210,
+        "fields": {
+            "answer": 13196,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13211,
+        "fields": {
+            "answer": 13197,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13212,
+        "fields": {
+            "answer": 13198,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13218,
+        "fields": {
+            "answer": 13213,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13219,
+        "fields": {
+            "answer": 13213,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.09
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13221,
+        "fields": {
+            "answer": 13214,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13222,
+        "fields": {
+            "answer": 13214,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13223,
+        "fields": {
+            "answer": 13213,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13224,
+        "fields": {
+            "answer": 13214,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13227,
+        "fields": {
+            "answer": 13225,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13228,
+        "fields": {
+            "answer": 13225,
+            "candidate": 2001622,
+            "affected_candidate": 127890,
+            "global_multiplier": -0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13234,
+        "fields": {
+            "answer": 13232,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13241,
+        "fields": {
+            "answer": 13231,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.034
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13253,
+        "fields": {
+            "answer": 13248,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13254,
+        "fields": {
+            "answer": 13248,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13255,
+        "fields": {
+            "answer": 13248,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13257,
+        "fields": {
+            "answer": 13249,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13258,
+        "fields": {
+            "answer": 13249,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13260,
+        "fields": {
+            "answer": 13247,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13261,
+        "fields": {
+            "answer": 13247,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13266,
+        "fields": {
+            "answer": 13264,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13272,
+        "fields": {
+            "answer": 13263,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13280,
+        "fields": {
+            "answer": 13278,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13281,
+        "fields": {
+            "answer": 13277,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13310,
+        "fields": {
+            "answer": 13302,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13311,
+        "fields": {
+            "answer": 13303,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13312,
+        "fields": {
+            "answer": 13304,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13313,
+        "fields": {
+            "answer": 13305,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13314,
+        "fields": {
+            "answer": 13305,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.38
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13315,
+        "fields": {
+            "answer": 13304,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.38
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13316,
+        "fields": {
+            "answer": 13303,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.38
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13317,
+        "fields": {
+            "answer": 13302,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.38
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13318,
+        "fields": {
+            "answer": 13302,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13319,
+        "fields": {
+            "answer": 13303,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13320,
+        "fields": {
+            "answer": 13304,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13321,
+        "fields": {
+            "answer": 13305,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -10
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13331,
+        "fields": {
+            "answer": 13325,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13334,
+        "fields": {
+            "answer": 13326,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13335,
+        "fields": {
+            "answer": 13326,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13337,
+        "fields": {
+            "answer": 13325,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13338,
+        "fields": {
+            "answer": 13327,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13339,
+        "fields": {
+            "answer": 13327,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13346,
+        "fields": {
+            "answer": 13322,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13347,
+        "fields": {
+            "answer": 13323,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13348,
+        "fields": {
+            "answer": 13324,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13349,
+        "fields": {
+            "answer": 13341,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13355,
+        "fields": {
+            "answer": 13351,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13356,
+        "fields": {
+            "answer": 13352,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13357,
+        "fields": {
+            "answer": 13353,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13363,
+        "fields": {
+            "answer": 13295,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13364,
+        "fields": {
+            "answer": 13296,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13365,
+        "fields": {
+            "answer": 13298,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13366,
+        "fields": {
+            "answer": 13361,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13367,
+        "fields": {
+            "answer": 13361,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13378,
+        "fields": {
+            "answer": 13370,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13379,
+        "fields": {
+            "answer": 13374,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13380,
+        "fields": {
+            "answer": 13372,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13381,
+        "fields": {
+            "answer": 13371,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13387,
+        "fields": {
+            "answer": 13372,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13396,
+        "fields": {
+            "answer": 13389,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13407,
+        "fields": {
+            "answer": 13401,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13408,
+        "fields": {
+            "answer": 13402,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13411,
+        "fields": {
+            "answer": 13403,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13416,
+        "fields": {
+            "answer": 13414,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.055
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13426,
+        "fields": {
+            "answer": 13419,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.024
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13428,
+        "fields": {
+            "answer": 13420,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13430,
+        "fields": {
+            "answer": 13421,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13441,
+        "fields": {
+            "answer": 13437,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13442,
+        "fields": {
+            "answer": 13438,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13443,
+        "fields": {
+            "answer": 13437,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13444,
+        "fields": {
+            "answer": 13438,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13447,
+        "fields": {
+            "answer": 13436,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13448,
+        "fields": {
+            "answer": 13436,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13454,
+        "fields": {
+            "answer": 13449,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13457,
+        "fields": {
+            "answer": 13450,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13458,
+        "fields": {
+            "answer": 13450,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13461,
+        "fields": {
+            "answer": 13451,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13466,
+        "fields": {
+            "answer": 13452,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13521,
+        "fields": {
+            "answer": 13514,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13523,
+        "fields": {
+            "answer": 13515,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13526,
+        "fields": {
+            "answer": 13514,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -500
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13527,
+        "fields": {
+            "answer": 13515,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -500
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13528,
+        "fields": {
+            "answer": 13516,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.085
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13529,
+        "fields": {
+            "answer": 13516,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -500
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13531,
+        "fields": {
+            "answer": 13522,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13532,
+        "fields": {
+            "answer": 13522,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13537,
+        "fields": {
+            "answer": 13535,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13538,
+        "fields": {
+            "answer": 13535,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13541,
+        "fields": {
+            "answer": 13534,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13542,
+        "fields": {
+            "answer": 13534,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13545,
+        "fields": {
+            "answer": 13533,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.055
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13546,
+        "fields": {
+            "answer": 13533,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13553,
+        "fields": {
+            "answer": 13550,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13554,
+        "fields": {
+            "answer": 13550,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13556,
+        "fields": {
+            "answer": 13548,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13557,
+        "fields": {
+            "answer": 13548,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13563,
+        "fields": {
+            "answer": 13558,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13566,
+        "fields": {
+            "answer": 13559,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13567,
+        "fields": {
+            "answer": 13559,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13569,
+        "fields": {
+            "answer": 13560,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13570,
+        "fields": {
+            "answer": 13560,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13574,
+        "fields": {
+            "answer": 13561,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13575,
+        "fields": {
+            "answer": 13561,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13580,
+        "fields": {
+            "answer": 13578,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13581,
+        "fields": {
+            "answer": 13578,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13585,
+        "fields": {
+            "answer": 13583,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13589,
+        "fields": {
+            "answer": 13587,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13595,
+        "fields": {
+            "answer": 13436,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13596,
+        "fields": {
+            "answer": 13437,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13597,
+        "fields": {
+            "answer": 13438,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13598,
+        "fields": {
+            "answer": 13514,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13599,
+        "fields": {
+            "answer": 13515,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13600,
+        "fields": {
+            "answer": 13516,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13601,
+        "fields": {
+            "answer": 13522,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13607,
+        "fields": {
+            "answer": 13514,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13608,
+        "fields": {
+            "answer": 13515,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13609,
+        "fields": {
+            "answer": 13516,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13610,
+        "fields": {
+            "answer": 13522,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13614,
+        "fields": {
+            "answer": 13603,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13615,
+        "fields": {
+            "answer": 13602,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13616,
+        "fields": {
+            "answer": 13602,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13617,
+        "fields": {
+            "answer": 13604,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.06
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13618,
+        "fields": {
+            "answer": 13605,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13619,
+        "fields": {
+            "answer": 13605,
+            "candidate": 2001622,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13620,
+        "fields": {
+            "answer": 13605,
+            "candidate": 2001622,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13621,
+        "fields": {
+            "answer": 13605,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13622,
+        "fields": {
+            "answer": 13469,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13623,
+        "fields": {
+            "answer": 13469,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13624,
+        "fields": {
+            "answer": 13470,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13626,
+        "fields": {
+            "answer": 13470,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13627,
+        "fields": {
+            "answer": 13471,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13628,
+        "fields": {
+            "answer": 13471,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13629,
+        "fields": {
+            "answer": 13479,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13630,
+        "fields": {
+            "answer": 13479,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13644,
+        "fields": {
+            "answer": 13635,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "global_multiplier": -0.055
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13645,
+        "fields": {
+            "answer": 13635,
+            "candidate": 12776,
+            "affected_candidate": 12947,
+            "global_multiplier": -0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13656,
+        "fields": {
+            "answer": 13633,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13657,
+        "fields": {
+            "answer": 13633,
+            "candidate": 12776,
+            "affected_candidate": 12947,
+            "global_multiplier": -0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13658,
+        "fields": {
+            "answer": 13632,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13659,
+        "fields": {
+            "answer": 13632,
+            "candidate": 12776,
+            "affected_candidate": 12947,
+            "global_multiplier": -0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13661,
+        "fields": {
+            "answer": 13634,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13662,
+        "fields": {
+            "answer": 13634,
+            "candidate": 2001622,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.15
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_issue_json = [
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13044,
+        "fields": {
+            "answer": 13035,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13052,
+        "fields": {
+            "answer": 13048,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13055,
+        "fields": {
+            "answer": 13049,
+            "issue": 34,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13061,
+        "fields": {
+            "answer": 13058,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13063,
+        "fields": {
+            "answer": 13057,
+            "issue": 32,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13079,
+        "fields": {
+            "answer": 13076,
+            "issue": 35,
+            "issue_score": 0.03,
+            "issue_importance": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13088,
+        "fields": {
+            "answer": 13084,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13090,
+        "fields": {
+            "answer": 13083,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13092,
+        "fields": {
+            "answer": 13081,
+            "issue": 32,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13093,
+        "fields": {
+            "answer": 13081,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13103,
+        "fields": {
+            "answer": 13100,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13106,
+        "fields": {
+            "answer": 13099,
+            "issue": 34,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13110,
+        "fields": {
+            "answer": 13098,
+            "issue": 35,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13111,
+        "fields": {
+            "answer": 13097,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13118,
+        "fields": {
+            "answer": 13116,
+            "issue": 36,
+            "issue_score": 0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13119,
+        "fields": {
+            "answer": 13116,
+            "issue": 32,
+            "issue_score": -0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13122,
+        "fields": {
+            "answer": 13115,
+            "issue": 35,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13123,
+        "fields": {
+            "answer": 13115,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13127,
+        "fields": {
+            "answer": 13113,
+            "issue": 36,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13138,
+        "fields": {
+            "answer": 13136,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13140,
+        "fields": {
+            "answer": 13135,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13143,
+        "fields": {
+            "answer": 13130,
+            "issue": 32,
+            "issue_score": -0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13160,
+        "fields": {
+            "answer": 13158,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13163,
+        "fields": {
+            "answer": 13157,
+            "issue": 35,
+            "issue_score": 0.12,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13165,
+        "fields": {
+            "answer": 13156,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13168,
+        "fields": {
+            "answer": 13155,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13169,
+        "fields": {
+            "answer": 13155,
+            "issue": 34,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13200,
+        "fields": {
+            "answer": 13198,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13201,
+        "fields": {
+            "answer": 13198,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13203,
+        "fields": {
+            "answer": 13197,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13220,
+        "fields": {
+            "answer": 13213,
+            "issue": 32,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13229,
+        "fields": {
+            "answer": 13225,
+            "issue": 32,
+            "issue_score": -0.09,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13235,
+        "fields": {
+            "answer": 13232,
+            "issue": 32,
+            "issue_score": -0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13238,
+        "fields": {
+            "answer": 13230,
+            "issue": 32,
+            "issue_score": 0.04,
+            "issue_importance": 0
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13239,
+        "fields": {
+            "answer": 13230,
+            "issue": 35,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13240,
+        "fields": {
+            "answer": 13230,
+            "issue": 36,
+            "issue_score": 0.04,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13242,
+        "fields": {
+            "answer": 13231,
+            "issue": 36,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13245,
+        "fields": {
+            "answer": 13231,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13246,
+        "fields": {
+            "answer": 13232,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13251,
+        "fields": {
+            "answer": 13247,
+            "issue": 35,
+            "issue_score": 0.09,
+            "issue_importance": 0.11
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13259,
+        "fields": {
+            "answer": 13249,
+            "issue": 35,
+            "issue_score": 0.05,
+            "issue_importance": 0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13267,
+        "fields": {
+            "answer": 13264,
+            "issue": 32,
+            "issue_score": -0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13276,
+        "fields": {
+            "answer": 13262,
+            "issue": 32,
+            "issue_score": -0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13332,
+        "fields": {
+            "answer": 13325,
+            "issue": 35,
+            "issue_score": -0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13333,
+        "fields": {
+            "answer": 13325,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13336,
+        "fields": {
+            "answer": 13326,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13340,
+        "fields": {
+            "answer": 13327,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13358,
+        "fields": {
+            "answer": 13351,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13359,
+        "fields": {
+            "answer": 13352,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13360,
+        "fields": {
+            "answer": 13353,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13376,
+        "fields": {
+            "answer": 13374,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13377,
+        "fields": {
+            "answer": 13370,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13383,
+        "fields": {
+            "answer": 13371,
+            "issue": 32,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13384,
+        "fields": {
+            "answer": 13370,
+            "issue": 36,
+            "issue_score": -0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13385,
+        "fields": {
+            "answer": 13374,
+            "issue": 36,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13386,
+        "fields": {
+            "answer": 13372,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13392,
+        "fields": {
+            "answer": 13388,
+            "issue": 32,
+            "issue_score": 0.15,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13394,
+        "fields": {
+            "answer": 13389,
+            "issue": 32,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13395,
+        "fields": {
+            "answer": 13389,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13398,
+        "fields": {
+            "answer": 13390,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13399,
+        "fields": {
+            "answer": 13390,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13400,
+        "fields": {
+            "answer": 13388,
+            "issue": 36,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13409,
+        "fields": {
+            "answer": 13402,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.13
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13412,
+        "fields": {
+            "answer": 13403,
+            "issue": 32,
+            "issue_score": -0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13413,
+        "fields": {
+            "answer": 13403,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13417,
+        "fields": {
+            "answer": 13414,
+            "issue": 32,
+            "issue_score": 0.02,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13418,
+        "fields": {
+            "answer": 13414,
+            "issue": 36,
+            "issue_score": 0.03,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13427,
+        "fields": {
+            "answer": 13419,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13429,
+        "fields": {
+            "answer": 13420,
+            "issue": 36,
+            "issue_score": 0.09,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13431,
+        "fields": {
+            "answer": 13421,
+            "issue": 36,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13432,
+        "fields": {
+            "answer": 13370,
+            "issue": 33,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13433,
+        "fields": {
+            "answer": 13388,
+            "issue": 33,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13434,
+        "fields": {
+            "answer": 13389,
+            "issue": 35,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13435,
+        "fields": {
+            "answer": 13390,
+            "issue": 33,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13455,
+        "fields": {
+            "answer": 13449,
+            "issue": 35,
+            "issue_score": 0.04,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13459,
+        "fields": {
+            "answer": 13450,
+            "issue": 36,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13462,
+        "fields": {
+            "answer": 13451,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13464,
+        "fields": {
+            "answer": 13451,
+            "issue": 32,
+            "issue_score": 0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13467,
+        "fields": {
+            "answer": 13452,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13468,
+        "fields": {
+            "answer": 13452,
+            "issue": 36,
+            "issue_score": 0.06,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13524,
+        "fields": {
+            "answer": 13515,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13525,
+        "fields": {
+            "answer": 13514,
+            "issue": 32,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13539,
+        "fields": {
+            "answer": 13535,
+            "issue": 34,
+            "issue_score": 0.12,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13543,
+        "fields": {
+            "answer": 13534,
+            "issue": 35,
+            "issue_score": 0.12,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13547,
+        "fields": {
+            "answer": 13533,
+            "issue": 35,
+            "issue_score": 0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13555,
+        "fields": {
+            "answer": 13550,
+            "issue": 32,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13564,
+        "fields": {
+            "answer": 13558,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13571,
+        "fields": {
+            "answer": 13559,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13572,
+        "fields": {
+            "answer": 13560,
+            "issue": 36,
+            "issue_score": -0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13576,
+        "fields": {
+            "answer": 13561,
+            "issue": 32,
+            "issue_score": -0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13582,
+        "fields": {
+            "answer": 13578,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13586,
+        "fields": {
+            "answer": 13583,
+            "issue": 32,
+            "issue_score": 0.12,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13590,
+        "fields": {
+            "answer": 13587,
+            "issue": 36,
+            "issue_score": 0.12,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13593,
+        "fields": {
+            "answer": 13591,
+            "issue": 36,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13594,
+        "fields": {
+            "answer": 13591,
+            "issue": 35,
+            "issue_score": 0.1,
+            "issue_importance": 0.12
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_state_json = [
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13174,
+        "fields": {
+            "answer": 13170,
+            "state": 267,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13175,
+        "fields": {
+            "answer": 13170,
+            "state": 268,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13176,
+        "fields": {
+            "answer": 13170,
+            "state": 270,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13177,
+        "fields": {
+            "answer": 13170,
+            "state": 269,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13180,
+        "fields": {
+            "answer": 13171,
+            "state": 264,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13181,
+        "fields": {
+            "answer": 13171,
+            "state": 265,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13182,
+        "fields": {
+            "answer": 13171,
+            "state": 266,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13184,
+        "fields": {
+            "answer": 13172,
+            "state": 251,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13185,
+        "fields": {
+            "answer": 13172,
+            "state": 252,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13186,
+        "fields": {
+            "answer": 13172,
+            "state": 253,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13187,
+        "fields": {
+            "answer": 13172,
+            "state": 256,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13188,
+        "fields": {
+            "answer": 13172,
+            "state": 257,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13190,
+        "fields": {
+            "answer": 13173,
+            "state": 260,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.024
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13191,
+        "fields": {
+            "answer": 13173,
+            "state": 259,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13192,
+        "fields": {
+            "answer": 13173,
+            "state": 258,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13193,
+        "fields": {
+            "answer": 13173,
+            "state": 262,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13274,
+        "fields": {
+            "answer": 13262,
+            "state": 267,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.005
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13275,
+        "fields": {
+            "answer": 13262,
+            "state": 262,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.0075
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13287,
+        "fields": {
+            "answer": 13283,
+            "state": 268,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13288,
+        "fields": {
+            "answer": 13284,
+            "state": 269,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13289,
+        "fields": {
+            "answer": 13285,
+            "state": 267,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13290,
+        "fields": {
+            "answer": 13286,
+            "state": 262,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13473,
+        "fields": {
+            "answer": 13469,
+            "state": 271,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13474,
+        "fields": {
+            "answer": 13469,
+            "state": 272,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13475,
+        "fields": {
+            "answer": 13469,
+            "state": 263,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13476,
+        "fields": {
+            "answer": 13469,
+            "state": 255,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13477,
+        "fields": {
+            "answer": 13469,
+            "state": 254,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13482,
+        "fields": {
+            "answer": 13470,
+            "state": 267,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13483,
+        "fields": {
+            "answer": 13470,
+            "state": 268,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.022
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13484,
+        "fields": {
+            "answer": 13471,
+            "state": 262,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13485,
+        "fields": {
+            "answer": 13471,
+            "state": 260,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13486,
+        "fields": {
+            "answer": 13471,
+            "state": 258,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13487,
+        "fields": {
+            "answer": 13479,
+            "state": 269,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13488,
+        "fields": {
+            "answer": 13479,
+            "state": 265,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13489,
+        "fields": {
+            "answer": 13479,
+            "state": 264,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13490,
+        "fields": {
+            "answer": 13479,
+            "state": 266,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13498,
+        "fields": {
+            "answer": 13495,
+            "state": 268,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13500,
+        "fields": {
+            "answer": 13496,
+            "state": 263,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13501,
+        "fields": {
+            "answer": 13496,
+            "state": 253,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13503,
+        "fields": {
+            "answer": 13494,
+            "state": 251,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13504,
+        "fields": {
+            "answer": 13494,
+            "state": 252,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13506,
+        "fields": {
+            "answer": 13493,
+            "state": 257,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13507,
+        "fields": {
+            "answer": 13493,
+            "state": 256,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13508,
+        "fields": {
+            "answer": 13493,
+            "state": 259,
+            "candidate": 2001622,
+            "affected_candidate": 2001622,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13640,
+        "fields": {
+            "answer": 13635,
+            "state": 264,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13641,
+        "fields": {
+            "answer": 13635,
+            "state": 265,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13642,
+        "fields": {
+            "answer": 13635,
+            "state": 266,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13643,
+        "fields": {
+            "answer": 13635,
+            "state": 269,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13646,
+        "fields": {
+            "answer": 13634,
+            "state": 260,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13647,
+        "fields": {
+            "answer": 13634,
+            "state": 262,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13648,
+        "fields": {
+            "answer": 13634,
+            "state": 258,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13649,
+        "fields": {
+            "answer": 13633,
+            "state": 267,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13650,
+        "fields": {
+            "answer": 13633,
+            "state": 268,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13651,
+        "fields": {
+            "answer": 13632,
+            "state": 271,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13652,
+        "fields": {
+            "answer": 13632,
+            "state": 272,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13653,
+        "fields": {
+            "answer": 13632,
+            "state": 263,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13654,
+        "fields": {
+            "answer": 13632,
+            "state": 255,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13655,
+        "fields": {
+            "answer": 13632,
+            "state": 254,
+            "candidate": 12776,
+            "affected_candidate": 12776,
+            "state_multiplier": 0.03
+        }
+    }
+]
+
+campaignTrail_temp.answer_feedback_json = [
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13038,
+        "fields": {
+            "answer": 13034,
+            "candidate": 2001622,
+            "answer_feedback": "The standard opening move for a third-party candidate, challenging the monopolistic political system of the two major parties."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13039,
+        "fields": {
+            "answer": 13037,
+            "candidate": 2001622,
+            "answer_feedback": "Although you don't currently have a strong appeal to KMT voters, due to your distinctive candidacy, perhaps you can attract those among them who lean towards the light blue spectrum?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13040,
+        "fields": {
+            "answer": 13035,
+            "candidate": 2001622,
+            "answer_feedback": "Strengthening support among young people has always been one of your strengths, with many supporters in the 20s and 30s age groups."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13041,
+        "fields": {
+            "answer": 13036,
+            "candidate": 2001622,
+            "answer_feedback": "Attacking the DPP can solidify your cohesion with supporters and focus on the strongest adversary."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13050,
+        "fields": {
+            "answer": 13047,
+            "candidate": 2001622,
+            "answer_feedback": "It seems you are the strongest third-party candidate since 2000. Make sure to sustain this momentum and create a political wave."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13051,
+        "fields": {
+            "answer": 13048,
+            "candidate": 2001622,
+            "answer_feedback": "Your YouTube channel's subscriber count, whether real or not, surpasses the fan base of Lai Ching-te and Hou You-yi by several times, or even dozens of times. In this aspect, you rightfully hold the first place."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13054,
+        "fields": {
+            "answer": 13049,
+            "candidate": 2001622,
+            "answer_feedback": "The People's Party has established branches in major cities across Taiwan, and this will be part of your nationwide campaign activities."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13060,
+        "fields": {
+            "answer": 13058,
+            "candidate": 2001622,
+            "answer_feedback": "Your staff uploaded the video of your conversation with young people to YouTube, and as expected, it garnered a large number of likes and comments."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13062,
+        "fields": {
+            "answer": 13057,
+            "candidate": 2001622,
+            "answer_feedback": "These figures are all influential individuals on the international stage. Being mentioned alongside them will provide substantial international exposure and enhance the trust of voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13065,
+        "fields": {
+            "answer": 13056,
+            "candidate": 2001622,
+            "answer_feedback": "This is your latest statement on foreign policy. It is widely known that you are adopting a centrist position on some key stances, aiming to garner the most votes."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13069,
+        "fields": {
+            "answer": 13067,
+            "candidate": 2001622,
+            "answer_feedback": "This is a standard response to strengthen your support base. Let's see how much support and voter turnout the TPP can achieve in this election."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13070,
+        "fields": {
+            "answer": 13068,
+            "candidate": 2001622,
+            "answer_feedback": "The high poll numbers for Hou You-yi seem to be short-lived. Since the start of the KMT primaries, he has been trailing behind Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13077,
+        "fields": {
+            "answer": 13076,
+            "candidate": 2001622,
+            "answer_feedback": "Certainly, gaining more diplomatic experience can only be beneficial for you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13082,
+        "fields": {
+            "answer": 13081,
+            "candidate": 2001622,
+            "answer_feedback": "This is a statement you have consistently emphasized, advocating not to trust individuals but to trust the system. This aligns with your rational, pragmatic, and scientific political agenda."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13085,
+        "fields": {
+            "answer": 13084,
+            "candidate": 2001622,
+            "answer_feedback": "This is part of your intense confrontation with the DPP. While your female voters have been affected, your main support base still relies on young males."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13089,
+        "fields": {
+            "answer": 13083,
+            "candidate": 2001622,
+            "answer_feedback": "This contrasts with the image of the DPP. At least the TPP does not have as many sexual harassment cases, and many people mock the DPP for this."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13101,
+        "fields": {
+            "answer": 13100,
+            "candidate": 2001622,
+            "answer_feedback": "Political observers criticize you for turning politics into entertainment, and older people are less accepting, seeing it as a joke. However, it is popular among young people, and you have earned a significant amount of money."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13104,
+        "fields": {
+            "answer": 13097,
+            "candidate": 2001622,
+            "answer_feedback": "The production of these items incurs costs, but what makes them more advantageous than small donations is their ability to generate a steady and continuous income. Many young people and children, show great enthusiasm for your campaign merchandise."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13105,
+        "fields": {
+            "answer": 13099,
+            "candidate": 2001622,
+            "answer_feedback": "This is a good way to gain support, but be cautious not to let your supporters discover your contacts with various corporations. They dislike the blue-green alliance due to its connections with big business."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13108,
+        "fields": {
+            "answer": 13098,
+            "candidate": 2001622,
+            "answer_feedback": "The enthusiasm from supporters for the TPP is so high that the fundraising goal was reached within just one hour of the campaign launch."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13117,
+        "fields": {
+            "answer": 13116,
+            "candidate": 2001622,
+            "answer_feedback": "You successfully gained political points here and avoided most of the media attacks; however, it may not have a particularly direct benefit for your election campaign."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13120,
+        "fields": {
+            "answer": 13115,
+            "candidate": 2001622,
+            "answer_feedback": "The media and other parties accuse you of turning this march into your personal campaign, but of course, you will benefit from it. Although the offline turnout may not be as high as your online numbers suggest."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13124,
+        "fields": {
+            "answer": 13114,
+            "candidate": 2001622,
+            "answer_feedback": "Afterwards, the young people you arranged were recognized as members of the TPP, which damaged Hou You-yi's image, and, of course, your own image as well. Has the open and hidden struggle of the opposition come to the surface so quickly?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13128,
+        "fields": {
+            "answer": 13113,
+            "candidate": 2001622,
+            "answer_feedback": "Lai Ching-te is certainly afraid to face the opposition crowd, but this won't affect the DPP's voter base. After all, they have a significant amount of support from the elderly, which you lack."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13137,
+        "fields": {
+            "answer": 13136,
+            "candidate": 2001622,
+            "answer_feedback": "According to TVBS and Formosa opinion polls, Hou's KMT intra-party support is only 70%. This is undoubtedly because you and Terry Gou have drawn away those dissatisfied voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13139,
+        "fields": {
+            "answer": 13135,
+            "candidate": 2001622,
+            "answer_feedback": "Terry Gou rejected your proposal; he believes that if you want to utilize his resources, you must let him be president for the first four years while you serve as vice president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13142,
+        "fields": {
+            "answer": 13130,
+            "candidate": 2001622,
+            "answer_feedback": "In 2014, you were a deep-green candidate, harboring strong resentment towards the Kuomintang. However, your current political affiliation just like the TPP, doesn't align with a specific color; it seems adaptable to any color."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13149,
+        "fields": {
+            "answer": 13148,
+            "candidate": 2001622,
+            "answer_feedback": "In fact, Terry Gou took away many of your pan-blue voters, but fortunately, his poll numbers began to decline after announcing an independent candidacy."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13154,
+        "fields": {
+            "answer": 13147,
+            "candidate": 2001622,
+            "answer_feedback": "Anyway, Terry Gou is fourth in the polls, putting too much focus on him may not be very useful. It's better to concentrate on Lai Ching-te and Hou You-yi."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13159,
+        "fields": {
+            "answer": 13158,
+            "candidate": 2001622,
+            "answer_feedback": "A nuclear-free homeland is, of course, impossible to achieve, but your energy policy, like many others, seems to be situated in the middle ground between the blue and green policies."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13162,
+        "fields": {
+            "answer": 13157,
+            "candidate": 2001622,
+            "answer_feedback": "It seems that the political views articulated by young people from the TPP are always much better than those of the KMT, perhaps due to the perception of political parties?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13164,
+        "fields": {
+            "answer": 13156,
+            "candidate": 2001622,
+            "answer_feedback": "You yourselves are a political stance, advocating to abandon the blue-green divide. This type of centrist voters has always existed, that's why James Soong has been in elections so many times, isn't it?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13167,
+        "fields": {
+            "answer": 13155,
+            "candidate": 2001622,
+            "answer_feedback": "If the blue and green parties control traditional media, then you perform well on the internet. However, the internet may not reach the elderly who watch television in rural areas."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13178,
+        "fields": {
+            "answer": 13170,
+            "candidate": 2001622,
+            "answer_feedback": "You have believed that your experience in Taipei is worth promoting. However, the satisfaction of Taipei residents with your performance is not high. Older citizens, who are part of the blue camp, also hold resentment against you for cutting their pensions."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13179,
+        "fields": {
+            "answer": 13171,
+            "candidate": 2001622,
+            "answer_feedback": "After having a meal with your mom, you attended a local gathering of young people and focused on visiting Miaoli."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13183,
+        "fields": {
+            "answer": 13172,
+            "candidate": 2001622,
+            "answer_feedback": "Your deep green background and Taiwanese identity may be helpful in the south, but be mindful that they also dislike those who oppose the Democratic Progressive Party halfway. Keep this in mind."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13189,
+        "fields": {
+            "answer": 13173,
+            "candidate": 2001622,
+            "answer_feedback": "The central region has always been a key to winning elections. If your third-party identity is played well, you might stand out here."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13195,
+        "fields": {
+            "answer": 13194,
+            "candidate": 2001622,
+            "answer_feedback": "Unfortunately, Hou You-yi and Lai Ching-te's visits have garnered more attention, while your second visit to the United States is perceived as following the trend."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13199,
+        "fields": {
+            "answer": 13198,
+            "candidate": 2001622,
+            "answer_feedback": "Now that you have attracted many dissatisfied individuals, it's important to ensure that you can retain them, as they may come and go quickly."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13202,
+        "fields": {
+            "answer": 13197,
+            "candidate": 2001622,
+            "answer_feedback": "This is a good way to double down on your core supporters. However, it might not significantly expand your voter base, as older people still may not be reached, and while many kids enjoy your show, they are not eligible to vote."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13204,
+        "fields": {
+            "answer": 13196,
+            "candidate": 2001622,
+            "answer_feedback": "This has gained you some appreciation, but the majority of elderly people in Taiwan tend to have specific party affiliations, making it challenging for you to sway a significant number of votes in this demographic."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13216,
+        "fields": {
+            "answer": 13213,
+            "candidate": 2001622,
+            "answer_feedback": "This will disappoint opposition voters and send a clear signal that you intend to chart your own course rather than choosing the option with the highest probability of success. While it strengthens your core supporters, it also contributes to the rise in support for Hou You-yi."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13217,
+        "fields": {
+            "answer": 13214,
+            "candidate": 2001622,
+            "answer_feedback": "The KMT immediately raised objections, claiming that polling results are prone to errors. They prefer conducting a democratic primary, allowing voters to cast their ballots in person. However, your party cannot accept a solution that relies more on offline strength."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13226,
+        "fields": {
+            "answer": 13225,
+            "candidate": 2001622,
+            "answer_feedback": "Suggesting directly that your opponent withdraw from the election might be seen as disrespectful to competition and voter choice, but it can strengthen your base, as they often enjoy ridiculing and disliking the KMT."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13233,
+        "fields": {
+            "answer": 13232,
+            "candidate": 2001622,
+            "answer_feedback": "Media captured you falling asleep during the morning assembly, and it has become a subject of amusement among people."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13236,
+        "fields": {
+            "answer": 13231,
+            "candidate": 2001622,
+            "answer_feedback": "This is an opportunity to further strengthen your third-party identity and support base. Taiwan is indeed entangled in confusion and uncertainty regarding national identity, but as an insider, you must make your decisions and choices."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13237,
+        "fields": {
+            "answer": 13230,
+            "candidate": 2001622,
+            "answer_feedback": "Ha ha, not many people attended TPP's events, but at least you taught young people that patriotism is a good thing, right?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13250,
+        "fields": {
+            "answer": 13247,
+            "candidate": 2001622,
+            "answer_feedback": "This deepens the impression among the young people following you, as they believe that indoor telephone polls are outdated and out of touch with the modern scientific trend.However, your own internal polls still use landline phones instead of exclusively relying on mobile phone surveys."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13252,
+        "fields": {
+            "answer": 13248,
+            "candidate": 2001622,
+            "answer_feedback": "Formosa was once the first poll to place you above Hou Youyi, but that's no longer the case. As for Ettoday, it has never ranked you as second."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13256,
+        "fields": {
+            "answer": 13249,
+            "candidate": 2001622,
+            "answer_feedback": "Street polls were proven to be unreliable in the 2020 election, but your young supporters seem to have short memories. They put a lot of trust in street poll videos on YouTube, where you're often depicted neck and neck with Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13265,
+        "fields": {
+            "answer": 13264,
+            "candidate": 2001622,
+            "answer_feedback": "The KMT won't be afraid of such easy blackmail. You've already placed TPP candidates in some of their constituencies, but they might not know whose votes will be drawn away – it could be from the blue camp or the green camp."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13268,
+        "fields": {
+            "answer": 13263,
+            "candidate": 2001622,
+            "answer_feedback": "This will help your campaign capability in some less explored areas. The KMT is willing to make concessions to show goodwill."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13271,
+        "fields": {
+            "answer": 13262,
+            "candidate": 2001622,
+            "answer_feedback": "This will help you gain votes in those deep green areas. The efforts of local legislators and cooperation with your joint campaign will assist you in securing votes in some green regions."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13279,
+        "fields": {
+            "answer": 13278,
+            "candidate": 2001622,
+            "answer_feedback": "Although your observations make sense, whether Terry Gou will become a spoiler or withdraw from the race to decrease Lai Ching-te's chances remains uncertain."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13282,
+        "fields": {
+            "answer": 13277,
+            "candidate": 2001622,
+            "answer_feedback": "This is a wise and sensible choice on your part. Don't be swayed by Terry Gou's substantial funding; ultimately, his resources are not yours to rely on."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13291,
+        "fields": {
+            "answer": 13283,
+            "candidate": 2001622,
+            "answer_feedback": "Strengthening your base is a good thing, but Taipei is a predominantly blue area. Please ensure that you can secure victory here; otherwise, your image might suffer."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13292,
+        "fields": {
+            "answer": 13284,
+            "candidate": 2001622,
+            "answer_feedback": "Taoyuan has seen an influx of a young population and hosts high-tech industries, many of whom could be your solid supporters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13293,
+        "fields": {
+            "answer": 13285,
+            "candidate": 2001622,
+            "answer_feedback": "New Taipei City is a place where both the blue and green camps have solid support bases and numerous battlegrounds. Disrupting the situation here would be beneficial for you. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13294,
+        "fields": {
+            "answer": 13286,
+            "candidate": 2001622,
+            "answer_feedback": "Taichung is a well-known swing region, and if you can establish a stronghold in central Taiwan, it may be possible to compete with both the blue and green parties."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13299,
+        "fields": {
+            "answer": 13298,
+            "candidate": 2001622,
+            "answer_feedback": "On the evening of November 15th, the Facebook and campaign accounts of TPP and KMT were filled with propaganda urging campaign supporters to vote for their respective candidates. Meanwhile, the media was fervently discussing who would emerge victorious and how the results of previous polls would impact the outcome."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13300,
+        "fields": {
+            "answer": 13296,
+            "candidate": 2001622,
+            "answer_feedback": "On the evening of November 15th, the Facebook and campaign accounts of TPP and KMT were filled with propaganda urging campaign supporters to vote for their respective candidates. Meanwhile, the media was fervently discussing who would emerge victorious and how the results of previous polls would impact the outcome."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13301,
+        "fields": {
+            "answer": 13295,
+            "candidate": 2001622,
+            "answer_feedback": "On the evening of November 15th, the Facebook and campaign accounts of TPP and KMT were filled with propaganda urging campaign supporters to vote for their respective candidates. Meanwhile, the media was fervently discussing who would emerge victorious and how the results of previous polls would impact the outcome."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13306,
+        "fields": {
+            "answer": 13302,
+            "candidate": 2001622,
+            "answer_feedback": "Congratulations, Mr. Ko Wen-je! You are very likely to become the next President of the Republic of China . The KMT has confirmed their defeat with a 5:4 ratio, and they cannot bear the responsibility of causing a deadlock. Therefore, they have accepted you as the presidential candidate. Congratulations!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13307,
+        "fields": {
+            "answer": 13303,
+            "candidate": 2001622,
+            "answer_feedback": "Congratulations, Mr. Ko Wen-je! You are very likely to become the next President of the Republic of China . The KMT has confirmed their defeat with a 5:4 ratio, and they cannot bear the responsibility of causing a deadlock. Therefore, they have accepted you as the presidential candidate. Congratulations!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13308,
+        "fields": {
+            "answer": 13304,
+            "candidate": 2001622,
+            "answer_feedback": "The most feared scenario for Lai Ching-te has become a reality: Ko Wen-je secures the presidency, while Hou You-yi assumes the position of vice president. This combination proves to be the most effective against Lai Ching-te. Does this signal the end of hope for the DPP's third term?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13309,
+        "fields": {
+            "answer": 13305,
+            "candidate": 2001622,
+            "answer_feedback": "The most feared scenario for Lai Ching-te has become a reality: Ko Wen-je secures the presidency, while Hou You-yi assumes the position of vice president. This combination proves to be the most effective against Lai Ching-te. Does this signal the end of hope for the DPP's third term?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13328,
+        "fields": {
+            "answer": 13325,
+            "candidate": 2001622,
+            "answer_feedback": "Some of your core supporters are displeased with your cooperation with the KMT, a party they have always disliked. However, since you hold a dominant position, they reluctantly accept it."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13329,
+        "fields": {
+            "answer": 13326,
+            "candidate": 2001622,
+            "answer_feedback": "From now on, the election has turned into a showdown between the Green and White camps. A fierce battle between the DPP and TPP is set to unfold, and currently, it appears that the mainstream public opinion in Taiwan is leaning towards opposition to the DPP."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13330,
+        "fields": {
+            "answer": 13327,
+            "candidate": 2001622,
+            "answer_feedback": "This will appease some supporters of the KMT. Even if they do not like Hou You-yi, they cannot accept their party being in a disadvantaged position. Saying some positive words about Hou You-yi can at least help alleviate the resentment within them."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13342,
+        "fields": {
+            "answer": 13341,
+            "candidate": 2001622,
+            "answer_feedback": "During the live broadcast, your emotional moment, wiping away tears with a towel, and the poignant words from your aide Huang Shanshan touched many supporters. However, some astute observers sense that things may not be as simple as they seem."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13343,
+        "fields": {
+            "answer": 13324,
+            "candidate": 2001622,
+            "answer_feedback": "During the live broadcast, your emotional moment, wiping away tears with a towel, and the poignant words from your aide Huang Shanshan touched many supporters. However, some astute observers sense that things may not be as simple as they seem."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13344,
+        "fields": {
+            "answer": 13323,
+            "candidate": 2001622,
+            "answer_feedback": "During the live broadcast, your emotional moment, wiping away tears with a towel, and the poignant words from your aide Huang Shanshan touched many supporters. However, some astute observers sense that things may not be as simple as they seem."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13345,
+        "fields": {
+            "answer": 13322,
+            "candidate": 2001622,
+            "answer_feedback": "During the live broadcast, your emotional moment, wiping away tears with a towel, and the poignant words from your aide Huang Shanshan touched many supporters. However, some astute observers sense that things may not be as simple as they seem."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13354,
+        "fields": {
+            "answer": 13351,
+            "candidate": 2001622,
+            "answer_feedback": "KMT accusing your side of shelving three polls that favored the KMT during negotiations and excluding all indoor telephone polls, including the reputable and internationally recognized Formosa Poll."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13362,
+        "fields": {
+            "answer": 13361,
+            "candidate": 2001622,
+            "answer_feedback": "You responded to the host with a seemingly casual expression, leaving many to speculate if you have alternative plans. Discussions have already started on forums, questioning whether a coalition agreement is now unattainable."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13368,
+        "fields": {
+            "answer": 13352,
+            "candidate": 2001622,
+            "answer_feedback": "What you're saying is indeed factual, but the sentiments of KMT and TPP voters may not align. Since you've already signed an unequal agreement in black and white, why the change of heart now? This is certainly seen as a lack of integrity."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13369,
+        "fields": {
+            "answer": 13353,
+            "candidate": 2001622,
+            "answer_feedback": "If you intended to run independently, you shouldn't have initiated talks with the KMT from the beginning. Perhaps you were only afraid of facing criticism from the broader opposition voters? However, now that cooperation seems unattainable, blue-leaning voters are likely to drift away from your side."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13373,
+        "fields": {
+            "answer": 13370,
+            "candidate": 2001622,
+            "answer_feedback": "Some of your elderly KMT and deep-blue supporters may feel disappointed, but they are unlikely to vote for the DPP, at most, they may choose not to vote, right?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13375,
+        "fields": {
+            "answer": 13374,
+            "candidate": 2001622,
+            "answer_feedback": "This will contribute to shaping your image among the deep-blue and pro-unification voters. Some of them are hesitant to support Hou You-yi but are willing to back you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13382,
+        "fields": {
+            "answer": 13371,
+            "candidate": 2001622,
+            "answer_feedback": "The DPP criticizes your approach, claiming it is similar to theirs, but you strongly condemn their policies. Nevertheless, the TPP does have some distinguishing features from the DPP in terms of policies."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13391,
+        "fields": {
+            "answer": 13388,
+            "candidate": 2001622,
+            "answer_feedback": "This will set you apart from Lai Ching-te, presenting you as a patriotic candidate compared to his pro-independence stance. Just this small emblem can highlight the difference in your national identity."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13393,
+        "fields": {
+            "answer": 13389,
+            "candidate": 2001622,
+            "answer_feedback": "Alright, since you choose to enhance your independence, there's no problem. However, the elderly pan-blue voters may not see your national flag emblem during the debate."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13397,
+        "fields": {
+            "answer": 13390,
+            "candidate": 2001622,
+            "answer_feedback": "The KMT is more than willing to provide you with a substantial amount of national flags and campaign materials related to the Republic of China."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13405,
+        "fields": {
+            "answer": 13401,
+            "candidate": 2001622,
+            "answer_feedback": "As always, you and your policies seek a balance between the blue and green camps. Whether this aligns with the taste of the majority in Taiwan remains to be seen."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13406,
+        "fields": {
+            "answer": 13402,
+            "candidate": 2001622,
+            "answer_feedback": "While achieving a non-nuclear homeland may be unlikely, your policies in this regard lean towards the KMT, as you haven't sought the abolition of nuclear energy, unlike DPP."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13410,
+        "fields": {
+            "answer": 13403,
+            "candidate": 2001622,
+            "answer_feedback": "What you say is very straightforward, but your supporters and many who appreciate you happen to like this kind of blunt honesty."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13415,
+        "fields": {
+            "answer": 13414,
+            "candidate": 2001622,
+            "answer_feedback": "The election results may be more intense than you imagine, so please be prepared and don't lose the victory in the final stages."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13423,
+        "fields": {
+            "answer": 13419,
+            "candidate": 2001622,
+            "answer_feedback": "Although your attacks are quite harsh, it seems that Lai Ching-te has not been significantly affected by this issue. In the end, it's just a reinforcement within the support bases of both sides, without much impact on the swing voters."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13424,
+        "fields": {
+            "answer": 13420,
+            "candidate": 2001622,
+            "answer_feedback": "These are indeed harsh criticisms, but the damage to Lai Ching-te seems limited as his building violation isn't severe. Even if arrogant, his core support base may still stand by him."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13425,
+        "fields": {
+            "answer": 13421,
+            "candidate": 2001622,
+            "answer_feedback": "If you want to demolish his house, you might as well seek help from Mayor Hou You-yi; at least he is the mayor of New Taipei City and can assist you in addressing this issue."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13439,
+        "fields": {
+            "answer": 13438,
+            "candidate": 2001622,
+            "answer_feedback": "The relentless pursuit by the DPP has forced you to donate these funds and demolish the parking lot. Hopefully, this won't affect your chances of victory."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13440,
+        "fields": {
+            "answer": 13437,
+            "candidate": 2001622,
+            "answer_feedback": "This is a swift action that can help you stop the bleeding. Unfortunately, these annoying real estate disputes have indeed impacted your poll numbers."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13445,
+        "fields": {
+            "answer": 13436,
+            "candidate": 2001622,
+            "answer_feedback": "Haha, it seems you are destined for a brawl with Lai Ching-te, and who will have the last laugh remains to be seen."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13453,
+        "fields": {
+            "answer": 13449,
+            "candidate": 2001622,
+            "answer_feedback": "Doubling down on your third-party identity will benefit you. After all, Taiwan has never experienced a third party in power, and you might have a chance to win."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13456,
+        "fields": {
+            "answer": 13450,
+            "candidate": 2001622,
+            "answer_feedback": "The DPP has spent a lot of special budgets on various plans in recent years, and you have been criticizing them for their lack of fiscal discipline because special budgets were not used so frequently in the past."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13460,
+        "fields": {
+            "answer": 13451,
+            "candidate": 2001622,
+            "answer_feedback": "You are the strongest third-party candidate since James Soong in 2000. Emphasizing this point will always be beneficial and attractive."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13465,
+        "fields": {
+            "answer": 13452,
+            "candidate": 2001622,
+            "answer_feedback": "This is a strong counterattack against the DPP, and many people have noticed that you have been assisting the blue camp in attacking Lai Ching-te throughout this debate."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13472,
+        "fields": {
+            "answer": 13469,
+            "candidate": 2001622,
+            "answer_feedback": "As long as you all don't give up, Uncle Ko won't give up either! Let's create another miracle in the history of Taiwan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13478,
+        "fields": {
+            "answer": 13470,
+            "candidate": 2001622,
+            "answer_feedback": "You must not fail in Taipei; otherwise, it would suggest that your achievements in Taipei over the past eight years were not as impressive. I hope the Taipei experience can be extended nationwide!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13480,
+        "fields": {
+            "answer": 13471,
+            "candidate": 2001622,
+            "answer_feedback": "Taichung has a significant number of young supporters, while Changhua and Nantou, with fewer young residents and lower urbanization rates, face challenges in garnering support similar to Taichung."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13481,
+        "fields": {
+            "answer": 13479,
+            "candidate": 2001622,
+            "answer_feedback": "Chairman Ko Wen-je, your mother fervently hopes that you become the president, and she would be very happy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13497,
+        "fields": {
+            "answer": 13495,
+            "candidate": 2001622,
+            "answer_feedback": "Mayor Hou You-yi's ability as a mayor will undoubtedly help you gain more votes here."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13499,
+        "fields": {
+            "answer": 13496,
+            "candidate": 2001622,
+            "answer_feedback": "Mayor Hou has covered the entire east coast for you and has helped boost your visibility in Pingtung and Yilan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13502,
+        "fields": {
+            "answer": 13494,
+            "candidate": 2001622,
+            "answer_feedback": "Kaohsiung and Tainan are solid strongholds of the DPP, but the collaboration between our two parties could potentially disrupt this situation!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13505,
+        "fields": {
+            "answer": 13493,
+            "candidate": 2001622,
+            "answer_feedback": "Hou You-yi hasn't returned to his hometown for a long time, but with his local identity, he can secure many votes."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13518,
+        "fields": {
+            "answer": 13516,
+            "candidate": 2001622,
+            "answer_feedback": "Terry Gou ultimately accepted your suggestion, and he will withdraw from the election to ensure that the pan-blue votes are not further fragmented."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13519,
+        "fields": {
+            "answer": 13515,
+            "candidate": 2001622,
+            "answer_feedback": "No matter what you say, Joint Tickets are on the verge of collapse. The only remaining possibility is theoretical. You need to find a vice president now.\Fortunately, Terry Gou withdrew from the election, preventing further splitting of the pan-blue votes in this election."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13520,
+        "fields": {
+            "answer": 13514,
+            "candidate": 2001622,
+            "answer_feedback": "No matter what you say, Joint Tickets are on the verge of collapse. The only remaining possibility is theoretical. You need to find a vice president now.Fortunately, Terry Gou withdrew from the election, preventing further splitting of the pan-blue votes in this election."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13530,
+        "fields": {
+            "answer": 13522,
+            "candidate": 2001622,
+            "answer_feedback": "Gou said nothing at the moment, and you sensed that something was amiss. On November 24th, he registered as a presidential candidate along with his running mate,Lai Pei-Hsia, for the position of vice president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13536,
+        "fields": {
+            "answer": 13535,
+            "candidate": 2001622,
+            "answer_feedback": "Your voters dislike the image of being associated with big business, but her beautiful and feminine image can compensate for that. The Kuomintang's Hou You-yi also made a surprising choice by selecting Zhao Shao-kang as his running mate. The specific situation remains to be observed."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13540,
+        "fields": {
+            "answer": 13534,
+            "candidate": 2001622,
+            "answer_feedback": "Her English is excellent, but her Chinese may not be as fluent in certain situations. For example, in debates and public speeches, her performance can be like reading from a script."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13544,
+        "fields": {
+            "answer": 13533,
+            "candidate": 2001622,
+            "answer_feedback": "Choosing her will provide a good gender balance, and her beautiful image will capture the hearts of many voters. The People's Party is certainly not lacking in attractive women."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13551,
+        "fields": {
+            "answer": 13550,
+            "candidate": 2001622,
+            "answer_feedback": "Zhao Shao-kang strongly responded, urging you to ensure that there will be no cooperation with dpp after the election. Hou You-yi also remarked that must be quite envious of having a competent Vice President."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13552,
+        "fields": {
+            "answer": 13548,
+            "candidate": 2001622,
+            "answer_feedback": "The return of blue camp voters is happening at a faster pace than anticipated. According to Formosa and TVBS polls, the KMT-TPP has a support rate of 31%, compared to 23%, and 30.5% to 17.7%, respectively."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13562,
+        "fields": {
+            "answer": 13558,
+            "candidate": 2001622,
+            "answer_feedback": "This is a somewhat unclear response, and Mayor Hou has strongly criticized you in this regard. Based on this response, you seem to lean towards abolishing the death penalty."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13565,
+        "fields": {
+            "answer": 13559,
+            "candidate": 2001622,
+            "answer_feedback": "You are the strongest third-party candidate since James Soong in 2000. Emphasizing this point will always be beneficial and attractive."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13568,
+        "fields": {
+            "answer": 13560,
+            "candidate": 2001622,
+            "answer_feedback": "Lai Ching-te angrily countered you, stating that the 57 billion NTD debt repayment you frequently boast about for Taipei was concentrated in a specific year and is not something worth bragging about every day."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13573,
+        "fields": {
+            "answer": 13561,
+            "candidate": 2001622,
+            "answer_feedback": "Hou You-yi replied to you with just a few words, telling you not to shoot the arrow before drawing the target; there is no such thing."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13579,
+        "fields": {
+            "answer": 13578,
+            "candidate": 2001622,
+            "answer_feedback": "This statement directly triggered attacks from the green camp, implying that Wu Xinying has a spoiled style and completely lacks understanding of the people's hardships. In addition, DPP stated, \"We are Taiwanese! You are Chinese. Wu's identity is fundamentally problematic.\" "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13584,
+        "fields": {
+            "answer": 13583,
+            "candidate": 2001622,
+            "answer_feedback": "Many green supporters believe that if the CSSTA is signed, an influx of Chinese people will take away all the local jobs in Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13588,
+        "fields": {
+            "answer": 13587,
+            "candidate": 2001622,
+            "answer_feedback": "These attacks align well with the preferences of your voter base, but whether they can extend to capture more of the moderate voters remains to be seen."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13592,
+        "fields": {
+            "answer": 13591,
+            "candidate": 2001622,
+            "answer_feedback": "This is a response to the DPP's extensive spending plans and misuse of special budgets, supporting your stance on strengthening fiscal discipline."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13606,
+        "fields": {
+            "answer": 13605,
+            "candidate": 2001622,
+            "answer_feedback": "This is a clear signal to opposition voters; however, they might automatically choose the candidate with the highest poll numbers."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13611,
+        "fields": {
+            "answer": 13602,
+            "candidate": 2001622,
+            "answer_feedback": "Lai  immediately countered your agricultural land issue, stating that converting agricultural land into a parking lot is the real illegal activity. He mentioned plans to transform his own home into a mining museum for charitable trust purposes."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13612,
+        "fields": {
+            "answer": 13604,
+            "candidate": 2001622,
+            "answer_feedback": "Your attacks on Terry Gou won't go unnoticed by the voters. Since he started running as an independent, his support has steadily declined. Hopefully, Gou's supporters will come to your camp!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13613,
+        "fields": {
+            "answer": 13603,
+            "candidate": 2001622,
+            "answer_feedback": "Mayor Hou staunchly countered your accusations, stating that the property in question belongs to his wife and is entirely legal and justified. He emphasized that after the contract expires, it will be converted into affordable housing for the community.\""
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13636,
+        "fields": {
+            "answer": 13635,
+            "candidate": 12776,
+            "answer_feedback": "Chairman Ko Wen-je, your mother fervently hopes that you become the president, and she would be very happy!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13637,
+        "fields": {
+            "answer": 13634,
+            "candidate": 12776,
+            "answer_feedback": "Taichung has a significant number of young supporters, while Changhua and Nantou, with fewer young residents and lower urbanization rates, face challenges in garnering support similar to Taichung."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13638,
+        "fields": {
+            "answer": 13633,
+            "candidate": 12776,
+            "answer_feedback": "You must not fail in Taipei; otherwise, it would suggest that your achievements in Taipei over the past eight years were not as impressive. I hope the Taipei experience can be extended nationwide!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13639,
+        "fields": {
+            "answer": 13632,
+            "candidate": 12776,
+            "answer_feedback": "As long as you all don't give up, Uncle Ko won't give up either! Let's create another miracle in the history of Taiwan!"
+        }
+    }
+]
+
+
+
+
+cyoAdventure = function (a) {
+    
+    ans = campaignTrail_temp.player_answers[campaignTrail_temp.player_answers.length-1];
+   
+    let pop_vote = e.current_results[0];
+    let playerPolling = pop_vote[2].pvp;
+    let i = 0;
+
+        pop_vote.sort((a, b) => {
+            return a.pk - b.pk;
+        });
+      //吴欣盈，无论如何都破局
+      if (ans == 13295 || ans == 13296 || ans == 13298 && pop_vote[2].pvp > 0.29){    
+        campaignTrail_temp.questions_json[19] = {
+            "model": "campaign_trail.question",
+            "pk": 13033,
+            "fields": {
+                "priority": 0,
+                "description": "On the Midnight of November 18th, as the people of Taiwan slept, in a dark and windy evening, polling experts from the TPP and KMT were nervously discussing issues related to the margin of error in the polls and the number of victories for each party. and The final results are.....",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[20] = {
+            "model": "campaign_trail.question",
+            "pk": 13350,
+            "fields": {
+                "priority": 0,
+                "description": "On the Morning of November 18th, another shocking news rocked the political scene: the KMT and TPP were embroiled in disputes within the margin of error in the polls, leading to conflicting victory claims. The TPP insisted on a margin of error of 3%, with a range of plus or minus 1.5%, while the KMT argued that each poll should be calculated based on its own determined maximum margin of error. For example, Formosa Poll indicated a maximum sampling error of ±3.0% at a 95% confidence level, totaling 6%. Now, at this crucial moment deciding Taiwan's fate, how do you perceive the negotiations reaching a deadlock?",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[21] = {
+            "model": "campaign_trail.question",
+            "pk": 13509,
+            "fields": {
+                "priority": 0,
+                "description": "On November 23rd, you and Terry Gou invited Mayor Hou You-yi to the Taipei Grand Hyatt to discuss the last hope for Joint Tickets. However, Mayor Hou You-yi brought President Ma Ying-jeou and Chairman Eric Chu to the scene, causing dissatisfaction from Terry Gou. Chairman Ko Wen-je, what points do you need to emphasize during the meeting?",
+                "likelihood": 1
+            }
+        }
+
+        campaignTrail_temp.questions_json[23] = {
+            "model": "campaign_trail.question",
+            "pk": 13511,
+            "fields": {
+                "priority": 0,
+                "description": "November 24th, after you registered as a presidential candidate at the CEC, Hou Youyi called you, but you ignored it. An hour later, he teamed up with Zhao Shaokang, the chairman of China Broadcasting Corporation, and other media figures to form the presidential and vice-presidential ticket. In the following days, many blue camp voters were emotionally stirred by this, and it seems that many blue voters who had temporarily supported you are returning to the KMT's base.....",
+                "likelihood": 1
+            }
+    }
+    campaignTrail_temp.questions_json[22] = {
+        "model": "campaign_trail.question",
+        "pk": 13510,
+        "fields": {
+            "priority": 0,
+            "description": "As Joint Tickets completely failed, on November 24th, you unexpectedly chose legislator Cynthia Wu as the vice president. She is the daughter of a major business tycoon, bringing an impressive background to your campaign. Additionally, being an American-born Chinese (ABC), what special qualities do you see in her that led to your choice of her as the vice president?",
+            "likelihood": 1
+        }
+}
+    campaignTrail_temp.questions_json[24] = {
+        "model": "campaign_trail.question",
+        "pk": 13513,
+        "fields": {
+            "priority": 0,
+            "description": "Your vice president, Cynthia Wu, has many noteworthy qualities. Handing over the floor to her, what do you think she should say to attract voters?",
+            "likelihood": 1
+        }
+    }
+        campaignTrail_temp.questions_json[25] = {
+            "model": "campaign_trail.question",
+            "pk": 13026,
+            "fields": {
+                "priority": 0,
+                "description": "Some of your aides suggest that, following the tradition of KMT candidates, you add a small Republic of China (ROC) flag emblem on top of your KP badge to increase appeal to blue-leaning voters. Will you consider this suggestion?",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[28] = {
+            "model": "campaign_trail.question",
+          "pk": 13512,
+             "fields": {
+            "priority": 0,
+            "description": "In this year's presidential election, there are three candidates on the stage: Hou from the KMT, you from the TPP, and Lai from the DPP. This will be your moment to showcase your debating skills in the presidential election. What do you want to emphasize during the debate?",
+            "likelihood": 1
+         }
+        }
+    }
+    //民调低于30，整合失败
+     if (ans == 13295 || ans == 13296 || ans == 13298 && pop_vote[2].pvp <= 0.29 ){
+        campaignTrail_temp.questions_json[19] = {
+            "model": "campaign_trail.question",
+            "pk": 13033,
+            "fields": {
+                "priority": 0,
+                "description": "On the Midnight of November 18th, as the people of Taiwan slept, in a dark and windy evening, polling experts from the TPP and KMT were nervously discussing issues related to the margin of error in the polls and the number of victories for each party. and The final results are.....",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[20] = {
+            "model": "campaign_trail.question",
+            "pk": 13350,
+            "fields": {
+                "priority": 0,
+                "description": "On the Morning of November 18th, another shocking news rocked the political scene: the KMT and TPP were embroiled in disputes within the margin of error in the polls, leading to conflicting victory claims. The TPP insisted on a margin of error of 3%, with a range of plus or minus 1.5%, while the KMT argued that each poll should be calculated based on its own determined maximum margin of error. For example, Formosa Poll indicated a maximum sampling error of ±3.0% at a 95% confidence level, totaling 6%. Now, at this crucial moment deciding Taiwan's fate, how do you perceive the negotiations reaching a deadlock?",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[21] = {
+            "model": "campaign_trail.question",
+            "pk": 13509,
+            "fields": {
+                "priority": 0,
+                "description": "On November 23rd, you and Terry Gou invited Mayor Hou You-yi to the Taipei Grand Hyatt to discuss the last hope for Joint Tickets. However, Mayor Hou You-yi brought President Ma Ying-jeou and Chairman Eric Chu to the scene, causing dissatisfaction from Terry Gou. Chairman Ko Wen-je, what points do you need to emphasize during the meeting?",
+                "likelihood": 1
+            }
+        }
+
+        campaignTrail_temp.questions_json[23] = {
+            "model": "campaign_trail.question",
+            "pk": 13511,
+            "fields": {
+                "priority": 0,
+                "description": "November 24th, after you registered as a presidential candidate at the CEC, Hou Youyi called you, but you ignored it. An hour later, he teamed up with Zhao Shaokang, the chairman of China Broadcasting Corporation, and other media figures to form the presidential and vice-presidential ticket. In the following days, many blue camp voters were emotionally stirred by this, and it seems that many blue voters who had temporarily supported you are returning to the KMT's base.....",
+                "likelihood": 1
+            }
+    }
+    campaignTrail_temp.questions_json[22] = {
+        "model": "campaign_trail.question",
+        "pk": 13510,
+        "fields": {
+            "priority": 0,
+            "description": "As Joint Tickets completely failed, on November 24th, you unexpectedly chose legislator Cynthia Wu as the vice president. She is the daughter of a major business tycoon, bringing an impressive background to your campaign. Additionally, being an American-born Chinese (ABC), what special qualities do you see in her that led to your choice of her as the vice president?",
+            "likelihood": 1
+        }
+}
+    campaignTrail_temp.questions_json[24] = {
+        "model": "campaign_trail.question",
+        "pk": 13513,
+        "fields": {
+            "priority": 0,
+            "description": "Your vice president, Cynthia Wu, has many noteworthy qualities. Handing over the floor to her, what do you think she should say to attract voters?",
+            "likelihood": 1
+        }
+    }
+        campaignTrail_temp.questions_json[25] = {
+            "model": "campaign_trail.question",
+            "pk": 13026,
+            "fields": {
+                "priority": 0,
+                "description": "Some of your aides suggest that, following the tradition of KMT candidates, you add a small Republic of China (ROC) flag emblem on top of your KP badge to increase appeal to blue-leaning voters. Will you consider this suggestion?",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[28] = {
+            "model": "campaign_trail.question",
+          "pk": 13512,
+             "fields": {
+            "priority": 0,
+            "description": "In this year's presidential election, there are three candidates on the stage: Hou from the KMT, you from the TPP, and Lai from the DPP. This will be your moment to showcase your debating skills in the presidential election. What do you want to emphasize during the debate?",
+            "likelihood": 1
+         }
+        }
+    }
+    //直接节目上说不要合
+    else if (ans == 13361 ){
+        campaignTrail_temp.questions_json[19] = {
+            "model": "campaign_trail.question",
+            "pk": 13033,
+            "fields": {
+                "priority": 0,
+                "description": "On the Midnight of November 18th, as the people of Taiwan slept, in a dark and windy evening, polling experts from the TPP and KMT were nervously discussing issues related to the margin of error in the polls and the number of victories for each party. and The final results are.....",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[20] = {
+            "model": "campaign_trail.question",
+            "pk": 13350,
+            "fields": {
+                "priority": 0,
+                "description": "On the Morning of November 18th, another shocking news rocked the political scene: the KMT and TPP were embroiled in disputes within the margin of error in the polls, leading to conflicting victory claims. The TPP insisted on a margin of error of 3%, with a range of plus or minus 1.5%, while the KMT argued that each poll should be calculated based on its own determined maximum margin of error. For example, Formosa Poll indicated a maximum sampling error of ±3.0% at a 95% confidence level, totaling 6%. Now, at this crucial moment deciding Taiwan's fate, how do you perceive the negotiations reaching a deadlock?",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[21] = {
+            "model": "campaign_trail.question",
+            "pk": 13509,
+            "fields": {
+                "priority": 0,
+                "description": "On November 23rd, you and Terry Gou invited Mayor Hou You-yi to the Taipei Grand Hyatt to discuss the last hope for Joint Tickets. However, Mayor Hou You-yi brought President Ma Ying-jeou and Chairman Eric Chu to the scene, causing dissatisfaction from Terry Gou. Chairman Ko Wen-je, what points do you need to emphasize during the meeting?",
+                "likelihood": 1
+            }
+        }
+
+        campaignTrail_temp.questions_json[23] = {
+            "model": "campaign_trail.question",
+            "pk": 13511,
+            "fields": {
+                "priority": 0,
+                "description": "November 24th, after you registered as a presidential candidate at the CEC, Hou Youyi called you, but you ignored it. An hour later, he teamed up with Zhao Shaokang, the chairman of China Broadcasting Corporation, and other media figures to form the presidential and vice-presidential ticket. In the following days, many blue camp voters were emotionally stirred by this, and it seems that many blue voters who had temporarily supported you are returning to the KMT's base.....",
+                "likelihood": 1
+            }
+    }
+    campaignTrail_temp.questions_json[22] = {
+        "model": "campaign_trail.question",
+        "pk": 13510,
+        "fields": {
+            "priority": 0,
+            "description": "As Joint Tickets completely failed, on November 24th, you unexpectedly chose legislator Cynthia Wu as the vice president. She is the daughter of a major business tycoon, bringing an impressive background to your campaign. Additionally, being an American-born Chinese (ABC), what special qualities do you see in her that led to your choice of her as the vice president?",
+            "likelihood": 1
+        }
+}
+    campaignTrail_temp.questions_json[24] = {
+        "model": "campaign_trail.question",
+        "pk": 13513,
+        "fields": {
+            "priority": 0,
+            "description": "Your vice president, Cynthia Wu, has many noteworthy qualities. Handing over the floor to her, what do you think she should say to attract voters?",
+            "likelihood": 1
+        }
+    }
+        campaignTrail_temp.questions_json[25] = {
+            "model": "campaign_trail.question",
+            "pk": 13026,
+            "fields": {
+                "priority": 0,
+                "description": "Some of your aides suggest that, following the tradition of KMT candidates, you add a small Republic of China (ROC) flag emblem on top of your KP badge to increase appeal to blue-leaning voters. Will you consider this suggestion?",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[28] = {
+            "model": "campaign_trail.question",
+          "pk": 13512,
+             "fields": {
+            "priority": 0,
+            "description": "In this year's presidential election, there are three candidates on the stage: Hou from the KMT, you from the TPP, and Lai from the DPP. This will be your moment to showcase your debating skills in the presidential election. What do you want to emphasize during the debate?",
+            "likelihood": 1
+         }
+        }
+    } 
+    if (ans == 13388 || ans == 13390 ){
+        campaignTrail_temp.candidate_image_url = "https://i.imgur.com/84Ealxo.jpeg";
+    }   
+    if (ans == 13034 || ans == 13035 || ans == 13036 || ans ==13037){
+        campaignTrail_temp.election_json[0]["fields"].advisor_url = "https://i.imgur.com/5sM8nVt.jpeg";
+    }
+
+    if (ans == 13514 || ans == 13515 || ans == 13516 || ans == 13522 ){
+        campaignTrail_temp.running_mate_image_url = 'https://i.imgur.com/OdRj8T0.png';
+        campaignTrail_temp.running_mate_last_name = 'Wu';
+    }
+    if( ans == 13522 ){
+        campaignTrail_temp.questions_json[19] = {
+            "model": "campaign_trail.question",
+            "pk": 13033,
+            "fields": {
+                "priority": 0,
+                "description": "On the Midnight of November 18th, as the people of Taiwan slept, in a dark and windy evening, polling experts from the TPP and KMT were nervously discussing issues related to the margin of error in the polls and the number of victories for each party. and The final results are.....",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[20] = {
+            "model": "campaign_trail.question",
+            "pk": 13350,
+            "fields": {
+                "priority": 0,
+                "description": "On the Morning of November 18th, another shocking news rocked the political scene: the KMT and TPP were embroiled in disputes within the margin of error in the polls, leading to conflicting victory claims. The TPP insisted on a margin of error of 3%, with a range of plus or minus 1.5%, while the KMT argued that each poll should be calculated based on its own determined maximum margin of error. For example, Formosa Poll indicated a maximum sampling error of ±3.0% at a 95% confidence level, totaling 6%. Now, at this crucial moment deciding Taiwan's fate, how do you perceive the negotiations reaching a deadlock?",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[21] = {
+            "model": "campaign_trail.question",
+            "pk": 13509,
+            "fields": {
+                "priority": 0,
+                "description": "On November 23rd, you and Terry Gou invited Mayor Hou You-yi to the Taipei Grand Hyatt to discuss the last hope for Joint Tickets. However, Mayor Hou You-yi brought President Ma Ying-jeou and Chairman Eric Chu to the scene, causing dissatisfaction from Terry Gou. Chairman Ko Wen-je, what points do you need to emphasize during the meeting?",
+                "likelihood": 1
+            }
+        }
+
+        campaignTrail_temp.questions_json[23] = {
+            "model": "campaign_trail.question",
+            "pk": 13511,
+            "fields": {
+                "priority": 0,
+                "description": "November 24th, after you registered as a presidential candidate at the CEC, Hou Youyi called you, but you ignored it. An hour later, he teamed up with Zhao Shaokang, the chairman of China Broadcasting Corporation, and other media figures to form the presidential and vice-presidential ticket. In the following days, many blue camp voters were emotionally stirred by this, and it seems that many blue voters who had temporarily supported you are returning to the KMT's base.....",
+                "likelihood": 1
+            }
+    }
+    campaignTrail_temp.questions_json[22] = {
+        "model": "campaign_trail.question",
+        "pk": 13510,
+        "fields": {
+            "priority": 0,
+            "description": "As Joint Tickets completely failed, on November 24th, you unexpectedly chose legislator Cynthia Wu as the vice president. She is the daughter of a major business tycoon, bringing an impressive background to your campaign. Additionally, being an American-born Chinese (ABC), what special qualities do you see in her that led to your choice of her as the vice president?",
+            "likelihood": 1
+        }
+}
+    campaignTrail_temp.questions_json[24] = {
+        "model": "campaign_trail.question",
+        "pk": 13513,
+        "fields": {
+            "priority": 0,
+            "description": "Your vice president, Cynthia Wu, has many noteworthy qualities. Handing over the floor to her, what do you think she should say to attract voters?",
+            "likelihood": 1
+        }
+    }
+        campaignTrail_temp.questions_json[25] = {
+            "model": "campaign_trail.question",
+            "pk": 13026,
+            "fields": {
+                "priority": 0,
+                "description": "Some of your aides suggest that, following the tradition of KMT candidates, you add a small Republic of China (ROC) flag emblem on top of your KP badge to increase appeal to blue-leaning voters. Will you consider this suggestion?",
+                "likelihood": 1
+            }
+        }
+        campaignTrail_temp.questions_json[28] =   {
+            "model": "campaign_trail.question",
+            "pk": 13577,
+            "fields": {
+                "priority": 0,
+                "description": "This year's unprecedented presidential election features four candidates participating in a debate: yourself from the TPP, Hou from the KMT, Lai from the DPP, and the independent candidate Gou. Just a month ago, you suggested that Gou should withdraw from the election, but he did not consider this proposal and chose to run independently. In this debate, what main points would you like to emphasize?",
+                "likelihood": 1
+            }
+        }
+    }
+    //柯文哲被弃保：辩论后民调未达30%，选民归队
+    if (ans == 13449 || ans == 13450 || ans == 13451 || ans == 13452 && pop_vote[2].pvp < 0.29){    
+        campaignTrail_temp.questions_json[29] =   {
+            "model": "campaign_trail.question",
+            "pk": 13631,
+            "fields": {
+                "priority": 0,
+                "description": "In the final week before the election, you have the opportunity to visit specific regions nationwide to boost local support. In which areas do you hope to campaign in a final effort?",
+                "likelihood": 1
+            }
+        }
+    }
+    //各党特色颜色，背景图片
+    if ( ans == 13034 || ans == 13035 || ans == 13036 || ans == 13037){    
+        nct_stuff.themes[nct_stuff.selectedTheme].coloring_window = "#ffffff" 
+        nct_stuff.themes[nct_stuff.selectedTheme].coloring_title = "#28c8c8" 
+        $(".container")[0].style.backgroundColor = "#6848ff" 
+        $("#game_window")[0].style.borderColor = "#99A0A8" 
+        $(".container")[0].style.backgroundColor = "#F4F4EE" 
+        $("#game_window")[0].style.borderColor = "#ffffff" 
+        $("#game_window")[0].style.backgroundImage = "url(https://i.imgur.com/xAN3Ufz.png)" 
+        document.getElementById("header").src = "https://i.imgur.com/Q5BQ3fn.jpg" 
+        document.body.background = "https://i.imgur.com/u7NyV06.jpeg"
+    }
+    getResults = function (out, totv, aa, quickstats) {
+        if( quickstats[1] > 33.49 && quickstats[1] < 40.0  ) {
+            unlockAchievement("Cross The Song-Chu Yu wall");
+        }
+    }
+    getResults = function (out, totv, aa, quickstats) {
+        let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 256);
+        if( quickstats[1] > 29.9 && stateResult.result[2].candidate == 2001591 ) {
+            unlockAchievement("The pesky mayor");
+        }
+    }
+    getResults = function (out, totv, aa, quickstats) {
+        if(aa[2].candidate === 2001557 ) {
+            unlockAchievement("Lai the third");
+        }
+    }
+    getResults = function (out, totv, aa, quickstats) {
+        if(aa[2].candidate === 2001591 ) {
+            unlockAchievement("Old Third Boxed Lunch");
+        }
+    }
+    getResults = function (out, totv, aa, quickstats) {
+        if( quickstats[1] <= 50.29 && aa[0].candidate === 2001622 ) {
+            unlockAchievement("Election valid");
+        }
+    }
+    getResults = function (out, totv, aa, quickstats) {
+        let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 268);
+        let stateResulttwo = campaignTrail_temp.final_state_results.find((x) => x.state == 265);
+        if( stateResult.result[0].candidate == 2001622 && stateResulttwo.result[0].candidate == 2001622 ) {
+            unlockAchievement("Loves From Hometown");
+        }
+    }
+    getResults = function (out, totv, aa, quickstats) {
+        if( e.player_answers.includes(13194) && aa[0].candidate === 2001622) {
+            unlockAchievement("Votes White Votes Right");
+        }
+    }
+}
+
+campaignTrail_temp.jet_data = [{}
+]
+
+campaignTrail_temp.candidate_image_url = "https://i.imgur.com/3fQuylW.jpg";
+campaignTrail_temp.running_mate_image_url = "https://i.imgur.com/ZAZoO9r.jpeg";
+campaignTrail_temp.candidate_last_name = "Ko";
+campaignTrail_temp.running_mate_last_name = "For TPP 2024";
+campaignTrail_temp.running_mate_state_id = '265';
+campaignTrail_temp.player_answers = [];
+campaignTrail_temp.player_visits = [];
+campaignTrail_temp.answer_feedback_flg = 1;
+campaignTrail_temp.game_start_logging_id = '3660822';
+
+const style_overwrite = document.createElement("style");
+style_overwrite.innerHTML = 
+`#campaign_sign {
+  background-color: #28c8c8;
+  border-color: #7fcfc8;
+}
+#menu_container {
+  background-color: #c3c3c3;
+}
+#overall_result_container {
+  background-color: #c3c3c3;
+}
+#state_info h3 {
+  background-color: #ffffff;
+}
+#overall_result h3 {
+  background-color: #ffffff;
+}`
+;
+document.head.appendChild(style_overwrite);
+
+let style = document.createElement('style');
+style.type = 'text/css';
+style.id = 'dynamic-style';
+
+style.innerHTML = `
+  .inner_window_question h3 {
+    background-color: #e1e1e1;
+  }
+  .overlay_window h3 {
+    background-color: #b4b4b4;
+  }
+
+  
+`;
+
+document.head.appendChild(style);
+
+
+function checkIfCanAddMap() {
+    map = document.getElementById("map_container");
+    
+    if(map) {
+        map.style.backgroundImage = "url('https://images.rawpixel.com/image_800/czNmcy1wcml2YXRlL3Jhd3BpeGVsX2ltYWdlcy93ZWJzaXRlX2NvbnRlbnQvbHIvdjk5Ni0wMDlfMS1rcm9pcjRkay5qcGc.jpg')"; 
+    }
+}
+
+setInterval(checkIfCanAddMap, 250);
+
+(function(e, t, n, r, i) {
+    function s(e, t, n, r) {
+        r = r instanceof Array ? r : [];
+        var i = {};
+        for (var s = 0; s < r.length; s++) {
+            i[r[s]] = true
+        }
+        var o = function(e) {
+            this.element = e
+        };
+        o.prototype = n;
+        e.fn[t] = function() {
+            var n = arguments;
+            var r = this;
+            this.each(function() {
+                var s = e(this);
+                var u = s.data("plugin-" + t);
+                if (!u) {
+                    u = new o(s);
+                    s.data("plugin-" + t, u);
+                    if (u._init) {
+                        u._init.apply(u, n)
+                    }
+                } else if (typeof n[0] == "string" && n[0].charAt(0) != "_" && typeof u[n[0]] == "function") {
+                    var a = Array.prototype.slice.call(n, 1);
+                    var f = u[n[0]].apply(u, a);
+                    if (n[0] in i) {
+                        r = f
+                    }
+                }
+            });
+            return r
+        }
+    }
+    var o = 1010,
+        u = 500,
+        a = 50;
+    var f = {
+        stateStyles: {
+            fill: "#333",
+            stroke: "#666",
+            "stroke-width": 1,
+            "stroke-linejoin": "round",
+            scale: [1, 1]
+        },
+        stateHoverStyles: {
+            fill: "#33c",
+            stroke: "#000",
+            scale: [1.1, 1.1]
+        },
+        stateHoverAnimation: 500,
+        stateSpecificStyles: {},
+        stateSpecificHoverStyles: {},
+        click: null,
+        mouseover: null,
+        mouseout: null,
+        clickState: {},
+        mouseoverState: {},
+        mouseoutState: {},
+        showLabels: true,
+        labelWidth: 20,
+        labelHeight: 15,
+        labelGap: 6,
+        labelRadius: 3,
+        labelBackingStyles: {
+            fill: "#333",
+            stroke: "#666",
+            "stroke-width": 1,
+            "stroke-linejoin": "round",
+            scale: [1, 1]
+        },
+        labelBackingHoverStyles: {
+            fill: "#33c",
+            stroke: "#000"
+        },
+        stateSpecificLabelBackingStyles: {},
+        stateSpecificLabelBackingHoverStyles: {},
+        labelTextStyles: {
+            fill: "#fff",
+            stroke: "none",
+            "font-weight": 300,
+            "stroke-width": 0,
+            "font-size": "10px"
+        },
+        labelTextHoverStyles: {},
+        stateSpecificLabelTextStyles: {},
+        stateSpecificLabelTextHoverStyles: {}
+    };
+    var l = {
+        _init: function(t) {
+            this.options = {};
+            e.extend(this.options, f, t);
+            var n = this.element.width();
+            var i = this.element.height();
+            var s = this.element.width() / o;
+            var l = this.element.height() / u;
+            this.scale = Math.min(s, l);
+            this.labelAreaWidth = Math.ceil(a / this.scale);
+            var c = o + Math.max(0, this.labelAreaWidth - a);
+            this.paper = r(this.element.get(0), c, u);
+            this.paper.setSize(n, i);
+            this.paper.setViewBox(-500, 0, c, u, false);
+            this.stateHitAreas = {};
+            this.stateShapes = {};
+            this.topShape = null;
+            this._initCreateStates();
+            this.labelShapes = {};
+            this.labelTexts = {};
+            this.labelHitAreas = {};
+            if (this.options.showLabels) {
+                this._initCreateLabels()
+            }
+        },
+        _initCreateStates: function() {
+            var t = this.options.stateStyles;
+            var n = this.paper;
+            var r = {
+                Tainancity:"m178.94 309.54c1.821 0.85976 1.9013 1.8004 3.9722 1.3601 0.52002 1.6719-1.5712 1.0502-1.4009 2.6113 0.8704 0.21983 2.3913 0.20091 2.5009 1.2003 2.4514 1.3001-0.0196 1.501 0.46065 3.6413 2.191-0.12068 3.2917 1.4299 5.2733 1.8898 0.13963 1.4005-0.8306 1.1807-1.6207 1.8011-1.0903 0.85976-1.1105 1.2309-1.181 2.6706-0.0698 1.411-0.89063 5.8318 0.97023 6.032 0.0496 0.85128 0.0496 1.7515 0 2.6008-0.82081 0.37966-1.1705 1.4814-1.1105 2.3405 0.5807 0.0202 1.2006 0.03 1.7806 0.06 0.17029 0.33986 0.2897 0.71103 0.39083 1.0607 1.7114-0.20939 1.8902 1.5512 3.2813 1.8904 0.16051-0.81019 1.3415-1.1305 1.7219-0.3503 0.0692 0 0.55983-0.0104 0.61072 0 0.84039-1.4103 2.5114-1.3803 2.8611-3.2414 0.73077 1.1709 1.2312 1.6308 2.6314 1.7411 1.4909 0.10959 2.4716-0.39988 3.8418-0.0998 0.76079 1.1598 1.6618 0.69994 1.8817-0.36074 0.39931 0.31051 0.63942 0.76061 0.63029 1.3007-0.15986 0.0398-0.30014 0-0.45021 0.06-0.12984 1.3803-0.89063 1.4599-1.6501 2.4606-0.97023 1.2694-0.14094 1.9498-0.3804 3.1696-0.3308 1.6608-3.2924 3.1214-4.3331 4.6817-1.5007 2.2616-2.7815 3.6608-3.7217 6.3217-0.85083 2.4208-1.6612 4.5519-3.9122 5.5415-2.3711 1.0496-3.1919 3.0013-4.8727 4.8018-0.71055 0.74886-1.9209 1.7593-2.8317 2.1696-1.4204 0.63993-2.4814 0.69081-3.1815 2.3412-0.21009 0.50098-0.16051 1.4899-0.4502 1.8611-0.53047 0.68038-0.94022 0.39009-1.581 0.75996-1.0707 0.62036-1.4707 1.6112-2.281 2.6217-1.0505 1.291-1.0603 2.12-1.6906 3.5917-0.52068 1.2303-1.5509 2.2799-2.2915 3.3706-0.74056 1.0711-1.4707 2.1814-2.0312 3.1312-0.46065 0.77953 0.15007 1.1905-0.97088 1.3197-0.79015 0.0998-1.1705-0.12916-1.0603-0.96936-0.64008-0.0307-1.3108-0.0307-1.9509 0-1.2006 1.4703-2.7515 1.5004-4.0323 2.7711-1.0707 1.0705-0.46065 1.2303-2.0011 1.5695-0.89062 0.21005-2.3809 0.51991-2.1812-0.84019-1.8008-0.15982-3.432-0.77039-5.4827-0.69081-1.3604 0.0502-3.862-0.33008-4.8531 0.43053-1.3708-0.99153-4.3024-0.48011-4.8524-2.9113-1.641 0.95044-6.023-1.3503-7.784 0.42923-0.26034-1.9707-0.0803-4.4417-0.65052-5.7913-0.99045-2.3803-1.2103-4.501-3.1619-6.2114-2.0612-1.8102-4.8929-2.9609-6.513-5.122-1.4009-1.8806-2.9916-3.0216-5.3731-3.8415-5.5428-1.9009-6.4536-7.8024-2.5009-11.954 1.1608-1.2198 1.4811-1.2603 1.5007-3.2107 0.01-1.4606-0.20031-3.1207 0.15985-4.501 0.63029-2.3901 3.1521-3.9714 4.0225-6.3817 0.98067-2.7208-0.42019-5.6817 0.86062-8.4522 0.65051-1.4005 0.52002-2.7606 0.97022-4.1612 0.35038-1.1305 0.68053-0.7306 1.331-1.6308 0.52002-0.72016 0.39018-0.96087 0.49001-1.8813 0.21009-1.9198 0.97022-2.3601 1.7806-3.7815 1.4609 0.61123 2.4911 1.8709 4.0323 2.3008 0.1703 0.8702 0.81037 1.561 1.0603 2.4508 0.51024-0.0404 1.0903 0.09 1.611 0.0502 0.15007 1.9707 3.6819 4.7417 3.5618 1.1598 0.2499 0.3503 0.49001 0.45989 0.6603 0.96935 0.77057 0.0802 1.6012 1.1814 2.3111 1.0202 0.50045-0.11025 0.80059-1.1814 1.1608-1.6713 0.86062-1.1807 2.1108-1.7711 2.3613-3.4704 1.4211-1.5701 4.8028 0.42988 4.2822-2.8311-1.121-0.58122-0.30014-1.8513 0.65052-1.9113 0.98066-0.06 1.271 1.1403 2.6914 0.55121-0.30993-1.3614-1.2808-2.4221 0.31058-3.5512 1.4811-1.0405 2.8513 0.25897 2.7417-2.261 0.84038 0.0404 1.731 0.27006 2.6412 0.14025 1.5405-0.21984 0.94022-0.34965 1.9907-1.3001 1.3806-1.261 3.1521-1.0907 5.013-1.3705 1.611-0.24005 2.9316-1.0007 4.6626-1.0007 1.4707 0 3.9618 1.1102 5.0025-0.34965 0.97936 0.81476 2.5198 1.3144 3.6708 1.8546z",
+                Kaohsiungcity:"m156.17 440.89c0.0502 0.35029 0.20031 0.66993 0.12984 1.0502-0.0803-0.0111-0.15985 0-0.23032-0.0111-0.27991-0.50033-0.60027-0.33986-1.0309-0.58905-0.39996-0.24006-0.4502-0.63014-0.67009-0.96152-0.44042-0.67973-1.1105-1.3301-1.6312-1.9498-1.0707-1.291-2.0612-2.6908-3.0516-4.002-0.20031-0.27006-0.29035-0.8004-0.56047-0.93021-0.0202-0.06 0.01-0.12003-0.0202-0.17026-0.2499-0.34964-0.93043-0.3803-1.2404-0.63993 0.48022-0.15916 1.1608-0.0691 1.6808-0.0489-0.0202 0.17874 0.0803 0.30007 0.0803 0.47881 0.73077-0.0998 0.16051 0.93086 0.85083 0.96152 0.0202 0.0489-0.0104 0.12916 0.0202 0.17026 0.16964 0.14938 0.42998 0.17873 0.57026 0.30007 0.13963 0.12981 0.2897 0.47032 0.42998 0.63014 0.4502 0.49055 0.67009 0.78018 0.93043 1.3307 0.10961 0.2394 0.18986 0.5199 0.39017 0.72995 0.23033 0.24984 0.45021 0.2805 0.66031 0.47033 0.39018 0.36986 0.55068 0.78996 1.0603 1.06 0.12984 0.51012 0.52002 1.1103 0.78035 1.5408 0.0503 0.01 0.0998 0.01 0.15986 0.0196 0.0515 0.37052 0.29166 0.62036 0.69162 0.56035zm102.79-136.88c-0.15007 0-0.25968 0.0104-0.27012 0.0496-0.24011 0.69082-0.0502 1.1409 0.77057 1.3307 0.30992 1.6406 0.55982 2.8402 0.33994 4.6113-1.5203 0.24984-4.1014-0.3503-4.3226 1.5395-0.03 0.28116 0.51023 0.45011 0.51023 0.82063 0 0.77952-0.28969 0.71038-0.47043 1.2101-0.35038 0.93934-0.79014 1.5401-0.67009 2.6002 1.8015-0.20092 1.0309 0.68037 2.0109 1.3307 0.79015 0.53947 1.8413 0.33986 2.7717 0.39009-0.0692 0.3503 0.20096 0.81019 0.19052 1.0705 1.4609-0.61057 3.342 2.9113 3.1417 4.0412-1.0205 0.36987-1.1705 1.0705-0.95065 1.7704-0.8704 0.52056-2.052 0.29029-2.9818 0.6308-1.2006 0.42988-2.0409 1.3803-3.2115 1.9302-1.331 0.61122-2.4716 0.88129-3.832 1.2009-1.731 0.41031-2.2615 1.1507-3.3315 2.3412-0.7497 0.8291-1.4511 2.291-2.3411 2.9609-0.82929 0.61906-2.7012 0.25897-3.3113 1.2303-0.57026 0.92043 0.14028 3.2114-0.0202 4.3106-0.0698 0.54012-0.45021 0.92043-0.5011 1.4906-0.06 0.75996 0.29035 1.4514 0.17095 2.1703-0.28056 1.6204-1.6716 1.2616-2.3515 2.6608-0.30014 0.63014 0.21009 1.1807-0.35038 1.8011-0.39018 0.42075-1.4211 0.53034-1.9411 0.57013-0.27012 1.03 0.81037 1.291 1.611 1.5004 0.14028 2.6504 0.4104 5.9629-0.0998 8.5135-0.1703 0.91912-0.77057 2.0294-1.3604 2.8311-0.47043 0.63928-0.88997 0.75996-1.0498 1.5904-0.2101 1.0907 0.21988 0.88128 0.54025 1.5316 0.33015 0.66929 1.7604 2.621 0.96044 3.4808-0.89063 0.96087-2.9414-0.47098-3.462 1.1898-0.44108 1.4103 1.3108 2.0711 0.30013 3.6308-0.6205 0.95044-2.2419 1.6406-3.0118 2.4208-1.9809 2.0105-3.1514 6.702-1.6005 9.2728 0.24011-0.0189 0.55982 0.0802 0.79014 0.0502 0.53046 1.3999-0.06 3.1312 0.18009 4.6322 0.27012 1.6608 2.1212 2.0796 2.0305 3.651 1.9711-0.24005 1.7408 0.76061 1.8315 2.3308 2.0305 0.0189 1.3911 1.0705 0.28056 1.6497-0.0502-0.12916-0.11027-0.2394-0.18008-0.3503-0.74056-1.0796-3.5012-2.3901-4.7924-2.2799-1.4609 0.12916-2.3215 1.1298-3.5116 1.6797-1.2103 0.56035-2.1714 0.19048-2.0214 2.1409-2.251 0.10959-4.1125-0.60079-4.5021-3.1214-1.641-1.0705-2.9218-2.3105-4.8126-3.0209-1.1307-0.4201-1.7206-0.54012-2.9916-0.33007-1.2404 0.20091-1.5007 0.60013-2.4716 1.0202-0.30014 0.8702-1.4909 1.7293-2.071 2.5408-2.0011-2.0907-2.8122-4.2303-5.9936-3.561-1.38 0.28963-2.4409 1.2205-3.8013 1.7-1.1307 0.39074-2.9224 0.27006-3.8431 1.0802-0.90042 0.79062-1.0309 1.9707-1.8308 2.7104-0.71055 0.64972-1.791 1.9204-2.6314 2.3803-2.0312 1.1005-5.9232 0.28898-7.724-0.50098-1.0505-0.46054-2.3913-0.88064-3.6519-0.55056-1.5712 0.4214-1.4309 1.1703-1.3408 2.8409 0.0502 0.91064 0.73012 3.1996 0.33994 4.0014-0.45999 0.93021-1.1705 0.17874-1.6808 0.77887-0.35038 0.41097-0.15986 1.4814-0.15986 2.0516 0.01 2.7815 0 5.5617 0 8.3321 0 1.2101 0.2499 2.9309-0.36995 3.972-0.84038 1.4097-1.4707 1.079-1.4609 3.1996v4.3327c0 1.5604-0.39996 2.3706-0.68053 3.6602-0.58005 2.7815 0.28057 5.4221 0.64008 8.0118 0.18008 1.2407 0.39018 2.7411 0.2101 4.0014-0.32037 2.1514-1.2606 1.0007-2.3411 2.1709-1.3604 1.4814-0.50045 6.3817-0.50045 8.3321v0.21005c-0.92064-0.63993-1.301-0.42141-2.6614-0.54013-2.4213-0.23092-3.0118-2.5806-5.043-3.6308-1.4211-0.72995-2.1316-0.82911-3.2519-1.9107-0.96044-0.93086-2.4416-2.2009-3.2617-3.1918-0.2499-0.52055-0.8704-1.291-1.4309-1.5206 0.11027-0.53034 0.39018-0.50034 0.93043-0.47033 0.01 0.06 0 0.11024 0.0202 0.15982 0.03 0.0104 0.0698 0.0196 0.0998 0.03 0.0502 0.18982 0.15986 0.2805 0.2101 0.47032 0.2499 0.11024 0.69032 0.21005 0.86061 0.3914 0.24011 0.2394 0.2101 0.69994 0.50045 0.85911 0.28056 0.15982 0.91085-0.0189 1.1908-0.0496 0.46065-0.0404 0.72034 0.0404 1.181 0.14025 0.0104 0.69929 0.90041 0.25049 1.2508 0.7306 0.15007-0.97066-1.2208-1.2407-1.8713-1.7006-0.33994-0.24005-0.82016-0.45988-1.1105-0.74038-0.39997-0.39075-0.36995-0.78997-0.57026-1.2401-0.40976-0.8702-1.7108-0.54012-2.3809-1.3105-0.38039-0.42988-0.24011-0.88064-0.5807-1.3001-0.25968-0.33008-0.71054-0.60014-0.99045-0.93935-0.30993-0.36986-0.75035-0.66993-1.1307-1.0111-0.42019-0.39074-0.7001-0.91064-1.0303-1.3797-0.61071-0.83041-1.2006-1.6504-2.0116-2.231 0.42019-0.0307 1.331-0.17091 1.6912 0.03 0.40975 0.23027 0.36995 0.93086 0.55982 1.3803 0.38039 0.17026 1.4106 0.63015 1.3708 1.06 0.81037 0-0.35038-1.1011-0.56048-1.1898-0.19052-0.42075-0.23032-0.82975-0.49-1.1703-0.25969-0.33072-0.61007-0.48011-0.82995-0.86041-0.2499-0.44945-0.23032-0.57992-0.80058-0.84998-0.46-0.22048-0.86062-0.16047-1.3408-0.29028-0.81037-0.24006-1.5307-1.15-2.1714-1.6993-0.94021-0.81018-0.88084-1.3999-0.88084-2.6217v-2.1807c0-0.33073-0.0698-0.71038 0.1305-0.94 0.15985-0.19048 0.6603-0.23092 0.89062-0.42075 0.36017-0.31964 0.81037-1.06 0.91086-1.5206 0.15985-0.80105-0.29036-1-0.63029-1.6106-0.06-0.0307-0.12985-0.0496-0.18009-0.0698 0.39997-0.24984 0.70011 0.12981 0.96044 0.36073 0.40976 0.34965 0.47044 0.40966 1.1007 0.37965 0.0502-0.88976-0.0502-1.8891-0.38039-2.6706-0.97023-0.0907-0.88084 0.31051-1.1203 1.0405-0.50045 0.06-0.59049-1.3196-0.69032-1.73-0.16051-0.68103-0.74056-1.261-0.8704-1.9413-0.0698-0.39987 0.0698-0.77039-0.12984-1.1207-0.1703-0.30007-0.61072-0.45989-0.79015-0.75996-0.35037-0.61123 0.11027-1.2701-0.48022-1.8206 0.23033-1.4103-1.5307-2.2505-2.1616-3.1612-0.57026-0.82128-0.7001-1.6915-0.82995-2.6608-0.29035-2.0405-0.54024-1.5904-1.8713-2.9713-0.88084-0.91064-0.64008-1.3301-0.8306-2.6713-0.32036-2.2505-1.4811-4.1716-1.5105-6.4919-0.0202-2-0.53046-3.8911-1.3604-5.6517-1.1405-0.27006-1.581-1.4508-1.7806-2.9002 1.761-1.7802 6.1437 0.52055 7.784-0.42988 0.55003 2.4312 3.4816 1.9198 4.8524 2.9113 0.99046-0.76061 3.492-0.38031 4.8531-0.43054 2.0514-0.0796 3.6819 0.53034 5.4827 0.69147-0.20031 1.3601 1.2906 1.0496 2.1812 0.84019 1.5405-0.33986 0.93043-0.50098 2.0011-1.5701 1.2808-1.2707 2.8317-1.3007 4.0323-2.7711 0.64008-0.03 1.3108-0.03 1.9509 0-0.10962 0.84019 0.27012 1.0705 1.0603 0.97 1.121-0.12981 0.51023-0.54012 0.97088-1.3203 0.55982-0.94978 1.2906-2.06 2.0312-3.1312 0.74055-1.09 1.7708-2.1403 2.2915-3.3706 0.63029-1.471 0.64008-2.3008 1.6906-3.591 0.81037-1.0111 1.2103-2.0007 2.281-2.6223 0.64008-0.36922 1.0505-0.0796 1.5809-0.75996 0.29035-0.36922 0.24011-1.3601 0.45021-1.8611 0.7001-1.6504 1.761-1.7 3.1815-2.3405 0.91085-0.41031 2.1212-1.4214 2.8317-2.1703 1.6808-1.8011 2.5009-3.7515 4.8727-4.8018 2.251-0.99023 3.0614-3.1207 3.9122-5.5415 0.94021-2.6608 2.221-4.0614 3.7217-6.321 1.0407-1.561 4.0023-3.0216 4.3324-4.6824 0.24011-1.2198-0.58984-1.9002 0.38104-3.1696 0.76013-1.0007 1.5203-1.0802 1.6501-2.4606 0.15007-0.06 0.29035-0.0202 0.4502-0.06 0.0104-0.54012-0.23097-0.99088-0.63028-1.3007 0.01-0.0496 0.0189-0.10959 0.03-0.17026 0.12919-1.0496-0.43063-2.4306-0.71054-3.3308-0.65052-2.0509-1.3911-4.9316-0.64008-7.1521 0.8704-0.14025 2.8115-0.12916 3.6519 0.14025 1.5209 0.51012 0.67009 1.8513 1.9809 2.5114 2.8715 1.4508 2.482-2.7013 4.0121-3.8409 1.1405-0.85128 1.9809-0.11089 3.171-0.66145 0.35038-0.15982 1.9509-1.8402 2.1714-2.1305 0.65052-0.85063 0.5011-2.1207 1.4909-2.7515 0.98066-0.61971 2.6516-0.25963 3.8124-0.31964 0.28056-1.4306 0.39996-2.5506 1.821-3.1918 0.96109-0.42075 3.3315 0.25049 4.0519-0.39922 0.36995-0.33986 0.77122-2.8918 1.1105-3.6015 0.53046-1.1103 0.86061-2 1.2103-3.1514 0.38039-1.3105 0.82081-2.2805 2.1714-2.7593 1.2006-0.43053 3.0908 0.23941 4.0114-0.70059 0.21009-0.21983 0.36995-1.3601 0.6205-1.7202 0.27991-0.41031 0.93043-1.0802 1.3206-1.3418 1.0302-0.66928 2.4011-0.8004 3.5514-0.94978 1.1816-0.14025 1.9914-0.2094 2.6914-1.1298 0.79015 0.0802 1.821-0.27984 2.4018-0.88977 0.24989-0.0691 0.50044-0.12981 0.74055-0.18004 1.2208-0.24984 1.0903-0.11024 2.1714 0.36987 1.5509 0.69081 2.9316 0.59035 4.8022 0.69994 0.0104 0.33008 0.25055 0.55056 0.2101 0.93087 0.35037-0.0104 0.74055 0.27985 1.1307 0.23027 0.14942 0.98109-0.26033 1.7104-0.29035 2.6217 0.14028-0.0104 0.32037 0.0104 0.46065 0.0404 0.0176 0.12981-0.0124 0.30986-0.0124 0.45924z",
+                Pingtung:"m166.08 473.61c0.38039 0.47033 0.52002 0.84019 0.50045 1.4403-0.0398 0-2.1408 2.4514-2.3515 2.681-0.8704 0.88912-2.5212 1.7104-2.9016-0.16047 1.2808-0.74952 0.64008-2.0405 1.3206-3.1116 0.71054-1.1279 2.2615-0.91913 3.432-0.84933zm69.867-77.268c0.47044 1.2205-0.3693 2.9909 0.65052 4.0907 0.52002 0.57013 2.9218 1.4305 3.7119 1.7906 1.121 0.51012 1.121-0.18982 1.5007 1.1598 0.19052 0.6608 0.10961 1.9198 0.12984 2.5414 0.0692 1.8611-0.53046 2.5806-2.1016 3.4912 0.61137 1.8317 1.1307 5.6928-0.85017 7.1521-1.0107 0.75017-2.7613-0.18983-4.0121 0.32029-0.88997 0.36074-1.6605 1.4814-2.5414 2.1207-1.4106 1.0411-1.9607 1.03-3.802 1.2205-1.0603 0.10959-2.822-0.19047-3.5318 0.78997-0.73077 0.99153 0.25968 2.6413-0.1305 3.8722-0.39018 1.2205-1.6312 2.06-2.0005 3.3412-0.35038 1.2094-0.2499 1.8806-1.0002 2.9498-0.73077 1.0405-1.2906 1.76-1.701 2.8807-0.77057 2.0907-1.0303 4.201-1.1601 6.4828-3.0314 0.03 0.39932 5.3817 0.74056 6.1919 0.7001 1.6797 1.1608 5.4508 0.63029 7.0425-0.32037 0.96935-1.2006 2.1507-0.51024 3.4612 0.76079 1.4299 1.8015 0.21004 2.9616 1.0404 1.2704 0.90021 1.9013 5.1312 1.6808 6.6022-1.6612 0.0698-4.0114 0.74039-4.472 2.3601-0.25055 0.87085-0.0411 2.1011-0.18008 3.0013-0.10962 0.77105-0.46 1.6915-0.30014 2.471 0.48022-0.0802 0.8704 0.21983 1.2808 0.21983 0.45021 2.0516 2.0011 1.5401 3.5318 2.6419 1.671 1.1807 1.581 2.4808 1.4707 4.6406-2.2412 0.03-2.3711 1.6902-2.2817 3.5004 0.86061-0.0685 2.9414 0.40053 3.6421 0.82063 1.9711 1.1703-0.77058 1.8017-0.47044 3.1807 0.90042-0.12003 1.1908 0.50163 1.0002 1.3418 1.8511 0.0992 2.1212 0.57013 3.4712 1.1807 1.1908 0.53947 3.2421-0.0307 3.5318 1.6412 1.8008-0.23092 1.5907 1.9498 3.4418 0.99936 0.73077-0.38031 1.9711-1.7208 2.681-2.4508 0.33081 1.1598 0.67009 2.3608 0.39997 3.3608-0.2101 0.82062-0.6205 1.0907-0.71055 2.1207-0.09 0.91977-0.12984 1.7208-0.30013 2.5506-0.56048 2.7398 0.29035 6.411 0.0998 9.5931-0.98066 0.4201-1.2612 1.8206-0.97022 2.8611 0.38039 1.3601 0.94021 1.4292 2.4716 1.3601 0.09 0.48011 0.09 1.1403 0 1.6106-0.73077 0.6608-1.4511 0.59035-1.8113 1.531-0.33015 0.8702 0.0111 2.5617 0.0111 3.501 0 0.98044-0.27012 2.4103-0.0111 3.3406 0.32036 1.1011 1.2508 1.2101 0.98067 2.6308-0.61985 0.12981-1.2006 0.24006-1.7806 0.39988-0.0411 0.55056-0.21989 1.0404-0.21989 1.6002-1.5509 0.40966-0.93042 0.77104-1.4707 1.8702-0.70076 1.3908-0.68053 0.85976-2.3013 1.2003-2.5212 0.53034-2.0409 2.4814-2.0409 4.8011 0 1.8506-0.60028 4.9218 0.72033 6.2923 0.67988 0.69994 1.151 0.45989 1.6207 1.3712 0.29035 0.58971 0.38039 2.4808 0.30014 3.1507-1.7708 0.45989-1.8106-1.2309-2.7606-2.1905-0.51024-0.51991-0.95066-0.4899-1.3911-1.1207-0.34972-0.5199-0.4104-1.2198-0.82994-1.8004-1.0603-1.4703-1.8811-0.78018-3.5018-1.3608-0.71054-0.25962-1.2906-0.91977-1.9907-1.1814-0.59048-0.21983-1.3506-0.18982-1.9711-0.36008-0.79014-1.5003-4.5021-2.561-5.3327-0.44032-0.49001 1.2401 0.79014 1.6008 0.63029 2.8011-0.16965 1.3203-1.6606 1.3705-2.6712 1.8206-0.53046-0.78018-1.6605-1.4606-2.0011-2.1507-0.47956-0.97001-0.1592-2.7208-0.1592-3.8311 0-1.3007 0.1703-2.7208 0-4.0014-0.23097-1.7606-0.99111-1.5401-1.962-2.711-0.83973-1-0.69945-1.8891-1.0798-3.0809-0.20096-0.63079-0.65052-0.79061-0.63029-1.5506 0.03-0.82976 0.50958-0.75996 0.66944-1.501 0.12071-0.55056-0.25903-1.5095 0-2 0.51023-0.96087 0.56047-0.12068 1.331-0.66081 0.81038-0.55056 1.8511-2.1311 0.53046-2.8611-0.24011-0.39987-0.43063-0.99088-0.50109-1.4508 0.44041 0.0802 1.0107-0.12982 1.4518-0.0496 0.20944-1.2505 0.42933-2.4814 0.36016-3.8115-0.0998-1.8806-0.36995-1.8206-1.4707-3.0411-1.6906-1.8904-0.35038-4.8911-1.0309-7.2923-0.35038-1.2309-1.4909-1.8402-1.8008-3.1709-0.30013-1.291-0.13962-2.4599-0.54024-3.6608-0.8704-2.5695-3.1521-3.0007-4.3722-5.3014-0.60027-1.1292-0.46064-2.471-0.46064-3.8715 0-1.6112-0.46065-2.3608-1.0009-3.6713-0.84038-2.0405-2.0409-3.6817-3.7217-5.291-0.85082-0.82063-1.7304-1.2805-2.1108-2.381-0.54025-1.5395-0.65051-1.79-1.7108-3.1612-1.6508-2.1403-3.1019-2.7208-5.4632-4.0105-1.0714-0.5897-2.7117-0.83954-3.5018-1.8311-1.3904-0.17939-3.3518-0.50034-4.3722-1.2903-0.89063-0.7006-1.3108-1.8409-2.131-2.6719-1.7708-1.7906-4.8531-2.3797-6.0034-4.3706-0.72033-1.2401-0.95065-1.8617-2.1212-2.8709-0.2101-0.17026-0.39018-0.31051-0.55004-0.42075v-0.2094c0-1.9504-0.86061-6.852 0.50045-8.3321 1.0805-1.1703 2.0214-0.0202 2.3411-2.1709 0.18008-1.2603-0.03-2.7593-0.2101-4.0014-0.36017-2.591-1.2208-5.2316-0.64008-8.0118 0.28057-1.291 0.68053-2.1011 0.68053-3.6602v-4.3327c-0.0104-2.1207 0.62051-1.79 1.4609-3.1996 0.6205-1.0411 0.36995-2.7606 0.36995-3.972 0-2.7711 0.01-5.5519 0-8.3321 0-0.57013-0.19052-1.6412 0.15986-2.0516 0.51023-0.60014 1.2208 0.15003 1.6808-0.77888 0.39018-0.8017-0.2897-3.0907-0.33994-4.002-0.09-1.6712-0.23032-2.4208 1.3408-2.8402 1.2606-0.33007 2.6014 0.09 3.6519 0.55056 1.8008 0.78997 5.6935 1.6002 7.724 0.50099 0.84039-0.45989 1.9209-1.7306 2.6314-2.3803 0.80123-0.74039 0.93042-1.9198 1.8308-2.7111 0.92064-0.80953 2.7117-0.69016 3.8431-1.0796 1.3604-0.47946 2.4213-1.4103 3.802-1.7 3.1815-0.66994 3.9912 1.4703 5.993 3.561 0.58071-0.81019 1.7708-1.6706 2.071-2.5408 0.97022-0.4214 1.2306-0.82127 2.4716-1.0202 1.271-0.21005 1.8615-0.09 2.9916 0.33008 1.8909 0.71038 3.1717 1.9504 4.8126 3.0209 0.39083 2.5206 2.251 3.231 4.5021 3.1214-0.15007-1.9504 0.81037-1.5806 2.0214-2.1409 1.1908-0.54991 2.052-1.5506 3.5116-1.6797 1.2912-0.1109 4.0519 1.2003 4.7931 2.2799 0.0672 0.10763 0.12789 0.21787 0.17747 0.34703z",
+                Taidong:"m327.47 304.02c-0.32036 0.81019-0.64007 1.6302-0.96044 2.5004-0.7001 1.9204-0.23097 3.9309-0.55068 5.9518-0.27013 1.7417-1.1601 3.3412-1.4407 5.0627-0.25055 1.5904-0.0196 4.8415-1.181 6.0614-1.0903 1.1598-3.1417 1.2309-4.3122 2.6908-1.3108 1.6412-1.6508 2.9713-1.761 5.2519-0.0803 1.5708 0.36995 4.6217-0.50045 5.8116-0.76079 1.0607-2.852 0.77105-3.5723 2.3712-0.63095 1.4208-0.0698 3.651 0.0692 5.0712 0.29035 2.8611-0.1703 8.1527 3.7322 7.8129-1.0798 0.39009-1.35 1.6002-2.2308 2.1403-0.63029 0.39922-1.3004-0.0496-2.0116 0.50033-0.47956 0.36073-0.58983 1.1403-0.93042 1.3608-1.8211 1.1598-5.4827 0.12981-4.8126 3.9413 0.0502 1.7104-0.68053 3.561-1.331 4.8311-0.61072 1.1703-0.32037 2.4599-0.71055 3.621-0.42998 1.2805-1.4909 2.441-1.9607 3.732-0.44042 1.1807-0.36995 2.2199-1.0407 3.3216-1.301 2.1305-4.1621 2.5108-4.9229 4.8716-0.4502 1.3803-0.0907 2.3405-0.88084 3.591-0.59048 0.93021-1.0498 1.9504-1.7003 2.8611-0.42085 0.60013-0.98067 0.85063-1.2912 1.4814-0.25968 0.51991-0.10048 1.319-0.3693 1.8304-0.70075 1.2707-2.1114 0.97001-1.992 2.8409-2.2204 0.12003-6.4138-0.59035-7.4441 2.0607-1.0798 2.7698 0.82082 4.9603 1.6312 7.1319 0.71054 1.8898-0.31971 2.0411-1.5007 2.7111-1.5607 0.88063-1.1301 1.1403-1.331 2.9609-0.24989 2.2799-3.1619 3.1696-4.5223 5.1605-0.03 0.0502 0.01 0.39139-0.0104 0.48011-0.97023 0.75995-2.3913 1.1298-3.312 1.8904-0.93042 0.75996-1.2006 2.321-2.3313 2.9707-1.0107 0.59035-2.5212 0.14938-3.7021 0.6308-1.2208 0.50098-1.6312 1.5199-2.5009 2.5004-1.6012 1.8102-4.4022 2.1109-5.9232 3.9218-0.64008 0.74104-0.90041 2.3803-1.2103 3.2916-0.39931 1.2003-0.57026 2.4006-0.63029 3.7013-0.12005 2.5004-0.17029 4.3712-2.2014 5.8116-1.1203 0.78996-1.9202 0.91064-2.6308 1.9909-0.66095 0.99023-1.1908 2.1605-1.6716 3.3301-0.52003 1.2609-0.4202 2.5206-0.8704 3.8011-0.44042 1.2401-1.181 2.2805-1.5105 3.5408-0.63942 2.4821-0.44042 5.0327-1.181 7.4724-1.8308 0.47098-1.5607 4.6824-2.2713 6.203-0.88997 1.9002-1.2997 3.651-1.9111 5.5904-0.57026 1.8108-1.2208 4.4123-2.8017 5.5722-0.85017 0.6308-0.43977 2.3405-0.8293 3.6608-0.28121 0.91978 0.33016 7.2023 0.33016 8.1723 0 0.69016 0.24011 1.5004 0.47956 2.351-0.71054 0.72995-1.9502 2.0705-2.681 2.4508-1.8511 0.95043-1.6416-1.2303-3.4418-0.99936-0.28969-1.6719-2.3411-1.1011-3.5318-1.6412-1.35-0.61058-1.6201-1.0802-3.4712-1.1807 0.19052-0.84019-0.0998-1.4606-1.0002-1.3418-0.30013-1.379 2.4409-2.0105 0.47044-3.1807-0.70076-0.42009-2.7815-0.88911-3.6421-0.82062-0.09-1.8096 0.0411-3.4704 2.2817-3.5004 0.10962-2.1612 0.20031-3.4612-1.4707-4.6406-1.5307-1.1011-3.0816-0.59035-3.5318-2.6419-0.41041 0-0.80059-0.30007-1.2808-0.21983-0.15985-0.77953 0.19052-1.7 0.30014-2.471 0.14028-0.90021-0.0698-2.1305 0.18008-3.0014 0.46-1.6197 2.8115-2.2903 4.472-2.3601 0.21989-1.471-0.4104-5.702-1.6808-6.6022-1.1601-0.8291-2.2014 0.39074-2.9616-1.0405-0.69032-1.3105 0.18987-2.4906 0.51023-3.4612 0.53046-1.5904 0.0698-5.3628-0.63029-7.0425-0.33994-0.81019-3.772-6.1618-0.74056-6.1919 0.12919-2.2805 0.39018-4.3908 1.1601-6.4828 0.41041-1.1207 0.97023-1.8396 1.701-2.8807 0.75034-1.0705 0.65052-1.7404 1.0002-2.9498 0.3693-1.2805 1.611-2.1207 2.0005-3.3412 0.39083-1.2309-0.60028-2.8807 0.13049-3.8722 0.70989-0.98044 2.4716-0.68037 3.5318-0.78996 1.8406-0.19048 2.3913-0.17939 3.802-1.2205 0.88084-0.63927 1.6508-1.76 2.5414-2.1207 1.2508-0.50947 3.0027 0.42988 4.012-0.31964 1.9809-1.4599 1.4609-5.321 0.85018-7.1527 1.5712-0.91064 2.1714-1.6302 2.101-3.4912-0.0196-0.62036 0.0607-1.8806-0.12919-2.5414-0.38039-1.3497-0.38039-0.64971-1.5007-1.1598-0.79079-0.36008-3.1926-1.2205-3.7119-1.7906-1.0205-1.1011-0.18008-2.8702-0.65051-4.0907 1.1105-0.58057 1.7512-1.6308-0.28057-1.6497-0.0907-1.5701 0.14028-2.5708-1.8315-2.3308 0.0907-1.5701-1.7604-1.9902-2.0305-3.6511-0.24011-1.501 0.35038-3.231-0.18008-4.6322-0.23032 0.03-0.55069-0.0691-0.79015-0.0502-1.5509-2.5695-0.38039-7.2623 1.6005-9.2728 0.77057-0.77952 2.3913-1.4703 3.0118-2.4208 1.0107-1.561-0.74121-2.2205-0.30014-3.6302 0.52002-1.6615 2.5708-0.23092 3.462-1.1905 0.80059-0.85976-0.63028-2.8115-0.96044-3.4808-0.32036-0.65037-0.75034-0.44097-0.54024-1.5317 0.15985-0.8291 0.58004-0.94978 1.0498-1.5904 0.59048-0.80171 1.1908-1.9113 1.3604-2.8311 0.51024-2.5506 0.24011-5.8618 0.0998-8.5135-0.80058-0.2094-1.8811-0.47033-1.611-1.5004 0.52003-0.0404 1.5509-0.14938 1.9411-0.57013 0.55982-0.62036 0.0502-1.1709 0.35038-1.8011 0.67988-1.3999 2.071-1.0405 2.3515-2.6608 0.12005-0.72017-0.23098-1.4103-0.17095-2.1703 0.0502-0.57013 0.43063-0.95044 0.5011-1.4899 0.16051-1.1011-0.55004-3.3908 0.0202-4.3112 0.61072-0.97 2.4814-0.61122 3.3113-1.2303 0.89062-0.66993 1.5907-2.1318 2.3411-2.9609 1.0714-1.1905 1.6012-1.9309 3.3315-2.3405 1.3604-0.32029 2.5009-0.59036 3.832-1.2016 1.1705-0.54991 2.0109-1.5004 3.2115-1.9302 0.93043-0.33986 2.1114-0.11024 2.9818-0.6308 0.17943 0.65037 0.66031 1.3105 1.0309 1.7208 0.99046 1.1103 2.1401 2.0516 2.4905 3.7111 0.36082 1.7404 0.0111 2.8311 1.2508 4.2114 0.97023 1.0705 3.2617 0.81018 3.4118 2.09 1.4002 0.0907 4.1217-0.14938 5.133 0.69081 1.5209 1.2609 0.36016 3.1918 3.0014 3.3412 1.5509 0.09 3.3022-1.4508 4.8531-0.33986 1.3108 0.94979 1.4302 3.1996 1.5098 4.8115 0.81038 0.0489 1.6508 0.01 2.4514 0.06 0.06 1.03-0.03 2.1305 0.19052 3.1312 0.30014 1.3503 2.1414 2.1807 3.4816 2.03-0.33994 1.5095 0.63029 1.561 1.8315 1.501 0.21988 0.94 1.2208 1.4703 1.7408 2.2603 0.52002 0.79061 0.58918 1.9707 1.611 2.3908 2.131 0.89043 4.7226-0.91064 6.6533-1.03 0.11027-1.2694-0.28057-2.3712-0.14094-3.6413 0.0998-0.93934 0.9611-2.0105 0.9611-2.8696 0.0104-1.3203-1.2704-1.7606-1.2912-2.972-0.0196-1.2101 1.0603-2.2407 2.3013-2.0209 0.88084-2.3405 1.671-4.7117 2.8317-7.0118 0.63029-1.2505 0.03-2.6008 0.53046-3.8115 0.47044-1.1605 1.9914-1.3908 2.6308-2.4906 0.70011-1.2094 0.42998-2.6308 0.54025-4.0014 0.12071-1.4703 0.70989-2.2205 1.1705-3.501 0.15007-0.4201 0.0411-1.3503 0.48022-1.6406 0.50045-0.33007 1.5607 0.57013 2.2014-0.06 0.69031-0.69994 0.28969-2.6217 1.1503-3.471 1.0009-0.99153 2.5316-0.66993 1.5007-2.1709-0.30014-0.42988-2.1708-1.8304-2.6412-2.0202-0.10961-1.8709 0.12985-3.3914 0.84039-4.9414 1.2306-0.71038 0.7001-3.6308 2.2713-3.4012 0.68053-0.97001 2.4605-0.45011 2.2308-2.2707 1.0909-0.64972 2.9113-0.31964 3.9722 0.14025 0.41041 0.18004 1.1405 0.85128 1.5307 0.96087 0.62572 0.18004 1.1164-0.10894 1.7564-0.1396zm-3.9279 119.23-0.0202-0.18004c0.23097-0.12003 4.063-0.30985 4.3722-0.0189 1.5209-0.91064 2.4018-0.82975 2.6614 0.99088 0.15986 0.0404 0.29035 0.0196 0.45021 0.06-0.48022 0.80105-0.81037 1.7704-1.0002 2.7815-0.79015 0.12916-0.75035 0.21984-0.95066 0.82911 0.27013-0.0496 0.66031 0.0802 0.94022 0.0502-0.0607 0.78018 0.09 1.6302 0.33994 2.2694-1.5412 0.83041-3.4522-1.6706-5.1128-1.9902-0.21988-0.40053-0.29035-0.98044-0.17029-1.441 1.7003-0.91978-1.5509-2.3301-2.052-3.0307 0.1318-0.3105 0.29231-0.30007 0.5422-0.32029zm19.79 101.38c0.68053 1.6706 0.32037 2.231 0.33994 3.9518-1.301 0.17939-2.3222-0.39922-3.6121-0.33986-1.3611-2.1709-2.5616-3.0307-5.0025-3.171-0.60028-1.2609-2.6112-2.2407-3.573-3.4312-0.70989-0.88064-0.47043-2.1905-0.79014-3.201-0.27013-0.84019-1.7408-2.1005-1.3108-2.8109 0.8704-0.0802 1.5712 0.20026 2.4513 0.15982 0.0405 0.15916 0 0.30006 0.0502 0.44945 1.8106 0.0907 5.5428 0.55969 6.9834-0.41031 0.23098 0.81018 0.11027 0.33007 0.64008 0.8004 0.0104 0.58122 0.03 1.1905 0.0405 1.7802 0.15986 0.0404 0.30014 0.0104 0.46065 0.0502 0.2101 1.09-0.47043 1.1807-0.65052 1.6706-0.21988 0.61122-0.36995 1.1102-0.30014 1.9504 1.0903-0.18005 1.1105 0.85063 1.1608 1.6608 0.82994 0.03 0.68052 0.0496 1.0009 0.66994 0.70076-0.0398 1.4615 0.0307 2.1114 0.22048z",
+                Hualien:"m262.01 324.77c-0.21989-0.69994-0.0698-1.3999 0.95065-1.7704 0.20031-1.1298-1.6808-4.6517-3.1417-4.0411 0.0104-0.25897-0.25903-0.72017-0.19052-1.0705-0.93043-0.0496-1.9809 0.14938-2.7717-0.39009-0.98001-0.65037-0.20944-1.5317-2.0109-1.3307-0.12006-1.06 0.32036-1.6602 0.67009-2.6002 0.18008-0.50098 0.47043-0.43053 0.47043-1.2101 0-0.36921-0.54025-0.53947-0.50958-0.82062 0.21988-1.8898 2.8017-1.291 4.3226-1.5395 0.21988-1.7717-0.0307-2.972-0.33994-4.6113-0.82081-0.18983-1.0107-0.63993-0.77057-1.3307 0.0104-0.0404 0.12005-0.0496 0.27012-0.0496 0.2897-0.0196 0.72033-0.0104 0.84039-0.12981 0.20031-0.2094 0.15985-0.61057 0.47956-0.88977 0.8704-0.74104 0.48022-0.69081 1.7108-0.94978 0.72033-0.15004 1.4707-0.15004 2.1414-0.36987 0.14941-2.4906-2.191-1.9504-1.3108-4.3112 0.61985-1.6497 1.3304-3.3301 2.3802-4.8004 1.8713-2.6413 7.6137-2.561 10.085-0.72016 0.49001-0.7704 1.331-0.90021 2.0116-1.3405 0.10961-1.8311-0.2101-3.5715-0.0998-5.4417 1.6312-0.48011 1.4106-0.72017 1.7806-2.1709-0.27012 0.06-0.68053-0.0998-0.95065-0.0496-0.13963-0.78018-0.24011-1.6308 0.61136-1.8409 0.03-0.12003-0.0307-0.34899 0.06-0.43966 1.1601-0.5597 2.0514 0.60013 2.972 0.31963 0.48022-0.14025 1.4309-1.9002 1.5209-2.321 1.0198-0.71104 1.1908 0.20939 1.9411 0.20026 0.57026-0.0104 1.1014-0.32029 1.6716-0.42988 0.50045-0.71038 0.10961-1.3503 0.3693-2.1311 0.33994-1.0502 0.72033-0.5897 1.1712-1.3803 0.55982-1.0007-0.16051-2.3608 0.2499-3.441 0.39017-1 1.7003-1.7404 1.9111-3.0209 0.16051-0.9002-0.59049-1.5003-0.51023-2.3308 0.0907-0.8291 0.73011-1.2505 0.84038-2.3308 0.09-0.88064 0.0998-1.9707 0.01-2.8402-0.23946-2.1207-1.81-2.2805-2.0109-4.1612-0.2897-2.8213-0.2897-2.651-2.972-3.201-0.27991-1.4808 1.331-3.6113 2.7822-3.8311-0.17095-1.4103-0.24011-2.9211 0.21988-4.2812 0.53046 0 0.77971-0.2805 1.2808-0.39074 0.69031-1.3405 0.51023-3.06 1.1503-4.471 0.23097-0.5199 0.69031-0.65037 0.88083-1.1703 0.14094-0.3803 0.0411-0.93087 0.16051-1.3307 0.27013-0.84019 0.70011-1.2609 1.0303-1.9804 0.21988 0.0404 0.55003-0.0202 0.78036-0.0502 0.0698-1.3803-0.80059-5.8018 1.331-5.6615 0.1703-3.3816 0.51024-6.7822 0.33994-10.124-0.69945-0.0404-1.4204-0.01-2.1205-0.0502-0.12005-2.4808 0.64008-3.4312 1.3206-5.4717 0.42998-1.2903 0.75034-2.0607 1.3708-3.291 0.73011-1.4508 0.47108-2.4006 0.6205-3.8813 0.21988-2.2505 0.96109-1.0196 2.4611-1.8709 0.85996-0.47945 1.5405-1.6706 2.2112-2.4306 1.2912-1.4703 2.1812-4.9414 0.45999-6.1716-0.82994-0.59035-2.3313-0.90021-3.2513-1.5708-1.181-0.8702-1.0707-1.2903-2.8513-1.3105-0.23098-0.72017-0.3308-1.6902-0.0698-2.351 0.30013-0.72995 0.97022-0.77039 1.2208-1.2505 0.3804-0.70973 0.03-1.5304 0.32037-2.2199 0.42019-0.97979 0.4104-0.5199 1.3708-0.95043 1.6012-0.71038 2.4213-1.1814 3.6023-2.2205 1.2201-1.06 1.9411-0.93022 3.6721-1.0196 0.17943-0.80105 0.14028-1.6712-0.78036-1.8408-0.0998-1.1605 0.1305-1.5904 0.55069-2.1612 0.16964-0.21983 0.36995-0.47033 0.60028-0.8004 0.47108-0.67972 0.82994-2.3706 1.5209-2.9707 0.94087-0.82063 2.7326-0.0802 3.312-1.0307 0.59048-0.97979-0.35038-3.0607-0.01-4.1723 0.44042-1.4103 1.7304-1.4201 2.5205-2.4899 0.53046-0.74104-0.01-0.95043 0.82082-1.5108 0.49-0.33986 1.151-0.20026 1.7108-0.66994 0.78036-0.63014 1.7519-1.5095 2.1218-2.3301 0.50045-1.1403-0.30079-2.8317 0.20031-3.972 0.24011-0.54991 1.4504-1.7098 2.2412-2.1807 0.0411 0.0907 0.0907 0.18004 0.15007 0.27006 0.4104 0.60014 0.93956 0.39074 1.5712 0.59035 0.74056 0.23027 1.1705 0.87999 1.8811 1.2003 0.46064 0.21005 1.0009 0.27006 1.4302 0.54012 0.44107 0.27006 0.72033 0.59035 1.0805 0.93022 0.15986 0.15003 0.32037 0.25962 0.5011 0.39074 0.2897 0.18982 0.19052 0.21983 0.41041 0.0992 0.3693-0.19048 0.48022-0.66015 1.0407-0.50033 0.24011 0.0691 0.27013 0.21983 0.58005 0.24984 0.25055 0.0202 0.38039-0.0502 0.59049-0.0802 0.45021-0.0698 0.93043-0.06 1.3715 0.0411 0.61006 0.12916 1.1503 0.30985 1.7904 0.36921 0.41106 0.0404 0.84038 0 1.2508 0.0502 0.98067 0.0998 1.151 1.1905 1.761 1.8206 0.62051 0.63928 0.8306 1.3301 1.8106 1.4606 0.81037 0.10959 1.5809 0.01 2.3613 0.2094 0.39018 0.0998 0.82016 0.26027 1.2397 0.22048 0.26034-0.0307 0.47108-0.12981 0.74121-0.0907 0.23946 0.03 0.42019 0.15003 0.66944 0.12068-0.0998-0.25049-0.0398-0.53034-0.0803-0.82062-0.0502-0.47946-0.23032-0.45924-0.60027-0.80954-0.17943-0.17091-0.33015-0.28963-0.27013-0.55969 0.06-0.29029 0.03-0.14938 0.21989-0.14025 0.12984 0.0202 0.15006 0.18004 0.32036 0.17026 0.18987-0.0104 0.30014-0.19048 0.42998-0.31051 0.20031-0.20092 0.41041-0.65037 0.70076-0.72995 0.28904-0.0802 0.39018 0.21983 0.6205 0.10959 0.23946-0.10959 0.21988-0.63015 0.28904-0.84998 0.0901-0.27006 0.30014-0.53034 0.54025-0.66993 0.0502 0.24005 0.23098 0.48011 0.46065 0.53033 0.42019 0.11025 0.40975-0.1409 0.71054 0.23027 0.15986 0.20027 0.2897 0.78018 0.59049 0.58057 0.16964-0.11024 0.16964-0.61057 0.18987-0.80953 0.03-0.27006 0.0803-0.69994 0.0104-0.96087-0.11027-0.42989-0.44955-0.33986-0.74056-0.66016-0.19052-0.21004-0.19052-0.45988-0.33994-0.67972-0.2003-0.27984-0.55982-0.39009-0.6603-0.77039-0.20031-0.75017 0.49001-1.6308 1.2404-1.1305 0.32037 0.21984 0.68053 0.68038 0.95066 0.96022 0.33015 0.3503 0.63942 0.69995 0.98066 1.0411 1.1503 1.1507 0.0803-1.1011 1.2006-0.76061 0.24011 0.0802 0.36016 0.44032 0.55003 0.63015 0.38039 0.3803 0.90041 0.51011 1.2612 0.92043 0.36017 0.41031 0.66031 0.84997 1.1099 1.1598 0.35038 0.25049 0.66095 0.19048 1.0805 0.25049 0.46064 0.0691 0.53046 0.3105 0.90041 0.50033 0.39996 0.21005 0.96109-0.0404 1.3904 0.12003 0.29035 0.11024 0.59049 0.36073 0.8704 0.5199 0.53046 0.29028 0.99111 0.61123 1.5816 0.79062 0.46 0.14938 0.93043 0.12002 1.4204 0.12002 0.53046-0.01 0.92064 0.12982 1.4106 0.29029 0.61985 0.19048 1.4713 0.0196 2.0514 0.33986 0.33994 0.18983 0.60093 0.54012 0.93108 0.72995 0.2897 0.17026 0.58136 0.23027 0.90042 0.31051 0.49066 0.12981 1.5405 0.7606 2.022 0.3803 0.0196-0.01 0.0405-0.03 0.0405-0.0496 0.0796 0.42988 0.18987 0.96022 0.0411 1.3405-0.15007 0.43053-0.76078 0.27006-0.87105 0.88064-2.0905 1.3112-2.9414 2.9218-3.2219 5.4019-0.18987 1.7104-0.15985 2.2805-1.8811 2.8807-1.3708 0.48011-2.1904 0.8702-3.3518 1.6406 0.06 1.1305-1.0107 2.3908-1.9313 2.8311-0.57027 0.2805-1.2802 0.44032-1.8406 0.68037-0.95065 0.39009-1.0707 0.74952-1.7512 1.4508-0.99111 1.0196-1.4217 1.7606-1.5105 3.4006-0.0404 0.92043-0.33993 3.8011 0.61007 4.1416 0.57091 1.9615 0.39083 4.5115-1.2606 5.702-0.63943 0.4501-1.4707 0.72016-2.0612 1.1514-0.61071 0.44945-1.4511 1.3705-1.9411 1.9707-1.8504 2.2812-1.9307 8.5428-0.0698 10.763 0.39997 0.47032 1.0414 0.91064 1.5809 1.0502 0.97023 1.4508 1.7715 3.5506 0.62051 5.2016-0.36017-0.03-0.62051 0.16047-0.95066 0.17026-0.0496 0.1709-0.12919 0.29028-0.17029 0.46054-0.39997 0.0998-0.81037 0.19047-1.2097 0.29028-0.0998 0.23027-0.18987 0.21983-0.2897 0.45989-3.002 0.20026-1.7512 9.1221-1.8615 11.283-0.0907 1.8304-0.86062 3.8611-1.3611 5.5219-0.60028 1.9602-0.44042 3.8813-0.76079 5.972-0.17943 1.2303-1.0603 2.3706-1.8811 3.351-1.1601 1.4005-1.2397 2.1409-1.2397 4.0314 0 1.7508 0.68053 3.9818 0.12006 5.6322-0.53046 1.5806-1.9711 2.5004-2.4912 4.2512-1.0407 3.5708 0.0698 8.1723-1.5607 11.684-0.91085 1.9707-2.0807 2.2107-2.4513 4.5617-0.32037 2.0405 0.23032 4.2114 0.01 6.2623-0.21009 1.8611-1.4002 3.2805-1.761 4.9909-0.41041 1.9609-0.0796 3.9211-0.74056 5.762-0.59049 1.6706-2.1316 4.0907-0.12006 5.4913-0.57026 2.7411-1.4818 5.0418-2.4416 7.4926-0.64008 0.03-1.1307 0.31898-1.7519 0.13959-0.39018-0.10959-1.1203-0.77952-1.5307-0.96087-1.0603-0.45924-2.8813-0.78996-3.9723-0.14025 0.23097 1.8206-1.5503 1.3007-2.2308 2.2707-1.5712-0.23092-1.0407 2.6908-2.2713 3.4012-0.71054 1.5499-0.95065 3.0705-0.83973 4.9414 0.47043 0.18982 2.3411 1.5904 2.6412 2.0202 1.0309 1.501-0.5011 1.1814-1.5007 2.1709-0.86061 0.85063-0.45999 2.7711-1.151 3.471-0.63943 0.63015-1.7004-0.27006-2.2014 0.06-0.44042 0.28964-0.33015 1.2205-0.47957 1.6406-0.46064 1.2805-1.0505 2.0307-1.1705 3.501-0.11092 1.3712 0.1592 2.7906-0.54025 4.0014-0.64008 1.1011-2.1616 1.3301-2.6314 2.4906-0.5011 1.2094 0.0998 2.561-0.53046 3.8115-1.1601 2.3001-1.9502 4.6713-2.8317 7.0118-1.2397-0.21983-2.3215 0.81019-2.3006 2.0216 0.0196 1.2101 1.3004 1.6497 1.2906 2.9713 0 0.85977-0.86061 1.9302-0.96044 2.8702-0.13963 1.2694 0.25055 2.3712 0.14028 3.6406-1.9307 0.12068-4.5223 1.9204-6.6533 1.03-1.0198-0.4201-1.0903-1.6002-1.611-2.3908-0.52067-0.78996-1.5209-1.319-1.7408-2.2603-1.2006 0.06-2.1714 0.0104-1.8308-1.501-1.3415 0.14938-3.1821-0.67972-3.4822-2.03-0.21988-1.0007-0.12919-2.1011-0.19052-3.1312-0.80059-0.0502-1.641-0.0104-2.4513-0.06-0.0803-1.6112-0.20031-3.8618-1.5098-4.8115-1.5509-1.1102-3.3028 0.42988-4.8531 0.33986-2.6412-0.14938-1.4811-2.0803-3.0014-3.3412-1.0107-0.83954-3.7322-0.60014-5.133-0.69081-0.15007-1.2799-2.4416-1.0196-3.4118-2.09-1.2404-1.3803-0.89063-2.471-1.2508-4.2114-0.35037-1.6608-1.5013-2.6008-2.4911-3.7104-0.37778-0.41814-0.858-1.0783-1.0381-1.7287z",
+                ChiayiCity:"m184.85 297.29c0.06 1.2094-0.28056 1.4703-1.301 1.9994-0.12984 0.89042-0.33994 2.5317-1.6005 1.8017-0.42019-0.24005-0.55069-0.76061-1.0805-0.89042-0.39017-0.10959-1.2808-0.14938-1.671-0.09-0.75034 0.12003-1.4707 1.1005-1.9907 1.6706-0.51023 0.57013-1.4113 1.5506-2.3313 1.4005-0.48022-0.50164-0.2499-1.1709-0.67988-1.711-0.52002-0.64972-0.99046-0.55056-0.93043-1.5904-0.71054-0.0404-1.4309 0.0104-2.1414-0.03-0.0698-1.1011-1.1803-0.61057-1.8308-0.55056-0.98001 0.0992-1.4106-0.69994-0.27012-1.0404 0.0998-0.63993 0.76078-1.5904-0.39997-1.501-0.42019-0.53034-0.53046-1.4899-0.6205-2.1403-0.12984-0.97001-0.01-0.91978 0.94022-1.261 0.4502-0.17025 0.91085-0.42988 1.181-0.82062 0.0998-0.0104 0.21989 0.0104 0.30993 0 0.0502 0.33986 0.12005 0.66081 0.19052 0.98044 0.77057-0.0404 0.99045-0.63014 1.6605-0.82062 0.62051-0.17939 1.3911-0.0698 2.0612-0.0998-0.18009-1.3601 1.2606-0.94979 2.1714-1 0.0196-0.34899 0.17029-0.63014 0.42998-0.8291 0.33994 0.21983 0.26034 0.50033 0.48022 0.78018 0.20031 0.27985 0.63029 0.4488 0.79014 0.70973 0.49001 0.77952 0.03 1.2701 1.3004 1.1709 0.0998-0.29029 0.1703-0.57013 0.19053-0.89042 0.38039 0.03 1.5105 0.24005 1.7512 0.49054 0.32036 0.33008 0.24989 1.2101 0.33993 1.6497 0.93108 0.17026 1.3004 0.84019 2.3013 0.85976 0.03 0.4899 0.0398 0.93087 0.10961 1.3914 0.22967 0.17026 0.33994 0.2805 0.64008 0.36073z",
+                ChiayiCounty:"m205.81 336.38c-0.21988 1.0607-1.1216 1.5206-1.8817 0.36073-1.3708-0.30007-2.3515 0.2094-3.8418 0.0998-1.4002-0.11024-1.9013-0.57013-2.6314-1.741-0.35038 1.8611-2.0207 1.8311-2.8611 3.2414-0.0502-0.0104-0.54025 0-0.61071 0-0.38039-0.78018-1.5614-0.45988-1.7219 0.3503-1.3904-0.33986-1.5705-2.1011-3.2813-1.8904-0.0998-0.34965-0.22053-0.72017-0.39083-1.0607-0.5807-0.03-1.2006-0.0398-1.7806-0.06-0.0607-0.85912 0.2897-1.9609 1.1105-2.3405 0.0496-0.85063 0.0496-1.7508 0-2.6008-1.8615-0.20026-1.0414-4.6211-0.97023-6.032 0.0692-1.4397 0.09-1.8096 1.181-2.6706 0.79014-0.62036 1.761-0.39922 1.6207-1.8011-1.9816-0.45989-3.0816-2.0105-5.2733-1.8898-0.48022-2.1403 1.9914-2.3412-0.46064-3.6413-0.10962-0.99936-1.6312-0.98045-2.5009-1.2003-0.1703-1.561 1.9209-0.93935 1.4009-2.6112-2.071 0.44032-2.1512-0.50033-3.9723-1.3601-1.1503-0.54012-2.6915-1.0404-3.6721-1.8506-1.0407 1.4599-3.5318 0.34965-5.0025 0.34965-1.731 0-3.0516 0.76061-4.6626 1.0007-1.8609 0.27985-3.6317 0.10959-5.013 1.3705-1.0505 0.95044-0.45021 1.0802-1.9907 1.3001-0.91085 0.12982-1.8008-0.0998-2.6412-0.14025 0.10961 2.5206-1.2606 1.2205-2.7417 2.261-1.5907 1.1298-0.6205 2.1905-0.31057 3.5512-1.4204 0.58905-1.7108-0.61123-2.6915-0.55056-0.95065 0.06-1.7708 1.3294-0.65051 1.9106 0.52002 3.261-2.8618 1.2609-4.2822 2.8311-0.24989 1.7-1.5007 2.291-2.3613 3.471-0.36016 0.4899-0.6603 1.5604-1.1608 1.6706-0.71054 0.15982-1.5405-0.93934-2.3111-1.0196-0.17029-0.51012-0.40975-0.61971-0.6603-0.97 0.12005 3.5812-3.4118 0.81018-3.5618-1.1598-0.52003 0.0405-1.1007-0.0907-1.611-0.0502-0.2499-0.88912-0.89063-1.5806-1.0603-2.4508-1.5405-0.42989-2.5714-1.6908-4.0323-2.3001 0.03-0.0607 0.0698-0.12068 0.0998-0.17939 0.74056-1.3607-0.0404-3.7313 1.4811-4.471 0.21988-0.1109 0.48022-0.15982 0.7001-0.24006 0.30014-0.12133 0.42019-0.25962 0.67074-0.39074 0.10962-0.0607 0.76014-0.16047 0.82016-0.23092 0.67988-0.80106-2.3815-1.4201-2.6712-1.5199 1.8909-0.17025 6.6232-0.12068 4.6521-3.1814-0.36995-0.0411-0.55003 0.31051-0.80058 0.55969-0.53046-0.42074-1.2103-1.5506-0.93043-2.1011 0.20031-0.39987 0.58005-0.45989 0.56047-0.96935-0.0202-0.45011-0.33993-0.42988-0.0698-0.93087-0.48022-0.0104-0.86061-0.54012-0.81037-1.0104 0.06-0.62036 0.78036-0.88064 1.0505-1.3196 0.49001-0.79127 0.06-2.4019-1.0505-1.9309-0.44042 0.18983-0.44042 0.85977-1.1203 0.69081-0.53046-0.12981-0.70076-0.76061-0.44042-1.2309 0.35038-0.63993 0.78036-0.34965 1.3108-0.5199 0.7001-0.22114 0.38039-0.82128 0.38039-1.441 0-1.2401 0.88084-1.441 1.5607-2.2499 0.72033-0.86042 0.38039-2.0516-0.99046-1.5506-0.18987 0.0796-0.36995 0.31898-0.57026 0.37965-0.25968 0.0907-0.55003-0.0196-0.82016 0.0496-0.27012 0.0607-0.39996 0.33073-0.60027 0.39075-0.36995 0.11024-0.42019-0.0907-0.70076-0.15982-0.21988-0.06-0.63029 0.0104-0.82016-0.0998-0.42998-0.25049-0.17029-0.39922-0.30992-0.75996-0.20031-0.50098-0.73077-0.54012-0.94087-0.99087-0.27991-0.58971 0.21988-1.1905 0.36995-1.7104 0.0803-0.25962 0.0803-0.55969 0.20031-0.79061 0.13963-0.31051 0.36996-0.40966 0.50045-0.69081 0.47043-0.11025 0.58005 0.20091 0.96044 0.33072 0.33994 0.11025 0.80059 0.0405 1.1608 0.0405 0.58005 0 1.8909 0.25962 1.611-0.62036-0.12006-0.36008-0.66031-0.4201-0.55004-0.87999 0.06-0.27006 0.33994-0.35029 0.48022-0.59035 0.70011 0.45989 1.2006 0.95044 1.0505 2.0607 0.32036-0.0502 0.79014 0.12981 1.1105 0.06 0.42019 0.75996 2.9714 0.95044 3.862 1.1403 1.6508 0.35029 3.2317 0.85063 4.8224 1.1605 2.0312 0.39922 3.8724 0.40966 3.522-2.1709-0.0998-0.66994-0.89063-1.3601-0.98067-1.8617-0.14028-0.78997 0.38039-1.5304 0.50045-2.2805 0.33015-0.01 1.5607-0.21983 1.8113-0.03 0.63029 0.47098 0 1.0913 0.36996 1.6412 0.92064 1.3712 2.221 0.69081 1.9907-0.93021 1.9209-0.63993 1.1705-1.1403 2.101-2.7404 0.85082-1.441 1.6207-0.68038 3.342-0.82063-0.10049-0.63993-0.59049-1.1102-0.61072-1.7802 1.0407-0.09 2.161 0.18983 3.1214 0.4501 0.0405-2.2707 0.15007-2.651 2.3515-2.8122 1.4106-0.0998 3.0314-1.0405 2.7019-2.8004 0.88019-0.36008 1.9809-0.17939 2.9414-0.23027-0.2101-1.6615 1.9013-3.0516 3.3615-2.972 1.5007 0.0698 2.3515 2.9511 4.5125 1.6804 0.77057-0.4501 0.54025-1.3203 1.5307-1.6804 0.76013-0.27006 2.1512 0 2.9616 0 0.90041 0 1.9411 0.14025 2.8017-0.0398 0.96044-0.19048 1.38-0.86041 2.5114-0.60013 0.2499 1.3105 1.6207 1.8806 1.7206 3.1109 0.23098-0.0189 0.55004 0.0802 0.78036 0.06 0.80059 4.1514 4.6123 2.6112 7.694 3.3014 1.7114 0.39074 2.8115 1.291 4.8531 1.1703 1.7519-0.10959 3.1514-0.85976 4.9627-0.81019 0.35038 2.1514 0.06 3.1012 2.6614 2.4514 0.24011-0.49055 0.46064-0.47946 0.82994-0.79062 0.20096 2.0516 2.452 0.69994 3.5423 0.65037 1.4811-0.0692 3.6121 1.4103 5.0025 1 1.1007-0.33008 0.80059-0.71038 0.79015-1.8311 0-0.53034 0.09-2.0209-0.12071-2.5114-0.25903-0.62036-1.2306-0.4899-1.3604-1.3405-0.06-0.42988 0.64007-1.2003 1.1405-1.4305 0.2101 0.12068 0.5011 0.21983 0.89062 0.27006 1.2006 0.17026 2.5714-0.20026 3.9723-0.14025 0.0104 0.32029 0.19053 0.4899 0.2101 0.78018 0.75034 0.0502 1.5307 0.0202 2.2817 0.06 0.92064 0.68038 0.52002 1.4005 1.6906 1.8213 0.79014 0.27006 2.3111 0 3.1521-0.0404 0.0502-0.15004 0.01-0.29029 0.0502-0.45011 0 0 0.47957-0.0202 0.44955 0.0104 0.36995 0.66081 1.0903 1.3908 1.2012 2.1403 0.0692 0.55056-0.31123 1.9204-0.33994 2.6608-0.0502 0.98045-0.12985 1.6908-0.70011 2.4606-0.53046 0.7293-1.5007 0.77953-1.4511 1.8506 0.15986 0.0489 0.30014 0.0104 0.46065 0.0489 0.06 1.5904 0.70989 2.9811 1.01 4.4815 0.25055 1.2309 0.16051 3.7711 1.6508 4.1918 0.06 2.2499 0.52003 2.2805 2.6915 2.3001 1.6201 0.0196 3.0516 0.45011 4.6417 0.31116 0.39997-2.242 7.5844-0.54012 9.1849-0.44097 0 0-0.06 0.30007-0.0802 0.30007 0.0698 0.22049 0.28056 0.36074 0.29035 0.63993 0.45999-0.0698 0.94021-0.21005 1.4002-0.33008-0.58071 0.61058-1.6116 0.97001-2.4018 0.88977-0.7001 0.91978-1.5098 0.99088-2.6914 1.1298-1.151 0.14938-2.5212 0.27985-3.5514 0.94978-0.39084 0.26028-1.0414 0.93087-1.3206 1.3412-0.2499 0.36073-0.41041 1.501-0.6205 1.7208-0.92064 0.93934-2.8115 0.27006-4.0114 0.69994-1.3506 0.47946-1.791 1.4508-2.1714 2.76-0.35038 1.1507-0.67988 2.0411-1.2103 3.1514-0.33994 0.71038-0.74056 3.261-1.1105 3.6015-0.72033 0.64971-3.0908-0.0196-4.0519 0.39987-1.4204 0.63993-1.5398 1.76-1.821 3.1918-1.1601 0.06-2.8317-0.30007-3.8124 0.31899-0.99046 0.63145-0.84039 1.9009-1.4909 2.7522-0.21988 0.28898-1.821 1.9707-2.1714 2.1305-1.1901 0.55056-2.0305-0.18982-3.171 0.66081-1.5307 1.1403-1.1412 5.291-4.0121 3.8415-1.3108-0.6608-0.45999-2-1.9809-2.5114-0.84038-0.27006-2.7815-0.2805-3.6519-0.14025-0.75035 2.2205-0.01 5.1012 0.64008 7.1521 0.27991 0.90086 0.83973 2.2812 0.71054 3.3308-9e-3 0.0626-0.0189 0.12264-0.0287 0.17222zm-22.262-37.091c1.0198-0.53033 1.3604-0.78996 1.301-1.9994-0.30014-0.0802-0.41106-0.19048-0.64008-0.36008-0.0698-0.46054-0.0803-0.90151-0.10961-1.3914-1.0009-0.0196-1.3708-0.69081-2.3013-0.85976-0.09-0.43967-0.0202-1.3196-0.33993-1.6497-0.24012-0.25049-1.3708-0.46054-1.7512-0.49054-0.0202 0.32029-0.09 0.60013-0.19053 0.89042-1.2704 0.0992-0.81037-0.3914-1.3004-1.1709-0.1605-0.25963-0.59048-0.42988-0.79014-0.70973-0.21988-0.28115-0.14028-0.56035-0.48022-0.78018-0.25969 0.20026-0.41041 0.47946-0.42998 0.8291-0.91085 0.0502-2.3515-0.36008-2.1714 1-0.67009 0.03-1.4407-0.0796-2.0612 0.0998-0.67009 0.19048-0.89062 0.77953-1.6605 0.82062-0.0698-0.31963-0.14028-0.63992-0.19052-0.98044-0.09 0.0104-0.2101-0.0104-0.30993 0-0.27012 0.39074-0.73077 0.65037-1.181 0.82063-0.95066 0.33986-1.0707 0.28963-0.94022 1.2603 0.09 0.65037 0.20031 1.6112 0.6205 2.1409 1.1608-0.0907 0.50045 0.85976 0.39997 1.5004-1.1405 0.33986-0.70989 1.1403 0.27012 1.0411 0.65052-0.0607 1.761-0.55121 1.8308 0.55057 0.71055 0.0398 1.4309-0.0104 2.1414 0.03-0.06 1.0405 0.41041 0.94 0.93043 1.5904 0.42998 0.53947 0.20031 1.2094 0.67988 1.7104 0.92064 0.14938 1.821-0.82976 2.3313-1.3999 0.52002-0.57013 1.2404-1.5506 1.9907-1.6706 0.39018-0.0607 1.2808-0.0196 1.671 0.09 0.53047 0.12982 0.66031 0.65037 1.0805 0.89042 1.2606 0.7293 1.4707-0.91194 1.6005-1.8024z",
+                Nantou:"m217.09 275.91c-0.88997-0.5199-0.50958-1.5506-1.671-2.351-1.581-1.0907-0.96044 0.88977-1.7806 1.79-0.74056 0.81019-2.9805-0.4899-3.0314 0.98109-1.4818 0.0692-2.7515-0.20091-4.1125-0.33986-0.39084-0.82975-0.2101-1.8206-0.57027-2.6106-1.121 0.36009-1.7806 2.1905-2.9316 1.9504-0.39997-2.0307-0.12071-3.3308 0.25968-5.1918 0.36082-1.7515 1.4909-2.7906 1.9118-4.4214 0.36017-1.3307-0.35038-1.3001-0.7001-2.2009-0.36017-0.91065-0.27991-1.6504-0.32037-2.6706-0.0404-0.66993-0.58005-2.351-0.18008-3.0013 0.47109-0.77952 1.5209-0.47032 2.4716-0.52055 0.10962-2.0607-0.15986-3.7913-0.63942-5.6406-0.26034-1.0202-0.54025-1.2505-1.0903-1.9805 0.18987 0 0.39997-0.03 0.57027-0.0502-0.0698-0.8004 0.51023-1.2003 0.88997-1.7802 1.7519-0.41031 2.972-0.95043 4.9425-1.0496-0.01-0.0698-0.01-0.39074 0-0.4501-0.49 0-0.82994-0.31051-1.2808-0.39009-0.03-0.4899-0.27991-0.90021-0.21988-1.4403-0.33994-0.33008-0.86062-0.59035-1.2808-0.66994 0.03 1.7515-3.8118 0.54013-4.0519-0.50033-1.6605-0.42988-1.4609-2.9107-2.7815-3.0509 0.50958-1.2707-0.21989-6.3021 1.2697-6.8422 0.0698-1.1403-0.09-2.3308 0.32036-3.351 0.21989-0.55056 0.71055-0.6608 0.8815-1.291 0.12005-0.47032 0-1.1605-0.0307-1.6406-0.23032 0.03-0.55004-0.0802-0.77971-0.0502-0.0907-1.561-0.55003-3.2708-0.33015-4.7815 3.1208 0.12003 3.2806-4.201 1.9411-6.002-0.47043 0.09-0.85017-0.19048-1.2704-0.21983-0.3693-4.1012 4.553-0.39009 5.8931-2.6706 0.28057 0.15982 0.58071 0.29029 0.91086 0.36922 1.2006 0.3105 2.9218-0.0104 4.1726-0.0104 1.8106 0 2.3913 0.31116 3.8424 0.80105 3.342 1.1396 4.6221-0.93086 6.4543-3.1814 0.66944-0.81997 1.5007-1.7704 1.8902-2.7704 0.42085-1.1011 0.62051-2.8813 1.6912-3.6413 0.82081-0.58057 1.9711-0.3503 2.942-0.39987 0.12005-2.4808-0.21989-5.0516 0.65051-7.3119 0.47957-1.2101 1.2906-1.9602 2.7019-1.3203 0.58005 0.25962 0.75034 0.97 1.3004 1.2003 0.73077 0.29029 0.82015-0.03 1.6808-0.17938 0.44955 1.1102-0.33081 2.9211 0.23032 3.9302 0.88084 1.5904 2.4011 0.48011 2.6314-0.96023 0.19052-1.1605-1.1105-3.321 0.84038-3.0007 1.3408 0.20939 1.121 1.8898 2.9616 1.4703 0.54025-1.1814 1.7708-1.1814 2.8409-1.6602 2.3613-1.09 4.4825-0.32029 7.234 0.0196 0.33994-1.0196 0.79015-1.8402 2.052-1.73 0.09-2.291 1.151-4.0111 3.631-4.1012 2.6014-0.09 3.6023-0.40053 5.6635-1.6712 1.8308-1.1298 2.3711-2.8702 3.9618-4.1612 1.5614-1.2799 4.4434-0.58905 6.4738-0.69929 0.12919-1.4814 0.0496-2.7411 1.3604-3.1409 1.0198-0.3105 2.9414-0.63014 4.0023-0.50033 0.55982 0.0802 1.0498 0.60992 1.6312 0.47033 0.42998-0.0998 0.81037-0.95044 1.5398-1.1305 0.70076-0.17939 1.4217-0.12916 2.1714-0.33986 0.66096-0.19048 0.84039-1.2205 1.3604-0.19048 0.72033 0.0404 1.5509 0.10046 2.2713 0.06 1.1405-0.0691 0.48022 0.48011 1.2006-0.69994 0.82016-1.3497 0.99111-2.6406 3.1417-2.3105-0.33994 2.1507 1.6201 1.0411 2.2204 2.1103 0.7001 0.12002 1.4818 0.0502 2.1108-0.15982 0.24011-2.0105 6.0934-0.0202 6.7936 1.0202-0.0802 0.19048-0.0502 0.28963-0.0698 0.47946 0.0196 0 0.03 0.0104 0.0502 0-0.42019 0.57013-0.65052 1-0.55069 2.1612 0.92064 0.17025 0.96044 1.0404 0.78036 1.8402-1.731 0.0907-2.452-0.0404-3.6728 1.0202-1.181 1.0404-2.0005 1.5101-3.6023 2.2205-0.96044 0.42988-0.95065-0.03-1.3708 0.95043-0.29035 0.69016 0.06 1.5101-0.32036 2.2199-0.2499 0.48011-0.92064 0.5199-1.2208 1.2505-0.26033 0.66081-0.16051 1.6308 0.0692 2.351 1.7806 0.0202 1.6716 0.44032 2.852 1.3105 0.92064 0.66993 2.4213 0.98044 3.2513 1.5708 1.7212 1.2303 0.82995 4.7013-0.45999 6.1716-0.67009 0.76061-1.3506 1.9504-2.2112 2.4306-1.5007 0.85128-2.2419-0.38031-2.4611 1.8709-0.14942 1.4814 0.10961 2.4312-0.62051 3.8813-0.61985 1.2303-0.94021 2.0007-1.3708 3.291-0.67988 2.0405-1.4407 2.9909-1.3206 5.4717 0.7001 0.0411 1.4211 0.0104 2.1205 0.0502 0.17095 3.3412-0.16964 6.7418-0.33994 10.124-2.1323-0.14025-1.2612 4.2812-1.331 5.6615-0.23097 0.03-0.56047 0.09-0.78035 0.0502-0.33016 0.72016-0.76079 1.1403-1.0303 1.9804-0.12005 0.39988-0.0202 0.95044-0.16051 1.3307-0.19052 0.5199-0.65051 0.65037-0.88084 1.1703-0.64007 1.4103-0.45999 3.1305-1.1503 4.471-0.5011 0.10959-0.75034 0.39074-1.2815 0.39074-0.45999 1.3608-0.39017 2.8702-0.21988 4.2812-1.4511 0.21983-3.0608 2.351-2.7815 3.8311 2.6817 0.54991 2.6817 0.3803 2.972 3.201 0.20097 1.8806 1.7715 2.0405 2.0109 4.1612 0.0907 0.8702 0.0802 1.9602-0.01 2.8402-0.11027 1.0802-0.75034 1.501-0.84039 2.3308-0.0802 0.83041 0.67009 1.4306 0.51024 2.3308-0.2101 1.2805-1.5209 2.0209-1.9111 3.0209-0.4104 1.0802 0.31058 2.441-0.25055 3.441-0.44955 0.78997-0.82994 0.33008-1.1705 1.3803-0.25904 0.77953 0.13049 1.4208-0.3693 2.1311-0.57092 0.10959-1.1014 0.42075-1.6716 0.42988-0.74969 0.0104-0.92064-0.91064-1.9411-0.20026-0.09 0.42075-1.0407 2.1807-1.5209 2.321-0.92064 0.2805-1.8113-0.88064-2.972-0.31964-0.0907 0.0907-0.03 0.31964-0.0607 0.43966-0.85017 0.21005-0.74969 1.0607-0.61072 1.8409 0.27013-0.0502 0.68053 0.10959 0.95066 0.0496-0.36995 1.4508-0.15007 1.6908-1.7806 2.1709-0.11027 1.8702 0.21009 3.6106 0.0998 5.4417-0.68053 0.44032-1.5209 0.57014-2.0116 1.3405-2.4716-1.8396-8.214-1.9198-10.085 0.72017-1.0498 1.4703-1.761 3.1507-2.3802 4.8004-0.8815 2.3608 1.4602 1.8206 1.3108 4.3112-0.67009 0.21984-1.4217 0.21984-2.1414 0.36987-1.2306 0.25897-0.84039 0.20874-1.7108 0.94978-0.32036 0.2805-0.28056 0.68038-0.48022 0.88977-0.12005 0.12068-0.55003 0.11025-0.84038 0.12981 0-0.14938 0.0307-0.33007 0.0111-0.45988-0.14028-0.03-0.32037-0.0502-0.46065-0.0405 0.03-0.91064 0.44042-1.6412 0.29035-2.6217-0.39083 0.0496-0.78036-0.24005-1.1307-0.23027 0.0411-0.3803-0.20031-0.60079-0.2101-0.93086-1.8713-0.10959-3.2513-0.0104-4.8022-0.69995-1.0805-0.48011-0.95065-0.6197-2.1714-0.36986-0.24011 0.0502-0.49 0.11024-0.74055 0.18004-0.46 0.12003-0.94022 0.25897-1.4002 0.33007-0.0104-0.2805-0.21989-0.42074-0.29035-0.63993 0.0202 0 0.0802-0.30006 0.0802-0.30006-1.6012-0.0992-8.7849-1.8011-9.1849 0.44097-1.5907 0.14025-3.0216-0.29029-4.6417-0.31116-2.1714-0.0196-2.6314-0.0502-2.6915-2.3001-1.4909-0.42074-1.4002-2.9609-1.6508-4.1918-0.30014-1.5003-0.95066-2.8911-1.01-4.4815-0.16051-0.0398-0.30014 0-0.46065-0.0489-0.0502-1.0711 0.92064-1.1213 1.4511-1.8506 0.57026-0.77104 0.65052-1.4814 0.70011-2.4606 0.03-0.74039 0.4104-2.1103 0.33994-2.6608-0.11027-0.74952-0.82995-1.4808-1.2006-2.1403 0.03-0.03-0.44955-0.0104-0.44955-0.0104-0.0411 0.16047 0 0.30007-0.0502 0.4501-0.84039 0.0405-2.3613 0.31051-3.1521 0.0405-1.1705-0.42075-0.77057-1.1409-1.6906-1.8213-0.75034-0.0398-1.5314-0.01-2.2817-0.06-0.0196-0.29028-0.20031-0.46054-0.21009-0.78017-1.4002-0.06-2.7717 0.31115-3.9723 0.14024-0.39083-0.0489-0.68053-0.14873-0.89063-0.26875z",
+                Yunlin:"m204.7 249.7c0.55004 0.72995 0.82929 0.96022 1.0903 1.9805 0.47957 1.8506 0.7497 3.5806 0.63943 5.6406-0.95066 0.0502-2.0005-0.25897-2.4716 0.52055-0.39932 0.65037 0.14028 2.3308 0.18008 3.0014 0.0411 1.0196-0.0405 1.7606 0.32037 2.6706 0.35037 0.90021 1.0603 0.8702 0.7001 2.2009-0.42085 1.6308-1.5503 2.6706-1.9118 4.4214-0.38039 1.8611-0.6603 3.1612-0.25968 5.1918 1.151 0.24006 1.8106-1.5904 2.9316-1.9504 0.36017 0.78997 0.17943 1.7802 0.57026 2.6106 1.3604 0.14025 2.6308 0.41032 4.1125 0.33986 0.0502-1.471 2.2908-0.17025 3.0314-0.98109 0.82147-0.90021 0.20097-2.88 1.7806-1.79 1.1608 0.8004 0.78036 1.8304 1.671 2.351-0.50045 0.23092-1.2006 1.0007-1.1405 1.4305 0.12984 0.84998 1.1014 0.72017 1.3604 1.3405 0.2101 0.49055 0.12071 1.9804 0.12071 2.5114 0.01 1.1207 0.30992 1.501-0.79015 1.8311-1.3904 0.41031-3.522-1.0705-5.0025-1-1.0903 0.0496-3.342 1.3999-3.5416-0.65037-0.36996 0.31116-0.59049 0.30007-0.8306 0.79062-2.6014 0.64971-2.3111-0.30007-2.6614-2.4514-1.8113-0.0496-3.2115 0.7006-4.9627 0.81019-2.0409 0.12068-3.141-0.77953-4.8531-1.1703-3.0816-0.69016-6.8934 0.85063-7.694-3.3008-0.23032 0.0196-0.55003-0.0802-0.78036-0.0607-0.0992-1.2303-1.4707-1.8004-1.7206-3.1109-1.1307-0.25962-1.5509 0.41032-2.5114 0.60014-0.86061 0.17939-1.902 0.0398-2.8017 0.0398-0.81037 0-2.2014-0.27006-2.9616 0-0.9911 0.36009-0.76078 1.2303-1.5307 1.6804-2.1616 1.2707-3.0118-1.6106-4.5125-1.6804-1.4609-0.0802-3.5723 1.3105-3.3615 2.972-0.96044 0.0502-2.0612-0.13046-2.9414 0.23027 0.33015 1.7606-1.2912 2.7013-2.7019 2.8004-2.2014 0.15982-2.3111 0.54012-2.3515 2.8122-0.96044-0.26027-2.0807-0.54012-3.1214-0.4501 0.0202 0.66994 0.51024 1.1403 0.61072 1.7802-1.7212 0.14025-2.4912-0.62036-3.342 0.82063-0.93043 1.6002-0.18009 2.1005-2.101 2.7404 0.23033 1.6197-1.0707 2.3001-1.9907 0.93021-0.36996-0.54991 0.25968-1.1703-0.36996-1.6412-0.25055-0.18982-1.4811 0.0202-1.8113 0.0307-0.12006 0.74952-0.64008 1.4899-0.50045 2.2799 0.09 0.50164 0.88084 1.1905 0.98067 1.8617 0.35038 2.5806-1.4909 2.5708-3.522 2.1709-1.5907-0.31116-3.1717-0.81019-4.8224-1.1605-0.89063-0.18983-3.4418-0.38031-3.862-1.1403-0.32037 0.0698-0.79015-0.11024-1.1105-0.06 0.15006-1.1102-0.35038-1.6008-1.0505-2.0607 0.0405-0.0496 0.06-0.11024 0.0803-0.18004 0.26033-1.0705-0.55004-0.88912-0.95066-1.5304-0.0502-0.0104-0.11026 0-0.1605-0.0196-0.0503-0.87085-0.06-1.8011-0.01-2.6804 0.0405-0.71038 0.27991-0.36987 0.50045-0.81019 0.21988-0.45988-0.21989-0.63993-0.4202-0.88977-0.57026-0.71038-0.38039-1.6908-0.33015-2.621 0.0202-0.52056 0.30014-0.66994 0.36995-1.0607 0.0803-0.40966-0.24011-0.75017-0.31057-1.1403-0.0803-0.48011 0.0202-1.0405-0.01-1.5304-0.36995-0.13047-1.151-0.74104-1.0505-1.2107 0.0998-0.5199 0.85082-0.27006 1.1105-0.80105 0.18008-0.36922 0.0104-1.2505 0.0104-1.6797 0-0.72017 0.32036-0.94 0.50044-1.5708 0.18009-0.62036 0.4202-1.0098 0.88084-1.5101 0.49001-0.53034 0.6205-0.84019 0.85996-1.5095 0.24011-0.66993 0.39018-1.09 0.45021-1.7906 0.0398-0.56035 0.27012-0.89043 0.64008-1.3007 0.57026-0.62036 2.2112-1.6008 1.7206-2.6308-0.21989-0.45989-0.45021-0.48989-0.48022-1.1403-0.03-0.4201 0.0998-0.97979-0.0803-1.3601-0.21009-0.44945-0.48022-0.3803-0.85082-0.30985-0.32037 0.06-0.20031 0.36008-0.57026 0.10959-0.18009-0.12068-0.27992-0.33986-0.26034-0.56034 0.12005-0.97979 1.8413-0.62036 2.5016-0.70973 0.0398-0.8702-0.15007-1.7404-0.18008-2.6008-0.0398-0.99022 0.20031-1.2505 0.70076-2 0.81037-0.0404 2.681 0.30007 3.1214-0.44032-0.0998-0.52055-0.20031-0.99088-0.20031-1.561 0-0.27985-0.0803-0.69016 0.0802-0.93021 0.18009-0.27007 0.55069-0.27007 0.73077-0.50034-0.6603-0.30007-0.88084 0.2505-1.181 0.66994-0.27991 0.39987-0.81037 0.75996-1.0205 1.1905-0.45021 0.12003-0.72033 0.63993-1.121 0.87999-0.32037 0.19047-0.67988 0.12068-0.99046 0.25049-0.24011 0.0998-0.42019 0.30007-0.67987 0.30007-0.09-0.68038-0.59049-1.2101-1.0205-1.7215-0.51024-0.6197-0.47043-1.0796-0.49001-1.8806 0.21988 0.51011 0.70011 1.0307 1.3004 0.93999 0.52002-0.0907 0.59049-0.54991 0.78036-1.0007 0.38039-0.89042 0.47043-1.8904 0.42019-2.8807-0.68053 0.0698-1.0309 0.24984-1.5105 0.74038-0.46065 0.45989-0.78036 0.58057-1.3506 0.8702-0.09-0.50033 0.74055-1.0307 1.1105-1.2903 0.47043-0.33986 0.68053-0.7306 1.1307-1.0711 0.39018-0.28898 0.89063-0.74952 1.3708-0.9002 0.88084-0.28964 1.3206-0.57013 1.9711-1.2094 0.6205-0.62036 1.2906-1.1703 2.1616-1.4005 0.75034-0.21005 3.3015 0.46054 2.9414-1-0.15007-0.60014-0.88084-0.63928-0.24011-1.3001 0.27991-0.2805 0.67009-0.36987 1.0603-0.39075 0.30014 0.12068 0.74056 0.18005 1.1307 0.11025 0.67009 2.0516 3.5919 0.81997 4.3918 2.2805 2.3411 0.66015 4.3226 0.86042 6.9736 0.86042 1.1908 0 2.681 0.24984 3.8418 0.01 1.4009-0.30007 1.9013-1.2903 3.1319-0.20026 0.97023-2.0516 1.7708-1.8102 4.0323-1.8102 0.92064 0 1.8308-0.06 2.6216 0.21005 1.0407 0.35029 1.241 0.9002 2.5212 0.82062-0.0398 0.27006 0.11027 0.66994 0.06 0.94 0.20031 0.20026 0.20031 0.01 0.33015 0.33986 1.581 0.0907 2.4611 0.06 3.6317 0.69081 0.99045 0.53034 1.7212 1.3307 2.6614 1.6608 2.651 0.90999 5.593 0.20939 8.3543 0.33986 0.4104 0.0202 1.4818-0.0189 1.8413 0.16047 0.47043 0.23092 0.73012 1.06 1.1908 1.3105 0.91085 0.47097 2.7417 0.48011 3.802 0.53034 1.6801 0.0802 3.3818 0.17025 5.0626 0.14938 1.9111-0.0189 2.0214-0.0802 3.141 1.4814 0.0215 0.0157 0.0313 0.0359 0.0418 0.0555z",
+                Penghu:"m30.865 336.76c0.46065 0.0698 0.20031 0.18004-0.06003 0.3503-0.51023 0.33986-0.21988 1.15-0.59049 1.6504-0.15007 0.20026-0.32036 0.4788-0.49001 0.64906-0.23032 0.21005-0.47043 0.0907-0.7001 0.25114-0.28056 0.20027-0.14028 0.50947-0.2499 0.8004-0.09004 0.24006-0.27012 0.39988-0.32036 0.66994-0.04045 0.24006 0.0098 0.50033-0.33015 0.50033-0.1703-0.21983-0.40975-0.47032-0.60028-0.69016-0.15986-0.19047-0.56048-0.33072-0.6603-0.53034-0.10962-0.23027 0.1305-0.58904 0.16051-0.80953 0.02023-0.18982 0.02023-0.52055-0.06981-0.69081-0.21988-0.41031-0.76078-0.48989-1.0009-0.90021-0.03001-0.0698-0.05024-0.19047-0.09983-0.24005-0.09983-0.0998-0.18987-0.0405-0.30014-0.11024-0.1703-0.09-0.25968-0.4488-0.47043-0.45989 0.45021 0 0.90041-0.03 1.3506-0.0405 0.32036 0 0.39018-0.0411 0.61072-0.21983 0.23032-0.19048 0.2897-0.18004 0.64008-0.18004 0.48022 0 0.95065 0.0404 1.3708-0.12003 0.20031-0.0698 0.36016-0.0502 0.56047-0.0998 0.27012-0.0607 0.15986-0.22049 0.33994-0.31116 0.10896 0.4214 0.56961 0.48076 0.90955 0.53099zm9.855-23.999c0.12006 0.36008 0.21988 0.66015 0.06981 1.06-0.15986 0.4214-0.55004 0.48011-0.59049 0.96087-0.02023 0.42075 0.24011 0.69994 0.4104 1.0496-0.73077 0.11024-4.3827 0.0907-4.3925-0.78996 0.33015-0.0202 0.60028-0.19048 0.6603-0.50034 0.80058-0.41031 1.3904-1.1905 1.3108-2.0803-0.09983-0.0104-0.2101-0.0307-0.31058-0.0307-0.55982-0.66015-0.09004-0.97-0.09983-1.6497 0-0.54013-0.64008-1.3412 0.26034-1.6713 0.13963-0.03 0.33994 0.17026 0.48022 0.17939 0.11027 0.78997 0.51023 0.0998 0.85082 0.15982 0.81037 0.12981 0.2499 0.25049 0.58005 0.75017 0.1703 0.25898 0.73077 0.42989 0.82016 0.60014 0.24011 0.4201-0.2101 0.85063-0.24011 1.06-0.06916 0.55186 0.03067 0.38226 0.19052 0.90216zm4.2326 0.90021c0.01957 0.25962 0.06981 0.21005-0.1703 0.34964-0.12006 0.0607-0.29035 0.12134-0.43063 0.18004-0.53046 0.25898-0.40975-0.20091-0.85017-0.24983-0.31058-0.0411-0.20031 0.18982-0.33015 0.33986-0.08025 0.11024-0.11027 0.0998-0.2101 0.17025-0.09983 0.0613-0.24011 0.16047-0.36995 0.24006-0.0098 0.22048 0.08025 0.55056-0.1703 0.65036-0.36995 0.12982-0.40975-0.33007-0.45999-0.55056-0.50045 0.03-0.43063-0.69994-0.43063-1.0404 0.33015 0 0.6603 0.0104 0.99046-0.0111 0.09004-0.25898 0.08025-0.57013 0.06003-0.85911-0.11027-0.0111-0.23032-0.0998-0.24011-0.22049-0.04045-0.3105 0.24011-0.14025 0.38039-0.25962 0.11027-0.0998 0.03001-0.27007 0.11027-0.34965 0.10962-0.0907 0.39997 0 0.49001 0.12981 0.20031 0.31051-0.1703 0.55056 0.33994 0.60014 0.19052 0.0196 0.42019-0.12981 0.5807-0.09 0.14028 0.03 0.15007 0.14938 0.2499 0.20874 0.09983 0.0613 0.2101 0.0111 0.30014 0.10046 0.1703 0.15134 0.15072 0.46185 0.16051 0.66146zm0.24011-20.209c-0.21988 0.4201-0.13963 0.91978-0.16964 1.3901-0.90041 0.0502-1.6012 0.2805-2.4213 0.20027-0.42019-0.0489-0.7399-0.16961-1.1503 0-0.32036 0.13046-0.09983 0.63993-0.73077 0.55121-0.0398-0.18004-0.15986-0.21983-0.20031-0.39074-0.21988 0.0411-0.50045-0.0607-0.72033-0.03-0.06003-0.6308 0.71054-0.60079 0.6603-1.1507 0.73012 0.17874 1.7108-0.22048 2.3913-0.42988 0.77057-0.25049 1.4909-0.2107 2.3411-0.14025zm0.26034-23.275c0.19052 0.0998 0.19052 0.8402 0.09004 1.09-0.6603 1.6112-2.3913 0.72016-3.7419 1.2609-0.02023 0.74952-0.0098 0.82975 0.30014 1.4299 0.30014 0.55056 0.36995 0.75017 0.33015 1.4606-0.04045 0.95044 0.15986 2.7019-1.2103 2.6106-0.14028 0.53034 0.98002 1.8011-0.25055 1.8409-0.01957 0.33986-0.12006 0.90021-0.01957 1.2401 0.09983 0.3105 0.43977 0.45989 0.57026 0.75995 0.44042 1.0705-0.38039 1.1807-1.2208 1.1403 0.02023-0.12068-0.0398-0.2805-0.01957-0.39075-0.76078-0.0404-1.7512-0.53034-2.4018-0.09 0.30014 1.3405-1.6207 0.0496-1.611 1.06-0.69032-0.0802-1.0805 0.32029-1.8008 0.25049-0.39997-0.98044 0.06981-1.1102 0.75034-1.5095 0.58005-0.33986 0.27012-0.3803 0.57026-0.81018 0.2101-0.31116 0.1703-0.52056 0.72033-0.58122 0.30992 0.51012 0.51023 0.61971 1.0505 0.60079 0.26034-0.0111 1.1412-0.27006 1.331-0.42075 0.60028-0.50099 0.67009-2.1507 0.38039-2.9211-1.3911 0-1.4009-1.3412-0.08026-0.86041 0.03001-0.61123-0.03001-0.92043 0.32036-1.3803 0.33015-0.44032 0.76078-0.42075 0.85082-1.09-0.14028 0.03-0.33994-0.0502-0.48022-0.03 0.02023-0.11024-0.0398-0.28115-0.02023-0.39074-0.24011-0.0404-0.47043-0.16047-0.73012-0.11024 0.27012-0.8004-0.2499-1.9198 0.09004-2.6406 0.85017-0.0104 0.70989-0.25049 0.98002-0.85063 0.2101-0.44032 0.61072-0.66015 0.75034-1 0.36995-0.8004-0.18008-0.69016 0.75034-1.0802 0.45021-0.19048 0.86061-0.46054 1.3108-0.65037l0.03001 0.0698c0.1305-0.01 0.27012-0.01 0.40062 0.0104-0.2101 0.36074-0.39018 0.6608-0.63029 1.0111-0.29035 0.39922-0.69032 0.39922-0.51024 1.0496 0.77057-0.0502 1.3708 0.57013 2.2412 0.3503 0.21923-0.0587 0.71902-0.52838 0.90955-0.42858zm8.5742-4.4032c-0.23032 1.3803 1.641 2.2205 1.5007 3.8109-0.36995 0.0202-0.76078 0.0104-1.1405 0.0307-0.26034 0.38031-0.32036 1.2401-0.2499 1.7208 0.84039-0.19048 0.82995 0.8004 0.39018 1.1703-0.63029-0.0404-0.50045 0.63014-0.47043 1.0802 1.5307 0.03 1.2912 1.1005 1.2208 2.4208-0.4104 0.03-0.89063-0.2805-1.2306-0.48989-0.7001-0.45011-0.29035-0.48011-0.59049-1.2505-0.39018-1.0411-1.761-0.57013-1.3206-1.9915 0.54025-0.09 0.33015-1.1096 0.31058-1.5806-0.86061 0.0411-0.49001-0.77953-0.75034-1.2603-0.16051-0.29029-0.53046-0.33986-0.65052-0.66994-0.09983-0.24984 0-0.72016-0.01957-0.99023-0.8704-0.26027-2.191-0.63014-2.0814 0.63928-0.53046-0.0196-0.44042 0.52056-0.74056 0.78018-0.50045-0.3803-0.69032-0.93935-1.331-0.65037 0.09004-0.06 0.01044-0.16047 0.08025-0.27984h0.09004c0.31058-0.76061-0.38039-1.1905-0.32036-1.9009 0.56048 0.10959 0.84039-0.36987 1.4009-0.43054 0.54025-0.0691 1.2306 0.0998 1.8211 0.0698-0.04045-0.15982 0.06003-0.39987 0.03001-0.56035 0.41041-0.03 1.0309 0.17026 1.0805-0.33007 0.7001-0.21005 0.84039 0.41031 1.3408 0.63014 0.52981 0.22179 1.0505-0.058 1.6305 0.032zm1.592-17.163c0.09004 0.40966 0.1703 0.78997 0.16051 1.2205-0.18008-0.0411-0.45021 0.0691-0.64008 0.03-0.04045 0.78996-0.31058 0.85976-0.67009 1.3999-0.23032 0.33986-0.15007 1.4606-0.91085 1.2401 0.02023-0.1396-0.08025-0.18004-0.09983-0.24005-0.0098-0.66016-0.10962-1.3503 0.27012-1.9009 0.30014-0.44031 1.1307-0.55056 1.1405-1.1703-0.32036-0.06-0.52002-0.33987-0.59049-0.66994-0.39018 0.0411-0.65052-0.20026-0.64008-0.57992 0.78036-0.21005 1.1803 0.78018 1.9803 0.67059zm0.75687 4.9772c0.27012 0.19048 1.1405 1.0007 1.0009 1.4208-0.14028 0.42988-1.4811 0.24984-1.8511 0.39988-0.5807 0.24005-1.0603 0.92043-1.2306 1.5708-0.39018-0.31116-0.47043-0.78996-0.42998-1.291-0.24011 0.0411-0.43063-0.10959-0.64008-0.10959-0.19052-0.63014 0.40975-0.54012 0.67009-0.9002 0.25968-0.36009 0.23032-0.60014 0.24011-1.0705 0.45999-0.0907 0.78036-0.80105 0.99046-1.1814 0.25968 0.75147 0.64986 0.75147 1.2501 1.1611zm9.1868 29.42c1.0309 0.25049 1.4211 0.16047 1.3904 1.4097-1.1608 0.0913-2.5812 1.0411-2.5009-0.88912-1.3506-0.0698-2.8415-0.14025-4.1523-0.0907-0.82016 0.0307-1.2704 0.22049-1.5007 0.91064-0.2499 0.72017 0.02023 1.1207-0.82995 1.4208-0.30014 0.11024-0.64008-0.0405-0.92064 0.0998-0.35038 0.17939-0.45021 0.52055-0.73012 0.74952-0.46065 0.39074-1.0009 0.33986-1.3408 0.84019-0.75034 1.1103 0.81037 2.8918-0.08026 3.9818-0.30992 0.37965-0.89063 0.25897-1.4204 0.23027-0.43063-1.561-2.0011 0.12068-3.1019 0.17939-0.61072 0.0404-1.4009-0.14939-1.5907-0.82976-0.14028-0.50033 0.42998-1.2394-0.06003-1.7704-0.49001-0.55056-1.2404 0.0998-1.8308-0.50033-0.47043-0.47032-0.21988-1.1605-0.77057-1.5617-0.44042-0.31899-1.5509 0.0698-1.7708-0.64972-0.18987-0.58056 0.55069-0.82062 0.6205-1.3412 0.43063-0.20027 0.30014-0.66015 0.5807-1 1.2103-0.33007-0.02023 2.3412 1.3108 2.1703 0.27991 0.72016 0.75034 1.0104 0.69032 1.8904 0.52002 0.14938 0.8704-0.0998 0.8306-0.63993 1.6207-0.0796 0.81037 0.53034 1.2508 1.6412 1.0407 0.20026 1.2906-0.66994 1.2508-1.561 0.67988 0.0496 2.9616 1.6204 2.5512 0.0111-0.0398-0.19048-0.45999-0.27007-0.48022-0.52121-0.04045-0.47946 0.30014-0.45924 0.50045-0.66929 0.27012-0.30006 0.49001 0.0496 0.51023-0.59035 0-0.12981-0.28056-0.63014-0.36016-0.74039-1.1007-1.3901-2.101 0.20092-3.1417 0.33073-0.97023 0.12003-2.6216-0.76061-2.4911-1.9009 0.68053-0.0691 1.7108 1.2101 2.2412 0.24006 0.65052-1.2101-1.0407-1.4703-1.7408-1.2401-0.09004 0.48011-0.59049 0.31116-1.0107 0.31964 0.15007-0.88977 0.31058-1.1801 1.151-1.6002 0.12006-0.68038-0.98067-1.6106-0.6603-2.0607 0.2499-0.33986 2.0311-0.01 2.4716 0-0.33994-0.90021 0.33994-0.85911 1.0205-0.82911 0.03001 0.66929-0.18008 1.9994 0.36995 2.471 0.09983 0.09 1.0303 0.30007 1.1405 0.26941 0.67009-0.17939 0.39997-0.36987 0.44042-0.94 0.10962-1.6902 0.96044-0.33986 1.5705-1.15 0.64008-0.84084-0.65052-1.4703-0.85017-1.9009-0.12006-0.03-0.1703-0.06-0.2499-0.0998 0.45021-0.12002 0.82016-0.67972 1.4302-0.50033 0.53046 0.16047 0.35038 0.88977 1.2306 0.4899-0.12006-0.74104 0.91085-1.1403 1.2808-0.4899 0.16051 0.28963-0.36016 0.99023-0.42998 1.3405-0.09004 0.4501-0.09983 1.3001 0 1.7508 0.10962 0.48011 0.58005 1.1514 1.0903 0.50099-0.26034-0.36987-0.18008-1.5506-0.06981-1.9413 0.27991-1.0196 0.88084-0.30007 1.8008-0.41031 0.06982-1.3999-0.16051-2.1709 1.5007-1.8898 0.09983 0.67972 0.33015 1.1292 0.36016 1.8898 0.2499-0.03 0.55069 0.0502 0.81037 0.03 0.06981 0.0802 0.09004 0.0907 0.1703 0.17091-0.04045 0.19048 0.02023 0.45989 0.02023 0.72016 0.76078-0.0802 0.23032-1.1605 0.39997-1.6608 0.24011-0.66016 0.76078-0.51991 1.4909-0.48011 0.02023 0.4501-0.15007 1.2205 0.01044 1.6504 0.23032 0.59035 0.52002 0.57991 0.59049 1.3307 0.09722 1.1285-0.05285 2.2884 0.0072 3.409z",
+                Changhua:"m211.1 246.37c-0.01 0.0607-0.01 0.3803 0 0.4501-1.9711 0.0998-3.1919 0.63928-4.9425 1.0496-0.38039 0.58057-0.96044 0.98044-0.88997 1.7802-0.17095 0.0202-0.38039 0.0502-0.57026 0.0502-0.0111-0.0202-0.0202-0.0411-0.0411-0.06-1.1203-1.561-1.2306-1.501-3.141-1.4814-1.6808 0.0202-3.3824-0.0692-5.0632-0.14938-1.0603-0.0502-2.8918-0.0607-3.8013-0.53034-0.46064-0.24984-0.72033-1.0802-1.1908-1.3105-0.36017-0.18004-1.4309-0.14025-1.8413-0.16047-2.7606-0.12981-5.7033 0.57013-8.3543-0.33986-0.94022-0.33008-1.671-1.1298-2.6614-1.6608-1.1705-0.63014-2.0514-0.60014-3.6317-0.69016-0.12984-0.33007-0.12984-0.13959-0.33015-0.33986 0.0502-0.26941-0.0998-0.66928-0.06-0.93934-1.2802 0.0802-1.4805-0.47033-2.5212-0.82063-0.79015-0.27006-1.7004-0.21004-2.6216-0.21004-2.2608 0-3.0614-0.24006-4.0323 1.8102-1.2306-1.0907-1.731-0.0998-3.1319 0.20027-1.1608 0.24005-2.651-0.01-3.8418-0.01-2.6517 0-4.6326-0.20091-6.9736-0.86041-0.80059-1.4606-3.7217-0.23093-4.3918-2.2805-0.39018 0.0698-0.8306 0.01-1.1307-0.11024 0.18009-0.01 0.36996-0.01 0.54025 0 0.60028 0.03 1.4309 0.27006 1.8909-0.21983 0.48022-0.53034-0.18008-0.72017-0.32036-1.3503-0.20031-0.90021 0.59048-1.6008 1.4309-1.561 0.11027-0.69081 0.0803-0.91065 0.8306-0.93022 0.6205-0.0202 1.5105 0.17026 2.0514-0.12981 0.4502-0.25049 0.84038-1.0502 1.0903-1.4814 0.30014-0.53033 0.20031-1.1102 0.42998-1.6406 0.53046-1.2205 1.4309-2.1103 2.2112-3.1312 0.33015-0.43967 0.60028-1.1011 0.77057-1.6204 0.06-0.21004 0.0202-0.57013 0.12984-0.75017 0.19053-0.30985 0.36996-0.23027 0.50045-0.60992 0.10962-0.31051 0.06-0.94 0.06-1.2603-1.1007-0.29028-2.071-0.40053-1.3506-1.6608 0.54025-0.95043 1.3806-1.7 1.731-2.8506 0.27012-0.89042 0.43063-1.8506 1.0009-2.6713 0.15985-0.23027 0.36016-0.36921 0.52002-0.63927 0.12984-0.23093 0.12005-0.48011 0.35037-0.63015 0.50045-0.32029 1.3911 0.30007 1.8811-0.0698 0.33993-0.25049 0.39017-1.0907 0.48022-1.4703 0.15985-0.66994 0.35037-1.3503 0.78035-1.8898 0.58071-0.72016 1.181-1.1807 1.3206-2.1103 0.14028-0.88064 0.7001-1.3712 1.3604-1.9407 0.48022-0.42074 1.9711-0.97 2.131-1.5101 0.88083-0.15004 2.6014-0.66994 2.4213-1.8709-1.0002-0.0802-2.131 0.11024-3.1717 0.0502-0.80058-0.0404-0.78036-0.21983-0.71054-0.95044 0.0502-0.44031-0.0405-1.09 0.0803-1.5506 0.28057-1.1305 1.761-1.1605 2.7613-1.2505 0.57026-0.0502 1.0707-0.26028 1.611-0.31116 0.56047-0.0496 1.1412 0 1.6912 0 0.61071 0 1.5809 0.21005 1.9209-0.42923 0.27991-0.53034 0.0196-1.3412-0.06-1.8709-0.0998-0.65037 0.12984-1.09 0.26034-1.7006 0.13963-0.5897 0.09-1.3196 0.06-1.9302-0.53046-0.0202-1.0309-0.06-1.5607-0.0691-0.77057-0.0104-0.71054 0.0802-0.75034 0.8004-0.06 0.0202-0.11027 0-0.1703 0.0202-0.0202 0.33986 0 0.70059-0.0202 1.0496-0.64007-0.09-0.28056 1.1011-0.44042 1.4906-0.84038 0.0502-1.9914-0.21984-2.8011 0.0111-0.57026 0.1696-0.40061 0.69929-0.95065 0.99022-0.15007 0.0802-0.45021 0.0404-0.61071 0.09-0.2897 0.0907-0.3804 0.33987-0.73012 0.29029 0.21988-1.1703 1.1608-1.4208 1.8511-2.2407 0.76078-0.91065 1.4407-1.8506 2.251-2.7104 0.7001-0.74039 1.5007-1.5108 2.2713-2.2812 0.33015-0.33008 0.67988-0.72017 0.92064-1.1403 0.29035-0.53034 0.36016-1.0502 0.81037-1.4906 1.0205-1.0007 3.0216-0.43053 4.4322-0.51011 0-0.53947 0.06-0.5199-0.12005-0.99023-0.45021-1.2603 0.92064-1.4403 1.4002-2.3608 0.27012-0.53034 0.2003-1.2701 0.71054-1.7202 0.96109-0.85063 2.7913-0.50033 4.0121-0.31116-0.0405-0.12002-0.0803-0.23027-0.12071-0.31963 0.0803 0.03 0.15986 0.0691 0.24011 0.11024 0.0803 1.3497 0.11027 2.2903 0.54025 3.4612 0.42084 1.15 1.0714 1.8402 1.5007 2.8409 0.49001 1.1703 0.0907 2.9002 0.7001 3.9713 0.72033 1.2505 2.0312 0.78997 3.1019 1.2303 0.09 0.68037 0.67009 0.81018 1.331 0.66015-0.0692 0.32029 0.12984 0.80105 0.06 1.1102 1.1405 0.58122 2.0011 1.0502 3.3028 1.2003 1.4106 0.15982 2.6712-0.0802 3.9723 0.36073-0.09 1.8004 0.58005 1.8102 1.2404 3.1012 0.58984 1.15 0.3804 3.0007 2.2706 2.5604-0.11027 0.46054 0.0202 0.21983-0.28056 0.51012-0.0803 0.96022-0.93043 1.5604-1.0303 2.471-0.11027 0.98044 0.33994 2.1005 0.36017 3.1403 0.64007 0.03 1.3108 0.03 1.9509 0-0.0802-0.38031 0.1305-0.91 0.0502-1.2903 2.1512 0.25962 3.2017 2.6106 5.0626 3.621-1.3408 2.2805-6.2631-1.4306-5.8931 2.6706 0.42084 0.03 0.80123 0.30986 1.2704 0.21983 1.3408 1.8004 1.181 6.1221-1.9418 6.002-0.21988 1.5101 0.24011 3.2212 0.3308 4.7815 0.23033-0.03 0.55004 0.0802 0.77971 0.0502 0.03 0.47945 0.15007 1.1703 0.03 1.6406-0.17029 0.63015-0.6603 0.74039-0.88084 1.291-0.4104 1.0196-0.24989 2.2107-0.32036 3.351-1.4909 0.54012-0.76078 5.5715-1.2697 6.8422 1.32 0.14025 1.1203 2.621 2.7815 3.0509 0.24011 1.0404 4.0825 2.2512 4.0519 0.50033 0.42019 0.0802 0.93956 0.33986 1.2808 0.66994-0.06 0.54012 0.19052 0.95043 0.21988 1.4403 0.45151 0.0776 0.79145 0.38813 1.2821 0.38813z",
+                Taichung:"m182.09 177.11c-0.03-0.84997-0.10962-2.0907 0.38039-2.8004 0.42998-0.63015 1.5209-1.4606 2.3515-1.5206-0.0411-0.8004 0.47957-1.09 0.0496-1.8604-0.27012-0.4899-0.80058-0.80106-1.2097-1.1814 1.2397 0.63993 2.5707 0.71038 2.6712 2.4814 0.33015 0.0398 0.57026-0.20092 0.80124-0.36987 0.11027-0.91065 0.26947-1.0202 1.121-1.0705 0.21988-0.97979-0.93108-0.39988-1.0603-1.291-0.74121-0.12982-1.5209-0.21005-2.2817-0.20027 0.82995 0 1.3108-0.48989 1.8713-1 0.3693-0.33986 0.39932-0.29028 0.47957-0.81018 0.06-0.36009 0.0907-0.74039 0.0502-1.1103-0.0692-0.03-0.11027-0.0502-0.18008-0.0802 0.43063 0.0104 1.1307-0.0802 1.701-0.06 0.96044 0.0411 0.76078 0.11024 1.0009 0.8702 0.40975-0.01 0.81037-0.09 1.1705-0.25897 0.0405-0.33073 0.31058-1.1703 0.12005-1.4103-0.0803-0.0998-0.52002-0.15003-0.6603-0.21004-0.24011-0.10959-0.32036-0.32029-0.75034-0.30986 0.41105-0.44097 1.6207 0.0992 1.9809-0.30007 0.56047-0.63079-0.17943-1.9504 0.0411-2.6719 0.2897-0.96936 1.4909-1.5206 2.0801-2.2701 0.97022-1.2205 0.17094-2.591 0.80123-3.8813 0.39018-0.78018 1.1105-1.15 1.761-1.7306 0.60028-0.54012 1.1803-1.2394 1.5698-1.9504 0.32037-0.57991 0.97088-1.1598 1.1816-1.7704 0.24011-0.65036 0.16051-1.1102 0.63942-1.6908 0.8306-1.0104 2.0716-1.4906 2.7019-2.6106 0.0196-0.03 0.0404-0.0691 0.06-0.0998 1.4106 1.1305 1.5105 2.7815 2.5512 4.2114 1.0707 1.4514 2.8709 1.9707 4.0917 3.6217 1.121 1.5003 2.0612 2.351 3.4627 3.591 0.74969 0.66015 1.0407 1.5506 1.9907 1.9602 1.0909 0.47946 1.7212 0.06 2.8017 0.8702 1.7806 1.3405 3.2017 3.2714 5.163 4.4912 2.1212 1.3203 4.9829 0.7006 6.834 2.1807 0.88084 0.70973 1.4609 1.8702 2.4318 2.5806 1.0798 0.78018 2.0605 0.41031 3.4522 0.20092 2.4514-0.36987 5.4821 0.50946 7.6737-0.33073 3.2017-1.2198 0.0998-4.6211 1.6201-6.882 1.4413-2.1096 4.6423 0.0998 6.3831 0.3803 2.2119 0.36008 5.7333-0.30007 7.174 1.8702 0.35038 0.53034 0.15985 1.2505 0.53046 1.7704 0.2499 0.3503 0.93956 0.48011 1.2508 0.74039 1.2306 1.0307 1.4407 1.5708 3.1919 1.4305 0.14028-0.69994 0.63029-1.1507 0.88084-1.7802 1.5907-0.0307 1.5405-1.3803 2.482-1.7006 1.2306-0.41031 1.5712 0.8402 2.6712 0.68038 0.33994-0.0502 2.0514-1.0104 2.3313-1.1703 1.32-0.78997 0.55917-1.0502 1.3708-2.1409 0.36995-0.50033 1.1014-0.33007 1.4609-0.69016 0.38039-0.3803 0.33015-0.8702 0.63029-1.2101 0.89062-1.03 1.151-0.84019 2.542-1.1292 2.3006-0.47098 3.1514-1.2505 4.2013-3.3021 2.221-0.39922 2.052-1.0705 2.1616-3.1703 0.69032-0.12067 1.4602-0.0202 2.1212 0.15917 0.31058 1.501 0.70011 2.8618 2.5205 1.6804 1.1014-0.72995 1.1412-2.03 2.6419-2.561 0.47044-1.1703-0.0802-2.6106 0.39018-3.7809 0.81038 0.0404 1.4106-0.39988 1.9411-0.87999v0.1396c1.6208 0.0802 3.4627 0.0802 5.043-0.15982 1.32-0.20092 2.4905-0.84019 3.4118-1.7802 0.0411 0.03 0.0803 0.0502 0.12071 0.0698 0.2499 0.15982 0.51023 0.28963 0.7001 0.5199 0.20031 0.25962 0.26948 0.60014 0.42998 0.87998 0.33081 0.60014 0.2101 1.1703 0.2101 1.8506-0.01 0.35029-0.0502 0.65036-0.2101 0.92043-0.14941 0.25962-0.35037 0.48011-0.42998 0.78017-0.0607 0.24984-0.18008 0.74039-0.0698 1.0007 0.11027 0.30007 0.49001 0.45989 0.74056 0.63928 0.28056 0.21004 0.44042 0.52055 0.68053 0.78018 0.29035 0.32029 0.42998 0.29028 0.8704 0.29028 0.83059 0 2.0109-0.20092 2.7019 0.17026 0.31971 0.18004 0.91085 0.29028 1.121 0.57991 0.17029 0.23092 0.0998 0.76061 0.0998 1.0411 0 0.82062-0.0202 1.6908 0.82929 2.0111 0.38039 0.14025 0.90041 0.17939 1.3206 0.12003 0.49-0.0691 0.55003-0.3105 0.85017-0.66015 0.2499-0.29028 0.56047-0.3803 0.89062-0.58122 0.41041-0.2394 0.68053-0.21983 1.1412-0.30985 0.50045-0.0998 1.0107-0.12003 1.5607-0.12003 0.35038 0 0.39996 0 0.65051-0.15982 0.16051-0.11024 0.26034-0.28115 0.46065-0.33986 0.48022-0.12981 1.0505-0.12981 1.5307-0.0992 0.73012 0.03 0.85083 0.2094 1.2808 0.76061 0.24011 0.30986 0.25968 0.17939 0.61071 0.30007 0.5807 0.20027 0.70076 0.61971 0.79015 1.1703 0.03 0.20027 0.0802 0.38031 0.14941 0.5597-0.79014 0.47097-2.0005 1.6308-2.2412 2.1814-0.50045 1.1396 0.30014 2.8311-0.20031 3.9713-0.36995 0.81997-1.3415 1.7-2.1212 2.3301-0.56048 0.47098-1.2208 0.33073-1.7114 0.66994-0.82995 0.56035-0.2897 0.77039-0.82081 1.5108-0.79015 1.0705-2.0801 1.0796-2.5205 2.4899-0.33993 1.1103 0.60028 3.1918 0.01 4.1723-0.58005 0.95044-2.3711 0.2094-3.312 1.0307-0.69032 0.60014-1.0498 2.291-1.5209 2.9707-0.23032 0.33007-0.43063 0.58056-0.60028 0.8004-0.0202 0.0104-0.03 0-0.0502 0 0.0196-0.19048-0.0104-0.28963 0.0698-0.47946-0.70011-1.0411-6.5534-3.0307-6.7936-1.0202-0.63029 0.21005-1.4106 0.27985-2.1108 0.15982-0.60027-1.0705-2.5616 0.0411-2.2204-2.1103-2.1512-0.33008-2.3222 0.96087-3.1417 2.3105-0.72033 1.1807-0.06 0.63079-1.2006 0.69994-0.72033 0.0411-1.5509-0.0202-2.2706-0.06-0.52067-1.03-0.70011 0-1.3611 0.19048-0.74969 0.21004-1.4707 0.16047-2.1708 0.33986-0.73012 0.18004-1.1105 1.0307-1.5405 1.1305-0.5807 0.1396-1.0707-0.39009-1.6312-0.47032-1.0603-0.13047-2.9818 0.18982-4.0023 0.50033-1.3115 0.39987-1.2312 1.6602-1.3604 3.1409-2.0312 0.11024-4.9125-0.58057-6.4732 0.69929-1.5907 1.291-2.1323 3.0307-3.9625 4.1618-2.0612 1.2694-3.0614 1.5806-5.6628 1.6706-2.482 0.09-3.5423 1.8102-3.6317 4.1012-1.2606-0.11024-1.7108 0.70973-2.052 1.7306-2.7515-0.33986-4.8727-1.1103-7.234-0.0202-1.0707 0.47945-2.3006 0.47945-2.8409 1.6602-1.8406 0.4201-1.6207-1.2603-2.9616-1.4703-1.9509-0.32029-0.65052 1.8402-0.84039 3.0007-0.23032 1.4403-1.7512 2.5506-2.6314 0.96087-0.55983-1.0111 0.21988-2.8206-0.23033-3.9309-0.86061 0.14938-0.95065 0.47033-1.6808 0.18004-0.55003-0.23092-0.72033-0.93999-1.3004-1.2009-1.4113-0.63928-2.221 0.10959-2.7019 1.3203-0.8704 2.261-0.53046 4.8318-0.65052 7.3119-0.97023 0.0502-2.1212-0.18004-2.9414 0.39988-1.0714 0.76061-1.271 2.5408-1.6919 3.6413-0.39018 0.99936-1.2201 1.9498-1.8902 2.7711-1.8315 2.2499-3.1123 4.3216-6.4543 3.1807-1.4511-0.48989-2.0305-0.80105-3.8424-0.80105-1.2508 0-2.9714 0.32029-4.1726 0.0111-0.3308-0.0802-0.63094-0.21005-0.91085-0.36987-1.8608-1.0104-2.9113-3.3608-5.0625-3.621 0.0803 0.38031-0.12984 0.91064-0.0502 1.2903-0.63943 0.03-1.3108 0.03-1.9509 0-0.0196-1.0405-0.47043-2.1605-0.36016-3.1403 0.0998-0.91064 0.95065-1.5101 1.0302-2.471 0.30014-0.29029 0.1703-0.0502 0.28057-0.51012-1.8902 0.44032-1.6801-1.4103-2.2706-2.5604-0.66096-1.291-1.331-1.3007-1.2404-3.1012-1.301-0.44097-2.5616-0.20091-3.9723-0.36073-1.301-0.14938-2.1616-0.61971-3.3022-1.2003 0.0692-0.3105-0.12984-0.78996-0.0607-1.1102-0.6603 0.15003-1.2404 0.0202-1.331-0.66015-1.0707-0.43967-2.3809 0.0202-3.1019-1.2303-0.61007-1.0711-0.20945-2.8011-0.69946-3.9714-0.43063-1.0007-1.0805-1.6908-1.5013-2.8409-0.42932-1.1703-0.45999-2.1103-0.54024-3.4612-0.0796-0.0411-0.15921-0.0802-0.23946-0.11024-0.60028-1.2303-2.0612-0.78018-3.0614-1.5206-0.55069-0.40053-0.86061-0.63993-1.5007-0.84019-0.60027-0.18004-0.96044-0.33008-1.4811-0.67059 0.33015-0.12003 0.64008-0.25897 0.92064-0.45989 0.50045-0.3803 0.48022-0.58057 0.6205-1.1005 0.11027-0.4501 0.26034-0.72995 0.46065-1.1305 0.15007-0.30985 0.17029-0.8004 0.48022-0.99022-0.06 0.57013-0.0196 1.3999 0.06 1.9811 0.12005 0.7704 0.67987 0.90021 0.88018 0.12003 0.15007-0.57991-0.20031-1.4606 0.44042-1.6902 0.51024-0.18004 1.4217 0.21983 1.9209 0.30985 0.14029-0.57013 0.0502-1.0404 0.0803-1.6197 0.0202-0.56034 0.16051-1.1213 0.17029-1.6804-0.33994-0.0698-0.53046 0.27006-0.72033 0.51012-0.44042 0.55056-0.32036 0.50033-0.90041 0.44031-0.87562-0.10437-0.94609 0.2655-1.2958 1.0359z",
+                Yilan:"m393.17 81.6c0.64987 0.54012 1.0505 1.2003 1.0002 2.0405-0.0404 0.04044-0.0692 0.0698-0.12005 0.12068-1.1014 0.06915-3.342 0.46054-3.2519-1.1011-0.20031-0.06001-0.4104-0.12981-0.60027-0.21005-0.0104-0.03979-0.0104-0.06915-0.0104-0.10959h0.0196c0.36995 0.06067 0.81037 0.12981 1.2103 0.10959 0.18987-0.39922 0.11027-0.87998 0.53046-1.12 0.4613-0.25962 0.89193 0 1.2221 0.27006zm-72.209 76.407c-0.0692-0.17938-0.12006-0.36008-0.14942-0.55969-0.0907-0.55056-0.21009-0.97-0.79014-1.1709-0.35038-0.12003-0.36995 0.0104-0.61072-0.30007-0.43063-0.55056-0.55068-0.72995-1.2808-0.76061-0.48022-0.03-1.0505-0.03-1.5307 0.0998-0.20096 0.06-0.30013 0.23092-0.46064 0.33986-0.2499 0.15982-0.30014 0.15982-0.65052 0.15982-0.55003 0-1.0603 0.0196-1.5614 0.12002-0.45999 0.09-0.73011 0.0692-1.1412 0.30986-0.33015 0.20091-0.63943 0.29028-0.88998 0.58122-0.30013 0.3503-0.36016 0.5897-0.85082 0.66015-0.42019 0.06-0.93956 0.0202-1.32-0.12003-0.85017-0.32029-0.82994-1.1905-0.82994-2.0111 0-0.2805 0.0698-0.81019-0.0992-1.0411-0.21009-0.28898-0.80123-0.39922-1.1216-0.57992-0.69032-0.36986-1.87-0.17025-2.7012-0.17025-0.44042 0-0.58005 0.03-0.8704-0.29029-0.24011-0.25962-0.39996-0.57013-0.68053-0.78018-0.2499-0.17938-0.63029-0.33986-0.74056-0.63927-0.10961-0.26028 0.0104-0.75018 0.0692-1.0007 0.0803-0.30007 0.28056-0.5199 0.43063-0.78018 0.15986-0.27006 0.20096-0.57078 0.2101-0.92043 0-0.67972 0.12005-1.2505-0.2101-1.8506-0.16051-0.27984-0.23032-0.62036-0.43063-0.87998-0.19053-0.23092-0.44956-0.36008-0.69945-0.5199 0.39017-0.73061 0.31971-1.8311 0.79014-2.5708 0.27012-0.41031 0.77057-0.36922 1.0107-0.66015 0.2101-0.24984 0.24011-0.80106 0.39018-1.1305 0.24011-0.57013 0.73012-1.7404 1.2103-2.06 0.47043-0.32029 0.90041-0.0698 1.3904-0.25114 0.63942-0.23027 0.29035-0.5199 0.74056-0.84998 0.0998-0.71038 0.53046-0.62036 1.0107-0.81997 0.75034-0.31116 0.5807-0.17026 0.75034-1.0007 0.30014-1.4103 1.0107-0.84997 2.1616-1.2603 0.31057-1.1011-0.23033-1.7515 0.93108-2.2505 0.91998-0.40966 1.2508-0.33986 1.0798-1.4906-0.15986-1.1103-1.1301-3.7313-0.34973-4.6915 0.39018-0.47946 1.1705-0.44032 1.6312-0.95044 0.74969-0.85911 0.0692-0.95043-0.35038-1.6902-0.16051-0.28963-0.24011-0.66928-0.24011-1.0705-0.0104-1.06 0.50045-2.3105 1.3708-2.6217 0.71054-0.24984 1.1608-0.01 1.7114-0.72017 0.46-0.60013 0.44042-1.3001 0.65052-2.0105 0.41041-1.4208 1.4609-1.8709 2.5714-2.681 0.21988-0.66928 0.57026-1.9009 0.27991-2.5004-0.30993-0.66015-0.72033-0.46054-0.45999-1.2394 0.12005-0.33008 0.47043-0.77105 0.71054-1.0307 0.67009-0.74039 2.3411-0.88129 3.5618-0.95044 0.2101 0 0.39997-0.0111 0.57026-0.0202 0.88149-0.0404 1.2704-0.06 2.0011-0.43053 0.58005-0.28898 1.0805-0.77953 1.7708-0.92043 0.70989-0.14025 1.5307 0.0607 2.1812-0.20026 0.35038-0.14025 0.63029-0.4201 0.98067-0.54991 0.2897-0.0998 0.67988-0.0802 0.92064-0.23093 0.86061-0.50033 0.54025-1.7802 1.0714-2.5108 0.53959-0.76061 2.4905-0.91064 3.432-0.90021 1.2208 0 1.5907-0.40966 1.5098-1.6602 2.7026 0.12003 2.7326-2.0705 1.9711-4.0712-0.33016-0.87998-0.44042-1.7508 0-2.6908 0.33015-0.69016 1.2097-1.8304-0.0503-2.2603 0-0.12068 0.0405-0.26028 0.0503-0.33986 0.0692-1.4299 2.3613-1.6197 3.3518-1.6497 1.1105-0.04045 0.85017-0.20092 1.0002-1.1709 0.0998-0.60014 0.36017-1.1096 0.85083-1.4808 1.0302-0.76061 2.7913-0.69016 4.0721-0.77039 1.3806-0.08024 2.7515-0.02022 4.1524-0.09067 0.0398-0.69016-0.12071-1.5506 0.33015-2.1005 0.36995-0.44945 1.151-0.63014 1.6012-0.97 0.49-0.36922 0.81037-1 1.1705-1.4299 0.65052-0.78018 2.3006-1.7306 3.312-1.9302 1.3408-0.26028 2.7404 0.21983 3.9416-0.48011 1.1601-0.66015 1.6116-1.6106 2.9009-2.0105 0.29035-0.56035 0.86061-0.66994 0.75034-1.3007-0.0998-0.57992-0.7001-0.62036-0.38039-1.4208 1.4009-0.0098 0.94021-1.7202 1.4106-2.5004 1.2097-0.24984 2.3913-0.3503 3.6525-0.3503 0.53047 0 1.2808 0.0698 1.7004-0.23027 0.3693-0.26028 0.68053-0.72016 1.1405-1.0202 0.58071-0.36987 2.0801-1.2003 2.2315-1.9107 0.21989-1.06-1.0805-1.9805-2.1414-1.9413-0.42998-1.4403 0.26033-2.0796 1.1712-3.0711 1.1014-1.1703 2.2608-0.84019 3.8215-0.91064 0.6603-0.04044 1.4296-0.02022 2.0801-0.15004 0.82081-0.14938 1.0805-0.60014 1.5705-1.12 0.84039-0.91064 2.0912-1.5206 3.2722-1.6504 0.46-0.04958 1.4309-0.01957 1.8517-0.23027 0.56961-0.2805 0.60028-0.88064 1.2312-1.1305 1.2006-0.47033 2.2008 0.42988 3.3916 0.36987-0.11027 0.30007-0.15007 0.66015-0.0998 1.1103-1.4106-0.05023-2.882 0.66015-4.1432 1.2094-0.39931 0.17091-1.181 0.32029-1.3708 0.69081-0.19053 0.39009 0.15985 1.0796-0.44042 1.2394-0.0202 0.03001 0 0.0698-0.0104 0.10959-0.4215 0.28115-0.64008 0.6608-1.0303 0.97066-0.36995 0.31051-0.71054 0.91064-1.2103 0.96022-0.42084 0.4899-0.93108 1.0202-1.6312 1.1605-0.39018 0.08024-0.50045 0.08024-0.82929 0.33008-0.25969 0.20092-0.68053 0.42988-0.8306 0.75017-0.2897 0.63014 0.16051 1.4808 0.16051 2.1311-0.0104 0.6608-0.65052 1.3203-1.1705 1.6602-0.24011 0.17091-0.52067 0.30007-0.72033 0.50098-0.18987 0.19048-0.49001 0.41031-0.68053 0.63014-0.4489 0.53034-0.84039 1.1298-1.3604 1.5701-0.47957 0.41031-1.0107 0.98044-1.4413 1.4403-0.47892 0.53034-0.88932 0.8291-1.0407 1.5604-0.12984 0.63014-0.49 1.1103-0.76013 1.6902-0.31058 0.6608-0.53046 1.4103-0.82081 2.0907-0.60028 1.3901-0.47043 2.9811-0.58984 4.5219-0.0502 0.61058-0.09 1.2805-0.25903 1.8402-0.12984 0.45989-0.2512 0.85063-0.3308 1.3301-0.0796 0.50098-0.18987 0.97066-0.28057 1.4305-0.27012 1.3307-0.0502 2.7906-0.0502 4.1514 0 1.2303 0.2101 2.5702 0.51024 3.7509 0.27012 1.0705 1.1014 2.1703 1.6312 3.0901 0.27991 0.46054 0.40976 0.69081 0.44042 1.2101 0.03 0.44945 0.0796 0.85976 0.1703 1.291 0.12984 0.69081 0.36995 1.3999 0.3308 2.1207-0.03 0.60014-0.0411 1.2205-0.0411 1.8402 0 0.60013 0.0496 1.1814 0.0802 1.7802 0.0196 0.48989 0.26947 0.93021 0.31971 1.4208 0.0405 0.36008-0.0998 0.67972-0.0411 1.0496 0.12136 0.74104 0.72033 1.2909 0.93173 1.9915 0.28904 0.93021 0.17878 1.7 0.79014 2.4899 0.47044 0.61057 0.68053 1.501 1.3708 1.9009 0.65052 0.38031 1.1014 0.5199 1.8413 0.66081 0.20879 0.0404 0.39997 0.14024 0.61985 0.17025-0.0111 0.31051 0.23946 1.2205-0.36995 1.1207-0.2101-0.0404-0.33015-0.35029-0.50045-0.47032-0.2101-0.15004-0.30014-0.15004-0.58135-0.16047-0.49001-0.01-1.0407-0.0998-1.4106 0.24984-0.34973 0.33007-0.28057 0.8702-0.2499 1.3307 0.25969 0.12981 0.45999 0.36986 0.74056 0.47032 0.20944 0.0698 0.44107 0.0698 0.66095 0.17091 0.0992 0.15982 0.21989 0.33986 0.30014 0.50033 0.12006-0.0998 0.21989-0.21004 0.30014-0.33986 0.18987-0.0196 0.39083 0.0196 0.57026 0.0907 0.0104 0.28049-0.17943 1.1403 0.12071 1.2094 0.18987 0.32029-0.14028 0.36987-0.3693 0.43054-0.48022 0.12068-0.51024 0.03-0.56048 0.61057-0.0998 1.09-0.03 2.1898 0.03 3.2805 0.68053-0.17026 0.4502 1.4005 0.4502 1.8011 0 0.68038 0.28057 1.7097-0.50109 1.9602-0.72034 0.21983-1.4511 0.06-2.1212 0.57078-0.28904 0.2094-0.52067 0.40966-0.88084 0.47032-0.54024 0.09-1.0407 0.0196-1.3715 0.57992-0.25055 0.42075-0.22054 1.0307-0.1703 1.5101 0.0411 0.33986 0.0998 0.66994 0.30014 0.93935 0.25968 0.35029 0.68053 0.29028 0.95065 0.55121 0.25969 0.24005 0.1703 0.63014 0.25969 0.96022 0.14028 0.53034 0.39018 0.78018 0.82081 1.1207 0.17943 0.14025 0.82016 0.72995 0.84038 0.92043 0.0398 0.31116-0.73077 0.32029-0.99176 0.33008-1.4707 0.0698-2.3606 1.2407-3.4411 2.1318-0.31971 0.25897-0.88084 0.57992-1.0714 0.95044-0.20031 0.3803-0.1703 1.0104-0.30014 1.4208-0.63942 0.06-1.181 1.1807-1.6305 1.6308-0.35038 0.33986-0.63094 0.66993-0.90107 1.0802-0.20031 0.30986-0.53046 0.60014-0.70989 0.91-0.17029 0.32029-0.25968 0.74038-0.39083 1.0907-0.14028 0.36987-0.2101 0.81997-0.24011 1.2101-0.0796 0.96022-0.06 1.9504-0.25968 2.8702-0.18987 0.8702-0.27013 1.7306-0.31058 2.6308-0.0411 0.75017-0.31971 1.3105-0.73012 1.9204-0.49001 0.71038-0.82081 1.3503-0.8704 2.2505-0.0405 0.8702-0.25055 1.6706-0.25055 2.5512 0 0.63015-0.0411 1.2505-0.0496 1.8696-0.0104 0.36074 0.15986 1.0502-0.0998 1.3307 0 0.0202-0.0196 0.0411-0.0405 0.0502-0.48022 0.38031-1.5314-0.24984-2.0214-0.3803-0.31971-0.0802-0.61137-0.14025-0.90107-0.31051-0.33015-0.18983-0.58983-0.54012-0.93108-0.72995-0.58005-0.32029-1.4302-0.15003-2.0514-0.33986-0.49001-0.16047-0.88084-0.30007-1.4106-0.28963-0.49001 0-0.96109 0.03-1.4204-0.12068-0.59048-0.17939-1.0505-0.50033-1.5816-0.78997-0.27991-0.15982-0.58005-0.40966-0.8704-0.5199-0.42933-0.15982-0.99045 0.09-1.3904-0.12003-0.3693-0.18982-0.44042-0.42988-0.90041-0.50098-0.4202-0.06-0.73012 0-1.0805-0.24984-0.44955-0.31051-0.74969-0.75017-1.1099-1.1605-0.36082-0.41032-0.88084-0.54013-1.2612-0.92043-0.18987-0.19048-0.30992-0.55056-0.55003-0.63015-1.1203-0.33986-0.0502 1.9113-1.2006 0.76061-0.33994-0.33986-0.65052-0.69016-0.98067-1.0404-0.27013-0.27985-0.63029-0.74039-0.95066-0.96022-0.75034-0.50099-1.4407 0.3803-1.2404 1.1298 0.0998 0.3803 0.46065 0.48989 0.6603 0.77105 0.15007 0.21983 0.15007 0.47032 0.33994 0.67972 0.2897 0.31964 0.63029 0.23027 0.74056 0.66015 0.0698 0.25962 0.0196 0.69016-0.0104 0.96022-0.0202 0.20092-0.0202 0.69994-0.18987 0.81019-0.30014 0.20026-0.43063-0.38031-0.59049-0.58057-0.30013-0.36987-0.29035-0.12068-0.71054-0.23093-0.23098-0.0502-0.41041-0.28963-0.46065-0.53033-0.24011 0.13959-0.4502 0.39922-0.54024 0.66928-0.0692 0.21983-0.0503 0.74104-0.2897 0.85063-0.23033 0.11024-0.33015-0.19048-0.61985-0.10959-0.29035 0.0802-0.5011 0.53034-0.70076 0.7293-0.12984 0.12068-0.24011 0.30007-0.42998 0.31116-0.17029 0.01-0.19052-0.15004-0.32036-0.17026-0.19053-0.0104-0.16051-0.15004-0.21989 0.14025-0.06 0.27006 0.0907 0.39009 0.27013 0.55904 0.36995 0.3503 0.55003 0.33008 0.60027 0.81019 0.0411 0.29028-0.0202 0.57013 0.0803 0.81997-0.2499 0.03-0.42998-0.09-0.66944-0.12003-0.27013-0.0404-0.48022 0.06-0.74121 0.09-0.42019 0.0411-0.85017-0.12003-1.2397-0.21983-0.78036-0.20027-1.5509-0.0998-2.3613-0.21005-0.98002-0.12981-1.1908-0.81997-1.8106-1.4599-0.61071-0.6308-0.7797-1.7215-1.761-1.8206-0.41041-0.0502-0.83973-0.0111-1.2508-0.0502-0.63943-0.06-1.181-0.24005-1.7904-0.36986-0.44107-0.0992-0.92064-0.11025-1.3715-0.0405-0.2101 0.03-0.33994 0.0992-0.59049 0.0802-0.30992-0.03-0.33994-0.18004-0.58005-0.25049-0.56047-0.15917-0.67009 0.31115-1.0407 0.50098-0.21988 0.12003-0.12071 0.09-0.41041-0.0998-0.18008-0.13047-0.33994-0.24006-0.5011-0.39009-0.36016-0.33986-0.63942-0.66016-1.0798-0.93022-0.42998-0.27006-0.97023-0.33007-1.4309-0.54012-0.71055-0.32029-1.1405-0.97001-1.8811-1.2003-0.63094-0.20091-1.1608 0.01-1.5712-0.59035-0.0574-0.0855-0.10701-0.17548-0.14746-0.2655z",
+                HsinchuCounty:"m293.48 147.63c0.0196-0.71104-0.09-1.4514-0.0502-2.1514 0.03-0.55969 0.18987-1.1807 0.0698-1.73-0.12005-0.56034-0.58005-0.84019-0.91085-1.2707-0.2897-0.38031-0.67009-0.63015-1.0002-0.96023-0.67988-0.71103-1.2312-1.5812-1.9118-2.2805-0.60027-0.61123-1.2704-1.1102-1.7604-1.8011-0.55982-0.80041 0.47043-1.3705 0.19052-2.1403-0.25968-0.66993-1.0002-1.1703-1.5705-0.70973-0.69097 0.57013-1.5509 0.16961-2.2315 0.69016-0.30014 0.23027-0.52002 0.57079-0.88084 0.66015-0.36017 0.0907-0.88997 0.0111-1.2508 0-0.35038-0.01-0.66944-0.03-1.0002 0-0.39997 0.0411-0.58071 0.24006-0.93108 0.32029-0.47044 0.12003-0.61072-0.12981-0.95066-0.30985-0.34972-0.19048-0.72946-0.12068-1.1203-0.14025-0.69032-0.0307-1.0498-0.93086-1.7108-0.48011-0.25968 0.16961-0.38039 0.62036-0.61072 0.73974-0.18008 0.10045-0.82015 0.0502-1.0205 0-0.39018-0.10959-0.43064-0.51012-0.76079-0.69995-0.30014-0.19048-0.6205-0.06-0.90041 0.11025-0.21988 0.12981-0.3693 0.28963-0.55004 0.48011-0.24011 0.26027-0.47043 0.35029-0.79014 0.53033-0.30014 0.16961-0.44042 0.24984-0.67988 0.4899-0.24011 0.23027-0.33015 0.33986-0.6603 0.3803-0.69097 0.0692-1.3604-0.0607-1.8615-0.39074-0.52067-0.3503-1.1705-0.0691-1.791-0.24984-0.15985-0.2805-0.44955-0.47032-0.58005-0.78996-0.14028-0.3503-0.0802-0.75017-0.13049-1.1207-0.0998-0.66994-0.74056-1.3901-0.2499-2.0516 0.23032-0.32029 0.54025-0.36008 0.91085-0.43967 0.53047-0.0998 0.36996-0.18004 0.60093-0.57013 0.20945-0.3503 0.58984-0.55056 0.66031-1.0104 0.0692-0.42009-0.24011-0.4501-0.5011-0.62036-0.2897-0.20026-0.61072-0.48989-0.84039-0.77039-0.23946-0.2805-0.50958-0.5199-0.80058-0.75996-0.3804-0.32029-0.89063-0.74039-1.3604-0.95043-0.0803-0.47033 0.76078-0.33987 1.0407-0.44032 0.32037-0.12068 0.53046-0.36074 0.58136-0.72017 0.10961-0.78018 0.3693-1.5003 0.85996-2.1305 0.35038-0.46054 0.39083-0.9002 0.70989-1.3307 0.27012-0.36008 0.65051-0.66015 0.55134-1.1703-0.15007-0.78018-1.0414-1.0502-1.2808-1.711-0.17095-0.47033 0.12919-0.69994-0.33994-1.0405-0.39018-0.27006-0.73011-0.25049-0.99045-0.66993-0.23098-0.36009-0.29035-0.74039-0.81037-0.59036-0.30014 0.09-0.99111 0.48011-1.0407 0.76061-0.22053-0.0802-0.39996-0.41031-0.55069-0.58057-0.24011-0.27006-0.52002-0.48989-0.7797-0.74038-0.65052-0.6308-1.3115-1.0104-2.2119-1.3301-0.58983-0.21005-0.81037-0.78996-1.4106-1.0111-0.14942-0.0496-0.3693-0.03-0.50045-0.0802-0.2101-0.0991-0.12984-0.0691-0.25968-0.30007-0.19053-0.31964-0.20031-0.39009-0.57027-0.50033-0.19052-0.41031 0-0.89042-0.09-1.3307-0.10961-0.50033-0.60027-0.3503-1.0805-0.36987-0.80059-0.0496-1.1099-0.69016-1.5607-1.2394-0.23098-0.27985-0.54025-0.47033-0.76078-0.76061-0.30993-0.39009-0.43977-0.88129-0.78036-1.2505-0.21989-0.23092-0.54025-0.3105-0.77971-0.51011-0.25968-0.21984-0.35038-0.54013-0.64007-0.69016-0.54025-0.2805-0.91086-0.0411-0.66031-0.81019 0.12984-0.39987 0.50045-0.62036 0.76013-0.96022 0.33016-0.44097 1.2508-1.4814 0.82995-2.1612-0.27012-0.44945-1.4811-0.43053-1.9111-0.29028-0.64008 0.21005-0.33994 1-1.1705 0.8702-0.78036-0.12003-0.76079-1.0104-1.5907-0.5897-0.2897 0.14025-0.39018 0.3105-0.70011 0.0991-0.18008-0.10959-0.39083-0.47946-0.42084-0.66015-0.0196-0.0202-0.0502-0.0404-0.0803-0.06 1.2612-1.0104 0.11027-3.2212 0.85148-4.5213 0.8293-0.29028 1.8008-0.15003 2.7215-0.20092 0.0496-0.97001-0.15007-2.1207 0.65051-2.8206 0.76079-0.66015 2.1408 0.02022 2.6112-0.91064 0.2499-0.4899 0.13963-0.93021 0.47957-1.4403 0.30014-0.4501 0.41041-0.63014 0.94022-0.7306 0.74055-0.15004 1.9711 0.66015 2.1812 1.3203 0.2897 0.01044 0.60028 0.01957 0.89063 0.03001 0.0398 0.20026 0.18987 0.31964 0.18987 0.54991 0.5807 0.46054 0.28056 1.0307 0.49001 1.6804 0.33015 1.0307 0.63029 0.27985 1.2397 0.08024 0.90106-0.28963 1.1712 0.09915 0.91085-1.1403-0.10962-0.53034-0.15986-1.3601-0.33994-1.9204-0.19052-0.60014-0.64986-0.91064-0.98067-1.4305-0.38039-0.60014-0.33015-1.1096-0.33015-1.8396 0-1.5101-0.65051-1.9909-1.84-2.7508-0.64008-0.41031-1.0603-1.0104-1.7519-1.2401-0.89063-0.30007-1.3708-0.0698-1.8406-0.99023-0.88084-0.06067-1.4602-0.21005-2.2204-0.45989-0.73077-0.23092-1.6207 0.0098-2.2921-0.36987-1.35-0.76061-1.4211-2.651-3.0216-2.8311 0.0404-0.06001 0.0698-0.11024 0.0404-0.19048 0.0992-2.471 1.9202-1.6008 2.9218-3.1709 0.4502-0.71038-0.03-1.9107 0.14028-2.7508 0.26034-1.2401 1.0205-2.3105 1.6312-3.3908 0.5011-0.85976 0.66096-1.9805 1.3115-2.6908 0.4202-0.44945 0.93043-0.78996 1.4407-1.12 0.47956 0.12981 1.1705 0.12981 1.5607 0.03979 0.61006-0.1396 0.82995-0.7293 1.4407-0.90021 0.63029-0.17939 1.1908 0.2805 1.8106 0.3803 0.8704 0.13046 1.35-0.24006 2.0807-0.39922 0.61072-0.12981 1.4707-0.01044 1.9907 0.27006 0.41041 0.21983 1.3806 0.8702 1.6606 1.1703 0.81037 0.88977 0.0202 2.9713 0.27012 4.1416 0.26034 1.2205 2.4716 1.09 3.5925 1.5708 0.66944 0.28898 1.0107 0.54991 1.8308 0.5199 0.69032-0.03001 1.3506-0.11024 2.071-0.0698-0.11027 0.54012-0.06 1.2003-0.23032 1.7404 0.0992-0.33008 1.4511 0.63993 1.4602 0.65037 0.70011 0.24006 1.9509 0.01044 2.7019 0.01044 0.71055 0 2.2204 0.33986 2.4213 1 0.0405 0.14025-0.24011 0.36074-0.17029 0.58057 0.0992 0.36008 0.3693 0.19048 0.47957 0.44032 0.15006 0.33986 0.15985 1.12 0.16964 1.5003 0.0111 0.66994-0.0496 0.84998-0.47957 1.3307-0.36995 0.40966-0.82016 0.42075-0.6603 1.1403 0.30014-0.03001 0.47957 0.0698 0.72033 0.19048 0.20031 0.09981 0.52002 0.67972 0.78036 0.85976 0.28969 0.20026 0.74969 0.39987 1.0798 0.5199 0.55069 0.19048 1.7108 0.14938 1.5907 1.0104 0.86061-0.1396 1.181 0.56035 1.331 1.2505 1.0407 0.33008 1.6808 1.5708 2.8918 1.3307 0-0.18004 0.14028-0.33986 0.11027-0.54991 0.53046-0.08024 1.0413 0.09915 1.5614 0.08024 0.03 0.66928-0.26034 1.6706 0.51023 1.8206 0.63942 0.12003 1.2606-0.72016 1.8308-0.75017 0.91085-0.03979 0.57091 0.92043 1.1705 1.3405 0.39018 0.27006 1.4002 0.43053 1.9013 0.51012-0.03 0.59035 0.01 1.3412 0.3693 1.8206 0.45021 0.60014 0.99111 0.29028 1.6312 0.67972 0.0998 0.06001 0.31058 0.3803 0.5011 0.50098 0.30014 0.20026 0.6205 0.33008 0.85082 0.4899 0.65052 0.44945 0.78036 0.55969 1.581 0.74039 1.3004 0.30007 2.2014 1.6706 1.9209 3.0914-0.12984 0.66015-0.67988 0.93021-0.82995 1.5003-0.15985 0.55969 0.0104 1.3803 0.18008 1.9009 0.21989 0.0502 0.12071 0.0802 0.2499 0.17026 0.11027-0.0202 0.27013 0.0202 0.39083 0.0202 0.41041 1.8004-1.3911 2.9707-0.72033 4.8115 0.12984 0 0.2499 0.03 0.38039 0 0.44042-0.48011 1.5509-0.51012 2.2713-0.39988 0.93957 0.1396 0.80059 0.50034 1.3108 1.1905 0.33994 0.45989 0.88084 0.76061 1.0198 1.3901 0.16051 0.71038 0 1.4703 0.18008 2.1507 0.39018 0.0202 1.6312-0.17939 1.9209 0.0802 0.31906 0.2805 0.17943 1.411 0.14942 1.8506-0.03 0.61123-0.14942 1.0502 0.2499 1.5708 0.45999 0.61057 0.80124 0.66994 0.76013 1.5904 1.4609-0.28898 0.30014 3.2812 0.33994 4.002 0.86061 0.50033 0.74056 1.7508 1.5809 2.2512 0.76079 0.01 1.2508 0.77039 1.8413 0.99023 0.73012 0.27984 1.8902 0.0502 2.6712-0.0502 0 0.39987 0.0802 0.78018 0.24011 1.0711 0.42019 0.74039 1.1007 0.82976 0.35038 1.6902-0.46065 0.50947-1.2404 0.47033-1.6312 0.95044-0.78036 0.96022 0.19052 3.5806 0.35038 4.6909 0.1703 1.1507-0.15986 1.0802-1.0805 1.4906-1.1608 0.50098-0.6205 1.1507-0.93042 2.2505-1.1516 0.41031-1.8622-0.15004-2.1616 1.2603-0.17029 0.8304 0 0.69081-0.74969 1.0007-0.48022 0.20026-0.91085 0.10959-1.0113 0.81997-0.44956 0.33008-0.0992 0.62036-0.74056 0.85063-0.49001 0.17939-0.92064-0.0698-1.3904 0.25049-0.48022 0.32029-0.97088 1.4906-1.2103 2.0607-0.14942 0.33008-0.17943 0.88064-0.39018 1.1298-0.24011 0.29028-0.74056 0.24984-1.0107 0.66015-0.47043 0.74104-0.39997 1.8402-0.79015 2.5708-0.0411-0.0202-0.0802-0.0404-0.1207-0.0698-0.91999 0.94-2.0905 1.5812-3.4118 1.7802-1.5809 0.24005-3.4222 0.24005-5.043 0.15982 6.5e-4 -0.0437 6.5e-4 -0.0939 6.5e-4 -0.14351z",
+                HsinchuCity:"m239.48 98.926c0.2101-0.57078 0.27012-0.55121 0.82995-0.91064 0.30013-0.19048 0.85996-0.51012 1.1209-0.81019 0.25904-0.30007 0.20031-0.63014 0.30993-0.98044 0.0803-0.27006 0.24011-0.77953 0.11027-1.0802-0.14942-0.36008-0.63029-0.4201-0.91086-0.60014-0.24989-0.14025-0.58135-0.4899-0.42084-0.8291 0.0998-0.20092 0.28056-0.12068 0.39083-0.29028 0.09-0.14938 0.03-0.46054 0.03-0.63014 0-0.71038-0.0502-1.4501 0-2.1611 0.0196-0.34965 0.10962-0.5897 0.24011-0.8702 0.12006-0.26941 0.39018-0.4201 0.55069-0.66015 0.18987-0.31051 0.21989-0.7006 0.40976-1.0196 0.21988-0.3803 0.47956-0.4501 0.51023-0.91064 0.0196-0.33986-0.03-0.68037 0.0803-1.0007 0.11027-0.30985 0.3693-0.5199 0.5396-0.78996 0.20096-0.30985 0.41106-0.4899 0.64008-0.74039 0.23032-0.24006 0.42019-0.53034 0.6205-0.84019 0.38039-0.55969 0.42019-1.4103-0.25969-1.7306-0.30013-0.14025-0.63029-0.21983-0.95065-0.24984 0.06-0.4899 2.5616-0.16047 3.0314-0.27985 0.03-0.06001 0.0692-0.0998 0.09-0.14025 1.6005 0.17939 1.6716 2.0705 3.0216 2.8311 0.67009 0.3803 1.5614 0.1396 2.2921 0.36987 0.75948 0.24984 1.3408 0.39922 2.2204 0.45989 0.47109 0.91978 0.95066 0.69016 1.8406 0.99023 0.69032 0.23027 1.1105 0.83041 1.7512 1.2401 1.1908 0.76061 1.8406 1.2401 1.8406 2.7508 0 0.72995-0.0502 1.2394 0.33015 1.8396 0.33015 0.52055 0.79014 0.83041 0.98067 1.4305 0.18008 0.56035 0.23097 1.3908 0.33993 1.9204 0.25969 1.2394-0.0104 0.85063-0.91085 1.1403-0.61006 0.20026-0.9102 0.95044-1.2397-0.08024-0.21009-0.65037 0.09-1.2205-0.49001-1.6804 0-0.23092-0.15006-0.3503-0.18986-0.54991-0.29036-0.01109-0.60028-0.02022-0.89063-0.03001-0.2101-0.6608-1.4407-1.4703-2.1812-1.3203-0.53046 0.0998-0.64008 0.27985-0.94021 0.7306-0.33994 0.51012-0.23033 0.95044-0.48022 1.4403-0.47044 0.93021-1.8511 0.24984-2.6112 0.91064-0.80059 0.69994-0.60028 1.8506-0.65052 2.8206-0.91999 0.05023-1.8902-0.09002-2.7215 0.20092-0.74055 1.3001 0.40976 3.5108-0.85082 4.5212-0.42019-0.29028-1.1608-0.33007-1.7206-0.33007-0.8306 0-1.2912-0.14025-1.2808-1.0411 0-0.63928-0.03-1.1298-0.4104-1.6197-0.14094-0.18004-0.41106-0.36986-0.51024-0.54991-0.12984-0.21983-0.0907-0.50098-0.16964-0.74104-0.69097-0.19048-1.1105 1.4103-1.791 1.5401-0.31123 0.06-1.0903 0.03-1.3715-0.09-0.40062-0.15004-0.44955-0.44032-0.91085-0.46054-0.0111-0.06002-0.0202-0.11024 0-0.15004 0.0189-0.20026 0.20944-0.2805 0.3693-0.4201 0.24272-0.2094 0.27273-0.28963 0.37256-0.54926z",
+                Miaoli:"m246.9 103.34c0.03 0.0202 0.06 0.0404 0.0803 0.06 0.03 0.18004 0.24011 0.54991 0.42019 0.66015 0.31123 0.21005 0.41106 0.0411 0.70076-0.0992 0.82994-0.42075 0.81037 0.47032 1.5907 0.5897 0.82994 0.12981 0.53046-0.66015 1.1705-0.8702 0.42998-0.14025 1.641-0.16047 1.9111 0.29028 0.42084 0.67973-0.50045 1.7202-0.82995 2.1612-0.25968 0.33986-0.63094 0.5597-0.76013 0.96022-0.2512 0.7704 0.12005 0.53034 0.6603 0.81019 0.29035 0.14938 0.38039 0.47032 0.63943 0.69016 0.24011 0.20026 0.56047 0.27984 0.78036 0.51011 0.33993 0.36922 0.47043 0.86042 0.78035 1.2505 0.21989 0.29028 0.53046 0.48011 0.76079 0.76061 0.44955 0.54991 0.76078 1.1905 1.5607 1.2394 0.48022 0.0202 0.97088-0.12916 1.0805 0.36987 0.09 0.44032-0.0998 0.92043 0.09 1.3307 0.36995 0.10959 0.38039 0.18004 0.57026 0.50033 0.12985 0.23093 0.0502 0.20092 0.25969 0.30072 0.13049 0.0496 0.35038 0.03 0.50044 0.0796 0.60028 0.22048 0.82016 0.80105 1.4106 1.0111 0.90042 0.31964 1.5607 0.69929 2.2112 1.3301 0.26034 0.25049 0.54025 0.47032 0.78036 0.74039 0.15007 0.17025 0.33015 0.50033 0.55004 0.58056 0.0502-0.27984 0.74121-0.66928 1.0414-0.76061 0.52002-0.14938 0.5807 0.23093 0.80971 0.59036 0.26034 0.42009 0.60093 0.39987 0.99111 0.66993 0.47044 0.33986 0.1703 0.57013 0.33994 1.0405 0.24011 0.66015 1.1307 0.93021 1.2815 1.711 0.0992 0.51012-0.28122 0.81019-0.55134 1.1703-0.31906 0.42988-0.36017 0.8702-0.70989 1.3307-0.49001 0.63015-0.74969 1.3497-0.86062 2.1305-0.0496 0.36009-0.25968 0.60014-0.5807 0.72017-0.27991 0.0991-1.1203-0.03-1.0407 0.44032 0.47043 0.21004 0.98067 0.63014 1.3604 0.95043 0.29035 0.24006 0.55982 0.48011 0.80058 0.75996 0.23098 0.2805 0.55004 0.57013 0.84039 0.77039 0.25968 0.17026 0.57026 0.20092 0.5011 0.62036-0.0698 0.45989-0.45021 0.66015-0.66096 1.0104-0.23032 0.39074-0.0692 0.47033-0.60028 0.57013-0.3693 0.0802-0.68053 0.12068-0.91085 0.43967-0.49001 0.6608 0.14942 1.3803 0.2499 2.0516 0.0502 0.36921-0.01 0.77039 0.13049 1.1207 0.12919 0.32029 0.4202 0.51012 0.58005 0.78996 0.6205 0.18004 1.2704-0.0998 1.791 0.24984 0.50045 0.33008 1.1705 0.46054 1.8609 0.39075 0.3308-0.0411 0.42084-0.15004 0.66095-0.38031 0.24011-0.24005 0.38039-0.32029 0.67988-0.48989 0.31971-0.18005 0.55003-0.27007 0.79014-0.53034 0.17943-0.19048 0.33016-0.3503 0.55004-0.48011 0.28056-0.17026 0.60027-0.30007 0.90041-0.11025 0.33015 0.19048 0.36996 0.59036 0.76079 0.69995 0.20031 0.0502 0.84038 0.10045 1.0205 0 0.23032-0.12003 0.34972-0.57013 0.61071-0.73974 0.6603-0.4501 1.0205 0.44945 1.7108 0.48011 0.39017 0.0196 0.77057-0.0502 1.1203 0.14025 0.33994 0.17939 0.48022 0.42923 0.95066 0.30986 0.35037-0.0802 0.53046-0.27985 0.93042-0.3203 0.33081-0.03 0.65052-0.01 1.0009 0 0.36016 0.0111 0.89062 0.0907 1.2508 0 0.36016-0.09 0.5807-0.42988 0.88084-0.66015 0.68053-0.5199 1.5405-0.12002 2.2315-0.69016 0.57026-0.46054 1.3108 0.0398 1.5698 0.70973 0.28121 0.7704-0.74969 1.3405-0.19052 2.1409 0.49 0.69016 1.1608 1.1898 1.761 1.8004 0.67988 0.69929 1.2306 1.5702 1.9118 2.2805 0.33015 0.33007 0.71054 0.58056 1.0002 0.96022 0.33015 0.43053 0.79015 0.71038 0.91085 1.2707 0.12006 0.54991-0.0404 1.1703-0.0698 1.73-0.0405 0.69995 0.0698 1.4403 0.0502 2.1514-0.53046 0.47946-1.1307 0.91977-1.9411 0.87998-0.47108 1.1703 0.0803 2.6106-0.39083 3.7809-1.5007 0.53034-1.5398 1.8311-2.6412 2.561-1.8211 1.1814-2.2112-0.17939-2.5212-1.6804-0.6603-0.17939-1.4302-0.27985-2.1212-0.15917-0.10962 2.1005 0.0607 2.7704-2.161 3.1703-1.0505 2.0516-1.9013 2.8311-4.2019 3.3021-1.3904 0.28898-1.6501 0.0991-2.5414 1.1292-0.30013 0.33986-0.24989 0.83041-0.63029 1.2101-0.36081 0.36008-1.0903 0.19048-1.4609 0.69016-0.81038 1.0907-0.0502 1.3503-1.3715 2.1409-0.28057 0.16048-1.9914 1.12-2.3306 1.1703-1.1014 0.15982-1.4407-1.0907-2.6719-0.68037-0.93956 0.32029-0.88997 1.6706-2.4814 1.7-0.2499 0.6308-0.74056 1.0802-0.88084 1.7802-1.7519 0.14025-1.9607-0.39988-3.1926-1.4306-0.31058-0.25962-1.0002-0.39009-1.2508-0.74039-0.3693-0.5199-0.17943-1.2401-0.53046-1.7704-1.4407-2.1709-4.9627-1.5101-7.1739-1.8702-1.7408-0.2805-4.9425-2.4899-6.3832-0.3803-1.5209 2.261 1.5809 5.6615-1.6201 6.882-2.191 0.8402-5.2224-0.0404-7.6744 0.33073-1.3911 0.2094-2.3711 0.58057-3.4522-0.20091-0.96958-0.71038-1.5509-1.8709-2.4311-2.5806-1.8511-1.4808-4.7128-0.85976-6.834-2.1807-1.9613-1.2205-3.3824-3.1507-5.163-4.4912-1.0805-0.81019-1.7108-0.39074-2.8017-0.8702-0.95065-0.40966-1.2404-1.3001-1.9913-1.9602-1.4002-1.2401-2.3411-2.0907-3.462-3.5917-1.2208-1.6497-3.0216-2.1696-4.0917-3.621-1.0414-1.4299-1.1405-3.0809-2.5512-4.2114 0.58984-0.96935 1.6312-1.7202 2.5414-2.4599 0.47044-0.39074 1.1908-0.75017 1.5614-1.2003 0.38039-0.46054 0.17943-0.91064 0.33994-1.4305 0.2897-0.92043 1.1705-1.4906 1.5607-2.3608 0.4502-1.0007 0.91085-1.6908 1.5614-2.6008 0.30013-0.42923 0.49-1.15 0.55982-1.6602 0.11027-0.84019 0.11027-1.1403 0.69097-1.8096 0.54025-0.63993 0.63942-0.99088 0.67988-1.8004 0.06-1.2309 0.5807-2.5617 0.88083-3.762 0.36996-1.4703 1.6312-2.1005 2.4109-3.381 0.50045-0.83041 0.61072-1.7906 1.1705-2.651 0.36995-0.55904 0.92064-1.5206 1.5607-1.6602 1.0413-0.24006 4.1928 1 3.7824-1.2394-0.54025-0.22048-0.92064 0.12916-1.4106 0.0992-0.0411-0.23027 0.5807-1.1298 0.74056-1.4103 0.30013-0.53034 0.68053-0.92043 0.86061-1.5304 0.33994-1.1305 0.65051-1.9407 1.6201-2.6706 0.70076-0.53034 1.562-1.3007 2.5218-1.4403 1.1803-0.18004 2.3802-0.39988 3.5618-0.50099 0.59049-0.06 1.2103 0.0202 1.8008-0.01 0.2499-1.3503 1.2208-2.621 2.5009-3.1312 0.0907-0.98045 1.0505-1.1103 1.5809-1.7802 0.49001-0.6197 0.44107-1.2805 0.49001-2.0803 0.0607-0.81997 0.53046-1.4703 1.0805-2.0307 0.44042-0.44032 0.97088-1.3307 1.562-1.5401-0.0202 0.04044-0.0111 0.09067 0 0.15004 0.45999 0.0202 0.50958 0.30985 0.91085 0.46054 0.27991 0.12003 1.0603 0.14938 1.3715 0.09 0.68053-0.12981 1.1007-1.7306 1.7904-1.5401 0.0803 0.24006 0.0404 0.52056 0.17029 0.74104 0.0992 0.17939 0.3693 0.36922 0.50958 0.54991 0.3804 0.4899 0.41106 0.98044 0.41106 1.6204-0.0111 0.90021 0.44956 1.0405 1.2808 1.0405 0.56112-5e-3 1.301 0.0346 1.7212 0.32486z",
+                Taipei:"m351.36 53.383c0.0104 0.32029 0.0104 0.65037 0 0.97066-0.52002-0.02022-1.0407 0.06915-1.5705 0.09915-0.25968 0.01044-0.5807-0.06001-0.82994 0.02022-0.20031 0.0698-0.4202 0.36008-0.56048 0.39987-0.50045 0.14938-0.96044-0.11024-1.5307-0.09067-0.63029 0.03066-0.92064 0.32029-1.4909 0.44097-0.90042 0.19048-2.3313-0.39987-3.141 0.17026-0.20096 0.1396-0.10962 0.44032-0.28056 0.63014-0.15986 0.17026-0.42933-0.05023-0.58984 0.26028-0.35038 0.66928 0.3693 0.87998 0.82016 1.0196 0.0692 1.2805-1.0303 5.092 1.0909 4.8318 0.06 0.3503 1.3004 0.54991 1.6605 0.66994 0.25968 0.96935-0.47043 0.77953-1.151 0.81997-0.82995 0.05023-0.77123 0.41031-1.4106 0.66928-0.59049 0.22048-1.2208-0.2394-1.761-0.31964-0.61071-0.09981-1.3708 0.23027-1.5098-0.59035-0.67009 0.13046-1.0414 0.65037-1.7414 0.57013-0.55004-0.06001-0.85996-0.47032-1.1601-0.92043-0.47108-0.67972-1.3506-1.6804-1.2704-2.5708-0.3804 0.02022-0.8704-0.03001-1.1705-0.2394-0.39997-0.2805-0.25969-0.74104-0.47044-0.94-0.72033-0.66994-1.4609 0.47032-1.9117 0.83041-0.01-1.2009 1.791-2.1905 0.74121-3.3412-0.44107-0.48011-0.97023-0.68037-1.4009-1.1703-0.44042-0.50098-0.60028-0.96087-1.3604-0.90021-0.82016 0.06001-1.0505 0.72016-1.4909 1.2505-0.61072 0.74039-0.79015 0.88977-1.3604 0.09981-0.46065-0.63928-0.42019-0.95044-0.55982-1.681-0.0907-0.43967-0.61137-1.1801-0.59049-1.5904 0.06-1.06 2.2308-1.06 2.8115-2.0209 0.59049-0.94 0.61137-2.8011 0.61137-3.9818 0-1.2205-0.73077-2.1507-1.5816-2.9811-0.41041-0.39922-0.69032-0.8004-1.2501-1.0196-0.57091-0.21983-1.2404-0.10959-1.8315-0.24984-0.52002-0.12981-1.0603-0.20092-1.5607-0.39987-0.84038-0.32029-0.75034-0.42075-0.79014-1.1905-0.0202-0.54991-0.19053-1.2903 0.03-1.8095 0.0992-0.23092 1.2306-1.0202 1.2208-0.69081 0.0405-0.8004-0.2101-1.7606 0.42998-2.2407 0.7001-0.53034 1.331-0.10959 1.2612-1.3999 1.0309-0.06001 1.2097 0.12981 1.4909-0.85063 0.16051-0.57992 0.28056-0.97 0.65052-1.5003 0.28904-0.42075 0.67987-1.1011 1.1803-1.2609 0.54025-0.17026 1.4211 0.01957 1.9914 0 0.19052-1.1703-0.0802-1.8102 1.3415-1.8206 0.5807-0.01044 1.0002-0.06915 1.4902-0.25962 0.24011-0.09067 0.89062-0.3803 1.0205-0.57013 0.2101-0.36008-0.1605-1.06 0.0502-1.4403 0.21989-0.39074 0.89063-0.4899 1.1301-0.80105 0.18008-0.23027 0.36082-1.03 0.64007-1.1703 0.58005-0.28963 0.96045 0.42075 1.3904 0.65037-0.33994 1.6308 0.90041 1.8617 2.191 1.9309 0.60028 1.5003-0.03 3.3308 0.76013 4.822 0.14942 0.27006 0.50958 0.50033 0.61072 0.7293 0.15007 0.36987 0.0202 0.86042 0.06 1.2707 0.0698 0.85063 0.53046 1.2401 1.151 1.7704 0.20944 0.77105 0.85996 0.80105 0.85082 1.8206-0.0111 1.1011-0.69097 0.98044-1.0909 1.8311-0.10962 0.21983-0.13963 0.82976-0.0803 1.0907 0.14029 0.51012 0.0104 0.30007 0.66944 0.40966 0.78036 0.12981 1.3917 0.60014 2.1512 0.68037 0.0307 1.0405 1.1908 0.69994 1.4309 1.6504 0.2499 0.93935-0.48022 2.9707-1.0002 3.6706-0.85083 1.1507-0.63029 1.0705-0.33015 2.4208 0.32036 1.4808 2.0011 2.8011 3.2519 3.3301 0.53047 0.23092 1.1007 0.3803 1.7512 0.42075 0.76666 0.04175 1.1966-0.49838 1.8974-0.23875z",
+                Newtaipei:"m400.14 55.204c1.2012 4.4117-4.7722 2.1905-5.6935 4.7613-1.1901 0.06001-2.1904-0.84019-3.3909-0.36987-0.6316 0.25049-0.66161 0.85063-1.2319 1.1305-0.4202 0.21005-1.3911 0.18004-1.8511 0.23092-1.181 0.12916-2.4318 0.74039-3.2722 1.6497-0.49001 0.5199-0.7497 0.97001-1.5705 1.12-0.65051 0.12981-1.4211 0.1109-2.0801 0.15003-1.562 0.0698-2.7221-0.25962-3.8215 0.91064-0.91085 0.99023-1.6012 1.6308-1.1712 3.0711 1.0609-0.04044 2.3613 0.88064 2.1414 1.9407-0.15007 0.71038-1.6508 1.5401-2.2315 1.9107-0.46 0.30007-0.77122 0.76061-1.1405 1.0202-0.42085 0.30007-1.1705 0.23027-1.7004 0.23027-1.2612 0-2.4416 0.09981-3.6526 0.3503-0.47043 0.78018-0.0104 2.4906-1.4106 2.5004-0.31972 0.80105 0.28056 0.84084 0.38039 1.4208 0.11027 0.6308-0.46 0.74104-0.75035 1.3007-1.2906 0.39988-1.7408 1.3503-2.9009 2.0105-1.2012 0.69994-2.6008 0.21983-3.9416 0.48011-1.0113 0.20026-2.6614 1.15-3.312 1.9302-0.36082 0.42988-0.67988 1.06-1.1705 1.4305-0.4502 0.33986-1.2312 0.5199-1.6012 0.96935-0.4502 0.54991-0.29035 1.4103-0.33015 2.1005-1.4009 0.0698-2.7717 0.01044-4.1523 0.09067-1.2808 0.08024-3.0418 0.0098-4.0721 0.77039-0.49 0.36987-0.75034 0.88064-0.85082 1.4814-0.15007 0.96935 0.11027 1.1298-1.0002 1.1703-0.99046 0.03001-3.282 0.21983-3.3518 1.6497-0.0104 0.08024-0.0502 0.21983-0.0502 0.33986 1.2606 0.42988 0.38039 1.5701 0.0502 2.2603-0.44042 0.94-0.33015 1.8108 0 2.6908 0.76078 2.0007 0.73077 4.1912-1.9711 4.0712 0.0803 1.2505-0.28905 1.6602-1.5098 1.6602-0.94021-0.01-2.8924 0.14025-3.4327 0.9002-0.53046 0.72995-0.20944 2.0105-1.0707 2.5108-0.24011 0.15003-0.63029 0.13046-0.92064 0.23092-0.35038 0.12981-0.63029 0.40966-0.98066 0.54991-0.65052 0.26027-1.4707 0.06-2.1812 0.20026-0.69097 0.1409-1.1908 0.6308-1.7708 0.92043-0.73077 0.36987-1.1203 0.39074-2.0011 0.43053-0.1703 0.0104-0.36017 0.0202-0.57026 0.0202 0.01-0.92043 0.0398-1.8409-0.0104-2.7508-0.94022 0.11024-0.91086-0.74039-1.6312-1.1814-0.42084-0.24984-0.54024-0.33986-1.0205-0.4201-0.36016-0.0502-0.85017 0.11024-1.151-0.0998-0.64007-0.42989-0.21988-1.3301-0.54025-1.9602-0.26033-0.51011-0.72033-1.0307-1.0407-1.5206-0.75035-1.15-1.4511-2.1605-1.8615-3.501-0.17029-0.57013-0.21988-1.3197-0.33015-1.9198-0.20031-0.98044-0.14028-1.2009 0.60028-1.6412 1.0603-0.63014 1.3715-1.9302 2.7215-2.1201 0.31123-0.2805 0.29035-0.76061 0.2499-1.2205-2.3411 0.1409-0.99959-2.6504-1.7304-3.6811-0.39997-0.57013-1.3004-0.06001-1.6906-0.99023-1.1105 0.12003-1.6612-1.8709-2.2315-2.4514-0.68053-0.69016-2.7019-1.5806-3.5919-0.7306-0.44956 0.43053-0.30014 1.0711-1.1601 1.2505-0.81037 0.17091-1.331-0.58057-1.9209-0.91978-1.3108-0.74104-2.5009-0.59035-3.9918-0.68037-0.21988-1.0502 2.0612-1.3007 2.7319-1.3307 0.03-0.44097 0.0803-0.82976-0.21988-1.1814-0.2101-0.24984-0.91086-0.21983-1.0805-0.57992-0.43063-0.89042 1.6808-1.1403 1.3408-1.9909-0.24989-0.61058-1.1705 0.08024-1.6207-0.23092-0.36017-0.25962-0.38039-1.2303-0.33994-1.6602-0.12005 0-0.28056-0.04044-0.39018-0.03001-0.35038-0.30007-0.39083-1.0007-0.76078-1.2407-0.31123-0.20026-1.0205 0.01109-1.3415-0.24006-0.69031-0.53034 0.0405-1.4808-0.0104-2.4103-0.30992-0.01044-0.63029-0.01044-0.91085-0.0698 0.0202-0.14025 0.0411-0.90021 0.11092-0.93021 0.23946-0.09981 0.44956-0.23092 0.72033-0.27006 0.15007-0.3803 0.19052-1.1807 0.01-1.4906-0.30993-0.54012-0.72033-0.14025-1.0707-0.4899-0.42998-0.42988 0-1.1005 0.39997-1.2603 0.36016-0.15003 1.1007 0.01044 1.4909-0.01044 0.12005-0.77953-0.33994-1.2805-0.49001-1.9909-0.14093-0.71038-0.19052-1.5095-0.16051-2.2505 0.0104-0.33986-0.0802-1.0705 0.0992-1.3405 0.30014-0.4501 0.44107-0.21005 0.90041-0.33008 0.74121-0.18983 1.3115-0.30007 2.1016-0.1396 1.1301 0.23027 3.0118 0.57013 4.1523 0.14938 1.1301-0.43053 0.74056-2 2.4011-1.9407 0.19052-0.39987 0.77057-0.82976 1.1705-1 0.0398-0.54012 0.03-0.8702-0.30014-1.2603-0.18987-0.21983-0.72033-0.21005-0.84039-0.57013-0.32036-0.96087 1.3604-1.0307 1.9711-1.0007-0.03-0.92043-0.58984-1.0405-0.88019-1.7606-0.31058-0.74039-0.09-1.8004 0.12984-2.4599-0.0411-0.01044-0.09-0.02022-0.14028-0.03001-0.0405-0.2805-0.0998-0.55056-0.19052-0.81019-0.99111-0.24006-0.94022-0.55969-1.0002-1.5003-0.31123-0.0698-0.54025-0.2805-0.5807-0.58057-1.1712-0.12003-2.052-0.54991-3.2422-0.60014-0.76078-0.02022-1.6012-0.44032-2.071-0.93021-0.30992-0.32029-0.33015-0.63993-0.53046-0.98044-0.32036-0.53034-0.5011-0.44032-0.90041-0.75017-0.68053-0.51012-1.3611-0.90021-1.6808-1.6602-1.0303-0.02022-2.0912-0.05023-3.1417-0.11024-0.0692-0.20026-0.18008-0.24984-0.20031-0.47033-0.36995-0.29028-0.5807-0.67972-1.0714-0.8702-0.47957-0.19048-1.0002-0.0411-1.4407-0.36987-0.66031-0.5199-0.42933-1.9107-0.39932-2.8109 0.21989-0.01044 0.39018-0.02022 0.46065-0.05023 0.42933-0.15003 1.7512-0.15982 2.5505-0.33008 1.8817-0.39074 3.5729-0.15003 5.5128-0.24006 0.86061-0.0411 1.5007-0.17026 2.2419-0.76061 1.0198-0.81019 1.32-1.3705 2.7515-2.0007 0.0404-0.21983 0.90041-0.28963 1.0009-0.50033 1.9809-1.1011 6.8738-4.0509 2.7815-5.702 1.5307-0.33986 0.9102-1.3105 1.4609-2.3105 0.47043-0.86042 1.7512-1.6106 2.2112-2.3007 0.94022-1.4299 1.9509-3.2603 1.8413-5.4006 0-0.13046 2.4311-0.0698 2.6712-0.18004 1.2103-0.60014 1.0002-1.3601 1.7806-2.2603 1.3408-1.5604 3.402-2.561 4.5523-4.3112 1.2508 0.01109 4.703 0.96087 3.4816-1.4899 0.67009 0.33986 0.53046-0.05023 1.0205 0.66015 1.38 0.08024 3.8418 0.53034 4.6521-0.62036 0.80058 0.63014 1.0407 0.69016 2.0214 0.4501 0.12071 0.21983-0.0202 0.44032 0.0803 0.66928 1.2006 0.20092 1.7408 1.0202 2.7117 1.5401 1.2606 0.66994 0.59048 0.66015 2.251 0.74952 0.06 0.97 1.3708 1.6804 1.7003 2.5917 0.42085 1.1801 0.12985 2.8604 0.33994 4.1201 0.55917-0.12003 1.3604 0.20092 1.9202 0.08024-0.25903 2.2805 1.5712 2.6308 1.581 4.6713 0.96109 0.04044 1.962 0.04044 2.9224 0 0.69032-1.0007 2.071-0.93021 2.9916-1.9302 0.1703 2.2603-1.9613 3.1709-2.1616 4.9322 0.0502-0.4899 1.5105 0.7704 2.4716 1.6308-1.1399 0.53034-1.9307 1.0796-2.9505 1.7208-0.47043 0.29028-0.43063 1.2094-1.0505 1.4508-0.66944 0.25962-1.9907-0.01044-2.7215 0.03001-0.65052 1.8409-2.3913 1.4103-4.0023 1.501-0.12984 0.40966-0.12984 1.2603 0 1.6706 0.58071-0.14938 1.3708 0.0411 1.9209-0.17026 0.09 1.711-0.26034 6.0209 2.0005 6.002 0.03 0.27985-0.03 0.65037 0.0802 0.92043 0.42998-0.02022 1.0009 0.14938 1.4211 0.07958 0.42085 1.1403 1.4511 1.5708 2.5512 0.81019-0.21009 0.15982-0.43063 0.55056-0.7797 0.78018 0-0.01957 0.0796 0.55056 0.06 0.58057 1.4504-0.30007 2.5708 0.5199 2.5009 2.0007 2.0801 0.12003 3.5619 1.0405 5.5323 1.2205 0.47108 0.05023 1.0107 0.44945 1.6912 0.33008 0.60027-0.09981 0.48022-1.06 1.0414-1.2101 1.2697-0.34965 2.7515 0.58057 3.2121-1.0405 0.36017-1.2603-0.95065-2.1709-1.9711-2.3001 0.0998-1.8311-0.13963-3.1312-1.4504-4.2218 1.0498-0.24006 1.8406-1.1103 2.9009-1.2505 1.2012-0.16047 2.0605 0.78996 3.4712 0.47098-0.09-0.63993 0.33994-1.1103 0.33015-1.6713 0.3308 0.0698 0.84038-0.12003 1.1705-0.08024 0.0613-0.32029 0.39148-1.09 0.42149-1.4208v-0.03001c0.36017 0.01044 0.73012 0.01957 1.0805 0.03001-0.12136 0.55969 0.20031 1.3607 0.0796 1.9204 1.1099 0.07958 1.6612-0.84019 2.2504-0.92043 1.271-0.15982 1.8622 0.33008 2.7117 0.46054 1.4211 0.23027 4.7526-0.42075 5.043 1.2094 1.1405 0.18983 2.6216 0.39009 2.7515-0.92043 0.53046 0.06001 1.4811-0.28898 1.7108-0.28898-0.42084 0.74039-0.33015 1.5695-0.21009 2.4599 0.23097 0.0698 0.44042 0 0.67074 0.08024 0.36017 1.4299-2.5714 5.9316 0.2499 6.002 0.24011 1.1801 0.7908 1.7202 0.98067 2.9009 0.14028 0.85976-0.2101 2.4899-0.15007 3.5206 2.4115 1.5701 4.2535 0.91064 7.1739 1.0802 0.41106 1.1507 2.512 0.84084 3.6225 0.71038zm-48.785-0.84998c0.0104-0.32029 0.0104-0.65037 0-0.97066-0.69946-0.25962-1.1301 0.2805-1.9013 0.24006-0.65052-0.0411-1.2201-0.19048-1.7512-0.42075-1.2508-0.53034-2.9316-1.8506-3.2519-3.3301-0.30014-1.3503-0.52002-1.2701 0.33015-2.4208 0.52068-0.69994 1.2508-2.7313 1.0002-3.6706-0.24011-0.95044-1.4002-0.61123-1.4302-1.6504-0.76013-0.08024-1.3715-0.55056-2.1512-0.68037-0.66096-0.10959-0.53046 0.09981-0.67009-0.40966-0.06-0.26028-0.03-0.8702 0.0802-1.0907 0.40062-0.85063 1.0805-0.72995 1.0909-1.8311 0.01-1.0196-0.64008-1.0496-0.85083-1.8206-0.6205-0.53034-1.0805-0.91978-1.151-1.7704-0.0405-0.41031 0.0907-0.90021-0.06-1.2707-0.0998-0.23027-0.46064-0.45924-0.61071-0.7293-0.79015-1.4906-0.15986-3.3216-0.76013-4.822-1.2912-0.06915-2.5316-0.30007-2.191-1.9309-0.43063-0.23027-0.81037-0.93935-1.3904-0.65037-0.28056 0.14025-0.46065 0.94-0.64008 1.1703-0.23945 0.31116-0.91085 0.41031-1.1301 0.80105-0.2101 0.3803 0.15986 1.0802-0.0502 1.4403-0.12984 0.19048-0.78036 0.47946-1.0198 0.57013-0.49066 0.19048-0.91085 0.24984-1.4909 0.25962-1.4211 0.01044-1.151 0.65037-1.3415 1.8206-0.57027 0.01957-1.4511-0.17026-1.9914 0-0.50045 0.15982-0.89063 0.84019-1.1803 1.2609-0.36995 0.53034-0.49001 0.92043-0.65051 1.5003-0.28057 0.98044-0.46 0.78996-1.4909 0.85063 0.0692 1.2909-0.56047 0.8702-1.2606 1.3999-0.64008 0.47946-0.39084 1.4403-0.43064 2.2407 0.0104-0.33008-1.1203 0.46054-1.2208 0.69081-0.21989 0.5199-0.0502 1.2603-0.03 1.8095 0.0398 0.77039-0.0502 0.8702 0.79015 1.1905 0.50044 0.20026 1.0407 0.27006 1.5607 0.39988 0.59049 0.14025 1.2612 0.03001 1.8315 0.24984 0.55982 0.21983 0.84038 0.62036 1.2508 1.0196 0.85017 0.83041 1.5809 1.7606 1.5809 2.9811 0 1.1807-0.0202 3.0411-0.61137 3.9818-0.5807 0.96022-2.7515 0.96022-2.8115 2.0209-0.0202 0.41031 0.50044 1.1507 0.59048 1.5904 0.14029 0.7306 0.0992 1.0411 0.55983 1.681 0.57026 0.78996 0.75034 0.63993 1.3604-0.0998 0.44042-0.53034 0.67009-1.1905 1.4909-1.2505 0.76078-0.06067 0.92064 0.39922 1.3604 0.90021 0.43063 0.4899 0.9611 0.69016 1.4009 1.1703 1.0498 1.15-0.75034 2.1396-0.74121 3.3412 0.45021-0.36074 1.1908-1.501 1.9118-0.83041 0.2101 0.20026 0.0692 0.66015 0.47043 0.94 0.30014 0.2094 0.79015 0.25962 1.1705 0.2394-0.0803 0.89042 0.80124 1.8904 1.2704 2.5708 0.30013 0.4501 0.61071 0.86042 1.1608 0.92043 0.7001 0.08024 1.0707-0.43967 1.7408-0.57013 0.13963 0.82062 0.90041 0.4899 1.5098 0.59035 0.54025 0.08024 1.1705 0.54012 1.761 0.31964 0.64008-0.25897 0.58071-0.61971 1.4106-0.66928 0.68053-0.04044 1.4106 0.14938 1.151-0.81997-0.36017-0.12068-1.6012-0.32029-1.6606-0.66994-2.1212 0.25962-1.0198-3.5512-1.0909-4.8318-0.45021-0.14025-1.1705-0.3503-0.82016-1.0196 0.1605-0.31116 0.43063-0.09067 0.58983-0.26028 0.17095-0.18983 0.0803-0.4899 0.28057-0.63014 0.81037-0.57013 2.2412 0.02022 3.141-0.17026 0.57026-0.12068 0.85996-0.41031 1.4909-0.44097 0.57027-0.01957 1.0309 0.24006 1.5307 0.09067 0.14093-0.0411 0.36081-0.33008 0.56047-0.39988 0.2499-0.08024 0.57026-0.01044 0.82995-0.02022 0.53372-0.03066 1.0537-0.12068 1.5744-0.10046z",
+                Taoyuan:"m324.59 106.65c0.0502 0.91065 0.0202 1.8304 0.0104 2.7508-1.2208 0.0691-2.8918 0.21005-3.5619 0.95044-0.24011 0.25962-0.59048 0.69994-0.71054 1.0307-0.26034 0.78018 0.15007 0.57991 0.45999 1.2394 0.29035 0.60079-0.06 1.8311-0.27991 2.5004-1.1105 0.81019-2.1616 1.2609-2.5714 2.681-0.2101 0.71038-0.19053 1.4103-0.65052 2.0105-0.55069 0.71038-1.0009 0.47033-1.7114 0.72017-0.8704 0.3105-1.3806 1.561-1.3708 2.621-0.78035 0.0998-1.9418 0.33008-2.6719 0.0502-0.58984-0.21983-1.0798-0.98044-1.8406-0.99088-0.84039-0.50033-0.72033-1.7508-1.5809-2.2505-0.0405-0.72017 1.1209-4.291-0.33994-4.002 0.0411-0.92043-0.30014-0.97979-0.76013-1.5904-0.39997-0.5199-0.28057-0.96087-0.2499-1.5708 0.03-0.43967 0.16964-1.5701-0.15007-1.8506-0.2897-0.25963-1.5307-0.06-1.9202-0.0802-0.18008-0.67972-0.0202-1.4403-0.18008-2.1507-0.13963-0.63014-0.67988-0.93021-1.0198-1.3901-0.51023-0.69081-0.36995-1.0502-1.3115-1.1905-0.72033-0.11025-1.8308-0.0802-2.2706 0.39987-0.12984 0.03-0.2499 0-0.38039 0-0.67009-1.8409 1.1301-3.0111 0.72033-4.8115-0.12005 0-0.27991-0.0411-0.39018-0.0202-0.12984-0.09-0.03-0.12068-0.2499-0.17026-0.17029-0.52055-0.33993-1.3412-0.18008-1.9009 0.15007-0.57013 0.70011-0.84019 0.82995-1.501 0.28056-1.4208-0.6205-2.79-1.9209-3.0907-0.80059-0.18004-0.93043-0.28963-1.581-0.74104-0.23097-0.15917-0.55068-0.28898-0.85082-0.4899-0.19052-0.12003-0.39997-0.44032-0.5011-0.50033-0.63943-0.39009-1.181-0.08024-1.6312-0.67972-0.36016-0.48011-0.39931-1.2303-0.3693-1.8206-0.50109-0.08024-1.5105-0.24006-1.9013-0.51012-0.60028-0.4201-0.26034-1.3803-1.1705-1.3405-0.57026 0.03001-1.1908 0.8702-1.8315 0.75017-0.77057-0.15004-0.47957-1.1514-0.50958-1.8206-0.52068 0.01957-1.0309-0.16047-1.5614-0.08024 0.03 0.2094-0.11027 0.36922-0.11027 0.54991-1.2097 0.24006-1.8511-1.0007-2.8918-1.3307-0.15007-0.69081-0.47109-1.3901-1.331-1.2505 0.12006-0.86042-1.0414-0.81997-1.5907-1.0104-0.33015-0.12068-0.79015-0.32029-1.0805-0.5199-0.25968-0.18004-0.5807-0.75996-0.7797-0.85976-0.24011-0.12003-0.42085-0.21983-0.72033-0.19048-0.15986-0.72016 0.29035-0.7306 0.66095-1.1403 0.42933-0.48011 0.49001-0.66015 0.47957-1.3307-0.01-0.3803-0.0196-1.1605-0.16964-1.5003-0.11027-0.24984-0.38039-0.08024-0.48022-0.44032-0.0692-0.21983 0.21009-0.44097 0.17095-0.58057-0.20097-0.66015-1.7108-1.0007-2.422-1.0007-0.74969 0-2.0005 0.23092-2.7012-0.0098-0.0104-0.01044-1.3611-0.98044-1.4609-0.65037 0.17094-0.54012 0.1207-1.2003 0.23097-1.7404-0.72033-0.04044-1.3806 0.0411-2.071 0.0698-0.82081 0.03001-1.1608-0.23092-1.8315-0.5199-1.121-0.48011-3.3309-0.3503-3.5919-1.5708-0.2499-1.1703 0.54025-3.2505-0.27012-4.1423-0.27991-0.30007-1.2508-0.95044-1.6606-1.1703-0.52002-0.27985-1.3806-0.39922-1.9907-0.27006-0.73077 0.16047-1.2103 0.53034-2.0814 0.39987-0.61985-0.09981-1.1803-0.55904-1.81-0.3803-0.61137 0.17026-0.8306 0.76061-1.4407 0.90021-0.39083 0.09067-1.0805 0.09067-1.5614-0.03979 0.45999-0.30007 0.92064-0.60014 1.2704-0.99088 0.60028-0.66015 1.9307-2.561 2.2308-3.4514 0.47043-1.3901-0.39018-4.4208 1.271-4.7313 0.49-2.7411 2.2608-4.6909 4.6326-6.002 2.1714-1.2003 5.133-1.0104 5.9532-3.6706 0.66096-0.04958 0.82016-0.44945 1.4217-0.58057 0.0692-4.3014 8.9037-0.39009 9.8347-3.9211 2.512-0.54012 4.6221-2.5708 6.9534-3.6113 3.0118-1.3405 4.6025-0.98044 7.5145-1.9302 0.35038-0.10959 1.3806-0.0998 1.9914-0.12003-0.03 0.90021-0.25968 2.291 0.39931 2.8109 0.44108 0.33008 0.9611 0.18004 1.4407 0.36987 0.49 0.19048 0.7001 0.57992 1.0714 0.8702 0.0202 0.21983 0.12984 0.27006 0.20031 0.47032 1.0505 0.06001 2.1114 0.09002 3.1417 0.11024 0.32036 0.75996 1.0009 1.15 1.6808 1.6602 0.39996 0.30985 0.5807 0.21983 0.90041 0.75017 0.20031 0.33986 0.21988 0.66015 0.53046 0.98044 0.47044 0.4899 1.3108 0.91064 2.071 0.93021 1.1908 0.05023 2.0716 0.48011 3.2421 0.60014 0.0405 0.30007 0.27013 0.51012 0.5807 0.57992 0.06 0.94065 0.01 1.2609 1.0002 1.501 0.09 0.25962 0.14941 0.53034 0.19052 0.80953 0.0502 0.01044 0.0992 0.02022 0.14028 0.03001-0.21988 0.6608-0.44042 1.7215-0.12984 2.4606 0.2897 0.72017 0.85017 0.84019 0.88084 1.7606-0.61137-0.03001-2.2921 0.04044-1.9711 1.0007 0.12006 0.36008 0.65052 0.34965 0.84039 0.57013 0.33015 0.39009 0.33994 0.72017 0.30014 1.2603-0.40062 0.17026-0.98067 0.60014-1.1705 1-1.6605-0.06067-1.2704 1.5095-2.4011 1.9407-1.1405 0.42075-3.0223 0.08024-4.1523-0.14938-0.79015-0.16047-1.3604-0.05023-2.101 0.1396-0.46064 0.12003-0.60092-0.12068-0.90106 0.33008-0.17943 0.27006-0.09 1-0.0992 1.3405-0.03 0.74039 0.0196 1.5401 0.16051 2.2505 0.14942 0.71038 0.61072 1.2094 0.49001 1.9909-0.39083 0.02022-1.1307-0.14025-1.4909 0.01044-0.39997 0.15982-0.82995 0.82976-0.39997 1.2603 0.35038 0.3503 0.76078-0.05023 1.0707 0.4899 0.18008 0.31051 0.14093 1.1103-0.01 1.4906-0.27012 0.03979-0.48022 0.1696-0.72033 0.27006-0.0698 0.03001-0.0907 0.78996-0.11027 0.93021 0.28057 0.06001 0.60028 0.06001 0.91086 0.0698 0.0502 0.93021-0.67988 1.8806 0.0104 2.4103 0.32036 0.24984 1.0302 0.04044 1.3415 0.24006 0.3693 0.24006 0.41041 0.94 0.76078 1.2407 0.10962-0.01109 0.27013 0.03001 0.39018 0.03001-0.0404 0.42988-0.0202 1.3999 0.33994 1.6602 0.44956 0.31051 1.3708-0.3803 1.6201 0.23027 0.33994 0.85128-1.7708 1.1011-1.3408 1.9915 0.1703 0.36008 0.8704 0.33008 1.0805 0.57992 0.30013 0.3503 0.25055 0.74039 0.21988 1.1807-0.67009 0.03001-2.9511 0.28115-2.7319 1.3307 1.4909 0.09067 2.681-0.06001 3.9918 0.68037 0.59049 0.33986 1.1105 1.09 1.9209 0.92043 0.85996-0.17939 0.71054-0.81997 1.1601-1.2505 0.89062-0.84998 2.912 0.0411 3.5925 0.7306 0.56961 0.57992 1.1203 2.5708 2.2308 2.4508 0.39018 0.93021 1.2906 0.42075 1.6906 0.99088 0.73077 1.0307-0.61072 3.8207 1.7304 3.6811 0.0411 0.46054 0.0607 0.94-0.2499 1.2205-1.35 0.18983-1.6605 1.4906-2.7215 2.1201-0.74056 0.44032-0.80059 0.66015-0.60028 1.6406 0.10962 0.60014 0.15986 1.3503 0.33015 1.9204 0.41041 1.3405 1.1105 2.351 1.8615 3.501 0.31971 0.4899 0.7797 1.0104 1.0407 1.5206 0.32037 0.63014-0.0998 1.5304 0.54025 1.9602 0.30014 0.21005 0.79015 0.0502 1.151 0.0998 0.48022 0.0802 0.60028 0.17025 1.0205 0.42009 0.71577 0.44684 0.6851 1.2975 1.626 1.1872z",
+                Keelung:"m354.05 44.801c-1.1007 0.76061-2.131 0.33008-2.5505-0.81019-0.42085 0.0698-0.99176-0.09915-1.4217-0.08024-0.10962-0.26941-0.0502-0.63928-0.0803-0.91978-2.2615 0.01892-1.9111-4.2916-2.0005-6.002-0.55069 0.2094-1.3415 0.01957-1.9209 0.17026-0.12984-0.40966-0.12984-1.2603 0-1.6706 1.611-0.09067 3.3518 0.33986 4.0023-1.501 0.73077-0.04044 2.052 0.23092 2.7215-0.03001 0.6205-0.24006 0.58135-1.1598 1.0505-1.4508 1.0205-0.63993 1.8106-1.1905 2.9511-1.7208 0.46064 0.42988 0.80972 0.76061 0.82016 0.77039 1.4811 1.0502 2.6621 1.0705 4.6326 1.1801 0.4502 1.8617-0.28057 2.7906-0.14942 4.4423 0.68053-0.86042 1.7004-1.4005 1.7304-2.6908 2.4611-1.3203 4.0525 1.6706 6.6742 0.7306-0.11027 0.4899 0.17878 1.2003 0.0796 1.6902 0.52068 0.02022 1.0498 0.03001 1.5907 0.05023v0.03001c-0.03 0.33008-0.36016 1.1005-0.42084 1.4208-0.33015-0.04044-0.84039 0.15004-1.1705 0.08024 0.0104 0.56035-0.42084 1.0307-0.33015 1.6706-1.4106 0.32029-2.2706-0.63014-3.4718-0.47032-1.0603 0.14025-1.8511 1.0104-2.9009 1.2505 1.3108 1.0907 1.5503 2.3908 1.4511 4.2212 1.0198 0.13046 2.3306 1.0411 1.9711 2.3007-0.46064 1.6204-1.9418 0.69016-3.2121 1.0405-0.55982 0.15003-0.44042 1.1103-1.0407 1.2101-0.68053 0.12003-1.2208-0.2805-1.6912-0.33008-1.9711-0.18004-3.4516-1.1011-5.5323-1.2205 0.0698-1.4814-1.0505-2.3007-2.5009-2.0007 0.0196-0.03001-0.06-0.60014-0.06-0.58057 0.34907-0.23027 0.56896-0.62036 0.77971-0.78018z",
+                Kinmen:"m41.675 107.89c-0.0762 4e-3 -0.14595 0.0243-0.18718 0.0468-0.0375 0.0225-0.0711 0.0402-0.0936 0.0702l-0.0468 0.0936c-0.05235 0.16473-0.0159 0.38094-0.0234 0.53817-0.77124 0.0375-1.3965-0.23867-2.1526-0.16379-0.17222 0.015-0.27516 0.0412-0.32758 0.0936-0.015 8e-3 -9e-3 9e-3 -0.0234 0.0234-0.09735 0.11235-0.102 0.2967-0.30418 0.49137-0.21714 0.20217-0.453 0.4034-0.46797 0.72537-0.0075 0.41931 0.2527 0.74409 0.1404 1.1933-0.09735 0.34443-0.40246 0.4268-0.51478 0.74877-0.08985 0.2471 0.015 0.66641 0 0.93596-0.0225 0.3669-0.1095 0.46984-0.49137 0.51477-0.15724 0.0225-0.32666 0.0524-0.49138 0-0.09735-0.0225-0.24522-0.1563-0.32757-0.16379-0.75626-0.0973-0.35661 1.154-0.3042 1.521 0.045 0.34443-0.0135 0.56532-0.1404 0.84236-0.1422 0.32946-0.03375 0.42867-0.0936 0.79557-0.045-7e-3 -0.0795 0-0.117 0-0.03 0.10485-0.1011 0.16098-0.0936 0.28078-0.38936 0.0748-0.53722-0.27891-0.88916-0.23398-0.0225 0.11235 0.07485 0.23959 0.1872 0.37438 0.03 0.0375 0.072 0.0795 0.117 0.117 0.15723 0.1497 0.32384 0.27611 0.42117 0.35097 0.0375 0.0225 0.087 0.0552 0.117 0.0702 0.1422 0.0599 0.26301 0.0468 0.39778 0.0468 0.09735 8e-3 0.20778 0.0328 0.32758 0.0702 0.11235 0.0375 0.21434 0.10485 0.30418 0.1872 0.05235 0.0375 0.1029 0.0954 0.1404 0.1404 0.0375 0.0448 0.0795 0.0954 0.117 0.1404l0.0702 0.0468 0.0468 0.0702c0.1797 0.1797 0.39498 0.30699 0.70197 0.18719 0.35192-0.1347 0.1161-0.47265 0.28078-0.77216 0.22462-0.41182 0.906-0.78433 1.3103-0.88917 0.21789-0.0598 0.66546-0.25176 0.91256-0.117 0.23211 0.1497 0.1104 0.43898 0.1404 0.67857 0.0075 0.0748 0.0411 0.1347 0.0936 0.1872 0.015-0.0225 0.0243-0.0318 0.0468-0.0468 0.1497-0.1497 0.41368-0.27705 0.60837-0.37438 0.25458-0.1347 0.5026-0.33975 0.77217-0.44459 0.07485-0.26206-0.10395-0.43615-0.35098-0.42117-0.11235-0.45675-0.0468-0.63364 0.32758-0.86577 0.31448-0.20965 0.58497-0.3697 0.95936-0.44457 0.36688-0.0823 0.69354-0.0795 1.0529 0.0702 0.2995 0.11985 0.55222 0.34349 0.88916 0.35099 0.1497-0.20966 0.0486-0.47079 0.0936-0.72537 0.015-0.12735-0.04215-0.20685 0.0702-0.30419 0.09735-0.0898 0.25272 0.0206 0.32758-0.0468 0.26208-0.20965 0.045-0.94999 0.1872-1.2869 0.0225-0.0448 0.0243-0.072 0.0468-0.117 0.0375-0.0899 0.0795-0.19842 0.117-0.28078 0.0225-0.0448 0.0477-0.0795 0.0702-0.117 0.03-0.0523 0.072-0.0795 0.117-0.117 0.11985-0.11235 0.24615-0.19374 0.35098-0.35099 0.22462-0.37438 0.0543-1.0389 0.0468-1.4507-0.2471-0.0225-0.57 0.0263-0.77217-0.0936-0.05235-0.03-0.1188-0.072-0.16378-0.117-0.03-0.03-0.0636-0.0561-0.0936-0.0936-0.05985-0.0748-0.09645-0.1591-0.1638-0.23398-0.03-0.0375-0.0795-0.0795-0.117-0.117-0.4268-0.3594-0.98836-0.45674-1.3103-0.93596-0.0225-0.0375-0.0243-0.0881-0.0468-0.1404-0.0225-0.0524-0.0636-0.10395-0.0936-0.16378-0.0375-0.0824-0.0645-0.18158-0.117-0.23399-0.0225-0.0225-0.0477-0.0318-0.0702-0.0468-0.18718-0.11235-0.59433-0.0468-0.81896-0.0468-0.15162 0-0.47348-0.0594-0.70197-0.0468zm32.666-14.206c-0.71882-0.05985 0.19842 0.96028 0.28078 1.1699v0.0234c0.03 0.07485 0.0468 0.17596 0.0468 0.28078 0 0.21714-0.0468 0.45114-0.0468 0.60837 0 0.3669 0.0402 0.51946-0.30418 0.63177-0.20217 0.06735-0.3332 0.08805-0.46798 0.1404-0.05235 0.0225-0.10395 0.0327-0.16378 0.0702-0.03 0.015-0.0561 0.0477-0.0936 0.0702-0.10485 0.06735-0.21526 0.13575-0.32758 0.2106-0.11235 0.08235-0.22276 0.15818-0.32758 0.21058-0.1422 0.06735-0.29482 0.0702-0.44458 0.0702-0.05235 0.0075-0.11145 0-0.16378 0-0.06735 0-0.14325 9e-3 -0.21058 0.0234-0.0375 0.0075-0.0795 9e-3 -0.117 0.0234-0.25458 0.07485-0.44085 0.21058-0.72537 0.21058-0.07485 0.12735-0.1338 0.30513-0.1638 0.51478-0.04485 0.45675 0.06645 1.0408 0.35098 1.3103 0.0375 0.0375 0.072 0.0711 0.117 0.0936 0.0075 0.0075 0.0159 0 0.0234 0 0.04485 0.015 0.0954 0.0393 0.1404 0.0468v-0.117c0-0.015-0.0075-0.0318 0-0.0468v-0.0234c-0.0075-0.0075 0.0075-0.0159 0.0234-0.0234-0.0075-0.0075-0.0075-0.0159 0-0.0234-0.0075-0.0225-0.01515-0.0318 0-0.0468-0.0075-0.03 9e-3 -0.0711 0.0234-0.0936 0.0075-0.03-0.0075-0.0402 0-0.0702 0-0.015 0.01605-0.0234 0.0234-0.0234v-0.0468c0.0225-0.07485 0.04035-0.14325 0.0702-0.2106 0.0225-0.06735 0.0477-0.12735 0.0702-0.18718 0.015-0.0225 0.0159-0.0711 0.0234-0.0936 0.08235-0.0075 0.19281-0.0075 0.32758 0 0.05985 0 0.13575-0.0075 0.2106 0 0.0375 0 0.072 0.0234 0.117 0.0234 0.0225 0 0.0318-0.0075 0.0468 0 0.0375 0 0.0795-0.0075 0.117 0 0.08985 0.0075 0.19936 0.0318 0.30418 0.0468l0.0936 0.0234h0.0234c0.05985 0.0075 0.10395 9e-3 0.16378 0.0234 0.05985 0.015 0.1347 0.0318 0.18718 0.0468 0.05235 0.0225 0.08805 0.0552 0.1404 0.0702 0.04485 0.015 0.1029 0.0402 0.1404 0.0702 0.05985 0.0225 0.0954 0.0561 0.1404 0.0936 0.045 0.03 0.0945 0.07215 0.117 0.117 0.045 0.06735 0.0777 0.12825 0.0702 0.21058v0.0234c-0.0075 0-0.0318-0.0159-0.0468-0.0234h-0.0231c-0.18718-0.015-0.42117 0.0216-0.60837-0.0234-0.22462-0.04485-0.33694-0.19467-0.56157-0.18718h-0.0702c-0.0375 0-0.0795 0.0159-0.117 0.0234-0.015 0.0075-0.0318 0.0234-0.0468 0.0234-0.0375 0.015-0.0636 0.0243-0.0936 0.0468-0.06735 0.05985-0.09735 0.1535 0 0.28078 0.0075 0.015 0.0318 9e-3 0.0468 0.0234 0.08235 0.05985 0.19188 0.0543 0.30418 0.0468 0.10485 0 0.21246 0.0135 0.25738 0.1404 0.0225 0 0.0477 0.01575 0.0702 0.0234 0.0225-0.0075 0.0318-0.0075 0.0468 0 0.10485 0.31448 0.12825 0.45861 0.0234 0.79556l-0.0234 0.0936c-0.03 0.0973-0.04965 0.18345-0.117 0.28079-0.05985 0.0823-0.18999 0.12075-0.25738 0.2106l-0.0468 0.0468c-0.0075 0.015 0 0.0243 0 0.0468-0.0075 0.0448-0.0075 0.0881 0 0.1404 0.04485 0.16473 0.19094 0.32571 0.28078 0.46797 0.11235 0.17221 0.19188 0.46705 0.30418 0.63177l0.0468 0.0468c-0.03-7e-3 -0.0402-0.0159-0.0702-0.0234-0.0375-8e-3 -0.087-9e-3 -0.117-0.0234-0.05985-0.0225-0.11145-0.0561-0.16378-0.0936-0.0375-0.015-0.0636-0.0243-0.0936-0.0468-0.35193-0.25458-0.44178-0.67482-0.56158-1.1465-0.22462-0.0974-0.14595-0.27237-0.28078-0.44459l-0.0702-0.0702-0.0234-0.0468c-0.0375-0.03-0.1029-0.0477-0.1404-0.0702-0.08235-0.0375-0.17595-0.0636-0.28078-0.0936-0.1422-0.0375-0.263-0.0486-0.39778-0.0936-0.04485-0.015-0.08805-0.0243-0.1404-0.0468 0 0-0.0234-0.0157-0.0234-0.0234-0.0225-0.015-0.0477-0.0168-0.0702-0.0468-0.015-0.0075-9e-3 -0.0318-0.0234-0.0468-0.0225-0.03-0.0477-0.04785-0.0702-0.0702-0.015-0.015-0.0318-0.0393-0.0468-0.0468-0.07485-0.04485-0.1769-0.04305-0.30418 0.0468-0.21039 0.1422-0.22725 0.48951-0.0468 0.63177 0.1497 0.11235 0.26114 0.0561 0.35098 0.0936l0.0468 0.0234c0.03 0.03 0.0561 0.058 0.0936 0.1404 0.1422 0.26957 0.2705 0.74034 0.2106 1.0998-0.015 0.0749-0.0477 0.12735-0.0702 0.18718-0.15724 0.015-0.30232 0.0402-0.44458 0.0702-0.1497 0.03-0.29482 0.0795-0.44458 0.117-0.08985 0.03-0.17595 0.0478-0.28078 0.0702-0.05235 8e-3 -0.1029 0.0318-0.1404 0.0468s-0.0636 0.0243-0.0936 0.0468c-0.0375 0.0225-0.0711 0.0402-0.0936 0.0702-0.015 0.0225-0.0318 0.0636-0.0468 0.0936-0.015 0.0448-0.0234 0.10395-0.0234 0.1638-0.0075 0.0748-7.5e-4 0.15255-0.0234 0.25739-0.0075 0.0449-0.0243 0.10395-0.0468 0.16378-0.07485 0-0.16004 8e-3 -0.25738 0h-0.1404c-0.0225 0-0.0552-7e-3 -0.0702 0-0.10485 8e-3 -0.18999 0.0252-0.25738 0.0702-0.03 0.015-0.0552 0.0402-0.0702 0.0702-0.1872 0.29951 0.1011 0.6168 0.28078 0.81897 0.0225 0.015 0.0552 0.0318 0.0702 0.0468 0.37438 0.4268 0.41182 0.96872 0.37438 1.5678-0.0075 0.0973-0.0075 0.18251-0.0234 0.25739-0.0075 0.0748-0.0243 0.14325-0.0468 0.21058-0.045 0.11985-0.11415 0.24803-0.23398 0.39779-0.0375 0.045-0.0795 0.087-0.117 0.117-0.03 0.0375-0.0636 0.0478-0.0936 0.0702-0.03 0.0225-0.0402 0.0552-0.0702 0.0702s-0.07965 0.0159-0.117 0.0234c-0.08235 0.0225-0.20124 0.0234-0.35098 0.0234-0.31448 1e-5 -0.66734-5e-3 -0.95936 0.0702-0.2995 0.0748-0.44739 0.22557-0.70197 0.39778-0.27704 0.19467-0.3126 0.25646-0.70197 0.23399-0.21714-0.32946-0.52881-0.25083-0.86576-0.28079-0.40432-0.03-0.4998-0.33132-0.88916-0.42118-0.08985-0.0225-0.18345-0.0393-0.28078-0.0468-0.23961-0.015-0.49324-1e-3 -0.72537-0.0468-0.61398-0.10485-1.0988-0.2499-1.638-0.63177-0.89103-0.62897-1.5668-1.5612-2.4802-2.1526-0.48669-0.32198-0.94156-0.32384-1.2635-0.79556-0.26206-0.41182-0.46518-0.85921-0.77216-1.2635-0.29952-0.40434-0.69356-0.92566-1.053-1.2402-0.55408-0.47172-0.87138-0.13755-1.0062 0.49138-0.614 0.03-1.1194-0.1236-1.5912 0.28079-0.44176 0.37438-0.8199 0.74782-1.4039 0.91255-0.89852 0.23961-1.856 1.7043-1.4741 2.7376 0.19468 0.48669 0.6065 0.32945 0.93596 0.56157 0.1347 0.0898 0.18532 0.19842 0.32758 0.28079 0.0225 8e-3 0.0477 0.0393 0.0702 0.0468 0.045 0.0225 0.0954 0.0318 0.1404 0.0468 0.045 0.0225 0.08805 0.0318 0.1404 0.0468 0.11235 0.03 0.22276 0.0542 0.32758 0.0468 0.0375-0.20217 6e-3 -0.3566-0.0702-0.49139-0.05235-0.10485-0.1422-0.20778-0.18718-0.32758-0.0075-0.0225-0.0159-0.0402-0.0234-0.0702l-0.0468-0.0936c-0.10485-0.19467-0.27237-0.47358-0.25738-0.60837 0.24708-0.0449 0.44644 0.0786 0.67856 0.0936 0.25458 0.03 0.36783-0.1329 0.58498-0.1404 0.38936-0.015 0.88728 0.73095 0.84236-0.0702h0.21058c0.22464 7e-3 0.44178 0.015 0.56158-0.18719 0.10485-0.1797-0.11235-0.57936 0.18718-0.63177 0.32198-0.0524 0.23025 0.44364 0.32758 0.60837 0.07485 0.11985 0.61866 0.4764 0.117 0.49137-0.18718 0.29202-0.25738 0.30606-0.25738 0.72537 0 0.41183 0.08985 0.68138-0.37438 0.74877h-0.0702c-0.12735 0.0225-0.32384 0.03-0.42118 0-0.1422-0.0524-0.27048-0.32853-0.39777-0.35098-0.1422-0.0225-0.21996 0.0272-0.2574 0.117-0.0075 0.015-0.0234 0.0243-0.0234 0.0468-0.0075 0.015-0.0234 0.0477-0.0234 0.0702-0.0225 0.1347-0.0168 0.28546-0.0468 0.39778-0.25458 0.015-0.51758 8e-3 -0.77216 0.0234-0.015 0.20966 0.16566 0.14505 0.21058 0.25739 0.015 0.03 0.0234 0.0636 0.0234 0.0936 0.0075 0.0225 0.0234 0.0477 0.0234 0.0702 0.0075 0.0523 0.0075 0.10395 0 0.16378v0.117c0 8e-3 0.0075 0.0159 0 0.0234 0.0075 0.0375-0.01575 0.0636-0.0234 0.0936-0.0225 0.23961-0.0711 0.45395-0.0936 0.67857-0.0375 0.5466 0.39966 1.0314 0.63177 1.4507 0.21714 0.39684 0.34443 0.58029 0.37438 1.0296 0.03 0.32196 0.117 0.58309 0.117 0.91255 0 0.26955 0.0162 0.54098 0.0234 0.79556 0.0075 0.35941 0.0234 0.69261 0.0234 1.0296 0 0.20966 0.0972 0.76374 0 0.93596-0.11235 0.19468-0.55408 0.26767-0.74877 0.32758-0.08235 0.0225-0.18344 0.0477-0.28078 0.0702-0.06735 0.015-0.11985 9e-3 -0.18718 0.0234-0.09735 0.0225-0.21434 0.0402-0.30418 0.0702-0.12735 0.0448-0.24522 0.11235-0.32758 0.18719-0.11235 0.11235-0.16098 0.27517-0.0936 0.51478 0.05985 0.23211 0.25458 0.47172 0.18718 0.74876 0 0.015 0.0075 0.0159 0 0.0234 0 0.03-0.0075 0.0477-0.0234 0.0702-0.0225 0.0448-0.07215 0.0954-0.117 0.1404-0.03 0.0225-0.0636 0.0552-0.0936 0.0702-0.0375 0.0225-0.072 0.0477-0.117 0.0702-0.06735 0.0448-0.12735 0.0795-0.18718 0.117-0.03 0.0225-0.0711 0.0477-0.0936 0.0702-0.29202 0.23212-0.33507 0.23961-0.70197 0.1872-0.08235-7e-3 -0.26206-9e-3 -0.37438-0.0234-0.0225 0-0.0318 7e-3 -0.0468 0-0.015-2e-5 -0.0318-0.0157-0.0468-0.0234-0.03-0.015-0.0552-0.0168-0.0702-0.0468-0.0075 7e-3 0-0.0157 0-0.0234-0.05985-0.0599-0.06555-0.11985-0.1404-0.1872-0.20216-0.18719-0.36128-0.27891-0.60837-0.23399-0.04485 8e-3 -0.08805 0.0318-0.1404 0.0468-0.0375 0.0973-0.09645 0.18158-0.16378 0.23399-0.0225 0.0225-0.0402 0.0318-0.0702 0.0468-0.12735 0.0898-0.28827 0.0918-0.46798 0.0468-0.08235-0.015-0.17502-0.0243-0.25738-0.0468-0.0225 0-0.0318-0.0162-0.0468-0.0234-0.08235-0.0225-0.17502-0.0552-0.25738-0.0702h-0.0234c-0.1422-0.0225-0.2939-0.0135-0.42118 0.0234-0.0375 0.015-0.0561 0.0318-0.0936 0.0468-0.0375 0.0225-0.0636 0.0168-0.0936 0.0468-0.04485 0.0375-0.1029 0.0879-0.1404 0.1404-0.15723 0.21715-0.14505 0.33882-0.0702 0.42118 0.05235 0.0524 0.14415 0.1029 0.234 0.1404 0.08985 0.03 0.19094 0.0561 0.28078 0.0936 0.24708 0.11235 0.59994 0.50636 0.77216 0.67857 0.0375 0.015 0.0795 0.0168 0.117 0.0468 0.045 0.03 0.0954 0.072 0.1404 0.117 0.26956 0.23961 0.5438 0.68699 0.67857 0.88916 0.05235 0.0748 0.0636 0.10395 0.0936 0.1638 0.015 0.015 0.0318 0.0402 0.0468 0.0702 0.0225 0.0599 9e-3 0.22836 0.0468 0.28078 0.03 0.03 0.0486 0.0627 0.0936 0.0702 0.04485 0.015 0.11145 0.0159 0.1638 0.0234h0.0234c0.04485 8e-3 0.0954 9e-3 0.1404 0.0234 0.03 7e-3 0.0477 0.0159 0.0702 0.0234 0.0225 7e-3 0.0318 0.0318 0.0468 0.0468 0.10485 0.0973 0.17408 0.23211 0.23398 0.37437 0.0375 0.0898 0.0636 0.20685 0.0936 0.3042 0.045 0.1422 0.08895 0.27704 0.16378 0.37437 0.05985 0.0824 0.16848 0.13485 0.28078 0.1872 0.11985 0.0448 0.23212 0.087 0.37438 0.117 0.13485 0.03 0.28641 0.0552 0.42118 0.0702 0.12735 0.015 0.26114 0.0318 0.35098 0.0468 0.03 0.12735 0.09735 0.23772 0.18718 0.32759 0.07485 8e-3 0.12735 0 0.1872 0 0.06735 0 0.1422 9e-3 0.18718 0.0234 0.0375 8e-3 0.0636-6e-3 0.0936 0.0234 0.05235 0.0375 0.0954 0.10485 0.1404 0.18718 0.0225 0.0448 0.0477 0.088 0.0702 0.1404 0.045 0.10485 0.0795 0.22277 0.117 0.32759 0.015 0.0524 0.0477 0.0954 0.0702 0.1404 0.05235 7e-3 0.087 0.0486 0.117 0.0936 0.09735 0.11985 0.16098 0.34723 0.28078 0.44458 0.25458 0.2396 0.2939 0.1694 0.60837 0.117 0.32946-0.0448 0.86109-0.20122 1.1232 0.0234 0.0225 0.015 0.0552 0.0402 0.0702 0.0702 0.0375 0.0524 0.0552 0.11235 0.0702 0.18719 0.15723 0.11985 0.43054 0.19749 0.65517 0.25738 0.03 0.015 0.0402 0.0159 0.0702 0.0234 0.03 7e-3 0.0711 0.0234 0.0936 0.0234 0.1347 0.03 0.2293 0.03 0.30418 0 0.015 0 0.0393-8e-3 0.0468-0.0234 0.0225-8e-3 0.0318-0.0243 0.0468-0.0468 0.05235-0.0674 0.0795-0.17782 0.117-0.32758 0.0375-0.015 0.0954-0.0234 0.1404-0.0234 0.10485-0.0225 0.19935-0.0309 0.30418-0.0234 0.10485 0 0.20684-7.5e-4 0.30418-0.0234 0.0225 0 0.0477 7e-3 0.0702 0 0.03-8e-3 0.0477-0.0161 0.0702-0.0234 0.0375-0.015 0.0795-0.0477 0.117-0.0702s0.0711-0.0402 0.0936-0.0702c0.20217-0.20216 0.26768-0.51758 0.32758-0.77216 0.15723-0.6664 0.14415-1.0436 0.60837-1.5678 0.39684-0.45675 0.52881-1.096 0.86576-1.5678 0.1497-0.20965 0.23118-0.4839 0.35098-0.67857 0.0375-0.0524 0.0795-0.0954 0.117-0.1404 0.08235-0.0824 0.1591-0.15163 0.23398-0.234 0.04485-0.0375 0.087-0.088 0.117-0.1404 0.0225-0.015 9e-3 -0.0477 0.0234-0.0702 0.1872-0.45673-0.0318-0.7029 0.51478-0.91255 0.23211-0.0974 0.30324-0.1161 0.46797-0.28079 0.43428-0.44176 0.58592-0.64113 1.1699-0.86575 0.32198-0.12735 0.5569-0.31167 0.81897-0.49139 0.17222-0.1347 0.35847-0.23772 0.53817-0.32758 0.35192-0.18719 0.73378-0.34161 1.1232-0.49137 0.61398-0.23961 1.082-0.4764 1.7782-0.49137 0.68138 0 1.3534-0.0748 2.0122-0.1872 0.63645-0.11235 1.183-0.23399 1.8718-0.23399 0.16473 0 0.31072 9e-3 0.46797 0.0234 0.1497 8e-3 0.31822 0.0168 0.46798 0.0468 0.07485 0.015 0.1347 0.0477 0.18718 0.0702 0.17222 0.0598 0.26582 0.13665 0.46798 0.23399 0.32944 0.1497 0.50634 0.1086 0.67856 0.46798 0.09735 0.1797 0.12825 0.41369 0.2106 0.60837 0.03 0.0598 0.0486 0.11145 0.0936 0.16379 0.04485 0.0523 0.10395 0.0795 0.16378 0.117 0.19468 0.0974 0.453 0.1179 0.65517 0.1404 0.15724 0.0225 0.34162-4e-3 0.49138 0.0468 0.1497 0.0598 0.2396 0.20497 0.37437 0.2574 0.15724 0.0523 0.32666 7.3e-4 0.49138 0.0234 0.03 0 0.0636 0.0159 0.0936 0.0234 0.0375 0.015 0.0636 0.0243 0.0936 0.0468 0.06735 0.0448 0.11985 0.0956 0.18718 0.1404 0.03 0.0225 0.0561 0.0552 0.0936 0.0702 0.15724 0.0898 0.31917 0.0824 0.49138 0.18718 0.1497 0.0824 0.20122 0.19749 0.35098 0.25739h0.0234l0.0234 0.1404c0.0075 0.0448 0.01605 0.0795 0.0234 0.117 0.015 0.0824 0.04875 0.17502 0.0936 0.25738 0.11985 0.23961 0.24522 0.36878 0.32758 0.60837 0.11235 0.28454 0.18063 0.52602 0.21058 0.79557 0.0075 0.0448 0.0234 0.0954 0.0234 0.1404 0.015 0.0898 0.0075 0.17595 0 0.28079-0.57656 0.20217-1.8064-0.30699-1.7316 0.56157 0.49419 0.0225 0.97246-0.0459 1.4741-0.0234 0.05985 0.41931-1.0333 0.20685-1.3103 0.30418-0.05235 0.20217 0.1245 0.28266 0.30418 0.32759 0.045 0.1347 0.0702 0.30231 0.0702 0.44458 0.30699-0.0375 0.57374-0.24241 0.86576-0.25738 0.26206-0.015 0.58965 0.1077 0.88916 0.0702 0.55334-0.0524 0.37083-0.1422 0.49138-0.56159 0.11985-0.42679 0.41276-0.29763 0.77216-0.32758 0.60651-0.0448 0.81054-0.70383 1.3571-0.93596 0.29202-0.11985 0.68325-0.0411 0.98276-0.0936 0.05985-8e-3 0.13485-0.0477 0.18718-0.0702 0.1497-0.0749 0.24054-0.19935 0.2106-0.49137-0.0225-0.20965-0.06555-0.30138-0.1404-0.42118-0.03-0.0448-0.0402-0.0647-0.0702-0.117l-0.0234-0.0234c-0.0225-0.0375-0.0318-0.0636-0.0468-0.0936-0.10485-0.16473-0.11235-0.18533 0-0.32759 0.015-0.0225 0.0243-0.0636 0.0468-0.0936 0.03-0.0449 0.0879-0.0954 0.1404-0.1404 0.2396-0.24709 0.61586-0.48201 0.79556-0.0702 0.33694 0.0973 0.57 0.15537 0.95936 0.1404 0.20966-0.24709 0.57375-0.61678 0.49138-1.0062-0.1497-0.0898-0.27986-0.20498-0.44458-0.25739-0.05235-0.12735-0.0375-0.27798 0-0.39778-0.16473-0.12735-0.53444-0.31355-0.63177-0.53817-0.08235-0.19467 7.5e-4 -0.64862 0.0234-0.86576 0.08985-0.74128 0.6636-0.80211 1.2401-0.58497-0.0225 0.22463 0.49138 0.27143 0.67857 0.23399 0.40434-0.0974 0.2527-0.40434 0.32758-0.74877 0.05985-0.25458 0.18158-0.48669 0.23398-0.74876 0.0075-0.03 0-0.0636 0-0.0936 0.0075-0.0748 0.0318-0.15912 0.0468-0.234 0.0075-0.03 9e-3 -0.0636 0.0234-0.0936 0.0075-0.015 0.0159-9e-3 0.0234-0.0234 0.05985-0.0898 0.2106-0.21432 0.2106-0.30418 0-0.45674-1.0923-0.1254-1.4741-0.51477-0.03-0.03-0.0786-0.072-0.0936-0.117-0.09735-0.2471 0.1125-0.54192 0-0.81896-0.09735-0.25458-0.41649-0.4165-0.49137-0.67857-0.1497-0.50916-0.05235-1.4732 0-2.0122 0.045-0.43428 0.28452-1.534 0.74876-1.6614 0.10485-0.23211 0.43522-0.34068 0.39778-0.65517-0.0075-0.10485-0.13005-0.24615-0.25738-0.35097-0.05235-0.0375-0.08805-0.0711-0.1404-0.0936-0.0225-8e-3 -0.0711-0.0159-0.0936-0.0234-0.05985-0.015-0.10395-0.0234-0.16378-0.0234-0.05985 0-0.11145 7e-3 -0.1638 0.0234-0.0225 8e-3 -0.0477 8e-3 -0.0702 0.0234-0.0225 0-0.0477 0.0159-0.0702 0.0234-0.05235 0.0225-0.1188 0.0477-0.16378 0.0702-0.1497 0.0748-0.263 0.1404-0.39778 0.1404-0.11985 0-0.25552-0.0459-0.39778-0.2106-0.06735-0.0824-0.12735-0.16659-0.18718-0.23398-0.05985-0.0824-0.1188-0.15911-0.1638-0.23399-0.05985-0.10485-0.1263-0.21528-0.16378-0.32758-0.03-0.10485-0.0318-0.2237-0.0468-0.35099-0.015-0.10485-0.03075-0.20029-0.0234-0.32758 0.03-0.614 0.25364-1.3272-0.39778-1.5444-0.05235-0.015-0.0954-0.0477-0.1404-0.0702-0.08235-0.0375-0.1422-0.0645-0.18718-0.117-0.20966-0.1872-0.19376-0.46611-0.1638-0.79557l0.0234-0.16379v-0.1872c0.0075-0.20216-0.0075-0.453 0.0234-0.65517 0.0075-0.06735 7.5e-4 -0.10395 0.0234-0.16378 0.11235-0.2995 0.3566-0.3828 0.30418-0.77217-0.05235-0.0075-0.1188-0.0159-0.16378-0.0234-0.0225 0-0.0318-0.0234-0.0468-0.0234-0.26956-0.015-0.51759 0.01785-0.77217 0.0702-0.16473 0.0375-0.31822 0.08055-0.46798 0.1404-0.03 0.015-0.0636 0.0393-0.0936 0.0468-0.05985 0.0225-0.12735 0.0402-0.18718 0.0702l-0.0702 0.0468c-0.11985 0.07485-9e-3 0.23306-0.23398 0.2106-0.1797-0.0075-0.36034-0.39591-0.39778-0.53817-0.03-0.0375-0.0327-0.0411-0.0702-0.0936-0.12735-0.0075-0.26206-0.0159-0.37438-0.0234-0.23211 0-0.43521-0.0135-0.58497-0.1404-0.08235-0.06735-0.1347-0.15351-0.18718-0.2808-0.04485-0.11985-0.0627-0.24708-0.0702-0.37437 0-0.06735 0.0075-0.12735 0-0.1872-0.015-0.06735-0.0318-0.12735-0.0468-0.18718-0.08985-0.28454-0.20498-0.497-0.2574-0.81897-0.0375-0.1797-0.1188-0.3828-0.16378-0.58497-0.015-0.05235-0.0159-0.11145-0.0234-0.16378-0.0075-0.07485-0.0075-0.15912 0-0.234v-0.1404c0.0075-0.11985 0.02265-0.26206 0-0.37437-0.0075-0.04485-0.01605-0.07215-0.0234-0.117-0.0375-0.1347-0.11415-0.26674-0.23398-0.30418-0.03-0.0075-0.072-0.015-0.117 0-0.015-0.0075-0.0318 0.0159-0.0468 0.0234l-0.0702 0.0234c-0.13485 0.08235-0.16473 0.30512-0.37438 0.32758-0.06735-0.16473-0.0243-0.35098-0.0468-0.53818-0.38187-0.1797-1.257 0.09825-1.6614 0.2106h-0.0234c-0.05985 0.0225-0.1029 0.0393-0.1404 0.0468h-0.0234c-0.16473 0.0375-0.24802 0.01785-0.39778-0.117-0.0375-0.03-0.072-0.0645-0.117-0.117h-0.0234c-0.16473-0.1497-0.36876-0.42962-0.60837-0.44458z",
+                Matsu:"m47.89 49.587c-0.5391 0.81864-0.3307 2.5646-0.0312 3.463-0.75874 0.08984-1.3228 0.52164-1.8719 1.0607 0.87854 1.6672-0.22714 1.5961-0.68638 2.9638-0.56906 1.6672 0.4917 2.5258 1.5599 3.2446 0.40934 0.27954 0.76624 0.68512 1.1856 0.90476 1.0383 0.46922 0.98962 0.07608 1.7783-0.09354 0.7288-0.18968 0.60276-0.31948 1.5911-0.24958 0.62896 0.02994 1.2292 0.46298 2.028 0.34318 0.39934-0.75874 1.4738-2.1078 2.4022-2.028 0.51914 1.6772 2.6594-0.27828 3.3382-0.71756 1.4876-0.98836 2.26-1.5712 2.0904-3.5878-1.797 0.08986-3.4904-0.45424-5.3974-0.37438-1.1381 0.04992-1.7571-0.1273-2.2464 0.81116-0.1198 0.22962-0.1572 0.47672-0.1872 0.68636l-0.0312 0.28078c0 0.03994-0.0212 0.08486-0.0312 0.1248-0.01 0.08986-0.012 0.1797-0.0312 0.24958-0.01 0.03994-0.012 0.09484-0.0312 0.1248-0.03 0.0599-0.065 0.10608-0.1248 0.156-0.1798 0.12978-0.52538 0.19468-1.1543 0.1248-0.1398-1.6972-0.2683-4.0908-2.7142-3.6814 0.32944-0.609 0.76498-1.0795 1.4039-1.2791 0.1598-0.16972 0.40708-0.72506 0.46798-0.90476 0.1598-0.32946-2.9376-1.4726-3.307-1.6223zm23.56-17.784c-0.38328 0.04264-0.8218 0.14792-1.2479 0.24958-0.21306 0.05082-0.42916 0.11702-0.62396 0.156-0.1948 0.03894-0.37314 0.05302-0.53038 0.0624-0.34942 0.02-0.85984-0.07238-1.2791-0.0624h-0.0312c-0.1698 0-0.31698 2e-3 -0.43678 0.0624-0.70882 0.26956-0.46922 0.52664-0.99836 0.93596-0.34442 0.24958-0.7213 0.5831-1.1231 0.87356s-0.82864 0.53786-1.2479 0.59278c-1.228 0.13978-1.807-0.80616-2.7454 0.31198-1.0882 1.2679 0.1548 1.9006 0.37438 3.0886 0.1198 0.6689-0.0212 0.95716-0.2808 1.2167-0.0698 0.0599-0.1386 0.12728-0.21838 0.18718-0.31948 0.24958-0.74252 0.54536-1.092 1.1543-0.1398 0.25958-0.2421 0.56532-0.31198 0.90476-0.02 0.1198-0.0524 0.25458-0.0624 0.37438-0.0598 0.58902 8e-3 1.2068 0.1872 1.7159 0.1598 0.04992 0.1872-0.04492 0.1872 0.1248 0.20966-0.02996 0.52914 0.09234 0.74876 0.0624-0.1572 0.84736 0.41046 1.3996 1.1232 1.2167 0.1018-0.02616 0.2059-0.06738 0.31198-0.1248-0.0486-0.1872-0.091-0.41458-0.1248-0.65516-0.23696-1.6842-0.0236-4.4052 1.8719-4.4926-0.0224-0.5441 0.0872-0.94332 0.28078-1.2479 0.0968-0.1523 0.20398-0.30146 0.34318-0.40558 0.69598-0.5206 1.8782-0.47422 3.0574-0.37438-0.0798 0.49918 0.1884 0.94468 0.21838 1.4039 1.797-0.7887 2.9938-1.7147 5.2102-0.93596 0.1872 0.38936-0.093 2.9332 0.49918 3.5254 0.0494 0.04932 0.125 0.07348 0.1872 0.09354s0.1106 0.0138 0.1872 0c0.153-0.02786 0.34192-0.1198 0.56156-0.31198 0.0674-0.0587 0.1122-0.13966 0.156-0.2184 0.0438-0.07876 0.1006-0.1542 0.1248-0.2496 0.1936-0.76316-0.191-2.0002-0.1248-2.839 8e-3 -0.10486 8e-3 -0.22142 0.0312-0.31198 0.024-0.09056 0.0812-0.14556 0.1248-0.2184 0.0436-0.07288 0.089-0.13552 0.156-0.1872 0.20096-0.15502 0.5154-0.22214 0.99836-0.1248 0.0798-0.45924 0.0798-1.1107 0-1.5599-0.76874-0.04992-3.01 0.68512-2.8702-0.34318 0.1598-0.99836 1.6186-0.7238 1.2791-2.371-1.1381 0.24958-1.1656-0.99836-2.184-1.2479-0.1798-0.04742-0.43086-0.0596-0.68636-0.03114z"
+                };
+            var i = {};
+            for (var s in r) {
+                i = {};
+                if (this.options.stateSpecificStyles[s]) {
+                    e.extend(i, t, this.options.stateSpecificStyles[s])
+                } else {
+                    i = t
+                }
+                this.stateShapes[s] = n.path(r[s]).attr(i);
+                this.topShape = this.stateShapes[s];
+                this.stateHitAreas[s] = n.path(r[s]).attr({
+                    fill: "#000",
+                    "stroke-width": 0,
+                    opacity: 0,
+                    cursor: "pointer"
+                });
+                this.stateHitAreas[s].node.dataState = s
+            }
+            this._onClickProxy = e.proxy(this, "_onClick");
+            this._onMouseOverProxy = e.proxy(this, "_onMouseOver"),
+            this._onMouseOutProxy = e.proxy(this, "_onMouseOut");
+            for (var s in this.stateHitAreas) {
+                this.stateHitAreas[s].toFront();
+                e(this.stateHitAreas[s].node).bind("mouseout", this._onMouseOutProxy);
+                e(this.stateHitAreas[s].node).bind("click", this._onClickProxy);
+                e(this.stateHitAreas[s].node).bind("mouseover", this._onMouseOverProxy)
+            }
+        },
+        _initCreateLabels: function() {
+            var t = this.paper;
+            var n = [];
+            var r = 860;
+            var i = 220;
+            var s = this.options.labelWidth;
+            var o = this.options.labelHeight;
+            var u = this.options.labelGap;
+            var a = this.options.labelRadius;
+            var f = s / this.scale;
+            var l = o / this.scale;
+            var c = (s + u) / this.scale;
+            var h = (o + u) / this.scale * .5;
+            var p = a / this.scale;
+            var d = this.options.labelBackingStyles;
+            var v = this.options.labelTextStyles;
+            var m = {};
+            for (var g = 0, y, b, w; g < n.length; ++g) {
+                w = n[g];
+                y = (g + 1) % 2 * c + r;
+                b = g * h + i;
+                m = {};
+                if (this.options.stateSpecificLabelBackingStyles[w]) {
+                    e.extend(m, d, this.options.stateSpecificLabelBackingStyles[w])
+                } else {
+                    m = d
+                }
+                this.labelShapes[w] = t.rect(y, b, f, l, p).attr(m);
+                m = {};
+                if (this.options.stateSpecificLabelTextStyles[w]) {
+                    e.extend(m, v, this.options.stateSpecificLabelTextStyles[w])
+                } else {
+                    e.extend(m, v)
+                }
+                if (m["font-size"]) {
+                    m["font-size"] = parseInt(m["font-size"]) / this.scale + "px"
+                }
+                this.labelTexts[w] = t.text(y + f / 2, b + l / 2, w).attr(m);
+                this.labelHitAreas[w] = t.rect(y, b, f, l, p).attr({
+                    fill: "#000",
+                    "stroke-width": 0,
+                    opacity: 0,
+                    cursor: "pointer"
+                });
+                this.labelHitAreas[w].node.dataState = w
+            }
+            for (var w in this.labelHitAreas) {
+                this.labelHitAreas[w].toFront();
+                e(this.labelHitAreas[w].node).bind("mouseout", this._onMouseOutProxy);
+                e(this.labelHitAreas[w].node).bind("click", this._onClickProxy);
+                e(this.labelHitAreas[w].node).bind("mouseover", this._onMouseOverProxy)
+            }
+        },
+        _getStateFromEvent: function(e) {
+            var t = e.target && e.target.dataState || e.dataState;
+            return this._getState(t)
+        },
+        _getState: function(e) {
+            var t = this.stateShapes[e];
+            var n = this.stateHitAreas[e];
+            var r = this.labelShapes[e];
+            var i = this.labelTexts[e];
+            var s = this.labelHitAreas[e];
+            return {
+                shape: t,
+                hitArea: n,
+                name: e,
+                labelBacking: r,
+                labelText: i,
+                labelHitArea: s
+            }
+        },
+        _onMouseOut: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("mouseout", e, t)
+        },
+        _defaultMouseOutAction: function(t) {
+            var n = {};
+            if (this.options.stateSpecificStyles[t.name]) {
+                e.extend(n, this.options.stateStyles, this.options.stateSpecificStyles[t.name])
+            } else {
+                n = this.options.stateStyles
+            }
+            t.shape.animate(n, this.options.stateHoverAnimation);
+            if (t.labelBacking) {
+                var n = {};
+                if (this.options.stateSpecificLabelBackingStyles[t.name]) {
+                    e.extend(n, this.options.labelBackingStyles, this.options.stateSpecificLabelBackingStyles[t.name])
+                } else {
+                    n = this.options.labelBackingStyles
+                }
+                t.labelBacking.animate(n, this.options.stateHoverAnimation)
+            }
+        },
+        _onClick: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("click", e, t)
+        },
+        _onMouseOver: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("mouseover", e, t)
+        },
+        _defaultMouseOverAction: function(t) {
+            this.bringShapeToFront(t.shape);
+            this.paper.safari();
+            var n = {};
+            if (this.options.stateSpecificHoverStyles[t.name]) {
+                e.extend(n, this.options.stateHoverStyles, this.options.stateSpecificHoverStyles[t.name])
+            } else {
+                n = this.options.stateHoverStyles
+            }
+            t.shape.animate(n, this.options.stateHoverAnimation);
+            if (t.labelBacking) {
+                var n = {};
+                if (this.options.stateSpecificLabelBackingHoverStyles[t.name]) {
+                    e.extend(n, this.options.labelBackingHoverStyles, this.options.stateSpecificLabelBackingHoverStyles[t.name])
+                } else {
+                    n = this.options.labelBackingHoverStyles
+                }
+                t.labelBacking.animate(n, this.options.stateHoverAnimation)
+            }
+        },
+        _triggerEvent: function(t, n, r) {
+            var i = r.name;
+            var s = false;
+            var o = e.Event("usmap" + t + i);
+            o.originalEvent = n;
+            if (this.options[t + "State"][i]) {
+                s = this.options[t + "State"][i](o, r) === false
+            }
+            if (o.isPropagationStopped()) {
+                this.element.trigger(o, [r]);
+                s = s || o.isDefaultPrevented()
+            }
+            if (!o.isPropagationStopped()) {
+                var u = e.Event("usmap" + t);
+                u.originalEvent = n;
+                if (this.options[t]) {
+                    s = this.options[t](u, r) === false || s
+                }
+                if (!u.isPropagationStopped()) {
+                    this.element.trigger(u, [r]);
+                    s = s || u.isDefaultPrevented()
+                }
+            }
+            if (!s) {
+                switch (t) {
+                case "mouseover":
+                    this._defaultMouseOverAction(r);
+                    break;
+                case "mouseout":
+                    this._defaultMouseOutAction(r);
+                    break
+                }
+            }
+            return !s
+        },
+        trigger: function(e, t, n) {
+            t = t.replace("usmap", "");
+            e = e.toUpperCase();
+            var r = this._getState(e);
+            this._triggerEvent(t, n, r)
+        },
+        bringShapeToFront: function(e) {
+            if (this.topShape) {
+                e.insertAfter(this.topShape)
+            }
+            this.topShape = e
+        }
+    };
+    var c = [];
+    s(e, "usmap", l, c)
+})(jQuery, document, window, Raphael)
+
+
+
+endingPicker = (out, totv, aa, quickstats) => {
+    
+    //out = "win", "loss", or "tie" for your candidate
+    //totv = total votes in entire election
+    //aa = all final overall results data
+    //quickstat = relevant data on candidate performance (format: your candidate's electoral vote count, your candidate's popular vote share, your candidate's raw vote total)
+  
+    /*
+    e.header = "<h2></h2>"
+    e.pages = ["<p></p>",
+               "<p></p>"]
+    */
+  
+    // NORMAL ENDINGS
+  e.final_overall_results.sort((a, b) => b.popular_votes - a.popular_votes);
+  map = document.getElementById("map_container");
+          ///柯文哲结局，以自身得票率和胜利者分结局
+          if (aa[0].candidate === 2001557 && quickstats[1] > 20.0 && quickstats[1] < 25.0) {
+            used=false
+            if (used != true) {
+                        setInterval(function () {
+                            used = true;
+                            imgg = document.getElementsByClassName("person_image")[0];
+                            if (imgg != null) {
+                                imgg.src =  "https://i.ntdtv.com/assets/uploads/2024/01/id103843225-GettyImages-1929871502.jpg";
+                            }
+                        }, 100);
+                    }
+            return "<div style='overflow-y:scroll;height:250px;'><p>On November 24th, when KMT and TPP registered as presidential candidates, many observers and commentators believed that the DPP would secure its third term. However, the young supporters dedicated to you still believed that Ko Wen-je would become the next president, bringing new politics to Taiwan. On January 13th, when the election results were announced, they could hardly believe their eyes. Ko Wen-je, who had surpassed both Hou Yu-ih and Lai Ching-te in previous polls, only received less than 25% of the votes. The reality was harsh, and that night, these young individuals grew up, realizing that strength in their own world did not necessarily translate to strength in the broader political arena...</p><p>Of course, it was expected that TPP wouldn't win the presidency in this election. On the spot, you announced your intention to participate in the next presidential election in 2028, indicating that there's still a political future for you. Your party gained significant visibility in this election, along with government subsidies, where each vote translates to a subsidy of 30 NTD. TPP secured 8 legislator-at-large seats in the Legislative Yuan. Unfortunately, none of your regional legislative candidates won, but at least your influence in the parliament has expanded, which is a positive outcome.</p><p>In the future, you won't be the mayor anymore or the high-profile presidential candidate, but rather the party chairman. It will be crucial for your party to consider how to increase exposure and secure more regional governing power in 2026. Best of luck to you, Chairman Ko Wen-je, in 2026 and 2028!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div> "  
+            
+              } 
+              if (aa[0].candidate === 2001557 && quickstats[1] > 25.0 && quickstats[1] < 30.0) {
+                used=false
+                if (used != true) {
+                            setInterval(function () {
+                                used = true;
+                                imgg = document.getElementsByClassName("person_image")[0];
+                                if (imgg != null) {
+                                    imgg.src =  "https://image.cache.storm.mg/styles/smg-800x533-fp-wm/s3/media/image/2023/12/09/20231209-052001_U29087_M914746_2cdf.jpeg?itok=QD-9_lDY";
+                                }
+                            }, 100);
+                        }
+                return "<div style='overflow-y:scroll;height:250px;'>  <h3>TPP Shakes the Foundation of Two-Party System: Lai Ching-te's Victory, Ko Wen-je Stirs the Nation</h3> <p>On November 24th, when both the KMT and TPP registered as presidential candidates, many observers and commentators believed that the DPP would secure a third term. As the final stage of the election passed, the steadfast support of the youth who remained loyal to you persisted, with the belief that Ko Wen-je would become the next president, bringing a new era of politics to Taiwan. On January 13th, when the election results were revealed, they were astonished that a party established only a few years ago could garner support from over a quarter of Taiwan's voters. Although you faced defeat, such an achievement was enough to shake the two-party system and strengthen your support. Despite Lai Ching-te's victory, the youth realized that following you was a decision they didn't regret. On that night, they understood that they had bravely stood by you, striving for the hope of overturning the monopoly of the two-party system in Taiwan.</p><p>Even though winning the presidency for TPP was expected to be challenging, given your already high popularity, you announced on the spot that you would participate in the next presidential election in 2028. This implies that you still have a role to play, and your party gained significant visibility and government subsidies in this election, with each vote equivalent to a subsidy of 30 NTD. In the Legislative Yuan, you secured 8 at-large legislators, though unfortunately, none were elected in specific constituencies. Nevertheless, your influence in the parliament has expanded, which is a positive development.</p><p>Looking ahead, without the position of mayor or the spotlight of a presidential candidate, you are now just a party chairman. Figuring out how to increase exposure and help the TPP gain more local governance in 2026 is a crucial consideration for your party. Best of luck to you, Chairman Ko, in 2026 and 2028!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div>"   
+                  } 
+                  if (aa[0].candidate === 2001557 && quickstats[1] > 30.0) {
+                    used=false
+                    if (used != true) {
+                                setInterval(function () {
+                                    used = true;
+                                    imgg = document.getElementsByClassName("person_image")[0];
+                                    if (imgg != null) {
+                                        imgg.src =  "https://d1b8dyiuti31bx.cloudfront.net/NewsPhotos/20240113/105_134341361554.jpg";
+                                    }
+                                }, 100);
+                            }
+                    return "<div style='overflow-y:scroll;height:250px;'><h3>Ko Wen-je Gains 30% Voter Trust: A New Major Party Rising</h3> <p>On November 24th, when both the KMT and TPP registered as presidential candidates, many observers and commentators believed that the DPP would secure a third term. As the final stage of the election passed, the steadfast support of the youth who remained loyal to you persisted, with the belief that Ko Wen-je would become the next president, bringing a new era of politics to Taiwan. On January 13th, when the election results were revealed, they and you were not disappointed. Ko Wen-je's TPP, established only a few years ago, gained over 30% of the votes. If it had been a bit higher, you might have even won the presidential position. Unfortunately, the KMT and DPP's electoral base was too strong, and you fell short. Despite the defeat, such an achievement was enough to shake the two-party system and strengthen your support. Although Lai Ching-te still emerged victorious, the youth realized that following you that night was a decision they didn't regret. They braved it with you once, striving for the hope of overturning the monopoly of the two-party system in Taiwan. The Taiwan People's Party is likely to become another major political party in Taiwan, forming a stable tripartite competition with the DPP and KMT.</p> <p>Even though winning the presidency for TPP was expected to be challenging, given your already high popularity, you announced on the spot that you would participate in the next presidential election in 2028. This implies that you still have a role to play. The young audience below passionately chanted for another chance. Your party gained significant visibility and government subsidies in this election, with each vote equivalent to a subsidy of 30 NTD. In the Legislative Yuan, you secured 8 at-large legislators. Unfortunately, none were elected in specific constituencies. Nevertheless, your influence in the parliament has expanded, which is a positive development.</p> <p>Looking ahead, without the position of mayor or the spotlight of a presidential candidate, you are now just a party chairman. Figuring out how to increase exposure and help the TPP gain more local governance in 2026 is a crucial consideration for your party. Best of luck to you, Chairman Ko, in 2026 and 2028!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div>"  
+                      } 
+                      if (aa[0].candidate === 2001557 && quickstats[1] < 20.0) {
+                        used=false
+                        if (used != true) {
+                                    setInterval(function () {
+                                        used = true;
+                                        imgg = document.getElementsByClassName("person_image")[0];
+                                        if (imgg != null) {
+                                            imgg.src =  "https://static.rti.org.tw/assets/thumbnails/2024/01/07/031ee53a27a76779d79707bf5c48ca56.jpg";
+                                        }
+                                    }, 100);
+                                }
+                        return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Enters Third Term, TPP Becomes a Historical Footnote</h3> <p>On November 24th, when both the KMT and TPP registered as presidential candidates, many observers and commentators believed that the DPP would secure a third term. As the final stage of the election passed, the steadfast support of the youth who remained loyal to you persisted, with the belief that Ko Wen-je would become the next president, bringing a new era of politics to Taiwan. On January 13th, when the election results were revealed, the youth couldn't believe their eyes; you received a vote percentage even below 20%. What happened? With such a low vote percentage, the survival of TPP to the next election is uncertain, as your supporters might dwindle. Lai Ching-te secured the presidency, but your low vote percentage indicates that TPP might not have sustained viability. Your vote percentage wasn't much better than James Soong's in 2016. Winning the presidency is still a distant dream. The eyes of the youth were filled with tears that night; they grew up, matured, becoming adults in the political world. They realized how cruel reality could be, not just in their own strong world, but also outside...</p><p>Although your vote percentage wasn't high, no one expected a victory in this election. On the spot, you announced your participation in the next 2028 presidential election, signaling that there's still a role for you to play. Your party gained significant visibility and government subsidies in this election, with each vote equivalent to a subsidy of 30 NTD. In the Legislative Yuan, you secured 7 at-large legislators. Unfortunately, none were elected in specific constituencies. Nevertheless, your influence in the parliament has expanded, which is a positive development.</p><p>Looking ahead, without the position of mayor or the spotlight of a presidential candidate, you are now just a party chairman. Figuring out how to increase exposure and help the TPP gain more local governance in 2026 is a crucial consideration for your party. Best of luck to you, Chairman Ko, in 2026 and 2028!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div>"  
+                          } 
+                      if (aa[0].candidate === 2001591 && quickstats[1] > 20.0 && quickstats[1] < 25.0) {
+                        used=false
+                        if (used != true) {
+                                    setInterval(function () {
+                                        used = true;
+                                        imgg = document.getElementsByClassName("person_image")[0];
+                                        if (imgg != null) {
+                                            imgg.src =  "https://i.epochtimes.com/assets/uploads/2023/12/id14132681-652212-600x400.jpg";
+                                        }
+                                    }, 100);
+                                }
+                        return "<div style='overflow-y:scroll;height:250px;'> <h3>Party Alternation Again, DPP Fades: KMT Secures Victory in 2024!</h3> <p>On November 24th, when both the KMT and TPP registered as presidential candidates, many observers and commentators believed that the DPP would secure a third term. As the final stage of the election passed, the steadfast support of the youth who remained loyal to you persisted, with the belief that Ko Wen-je would become the next president, bringing a new era of politics to Taiwan. On January 13th, when the election results were revealed, the unexpected happened: Hou You-yi and the KMT surpassed both you and Lai Ching-te. What happened on November 23rd must have affected the current outcome, leading to your vote percentage being below 25%. Winning the presidency remains a distant dream. The KMT, once disdained by you, reclaimed the presidential position. The 8-year curse continues, and the eyes of the youth who supported you were filled with tears that night. They grew up and matured, becoming adults in the political world. They realized how cruel reality could be, not just in their own strong world, but also outside...</p> <p>Although your vote percentage wasn't very high, no one expected a victory in this election. At least it shook the future of the two-party system and the KMT government. On the spot, you announced your participation in the next 2028 presidential election, signaling that there's still a role for you to play. Your party gained significant visibility and government subsidies in this election, with each vote equivalent to a subsidy of 30 NTD. In the Legislative Yuan, you secured 8 at-large legislators. Unfortunately, none were elected in specific constituencies. Nevertheless, your influence in the parliament has expanded, which is a positive development.</p><p>Looking ahead, without the position of mayor or the spotlight of a presidential candidate, you are now just a party chairman. Figuring out how to increase exposure and help the TPP gain more local governance in 2026 is a crucial consideration for your party. Best of luck to you, Chairman Ko, in 2026 and 2028!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div>"  
+                        
+                          } 
+                          if (aa[0].candidate === 2001591 && quickstats[1] > 25.0 && quickstats[1] < 30.0) {
+                            used=false
+                            if (used != true) {
+                                        setInterval(function () {
+                                            used = true;
+                                            imgg = document.getElementsByClassName("person_image")[0];
+                                            if (imgg != null) {
+                                                imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/800/20240113/2000x1333_wmky_321863552021_0.jpg";
+                                            }
+                                        }, 100);
+                                    }
+                            return "<div style='overflow-y:scroll;height:250px;'><h3>Kuomintang Triumphs Over DPP: TPP Emerges as the New Force of the Third Party</h3> <p>On November 24, when both the KMT and TPP registered as presidential candidates, many observers and commentators predicted that the DPP would secure its third term. As the final stages of the campaign unfolded, the steadfast young supporters still believed that Ko Wen-je would become the next president, bringing a new era to Taiwan. However, on January 13, when the election results were revealed, the KMT, led by Hou You-yi, surpassed both you and Lai Ching-te. This surprising turn of events could be attributed to your performance on November 23. Although your vote share exceeded 25%, it was far from winning the presidency. Nevertheless, this marks the strongest performance of a third party since James Soong in 2000.</p> <p>Unfortunately, the once-dismissed KMT and Hou You-yi reclaimed the presidential position, leveraging their strong support base. The curse of eight years persisted, and the eyes of the young supporters who backed you were filled with tears. On that night, they matured, growing into adults in the political world. They realized that reality is cruel, and strength in their own bubble doesn't necessarily translate to strength in the wider world.</p><p>Your vote share, while impressive for a third party, was not enough to secure the presidency. Nonetheless, your participation in this election has shaken the future of the two-party system and the KMT government. You promptly announced your intention to participate in the next presidential election in 2028, indicating that you still have a role to play. Your party gained significant visibility and received government subsidies in this election, with each vote equivalent to a subsidy of 30 New Taiwan Dollars. You also secured eight at-large legislative seats, although none were won in regional constituencies. Nevertheless, your influence in the parliament has expanded, which is a positive development.</p><p>In the future, you may no longer be the mayor or the highly anticipated presidential candidate, but rather the party chairman. How to increase exposure and ensure that TPP gains more local governance in 2026 is a matter your party needs to carefully consider. Best of luck to you in 2026 and 2028, Chairman Ko Wen-je!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div>"  
+                              } 
+                              if (aa[0].candidate === 2001591 && quickstats[1] > 30.0) {
+                                used=false
+                                if (used != true) {
+                                            setInterval(function () {
+                                                used = true;
+                                                imgg = document.getElementsByClassName("person_image")[0];
+                                                if (imgg != null) {
+                                                    imgg.src =  "https://image1.thenewslens.com/2024/1/wx33finxgrblpxqsfigaxro95slkwi.jpeg?fm=jpg&format=crop&h=630&q=70&w=1200";
+                                                }
+                                            }, 100);
+                                        }
+                                return " <div style='overflow-y:scroll;height:250px;'><h3>Rise of the TPP: DPP Faces Complete Failure, KMT Secures Presidency</h3><p>On November 24, when both the KMT and TPP registered as presidential candidates, many observers and commentators predicted that the DPP would secure its third term. As the final stages of the campaign unfolded, the steadfast young supporters still believed that Ko Wen-je would become the next president, bringing a new era to Taiwan. However, on January 13, when the election results were revealed, the KMT, led by Hou You-yi, surpassed both you and Lai Ching-te. This surprising turn of events could be attributed to your performance on November 23. While it had some impact, your vote share reached nearly 30%. Although it was not enough to win the presidency, it made your young supporters extremely proud.</p> <p>This marks the most powerful performance of a third party since James Soong in 2000. Unfortunately, the once-dismissed KMT and Hou You-yi reclaimed the presidential position, leveraging their strong support base. The curse of eight years persisted, and on that night, the young people who supported you realized that following you was not a decision they regretted. They wholeheartedly joined you in the hope of overturning the duopoly of the two-party system in Taiwan. The Taiwan People's Party (TPP) is likely to become another major political party in Taiwan, creating a stable triangular competition with the DPP and KMT.</p> <p>Your vote share is exceptional for a third party, and if you can maintain this level of support and base in the next four years, winning the presidency is entirely possible. This has shaken Taiwan's two-party system, the current DPP government, and the future KMT government. You promptly announced your intention to participate in the next presidential election in 2028, indicating that you still have a role to play. The young people in the audience demanded you to give it another shot. Your party gained significant visibility and received government subsidies in this election, with each vote equivalent to a subsidy of 30 New Taiwan Dollars. You also secured eight at-large legislative seats, although none were won in regional constituencies. Nevertheless, your influence in the parliament has expanded, which is a positive development.</p><p>In the future, you may no longer be the mayor or the highly anticipated presidential candidate but rather the party chairman. How to increase exposure and ensure that TPP gains more local governance in 2026 is a matter your party needs to carefully consider. Best of luck to you in 2026 and 2028, Chairman Ko Wen-je!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div>"  
+                                  } 
+                                  if (aa[0].candidate === 2001591 && quickstats[1] < 20.0) {
+                                    used=false
+                                    if (used != true) {
+                                                setInterval(function () {
+                                                    used = true;
+                                                    imgg = document.getElementsByClassName("person_image")[0];
+                                                    if (imgg != null) {
+                                                        imgg.src =  "https://media.zenfs.com/ko/news_tvbs_com_tw_938/b1d97931cbbe610f15b2cd031f8176da";
+                                                    }
+                                                }, 100);
+                                            }
+                                    return "<div style='overflow-y:scroll;height:250px;'><h3>KMT Completes Party Alternation, TPP Becomes a Historical Footnote</h3><p>On November 24, when the KMT and TPP registered as presidential candidates, many observers and commentators believed the DPP would secure its third term. As the final campaign stage passed, the steadfast young supporters still believed Ko Wen-je would become the next president and bring a new era to Taiwan. However, on January 13, when the voting results were revealed, the young people couldn't believe their eyes – you received a vote share of less than 20%. What happened? With such a low vote share, it's unlikely you'll survive until the next election, and your supporters might vanish. Hou You-yi won the presidency, but your low vote share may hinder TPP's sustained viability, barely surpassing James Soong's performance in 2016. It's a long way from winning the presidency. Tears filled the eyes of the young people that night; they grew up, realizing the harsh reality that strength in their own world doesn't necessarily translate to strength outside...</p><p>Although your vote share isn't high, no one expected you to win in this election. You immediately announced your participation in the next presidential election in 2028, indicating there's still a role for you to play. Your party gained significant visibility and government subsidies in this election – each vote equivalent to 30 New Taiwan Dollars in subsidies. You secured 7 at-large legislative seats, unfortunately none in regional constituencies. However, your influence in the parliament has expanded, which is a positive development.</p><p>In the future, you may no longer be the mayor or the highly anticipated presidential candidate but rather the party chairman. How to increase exposure and ensure that TPP gains more local governance in 2026 is a matter your party needs to carefully consider. Best of luck to you in 2026 and 2028, Chairman Ko Wen-je!</p><h3>Ke’s defeat speech:</h3><p>This election, amidst the blue-green competition, saw many people willing to step forward despite the challenging circumstances. We have successfully proven to the world that Taiwan is not limited to blue and green. With continuous effort, I believe we will gain more recognition and unite more strength in the next four years. Next time, we will undoubtedly take office and reclaim this country.</p><p>In this election, facing the blue-green competition, many individuals bravely stood up and persisted against the formidable blue-green barriers. I want to express my gratitude to my campaign team and, more importantly, to the grassroots supporters who stepped forward nationwide. Thank you all.</p><p>This election has successfully demonstrated to the world that Taiwan is not just blue and green. It has also reaffirmed that democracy is always Taiwan's most vital asset. We achieved many miracles in this election without hosting fundraising banquets, relying solely on everyone's small donations. This will undoubtedly have a positive impact on Taiwan's future political development.</p><p>The enthusiasm of elections is temporary, but the love for Taiwan should be enduring. On the path to justice and towards a sustainable nation, I, Ko Wen-je, will not give up, and I implore everyone not to give up. This time, the Taiwan People's Party has become a crucial force in opposition. As the party chairman, I want to express my thanks. Each vote is an expression of recognition and affirmation for the Taiwan People's Party, marking Taiwan's first time under the blue-green squeeze, establishing a new scenario with three parties standing strong.</p><p>This signifies that Taiwan truly needs voices beyond the blue and green, and this voice will become the new direction for the country. In democratic politics, the opposition serves as a supervisory force, political conscience, and a reliable strength for the people. Therefore, I ask you not to give up because I won't. The Taiwan People's Party won't give up. We will continue to be here, serving as Taiwan's conscience and your support.</p><p>Dear Taiwanese people, the Taiwan People's Party promises here that we will not disappoint your expectations. We will adhere to our beliefs, guard this country, and protect the future. Tonight, I believe everyone is feeling sad, but we don't have time for sorrow because this country will continue to move forward. So, we must continue to strive forward. We won't give up just because of setbacks. As long as we continue to love Taiwan, as long as you persist, as long as you don't give up, we have no reason to give up either.</p><p>Tomorrow, I will still go to work at 7:30 sharp. We must continue to fight for our future because we have only one Taiwan, and our future depends on us. As long as we keep working hard, I believe that in the next four years, we will gain more recognition and unite more strength. Next time, we will undoubtedly take office and reclaim this country.</p><p>As long as we bravely move forward, ideals have a chance to be realized. Let's continue to fight relentlessly. For me, in the past 10 years, whether in governance or elections, I have treated it as a social movement to change political culture. Since this movement has not fully realized, I will continue to strive. Don't be disheartened; after all, we have taken the first step towards success. Four years from now, I believe we will confidently cast our votes for Ko Wen-je and the Taiwan People's Party, just like today.</p></div>"  
+                                      } 
+                                  //白莲教结局
+                                  if (aa[0].candidate === 2001622 && quickstats[1] < 35.0){
+                                    used=false
+                                    if (used != true) {
+                                                setInterval(function () {
+                                                    used = true;
+                                                    imgg = document.getElementsByClassName("person_image")[0];
+                                                    if (imgg != null) {
+                                                        imgg.src =  "https://image.cache.storm.mg/styles/smg-800x533-fp/s3/media/image/2023/12/30/20231230-105730_U28894_M921121_1023.jpg?itok=vd3ZzsLd";
+                                                    }
+                                                }, 100);
+                                            }
+                                    return "<div style='overflow-y:scroll;height:250px;'><h3>Miracles Are Always Possible: Ko Wen-je Breaks Taiwan's Two-Party System, Wins Presidency</h3><p>On November 24, after you and the KMT introduced your respective vice-presidential candidates, everyone believed it was a sure thing for Lai Ching-te to become the next president. However, reality proved them all wrong. Despite Hou You-yi and Zhao Shao-kang boosting the KMT's prospects, the erosion of Lai Ching-te's support base and your party's excellent early campaign operations allowed you to maintain around 30% support in the final month. On election day, it was almost unbelievable; Ko Wen-je and Lai Ching-te, Hou You-yi were neck-and-neck in the vote count. After two hours, Ko Wen-je established a stable lead, and the hearts of young people pounded with excitement. They knew they were witnessing a new history and a new politics in Taiwan. A five-year-old party defeated the two major parties, KMT and DPP, in the presidential election. In that moment, with tears in their eyes, they chose to believe in miracles, to believe in risking it all for once!</p><p>The victory of the TPP and Ko Wen-je in the presidential race marks a new era in Taiwanese politics. On May 20, you will form a new government, securing 10 at-large legislative seats in the Legislative Yuan, and even winning one regional seat in the first electoral district of Taichung. Unfortunately, other regional candidates did not succeed due to their limited local foundations. Nevertheless, your influence in the parliament has expanded, which is a positive development. However, Taiwan has never seen such a small majority in the presidency. You will need to collaborate with both blue and green camps to pass any legislation, signifying that your governance will be constrained. Nonetheless, it also provides an opportunity to realize your vision of a coalition government and a united cabinet!</p><p>Looking ahead, what image will you shape for Taiwan? How should relations progress among China, the United States, and Taiwan? Economic, domestic, and energy policies, defense, and diplomacy are all challenges that the young TPP must confront. Winning the election is only the first step; governing the country is a more difficult task. How to secure more regional governance for the TPP in 2026 is something you and your party need to carefully consider. If you succeed, you might attempt re-election in 2028. Wishing you the best of luck in 2026 and 2028, President Ko Wen-je!</p></div>"  
+                                      } 
+                                      if (aa[0].candidate === 2001622 && quickstats[1] > 35.0  && quickstats[1] < 41.0){
+                                        used=false
+                                        if (used != true) {
+                                                    setInterval(function () {
+                                                        used = true;
+                                                        imgg = document.getElementsByClassName("person_image")[0];
+                                                        if (imgg != null) {
+                                                            imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/800/20240114/1200x798_wmky_641658631642_202401120168000000.jpg";
+                                                        }
+                                                    }, 100);
+                                                }
+                                        return "<div style='overflow-y:scroll;height:250px;'><h3>TPP Overpowers the Bipartisan System: Ko Wen-je Secures Presidency with Over 35% of Votes</h3> <p>On November 24, after both you and the KMT introduced vice-presidential candidates, everyone believed it was a done deal for Lai Ching-te to become the next president. However, reality proved them wrong. Despite the efforts of Hou You-yi and Zhao Shao-kang to boost the blue camp's prospects, the erosion of Lai Ching-te's support base, your party's excellent early campaign operations, and nearly flawless performances in debates allowed you to maintain a support rate of around 35% in the last month. On election day, the results were almost unbelievable—Ko Wen-je consistently held a fragile but stable lead, always ranking first. The hearts of the younger generation pounded as they witnessed the new history and politics of Taiwan. A new party, only five years old, defeated the KMT and DPP in the presidential election. In this moment, tears welled up, yet they chose to believe in miracles, believing in going all out with no regrets!</p><p>The TPP and Ko Wen-je securing the presidency mark a new era in Taiwanese politics. On May 20, you will form a new government, having gained 13 at-large legislators in the Legislative Yuan, already on par with the blue and green parties. Additionally, you obtained one regional legislator, representing Taichung's first electoral district. Unfortunately, other regional candidates were not successful due to their limited local bases. Nevertheless, your influence in the parliament has expanded, which is a positive development. However, Taiwan has never seen such a minority president. To pass any bills, you must cooperate with both the blue and green camps, meaning your governance will face constraints. Yet, you can still realize your vision of a coalition government and a joint cabinet!</p> <p>Looking ahead, what image will you shape for Taiwan? How should the relationships between China, the United States, and Taiwan evolve? Economic, domestic, and energy policies, defense, and diplomacy are challenges the young TPP must confront. Winning the election is only the first step; governing the country is the more difficult task. How to ensure TPP gains more local governance power in 2026 is something you and your party need to carefully consider. Your current approval rating is sufficient for a re-election attempt in 2028, but it will depend on your ongoing support and the situation with the blue and green parties. Best of luck in 2026 and 2028, President Ko Wen-je!</p></div>"  
+                                          } 
+                                          if (aa[0].candidate === 2001622 && quickstats[1] > 41.0 ) {
+                                            used=false
+                                            if (used != true) {
+                                                        setInterval(function () {
+                                                            used = true;
+                                                            imgg = document.getElementsByClassName("person_image")[0];
+                                                            if (imgg != null) {
+                                                                imgg.src =  "https://cc.tvbs.com.tw/img/upload/2023/05/11/20230511101843-4fbdaa77.jpg";
+                                                            }
+                                                        }, 100);
+                                                    }
+                                            return "<div style='overflow-y:scroll;height:250px;'><h3>Green-White Showdown: Lai Ching-te Upended, Ko Wen-je Triumphs as President!</h3><p>When the Blue-White Joint Ticket was formed, Lai Ching-te had to wake up from his dream and seriously face your campaign. However, with the erosion of Lai Ching-te's support base, your party's excellent early operations, nearly flawless performances in debates, and the full cooperation of the KMT, you maintained over 50% support in the last month. On election day, it was almost unbelievable—Ko Wen-je consistently held a fragile but stable lead, always ranking first. The hearts of the younger generation pounded as they witnessed the new history and politics of Taiwan. A new party, only five years old, defeated the corrupt and incompetent ruling party, the DPP, which had been in power for eight years. In this moment, tears welled up, yet they chose to believe in miracles, believing in going all out with no regrets!</p><p>The TPP and Ko Wen-je securing the presidency mark a new era in Taiwanese politics. On May 20, you will form a new government, having gained 13 at-large legislators in the Legislative Yuan, already on par with the blue and green parties. Additionally, you obtained one regional legislator, representing Taichung's first electoral district. Unfortunately, other regional candidates were not successful due to their limited local bases. Nevertheless, your influence in the parliament has expanded, which is a positive development. However, Taiwan has never seen such a minority president. To pass any bills, you must cooperate with both the blue and green camps, meaning your governance will face constraints. Yet, you can still realize your vision of a coalition government and a joint cabinet!</p><p>Looking ahead, what image will you shape for Taiwan? How should the relationships between China, the United States, and Taiwan evolve? Economic, domestic, and energy policies, defense, and diplomacy are challenges the young TPP must confront. Winning the election is only the first step; governing the country is the more difficult task. How to ensure TPP gains more local governance power in 2026 is something you and your party need to carefully consider. Your current approval rating is sufficient for a re-election attempt in 2028, but it will depend on your ongoing support and the situation with the blue and green parties. Best of luck in 2026 and 2028, President Ko Wen-je!</p></div>"  
+                                              } 
+                                              if (aa[1].candidate === 2001622 && quickstats[1] > 41.0 ) {
+                                                used=false
+                                                if (used != true) {
+                                                            setInterval(function () {
+                                                                used = true;
+                                                                imgg = document.getElementsByClassName("person_image")[0];
+                                                                if (imgg != null) {
+                                                                    imgg.src =  "https://cc.tvbs.com.tw/img/upload/2023/05/11/20230511101843-4fbdaa77.jpg";
+                                                                }
+                                                            }, 100);
+                                                        }
+                                                return "<div style='overflow-y:scroll;height:250px;'><h3>Bitter Defeat: Lai Ching-te and DPP Enter Third Term, Ko Wen-je Misses Presidency</h3><p>When the Blue-White Joint Ticket was formed, Lai Ching-te had to wake up from his dream and seriously face your campaign. However, your poor performance in the later stages of operations and debates negatively impacted your nationwide support, and by the end of the polling, you were trailing behind Lai Ching-te. On January 13, during the vote-counting program, the hearts of the younger generation pounded as they knew they were witnessing a new history and politics in Taiwan. Although Ko Wen-je and Lai Ching-te's rankings frequently exchanged places, a deathly silence shrouded your campaign headquarters a few hours later. Lai Ching-te still emerged victorious, leaving the young people in tears, wondering why things didn't turn out as they had hoped. You had to awkwardly deliver a concession speech, even though just a month ago, you were leading Lai Ching-te. Today proved that you were not the strongest.</p> <p>While the Joint Ticket didn't secure victory for you, it left 60% (perhaps less than 50%) of the people who hoped for a change in political parties disappointed. They questioned whether your capabilities were not as strong as you had previously claimed. However, you immediately announced your participation in the next presidential election in 2028, indicating that you still have a chance. Your party gained significant visibility in this election, along with government subsidies, where each vote is equivalent to a subsidy of NT$30. You also obtained 11 at-large legislators in the Legislative Yuan. Unfortunately, none of your regional legislators were successful, but your influence in the parliament has at least expanded, which is a positive development.</p><p>Looking ahead, with no mayoral position and not being the highly anticipated presidential candidate, but only the party chairman, how will you increase exposure and how the TPP can gain more local governance power in 2026 are crucial considerations for your party. Best of luck in 2026 and 2028, Chairman Ko Wen-je!</p></div>"  
+                                                  } 
+    }
+
+// in-game achievements
+
+setInterval(endingPicker, 250);
+
+//注释代码
+function getTooltips(str) {
+    let matches = [];
+
+    tooltipList.forEach((tooltip, index) => {
+        // Adjust the regex to match searchString potentially surrounded by “ and followed by optional punctuation
+       let regex = new RegExp(`(?<=\\b|\\s|^|“)${tooltip.searchString}(?=[.,;!?]?\\b|\\s|”|$)`, 'g');
+
+
+        let match;
+        while ((match = regex.exec(str)) !== null) {
+            matches.push({
+                start: match.index + (match[0].startsWith('“') ? 1 : 0), // Adjust for potential starting “
+                end: match.index + match[0].length - (match[0].endsWith('”') ? 1 : 0) - (match[2] ? 1 : 0), 
+                tooltipIndex: index
+            });
+        }
+    });
+
+    // Sort by starting position; if two start at the same position, longer match comes first
+    matches.sort((a, b) => a.start - b.start || b.end - b.start - (a.end - a.start));
+
+    // Filter out overlaps
+    for (let i = 0; i < matches.length - 1; ) {
+        if (matches[i + 1].start < matches[i].end) {
+            matches.splice(i + 1, 1); // Remove the next match since it overlaps
+        } else {
+            i++; // Move to next match
+        }
+    }
+
+    return matches;
+}
+function applyTooltips(str) {
+    const matches = getTooltips(str);
+    let result = '';
+    let lastIndex = 0;
+
+    matches.forEach(match => {
+        const tooltip = tooltipList[match.tooltipIndex];
+        result += str.slice(lastIndex, match.start);
+        result += `<span class='mytooltip'>${tooltip.searchString}<span class='mytooltiptext'>${tooltip.explanationText}</span></span>`;
+        lastIndex = match.end;
+    });
+
+    result += str.slice(lastIndex); // Add the remainder of the original string
+    return result;
+}
+
+function applyTooltipsToObject(obj) {
+    for (let key in obj) {
+        if (typeof obj[key] === 'string') {
+            obj[key] = applyTooltips(obj[key]);
+        } else if (typeof obj[key] === 'object') {
+            applyTooltipsToObject(obj[key]); // Recursive call
+        }
+    }
+}
+
+applyTooltipsToObject(campaignTrail_temp.questions_json);
+applyTooltipsToObject(campaignTrail_temp.answers_json);
+applyTooltipsToObject(campaignTrail_temp.answer_feedback_json);

--- a/static/mods/2024ROC_Lai-Hsiao.json
+++ b/static/mods/2024ROC_Lai-Hsiao.json
@@ -1,0 +1,8115 @@
+e=campaignTrail_temp // this is redundant, but Decstar uses this because it looks nicer in the code.
+campaignTrail_temp.multiple_endings=true
+campaignTrail_temp.cyoa = true
+campaignTrail_temp.questions_json = [
+    {
+        "model": "campaign_trail.question",
+        "pk": 12989,
+        "fields": {
+            "priority": 0,
+            "description": "Congratulations on being elected as the 18th Democratic Progressive Party (DPP) chairman, especially following the DPP's significant loss in the 2022 local elections and President Tsai Ing-wen's resignation from the position. As the current leader of the DPP, what would you like to emphasize at this moment?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12990,
+        "fields": {
+            "priority": 0,
+            "description": "After seven years in power, it seems that the people's attitude towards the DPP is no longer as enthusiastic as it was in 2016. Opinion polls indicate that the support rate for the Kuomintang's candidate, Hou You-yi, is on par with yours. Additionally, there is a possibility of Taiwan People's Party's (TPP) candidate Ko Wen-je joining this election. Vice President Lai, what kind of image do you plan to bring in this election?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12991,
+        "fields": {
+            "priority": 0,
+            "description": "This year, there are two legislative by-elections. The January election for the third Constituencyof Taipei City was won by the KMT. Next is the by-election for the second Constituency of Nantou County, where you can exert your influence to help the Democratic Progressive Party (DPP) secure a victory. This district is considered challenging for the DPP, but the DPP candidate, Cai Pei-hui, is working hard to gain the trust of the local people. How do you plan to assist her?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12992,
+        "fields": {
+            "priority": 0,
+            "description": "Some bad news has arrived: according to the latest intelligence, Honduras has announced the termination of diplomatic relations with Taiwan. Currently, our country only has 13 diplomatic allies left. The Ministry of Foreign Affairs has confirmed this and issued a strong protest. What are your comments on this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12993,
+        "fields": {
+            "priority": 0,
+            "description": "April 12th, the Democratic Progressive Party Central Executive Committee announced that Chairman Lai Ching-te has been nominated as the party's presidential candidate for the 2024 elections. Congratulations on being selected as the Democratic Progressive Party's presidential candidate for 2024! In this exciting moment, what would you like to emphasize the most?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12994,
+        "fields": {
+            "priority": 0,
+            "description": "Starting from April this year, a TV drama called \"Wave Makers\" has gained popularity in Taiwan. The drama portrays how sexual harassment allegations have severely impacted the ruling party. However, nobody anticipated that it would have an impact on the real world. Within the DPP, a party worker has accused a vendor employee who used to share a ride with them of sexual harassment. This immediately triggered a series of subsequent disclosures by victims. how would you address these situations?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12995,
+        "fields": {
+            "priority": 0,
+            "description": "Chairman Lai, great news! It seems we have found a position to attack. There has been an incident in New Taipei City where numerous children were allegedly fed unknown substances and subjected to inappropriate punishment. This incident has gained significant attention, and the parents of the children are dissatisfied with the response from the New Taipei City government and the police. Should we express our opinions on this matter? It could be a fantastic opportunity for us to criticize Mayor Hou and the Kuomintang!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12996,
+        "fields": {
+            "priority": 0,
+            "description": "On May 17th, there are two significant pieces of news that you need to take a look at. The primary election competition within the KMT party has finally concluded, with Hou You-yi defeating Gou, the chairman of Hon Hai Precision Industry, and emerging as the KMT's presidential candidate for 2024. On the other hand, the Taiwan People's Party has unquestionably nominated former Taipei Mayor Ko Wen-je as their presidential candidate. Who do you want to primarily target in the upcoming election battle?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12997,
+        "fields": {
+            "priority": 0,
+            "description": "it's time to put forward some specific policies. As an 8-year ruling party, your position in the minds of the Taiwanese people is complex. According to recent polls, about 60% of the people do not support the DPP for a third term. What policies on your platform do you need to emphasize to attract and maintain voters' enthusiasm?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12998,
+        "fields": {
+            "priority": 0,
+            "description": "As time moves into July, it seems that the TPP is planning a major demonstration. The opposition camp is dissatisfied with the lack of residential justice and judicial reform by the DPP government. They are preparing to hold a march on Ketagalan Boulevard in front of the Presidential Office. It is said that all potential presidential candidates will be asked to participate in this event. However, this march is widely seen as a demonstration in support of the TPP. If you also plan to join, there may be unexpectedly awkward situations. What is your attitude towards this march?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 12999,
+        "fields": {
+            "priority": 0,
+            "description": "The latest news has arrived - the KMT's national representative assembly has officially announced Hou You-yi as the presidential candidate. He defeated Terry Gou and resisted the internal voices within the party who sought to \"replace Hou You-yi.\" What kind of attacks and criticisms do you intend to make against the KMT and Hou in this election?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13000,
+        "fields": {
+            "priority": 0,
+            "description": "With about half a year until the presidential election day, as the current Vice President, you have plenty of time to participate in activities or campaign because the Constitution does not assign you too many responsibilities. In which regions do you primarily plan to visit and campaign?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13001,
+        "fields": {
+            "priority": 0,
+            "description": "As the Vice President, one of your few responsibilities is to represent the President in visiting foreign countries and maintaining friendly relations. You are about to visit Paraguay, a diplomatic ally of Taiwan, to attend the presidential inauguration of Santiago Peña. During the transit in the United States en route to Paraguay, you plan to engage in informal sightseeing and visits. What do you want to emphasize during the journey?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13002,
+        "fields": {
+            "priority": 0,
+            "description": "After returning to Taiwan, you are invited to participate in a less political rally. You are invited to join the Civic Square Action to promote transportation reform in Taiwan, aiming to raise awareness of pedestrian safety and improve the current state of transportation to reduce pedestrian casualties. Would you like to participate in this rally?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13003,
+        "fields": {
+            "priority": 0,
+            "description": "Vice President, Taiwan has encountered another diplomatic setback as the Central American Parliament approved Nicaragua's proposal to revoke the ROC's permanent observer status, recognizing the PRC as the sole legitimate representative of China. It seems our influence in Central America has been further weakened. how should the government respond?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13004,
+        "fields": {
+            "priority": 0,
+            "description": "Well... given the challenging diplomatic situation, let's focus on some positive news.Terry Gou, who was eliminated in the primary of the Kuomintang, has made a comeback. He announced his candidacy at today's \"Mainstream Opinion Alliance Press Conference,\" aiming to gather enough citizen signatures to qualify as a candidate again. This should be good news for you as he is a deep-blue candidate, evidently capable of diverting votes from Hou You-yi and Ko Wen-je.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13005,
+        "fields": {
+            "priority": 0,
+            "description": "As the election gradually enters deep waters, it's time to propose a new wave of specific policies and set a new pace for the campaign! What specific policies do you want to emphasize?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13006,
+        "fields": {
+            "priority": 0,
+            "description": "On October 10th, it is the National Day of the Republic of China. However, this year's National Day celebration was boycotted by the KMT and KMT county and city leaders because the National Day logo did not include the name of the Republic of China. Both in Chinese and English, only \"Taiwan\" was displayed, which the KMT viewed as an attempt to erase the existence of the Republic of China. They chose to hold their own flag-raising activities in the 15 counties and cities where they are in power. What is your response to this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13007,
+        "fields": {
+            "priority": 0,
+            "description": "On October 21st, the national campaign headquarters of Lai Ching-te was established in Taipei. President Tsai Ing-wen also attended the event to celebrate. Afterward, President Tsai and Lai Ching-te jointly delivered speeches. Lai Ching-te mentioned that the location of the campaign headquarters is an auspicious place and he hopes to continue the good fortune of President Tsai's two election victories. He aims to win by a large margin, continue the green governance, and further strengthen Taiwan on the path of democracy.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13008,
+        "fields": {
+            "priority": 0,
+            "description": "After Terry Gou announced his candidacy for President of Taiwan, it seems that China has set its sights on his campaign activities. Investigations regarding taxation and land use have been initiated in multiple locations in China. This may present an opportunity for us to capitalize on to counter China's actions, strengthen our support base, and assist Terry Gou. Would you like to voice your opinion?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13009,
+        "fields": {
+            "priority": 0,
+            "description": "Today, the joint tickets between the KMT and the TPP has been brought to the forefront. Meetings between Ko and Hou have taken place multiple times to determine the candidates for President and Vice President, but no decision has been reached yet. If the blue and white coalition succeeds, their polling numbers will likely surpass yours, making it very possible that you may not be elected as President. What are your thoughts on this?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13010,
+        "fields": {
+            "priority": 0,
+            "description": "It's time for the visits to various places again. In this upcoming visit, which regions do you want to focus on primarily?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13011,
+        "fields": {
+            "priority": 0,
+            "description": "Oh Damn... it seems like something that could completely ruin your campaign has happened: DPP candidate Zhao Tianlin for the 6th constituency of Kaohsiung has been caught in an extramarital affair. Made things even worse, that women he had an affair with is a Chinese national. Zhao Tianlin is even a member of the Legislative Youan's Foreign Affairs and National Defense Committee, potentially jeopardizing highly sensitive military and diplomatic information. This has led the public to perceive the DPP as “Kissing China Licking Commie” .facing heavy criticism from the opposition party. Immediate measures need to be taken to remedy this!",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13012,
+        "fields": {
+            "priority": 0,
+            "description": "As the impact of the Zhao Tianlin incident fades away, it seems that cooperation between the KMT and the TPP has been reached. I regret to inform you that they have decided to run on a joint ticket in the presidential election. The results of various polls will determine the final presidential and vice-presidential candidates. This is seen as favorable to the KMT, as if the polls are within the margin of error, it will be considered a victory for Hou You-yi. The poll numbers between Hou and Ke are very close... the DPP may be destined to fall in the face of the curse of eight years.",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13013,
+        "fields": {
+            "priority": 0,
+            "description": "On November 18, in the darkness of the midnight, the poll experts designated by the KMT and the TPP were discussing the final results of various polls and the polls indicating victory for the different sides to determine the presidential and vice-presidential candidates. The ultimate result was...",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13014,
+        "fields": {
+            "priority": 0,
+            "description": "As the KMT and TPP finalized its presidential candidate, it was also time for you to announce your running mate because there were only a few days left until the deadline for presidential candidate registration. There have been rumors circulating for some time that Hsiao Bi-khim, Taiwan's representative to the United States, would be your vice-presidential candidate for the election. On November 20, you indeed chose Hsiao Bi-khim as your vice-presidential candidate. What was the reason behind your choice?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13015,
+        "fields": {
+            "priority": 0,
+            "description": "During the campaign process, there are many interesting campaign advertisements worth mentioning. The DPP has released a series of various campaign ads to combat the opposition. Which one is your favorite?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13016,
+        "fields": {
+            "priority": 0,
+            "description": "One month before the election, your family home in Wanli District, New Taipei City, seems to have run into trouble. While it was discovered long ago that your home is considered an existing illegal structure, the issue has recently escalated. Many people are suggesting that you should demolish the house. However, this house is a property left by your family when they worked as miners. What steps should you take to prevent this house from impacting your electoral prospects?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13017,
+        "fields": {
+            "priority": 0,
+            "description": "As the presidential election enters the final sprint in December, presidential debates and policy forums are set to take place.  Amid all these political statements and rhetoric, is there anything that you are particularly proud of and concerned about?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 13018,
+        "fields": {
+            "priority": 0,
+            "description": "In the last week before the election, you have one final opportunity to influence support and party preferences in a specific region, which could ultimately determine the election outcome. Where would you like to hold your Election night campaign activities?",
+            "likelihood": 1
+        }
+    },
+    {
+        "model": "campaign_trail.question",
+        "pk": 15781,
+        "fields": {
+            "priority": 0,
+            "description": "As the presidential debate kicks off, you go head-to-head with Mayor Hou on stage. He speaks Mandarin with a strong Taiwanese accent, interweaving Taiwanese phrases in his speech. Your eloquence and image are probably stronger than his. So, what issues do you primarily want to focus on during the debate?",
+            "likelihood": 1
+        }
+     },
+    {
+        "model": "campaign_trail.question",
+        "pk": 195000,
+        "fields": {
+          "priority": 1,
+          "description": "Today, you will engage in a face-to-face debate showdown with the articulate TPP Chairman Ko Wen-je. You did not expect that a third-party candidate could possibly become the future president today, but you will not allow such a thing to happen, and the debate is your opportunity to outshine him. In what aspects do you plan to attack him? ",
+          "likelihood": 1
+    }
+    },
+    {
+    "model": "campaign_trail.question",
+    "pk": 1950,
+    "fields": {
+      "priority": 1,
+      "description": "As the presidential debate kicks off, you go head-to-head with Mayor Hou on stage. He speaks Mandarin with a strong Taiwanese accent, interweaving Taiwanese phrases in his speech. Your eloquence and image are probably stronger than his. So, what issues do you primarily want to focus on during the debate?",
+      "likelihood": 1
+    }
+    }
+]
+
+campaignTrail_temp.answers_json = [
+    {
+        "model": "campaign_trail.answer",
+        "pk": 15782,
+        "fields": {
+            "question": 15781,
+            "description": "Mayor Hou, you claim to support housing justice and public housing. Then please explain, why do you use your own building for rent at a high price, isn't this exploiting young people? I am the only candidate who doesn't engage in property speculation, please give a direct answer to this question."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 15783,
+        "fields": {
+            "question": 15781,
+            "description": "If the KMT returns, I believe black gold politics and local factions will return as well, including the families like the Luo family in Xindian, the Xie family in Changhua, the Yan family in Taichung, the Zhang family in Yunlin, and even the Fu family in Hualien, and numerous other instances of black gold forces entrenched in various regions. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 15784,
+        "fields": {
+            "question": 15781,
+            "description": "The KMT will obstruct our military procurements to safeguard Taiwan, it will inevitably stop. In the past, during my time in the Legislative Yuan, the KMT blocked the military procurement bills 69 times, while claiming outside to support such procurements. If the KMT returns, our defense autonomy and the hard-earned progress made over the past eight years will come to a halt."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 15785,
+        "fields": {
+            "question": 15781,
+            "description": "I will remain firm and maintain the status quo.  As long as China is willing to engage in equal dialogue. The world is watching to see whether the people of Taiwan, between the democratic camp and authoritarian groups, will choose what?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13019,
+        "fields": {
+            "question": 12989,
+            "description": "In this era, the mission of the Democratic Progressive Party (DPP) is to safeguard Taiwan. We must ensure Taiwan's freedom and sovereignty are not infringed upon. This will be the key emphasis for me. The purpose of the DPP is to work hard for the betterment of Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13020,
+        "fields": {
+            "question": 12989,
+            "description": "Party unity will be another point of emphasis for me. My goal is clear—to unite the entire party and lead everyone to reinvigorate the values of \"integrity, diligent governance, love for our homeland\" and \"green governance with guaranteed quality.\""
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13021,
+        "fields": {
+            "question": 12989,
+            "description": "I will emphasize a pragmatic approach. The DPP will humbly listen, respond to public opinion, and conduct thorough self-reflection to improve people's lives. Let's keep up the good work!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13029,
+        "fields": {
+            "question": 12990,
+            "description": "I will seek the support of young voters. The DPP has always had an advantage among young voters. Compared to the Kuomintang, we are a younger party! Let's rally the youth, just like they did in 2019. They are the future of our country!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13030,
+        "fields": {
+            "question": 12990,
+            "description": "I will demonstrate the DPP's strong relationships with international democratic nations and alliances. I will ensure that these relationships can only be maintained under DPP governance. The free world is standing up for Taiwan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13031,
+        "fields": {
+            "question": 12990,
+            "description": "We need to strengthen our base. It's well-known that we faced significant setbacks in local elections last year. We must reinforce our support in the southern region and among DPP supporters to prevent losing them. If it's a three-way competition, consolidating our base is crucial."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13032,
+        "fields": {
+            "question": 12990,
+            "description": "Opinion polls reflect only a snapshot in time. We highly respect the results of these polls. However, I believe that the DPP's achievements and accomplishments over the past seven years are substantial and will not be easily erased. I will strengthen party unity and seek compromise and cooperation with other factions."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13041,
+        "fields": {
+            "question": 12991,
+            "description": "I will promote her through social media platforms like Facebook to raise awareness. Nantou needs a DPP legislator for a better future. We must break through the barriers in this pro-KMT region."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13042,
+        "fields": {
+            "question": 12991,
+            "description": "I will personally endorse her and give speeches, highlighting her as an outstanding female member of the DPP. This will strengthen her local support. Elect Cai Pei-hui, and the DPP will bring more and better benefits to Nantou!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13047,
+        "fields": {
+            "question": 12992,
+            "description": "What? I attended an event with President Castro just a couple of weeks ago and even took photos together. And now she's embracing Beijing? We will immediately recall our ambassador and warn Honduras not to embrace Beijing!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13048,
+        "fields": {
+            "question": 12992,
+            "description": "This is just another round of Beijing's Dollar diplomacy. The Castro government demanded billions of dollars in economic and trade aid from Taiwan, comparing our assistance package to China's. We don't need allies who waste money like this. Breaking off diplomatic relations can save taxpayers' money."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13049,
+        "fields": {
+            "question": 12992,
+            "description": "I advise the people of Honduras to see the reality clearly. We hereby terminate diplomatic relations with the Republic of Honduras and urge the world to recognize China's deceptive nature in its foreign aid policies. We refuse to accept China's diplomatic suppression!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13057,
+        "fields": {
+            "question": 12993,
+            "description": "The DPP will break Taiwan's \"eight-year curse\" and strive for an unprecedented third term. This requires the continued support of the Taiwanese people! I will continue to promote democratic unity, democratic governance, and democratic peace to ensure the stability of democratic forces."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13058,
+        "fields": {
+            "question": 12993,
+            "description": "I will reaffirm the most important aspect: national identity. The Republic of China and the People's Republic of China are not subordinate to each other, and Taiwan is not part of China. The sovereignty of Republic of China-Taiwan must not be violated. The future of Taiwan lies in the hands of the 23 million people living here."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13059,
+        "fields": {
+            "question": 12993,
+            "description": "I will downplay my pro-independence stance. Taiwan has its own land and people, regularly holds elections for all levels of government, and exercises state power. \"In fact, it is already an independent and sovereign country\" without the need for a formal declaration of independence."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13060,
+        "fields": {
+            "question": 12993,
+            "description": "I want to criticize the KMT and former President Ma Ying-jeou. Recently, President Tsai Ing-wen made a transit visit to the United States, while former President Ma Ying-jeou visited China for ancestral worship. Tensions among the United States, China, and Taiwan have escalated. Ma Ying-jeou has returned to the \"one China\" framework, while Tsai Ing-wen is moving towards the future on the path of democracy and international engagement. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13073,
+        "fields": {
+            "question": 12994,
+            "description": "We need to immediately sever ties and dismiss those involved in sexual harassment. We should offer heartfelt apologies and compensation to the victims. We must address these sexual harassment cases seriously and uphold the party's consistent principles. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13074,
+        "fields": {
+            "question": 12994,
+            "description": "I will personally apologize to the victims and express our zero tolerance for sexual harassment. We will emphasize holding the responsible parties accountable and engaging in deep reflection. DPP members will also be required to participate in sexual harassment education courses."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13075,
+        "fields": {
+            "question": 12994,
+            "description": "I am aware KMT has had similar incidents. Why is the KMT so lenient towards Fu Kun-chi? There must also be similar incidents within the KMT, yet they criticize the DPP vehemently without fairness."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13076,
+        "fields": {
+            "question": 12994,
+            "description": "The #MeToo movement has been quite intense. It's probably best for me not to get involved in these matters. I should be cautious because taking on the role of a righteous hero might only add fuel to the fire. I don't want any individuals around me to be exposed for their sexual misconduct."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13087,
+        "fields": {
+            "question": 12995,
+            "description": "It's better not to politicize this matter, so as to avoid the perception of using children's suffering for political gain. We will only release a simple statement, demanding a thorough investigation to uncover the truth."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13088,
+        "fields": {
+            "question": 12995,
+            "description": "We shouldn't let Hou You-yi off the hook in this matter, but it's best not to personally engage in attacks. Let our legislators and councilors in New Taipei City initiate the criticism and suspicion towards the Kuomintang, questioning the capability and integrity of the New Taipei City government. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13089,
+        "fields": {
+            "question": 12995,
+            "description": "This is the best opportunity for us to attack Hou You-yi! I will immediately issue a statement personally, questioning the competence of the New Taipei City government and the truth of the case. Why has Hou You-yi's response to this matter been so slow? The parents of the victimized children cannot bear such pain. They should speak out!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13100,
+        "fields": {
+            "question": 12996,
+            "description": "The KMT has always been our toughest opponent. We must strike at the KMT's stronghold and solidify our own base. Has Hou You-yi, who has just been elected as the second-term mayor of New Taipei City, forgotten the lesson from Han Kuo-Yu in 2019?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13101,
+        "fields": {
+            "question": 12996,
+            "description": "Ko Wen-je has taken away many young supporters, pan-green supporters, and swing voters from us. The Kuomintang is an outdated and corrupt party, clinging only to its core supporters and unlikely to gain many votes. Ko Wen-je is a true dark horse, and we must keep a close eye on his campaign activities."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13102,
+        "fields": {
+            "question": 12996,
+            "description": "I will simultaneously criticize both parties while appealing to our beloved Taiwan-centric consciousness. The KMT is outdated and too close to China, while the TPP is too inexperienced to fulfill the responsibility of guiding Taiwan's future direction. Please support the Democratic Progressive Party for a third term!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13111,
+        "fields": {
+            "question": 12997,
+            "description": "The terrifying events of Chernobyl and Fukushima are not far from us. Taiwan must completely abolish nuclear power and instead transition to safe, clean, and stable solar power and clean energy sources. By 2025, we must achieve the goal of a non-nuclear homeland. This is our commitment!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13112,
+        "fields": {
+            "question": 12997,
+            "description": "I will continue along the path of President Tsai Ing-wen, opposing China's tactics of verbal intimidation and military threats, as well as various acts of aggression. Taiwan must establish its own deterrent capabilities. At the same time, we are also willing to open the door to communication and cooperation with China on the basis of equality and dignity, to enhance the well-being of people on both sides of the strait, and to achieve peaceful co-prosperity."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13113,
+        "fields": {
+            "question": 12997,
+            "description": "I want to help solve the issue of high housing prices and the lack of housing for young people. Housing justice must not be overlooked. By the year 2032, we aim to provide 500,000 units of social housing, increase the construction of a large number of social housing units, and crack down on individuals holding a large number of properties. We will raise the tax rates on non-owner-occupied properties to prevent them from solely relying on charging high rents to make a living."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13127,
+        "fields": {
+            "question": 12998,
+            "description": "I wouldn't go to such a place to seek trouble. I just want to say,people have the right to express dissatisfaction with the government, to listen to the voices on Ketagalan Boulevard, not to ignore people's words, and regardless of their number, the government must take them into account."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13128,
+        "fields": {
+            "question": 12998,
+            "description": "I want to bravely face these people, don't I? Perhaps I will receive some political credits. After all, this is not a march directly against the government. Let's go there and say some good words about judicial reform and fairness and justice."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13129,
+        "fields": {
+            "question": 12998,
+            "description": "Let's ignore this protest demonstration, and I will request all DPP members not to participate in this march. It is a waste of our time and will expose us to more attacks. I refuse the organizer's invitation."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13139,
+        "fields": {
+            "question": 12999,
+            "description": "Hou You-yi once led the arrest of the democratic pioneer Zheng Nanrong. Isn't it sad that such a persecutor of Taiwan's democratic movement has become a presidential candidate? This proves that the Kuomintang is nothing but a relic of an authoritarian party."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13140,
+        "fields": {
+            "question": 12999,
+            "description": "The KMT seems to never learn its lesson. Last time, they fielded Han Kuo-yu, who had served as mayor for a year, as a presidential candidate. This time, they have chosen Hou You-yi, who was just re-elected. Will they ever learn to finish their term before running for president again? Are the voters who support you just stepping stones?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13141,
+        "fields": {
+            "question": 12999,
+            "description": "The China-friendly Kuomintang should not think that nominating a Taiwanese can erase the red and authoritarian stains on themselves. The Democratic Progressive Party is the only indigenous party in Taiwan that is truly trustworthy. Please remember this!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13142,
+        "fields": {
+            "question": 12999,
+            "description": "I am more concerned about the moves and situation of Ko Wen-je, who has taken away the votes of many young people from us. Ko Wen-je is a political chameleon - sometimes leaning towards the green camp, and other times, aligning with the Kuomintang. We do not need such an unstable leader."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13155,
+        "fields": {
+            "question": 13000,
+            "description": "I want to strengthen support in our traditional base, the south. People in the south have always supported the Democratic Progressive Party. I hope to win in Chiayi by over 100,000 votes more than the Kuomintang and secure over 50% of the votes in Tainan and Kaohsiung to firmly secure the votes in the southern region."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13156,
+        "fields": {
+            "question": 13000,
+            "description": "The central region is the barometer of the presidential election; Central Taiwan is our target. I must win Changhua without fail. At the same time, Nantou and Taichung must be included! Let Central Taiwan turn green!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13157,
+        "fields": {
+            "question": 13000,
+            "description": "TaoYuan, Hsinchu, and Miaoli are the traditional strongholds of the Kuomintang. However, our influence in this area is increasing year by year. The Kuomintang may think they can gain a large number of votes here to compensate for their losses in the south. They are mistaken because we are about to encroach on their territory."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13158,
+        "fields": {
+            "question": 13000,
+            "description": "Why not go to Hualien, Pingtung, Taitung, and Yilan? Some counties and cities in these eastern regions support us, and some are strongholds of the Kuomintang. However, we must pay attention to our eastern coast, as these areas also have a population of over 1.6 million people! "
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13182,
+        "fields": {
+            "question": 13001,
+            "description": "I will be interviewed by Bloomberg and discuss the current situation in Taiwan and the threat from China. I will take Bloomberg journalists to my hometown, talk about my time as a doctor and my family background. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13183,
+        "fields": {
+            "question": 13001,
+            "description": "I need green media to extensively cover my meeting with AIT Chairman Rosenberger, demonstrating the strong relations between me and the United States, as well as the allyship between Taiwan and the U.S. We know that the U.S. and Taiwan are steadfast democratic allies. Cheers!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13184,
+        "fields": {
+            "question": 13001,
+            "description": "I've heard that there are many Taiwanese communities in Washington D.C. and other parts of the U.S., with a lot of them supporting the DPP and firmly opposing China. It might be a good idea to host a dinner or gathering with them!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13185,
+        "fields": {
+            "question": 13001,
+            "description": "I want to emphasize the relationship with our traditional ally, Paraguay. Paraguay and Taiwan have always been friendly allies, and we hope to continue maintaining our relationship with Paraguay as it is our only diplomatic ally in South America. We cannot afford to lose it. Let the Taiwan-Paraguay friendship continue!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13194,
+        "fields": {
+            "question": 13002,
+            "description": "I will personally attend and express support. I remember when we were constantly reminded to \"stop at red lights, go at green lights,\" a universal language in the world of traffic. Many pedestrians in Taiwan, however, seem to question this common understanding. This Sunday, numerous civic groups are calling for action on the streets to voice their demands, urging all parties to pay attention and propose improvements to prevent tragedies from happening again."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13195,
+        "fields": {
+            "question": 13002,
+            "description": "I don't want to participate in this event. I don't have time for these politically irrelevant social issues. Let some representatives from the Democratic Progressive Party go instead; this rally won't affect anything."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13202,
+        "fields": {
+            "question": 13003,
+            "description": "Nicaragua and some pro-China lawmakers have succumbed to China's scheme to exclude Taiwan, disregarding Taiwan's long-term contributions to the CAP and regional integration and development. They have divided parliamentary unity and disrupted democracy and harmony in the Central American region, persisting in promoting and encouraging the controversial \"exclude Taiwan, recognize China\" resolution. To uphold national sovereignty and dignity, we have decided to withdraw from the Central American Parliament with immediate effect."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13203,
+        "fields": {
+            "question": 13003,
+            "description": "We strongly condemn Nicaragua's Daniel Ortega dictatorship for wrongfully invoking UN General Assembly Resolution 2758, manipulating the so-called \"one China principle\" fallacy, and seeking to deprive Taiwan of its rights in the CAP. highlighting China's deliberate attempts to undermine democracy in Central America and its ambitions for regional expansion."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13204,
+        "fields": {
+            "question": 13003,
+            "description": "The Republic of China - Taiwan is a sovereign independent country that is not subordinate to the PRC. This is a fact and the current reality. Despite China's continuous efforts to suppress Taiwan's international participation and openly interfere in Taiwan's democratic election processes using various means, it not only fails to gain international recognition but also strengthens Taiwan's determination to actively expand its international space."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13216,
+        "fields": {
+            "question": 13004,
+            "description": "Haha, has the Kuomintang and the opposition camp already splintered before the election campaign heats up? That's great because Gou's entry will only attract blue votes away. I will easily become the 17th President, and we can all just sleeping until I am elected on January 13th."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13217,
+        "fields": {
+            "question": 13004,
+            "description": "Excellent! This is an great opportunity to strike at the opposition camp. We will secretly help Terry Gou obtain his eligibility for the election. Doesn't he need more citizen signatures? Let's mobilize our factions at the local level to support him and gather more citizen signatures, allowing him to capture more pan-blue votes!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13224,
+        "fields": {
+            "question": 13005,
+            "description": "I will push for a reduction of 35,000 NTD in tuition fees for private colleges, lessening the economic burden on university students and their families. In the future, I also plan to promote the concept of \"National Care from 0 to 22 years old,\" allowing young people to have a happy and fulfilling future."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13225,
+        "fields": {
+            "question": 13005,
+            "description": "We should emphasize transportation and road safety issues, aiming for \"Zero Pedestrian Deaths by 2040.\" I will also propose the draft of the \"Road Traffic Safety Basic Law\" to the legislature for review, symbolizing Taiwan's progress as a civilization. In the future, pedestrians and people with disabilities should not only have the right of way but also feel safe."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13226,
+        "fields": {
+            "question": 13005,
+            "description": "I will gradually introduce the \"National Hope Project Policy Platform,\" aiming to improve and prioritize the rights of people with disabilities. I look forward to everyone working together to create a more equal and friendly living environment for people with disabilities."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13227,
+        "fields": {
+            "question": 13005,
+            "description": "I will continue to promote the bilingual policy by 2030! English remains the most important international language. Whether it's to enhance international communication, improve knowledge in professional fields, or strengthen English proficiency, it is necessary. I hope to make English a primary language in Taiwanese society by 2030."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13236,
+        "fields": {
+            "question": 13006,
+            "description": "The Kuomintang is nothing more than a failed exiled political party. Without Taiwan today, where would the Republic of China be? The Kuomintang's ability to confuse priorities is shocking. The Kuomintang should not obstruct the trend of Taiwan's localization any longer."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13237,
+        "fields": {
+            "question": 13006,
+            "description": "The DPP has been in power multiple times, yet the Republic of China still exists. Every year during the National Day, a giant national flag flies over the Presidential Office. Does the KMT only pay lip service to caring about the Republic of China, which is why they turn a blind eye? On the contrary, it is the KMT's adherence to the \"1992 Consensus\" that truly seeks to eliminate the Republic of China!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13238,
+        "fields": {
+            "question": 13006,
+            "description": "Looking at the past elections, from county and city heads to the presidential election, the KMT either shouted that the ROC would be extinguished if the DPP candidates were elected, or the DPP wanted to destroy the ROC, so is it true that the ROC and the KMT would not hold any election without cursing the ROC?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13248,
+        "fields": {
+            "question": 13007,
+            "description": "\"We are Team Taiwan 2024! Let's unite and support Taiwan! Lai Ching-te wins by a large margin, gains a majority in parliament, safeguarding Taiwan with democracy and peace!\" "
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13251,
+        "fields": {
+            "question": 13008,
+            "description": "Of course! We should support the virtuous businessmen of Taiwan! I urge China not to pressure Taiwanese businesses or demand declarations during elections, causing innocent Taiwanese businesses to suffer and lose confidence in China. This approach is mutually damaging and detrimental."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13252,
+        "fields": {
+            "question": 13008,
+            "description": "I prefer not to get involved with Terry Gou. I have more important matters to attend to. Speaking on his behalf might seem insincere, especially considering he is a candidate from the blue camp. I see no reason to support my opponent."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13253,
+        "fields": {
+            "question": 13008,
+            "description": "Let me make a loud call to support Terry Gou. I urge China to cherish and value Taiwanese business owners. China should not suppress the freedom rights of the Taiwanese people during elections and should refrain from interfering through various means, including pressuring our candidates. This is absolutely unacceptable!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13261,
+        "fields": {
+            "question": 13009,
+            "description": "The blue and white coalition is nothing but a dirty political game of sharing the spoils. Both the KMT and the TPP want the position of President and aim to push the other to the position of VP. However, their scheme will not succeed because the DPP will garner the most support from the Taiwanese people and defeat them. We are ready for it!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13262,
+        "fields": {
+            "question": 13009,
+            "description": "Rather than believing in the blue and white, let's firmly choose Lai Ching-te! I only see calculations and spoils-sharing between the blue and white parties, without any vision for the nation. The DPP has been prepared for a one-on-one battle in the election. Eventually, the blue and white parties in the opposition will surely back down. Even in a one-on-one direct confrontation, we will win!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13263,
+        "fields": {
+            "question": 13009,
+            "description": "The blue and white coalition is only for the benefit of the political parties, with position distribution and full of calculations. Taiwan cannot allow such individuals to take the helm. I once again urge the people to \"choose the right person, walk the right path,\" and let Lai Ching-te and the DPP lead Taiwan forward! Believe Taiwan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13274,
+        "fields": {
+            "question": 13010,
+            "description": "I will participate in the temple fairs in Changhua, Younlin, and Chiayi, visit temples and shrines in different areas, and engage in conversations and close interactions with the Southern farmers who support us the most."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13275,
+        "fields": {
+            "question": 13010,
+            "description": "Kaohsiung, Pingtung, and Penghu are the areas where we need to strengthen our presence. These places are also our bases, but Ko Wen-je may capture some crucial young votes in the South. We must reinforce our position there."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13276,
+        "fields": {
+            "question": 13010,
+            "description": "The Greater Taipei metropolitan area is the most crucial region in the country with the highest population. The KMT strongholds in these areas must be uprooted, and we should campaign in Taipei, New Taipei, and Keelung!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13277,
+        "fields": {
+            "question": 13010,
+            "description": "I aim to bolster support in some traditional KMT strongholds, including Miaoli, Nantou, Taitung, Hualien, and Hsinchu County. We also need to make appearances in Kinmen and Matsu Islands. If we don't show up there, they will continue supporting the KMT. We need to break out of our comfort zone!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13299,
+        "fields": {
+            "question": 13011,
+            "description": "Fire him! I demand that this guy, who is damaging my chances in the presidential election, be removed from the list of legislative candidates and stripped of his DPP membership. Otherwise, I could lose the presidency because of a man involved in an affair!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13300,
+        "fields": {
+            "question": 13011,
+            "description": "Flip,Flip,Flip!These are all tactics of Chinese election interference; don't fall for it! We must once again hold high the banner of resisting China and protecting Taiwan, and try to bury this issue!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13301,
+        "fields": {
+            "question": 13011,
+            "description": "Disqualify him of his candidacy as a legislator and have Huang Jie take his place. We cannot afford to lose the seat in the 6th constituency of Kaohsiung because of this issue. Let him fade out from the political scene. Don't jeopardize my chances in the presidential race!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13309,
+        "fields": {
+            "question": 13012,
+            "description": "I understand. I am ready for a one-on-one battle. Even so, we must win."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13310,
+        "fields": {
+            "question": 13012,
+            "description": "No, why is this happening? I have been leading in the polls for over half a year. Just because of this, am I going to lose?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13319,
+        "fields": {
+            "question": 13013,
+            "description": "No matter how many candidates there are, we must definitely win!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13322,
+        "fields": {
+            "question": 13013,
+            "description": "No matter how many candidates there are, we must definitely win!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13323,
+        "fields": {
+            "question": 13013,
+            "description": "No matter how many candidates there are, we must definitely win!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13324,
+        "fields": {
+            "question": 13013,
+            "description": "No matter how many candidates there are, we must definitely win!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13344,
+        "fields": {
+            "question": 13014,
+            "description": "Hsiao Bi-khim is our country's representative to the United States, possessing strong diplomatic experience and a deep understanding of Taiwan-US relations. She can play a role in facilitating communication between me and the United States. I value her diplomatic experience!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13345,
+        "fields": {
+            "question": 13014,
+            "description": "Hsiao Bi-khim is a capable and promising young woman who will bring in a significant female vote for me. Having such a rational and eloquent woman with strong language skills as vice president can enhance my appeal!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13346,
+        "fields": {
+            "question": 13014,
+            "description": "Hsiao Bi-khim previously served as a legislator in Hualien. Her service in Hualien can help us secure more votes in that region. Let her go to Hualien and connect with the local communities there!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13356,
+        "fields": {
+            "question": 13015,
+            "description": "Let's continue to capitalize on voters' fear and dislike of Han Kuo-yu by running an anti-Han Kuo-yu ad. It emphasizes that if you vote for the Kuomintang and TPP, Han Kuo-yu could become the President of the Legislative Yuan. Remember, this is a person who has been impeached, yet could potentially hold one of the highest positions in the country!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13357,
+        "fields": {
+            "question": 13015,
+            "description": "I want to invite President Tsai Ing-wen to shoot a video with me, narrating our journey together during the four-year term while driving. Witnessing President Tsai's steady and resolute leadership in Taiwan is incredible. Oh, and let's have my vice presidential candidate join us on the screen - together, on the road!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13358,
+        "fields": {
+            "question": 13015,
+            "description": "Since entering politics, I have tried to minimize discussion about my family or have them appear in public. However, I know that my family also cares about me. It's time for my wife to step into the limelight. Let's shoot a video about my family, showcasing my caring image and the warm family atmosphere. I am the one who is capable of taking care of Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13367,
+        "fields": {
+            "question": 13016,
+            "description": "This is the inheritance left to me by my late father. I never expected it to come under attack! I... I really... (tears rolling down)."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13368,
+        "fields": {
+            "question": 13016,
+            "description": "This is an existing illegal structure that does not necessarily need to be demolished according to the law. It just needs to be documented and managed properly through photographs. The attacks from the Kuomintang and the TPP will only backfire, evoking sympathy from the public for me."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13369,
+        "fields": {
+            "question": 13016,
+            "description": "What about Hou You-yi and the Ko Wen-je? What about the high rental income from the private building owned by Hou You-yi and the agricultural land that Ko Wen-je has converted into a parking lot? Why are they always criticizing my illegal structure? Aren't they just trying to absolve their own masters?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13370,
+        "fields": {
+            "question": 13016,
+            "description": "I will demolish this house to prevent it from affecting my electoral prospects. it does go against the law, as a presidential candidate, I need to hold myself to high moral standards. Let the excavator come."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13383,
+        "fields": {
+            "question": 13017,
+            "description": "Mayor Hou has presented many proposals, most of which are outdated policies. It's 2024, and still talking about the \"1992 Consensus\" when Taiwan has made significant strides in renewable energy. Mentioning a restart of nuclear power is unnecessary. I will build a democratic and peaceful Taiwan. I will not follow the Kuomintang's path back to the past and be willing to become an appendage of authoritarianism."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13384,
+        "fields": {
+            "question": 13017,
+            "description": "Ko Wen-je's one-person party is unpredictable and constantly changing. This is not the direction the country should be taking. Chairman Ko often criticizes the DPP for ineffective governance, but it turns out that everything we do is what he says should be done, which is contradictory. Chairman Ko advocates for closer ties with the Mainland, while Mayor Hou advocates the \"1992 Consensus,\" both advocating the One China principle, which undermines Taiwan's international status. This is the manifestation of \"One Country, Two Systems\" in Taiwan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13385,
+        "fields": {
+            "question": 13017,
+            "description": "China has never acknowledged the existence of the ROC. They believe the only government representing China is the government of the PRC. Today, some still regard the ROC as the protector of both sides of the strait. Is this about promoting peace or bringing disaster to Taiwan? We must consider – Taiwan has moved from an era of dictatorship to democracy, do we want to go back to those old days?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13395,
+        "fields": {
+            "question": 13018,
+            "description": "We will conduct election activities in New Taipei City, the city with the largest population and area in the country.  It is also where my family is located, and I hope to achieve victory here.  New Taipei City is also governed by Hou You-yi, and I aim to prove that I can defeat him here!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13396,
+        "fields": {
+            "question": 13018,
+            "description": "I want to hold election activities in Tainan and spend the pre-election night there.  I served as the mayor of Tainan for many years, and returning to Tainan feels as natural as returning home.  Let's strengthen our base in Tainan!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13397,
+        "fields": {
+            "question": 13018,
+            "description": "I plan to hold election activities in Taichung, a swing district for the presidency.  Any slight shift in support and attention can lead to different winners.  We must defeat Hou and Ko in the central region;  otherwise, our base in the south may not be enough to secure victory."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13398,
+        "fields": {
+            "question": 13018,
+            "description": "I intend to conduct election activities in the capital, Taipei City.  Taipei City is a stronghold for the Blue Camp, but we also have a chance for victory here.  We must ensure that the capital turns green to prevent the Kuomintang from overpowering us here."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950001,
+        "fields": {
+            "question": 195000,
+            "description": "Ko Wen-je is an unpredictable chameleon. In the past, he said he detested mosquitoes, cockroaches, and the KMT, but today, he is cooperating with the KMT. Has he forgotten that his ancestors were once victimized by the KMT in the 228 Incident? Taiwan cannot be handed over to such a person for rule. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950002,
+        "fields": {
+            "question": 195000,
+            "description": "I want to remind everyone that pro-China reunification figures like  Chiu Yi strongly support Ko Wen-je. We really need to be vigilant. Aren't the People's Party and the Kuomintang colluding with the Communist Party to undermine Taiwan's freedom and independence? "
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950003,
+        "fields": {
+            "question": 195000,
+            "description": "Mayor Ke Wen-je, do you know that the citizens of Taipei really dislike you? Why do you keep boasting about your achievements during your time as mayor of Taipei, mentioning how much debt you paid off, yet why is your approval rating in Taipei so low? "
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 1950004,
+        "fields": {
+            "question": 195000,
+            "description": "TPP is a one-person party, completely under the command of Chairman Ke Wen-je. We all know that the true and only big figure in the People Party is Ke Wen-je himself. The rest are not well-known. Chairman Ke, will you govern the country just like how you manage your own party? "
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13436,
+        "fields": {
+            "question": 13014,
+            "description": "I have a good idea! Hsiao really likes cats, and I have a black dog, so we could hit up the pet owner's ballot and put on sale some cat and dog animal medals to campaign for us!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13440,
+        "fields": {
+            "question": 1950,
+            "description": "Mayor Hou has presented many proposals, most of which are outdated policies. It's 2024, and still talking about the \"1992 Consensus\" when Taiwan has made significant strides in renewable energy. Mentioning a restart of nuclear power is unnecessary. I will build a democratic and peaceful Taiwan. I will not follow the Kuomintang's path back to the past and be willing to become an appendage of authoritarianism. I will unite the people, strengthen national defense, and the economy."
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13441,
+        "fields": {
+            "question": 1950,
+            "description": "Ko Wen-je's one-person party is unpredictable and constantly changing. This is not the direction the country should be taking. Chairman Ko often criticizes the DPP for ineffective governance, but it turns out that everything we do is what he says should be done, which is contradictory. Chairman Ko advocates for closer ties with the Mainland, while Mayor Hou advocates the \"1992 Consensus,\" both advocating the One China principle, which undermines Taiwan's international status. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer",
+        "pk": 13442,
+        "fields": {
+            "question": 1950,
+            "description": "Do you know why Gou decided to run for president independently? Isn't it because your two opposition parties are too incompetent, forcing renowned business figures in Taiwan like us to enter the competition? Everyone knows that in the chaotic situation within the opposition camp, the DPP is the only one that remains resolute and unified!"
+        }
+    }
+]
+
+campaignTrail_temp.states_json = [
+    {
+        "model": "campaign_trail.state",
+        "pk": 251,
+        "fields": {
+            "name": "Tainan City",
+            "abbr": "Tainancity",
+            "electoral_votes": 1,
+            "popular_votes": 1120238,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 252,
+        "fields": {
+            "name": "Kaohsiung City",
+            "abbr": "Kaohsiungcity",
+            "electoral_votes": 1,
+            "popular_votes": 1636962,
+            "poll_closing_time": 180,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 253,
+        "fields": {
+            "name": "Pingtung County",
+            "abbr": "Pingtung",
+            "electoral_votes": 1,
+            "popular_votes": 475927,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 254,
+        "fields": {
+            "name": "Taidong County",
+            "abbr": "Taidong",
+            "electoral_votes": 1,
+            "popular_votes": 109941,
+            "poll_closing_time": 75,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 255,
+        "fields": {
+            "name": "Hualien County",
+            "abbr": "Hualien",
+            "electoral_votes": 1,
+            "popular_votes": 174157,
+            "poll_closing_time": 90,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 256,
+        "fields": {
+            "name": "Chiayi County",
+            "abbr": "ChiayiCounty",
+            "electoral_votes": 1,
+            "popular_votes": 292534,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 257,
+        "fields": {
+            "name": "Chiayi City",
+            "abbr": "ChiayiCity",
+            "electoral_votes": 1,
+            "popular_votes": 157656,
+            "poll_closing_time": 80,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 258,
+        "fields": {
+            "name": "Nantou County",
+            "abbr": "Nantou",
+            "electoral_votes": 1,
+            "popular_votes": 287296,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 259,
+        "fields": {
+            "name": "Yunlin County",
+            "abbr": "Yunlin",
+            "electoral_votes": 1,
+            "popular_votes": 380619,
+            "poll_closing_time": 130,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 261,
+        "fields": {
+            "name": "Penghu County",
+            "abbr": "Penghu",
+            "electoral_votes": 1,
+            "popular_votes": 49277,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 260,
+        "fields": {
+            "name": "Changhua County",
+            "abbr": "Changhua",
+            "electoral_votes": 1,
+            "popular_votes": 741368,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 262,
+        "fields": {
+            "name": "Taichung City",
+            "abbr": "Taichung",
+            "electoral_votes": 1,
+            "popular_votes": 1707203,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 263,
+        "fields": {
+            "name": "Yilan County",
+            "abbr": "Yilan",
+            "electoral_votes": 1,
+            "popular_votes": 267129,
+            "poll_closing_time": 120,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 264,
+        "fields": {
+            "name": "Hsinchu County",
+            "abbr": "HsinchuCounty",
+            "electoral_votes": 1,
+            "popular_votes": 340310,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 265,
+        "fields": {
+            "name": "Hsinchu City",
+            "abbr": "HsinchuCity",
+            "electoral_votes": 1,
+            "popular_votes": 266389,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 266,
+        "fields": {
+            "name": "Miaoli County",
+            "abbr": "Miaoli",
+            "electoral_votes": 1,
+            "popular_votes": 318665,
+            "poll_closing_time": 110,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 268,
+        "fields": {
+            "name": "Taipei City",
+            "abbr": "Taipei",
+            "electoral_votes": 1,
+            "popular_votes": 1542009,
+            "poll_closing_time": 200,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 267,
+        "fields": {
+            "name": "New Taipei City",
+            "abbr": "Newtaipei",
+            "electoral_votes": 1,
+            "popular_votes": 2458480,
+            "poll_closing_time": 225,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 269,
+        "fields": {
+            "name": "Taoyuan City",
+            "abbr": "Taoyuan",
+            "electoral_votes": 1,
+            "popular_votes": 1350792,
+            "poll_closing_time": 150,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 270,
+        "fields": {
+            "name": "Keelung City",
+            "abbr": "Keelung",
+            "electoral_votes": 1,
+            "popular_votes": 218781,
+            "poll_closing_time": 100,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 271,
+        "fields": {
+            "name": "Kinmen County",
+            "abbr": "Kinmen",
+            "electoral_votes": 1,
+            "popular_votes": 45612,
+            "poll_closing_time": 70,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.state",
+        "pk": 272,
+        "fields": {
+            "name": "Lienchiang County",
+            "abbr": "Matsu",
+            "electoral_votes": 1,
+            "popular_votes": 6159,
+            "poll_closing_time": 50,
+            "winner_take_all_flg": 1,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.issues_json = [
+    {
+        "model": "campaign_trail.issue",
+        "pk": 32,
+        "fields": {
+            "name": "Party coalition",
+            "description": 0,
+            "stance_1": "Deep Green",
+            "stance_desc_1": 0,
+            "stance_2": "Green",
+            "stance_desc_2": 0,
+            "stance_3": "Light Green",
+            "stance_desc_3": 0,
+            "stance_4": "Neutral",
+            "stance_desc_4": 0,
+            "stance_5": "Light Blue",
+            "stance_desc_5": 0,
+            "stance_6": "Blue",
+            "stance_desc_6": 0,
+            "stance_7": "Deep Blue",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 33,
+        "fields": {
+            "name": "Provincial differences",
+            "description": 0,
+            "stance_1": "Mostly Taiwanese",
+            "stance_desc_1": 0,
+            "stance_2": "Taiwanese and Hakka mixed",
+            "stance_desc_2": 0,
+            "stance_3": "Taiwanese,Hakka,Mainlanders mixed",
+            "stance_desc_3": 0,
+            "stance_4": "mixing of ethnic groups",
+            "stance_desc_4": 0,
+            "stance_5": "Aboriginal",
+            "stance_desc_5": 0,
+            "stance_6": "Taiwanese Hakka(Northern)",
+            "stance_desc_6": 0,
+            "stance_7": "Mostly Mainlanders",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 34,
+        "fields": {
+            "name": "Urban/rural differences",
+            "description": 0,
+            "stance_1": "Townships Rural",
+            "stance_desc_1": 0,
+            "stance_2": "Small towns and large towns",
+            "stance_desc_2": 0,
+            "stance_3": "Small cities and towns",
+            "stance_desc_3": 0,
+            "stance_4": "Medium-sized city",
+            "stance_desc_4": 0,
+            "stance_5": "Groups of Small Cities",
+            "stance_desc_5": 0,
+            "stance_6": "Large Cities",
+            "stance_desc_6": 0,
+            "stance_7": "Capitals",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 35,
+        "fields": {
+            "name": "Young population",
+            "description": 0,
+            "stance_1": "Very little",
+            "stance_desc_1": 0,
+            "stance_2": "Little",
+            "stance_desc_2": 0,
+            "stance_3": "Less",
+            "stance_desc_3": 0,
+            "stance_4": "Normal level",
+            "stance_desc_4": 0,
+            "stance_5": "Relatively much more",
+            "stance_desc_5": 0,
+            "stance_6": "Large young population",
+            "stance_desc_6": 0,
+            "stance_7": "Younger society",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    },
+    {
+        "model": "campaign_trail.issue",
+        "pk": 36,
+        "fields": {
+            "name": "Feelings about DPP Government",
+            "description": 0,
+            "stance_1": "DPP is the best!",
+            "stance_desc_1": 0,
+            "stance_2": "That's what we like!",
+            "stance_desc_2": 0,
+            "stance_3": "Pro-DPP",
+            "stance_desc_3": 0,
+            "stance_4": "no feelings for the DPP",
+            "stance_desc_4": 0,
+            "stance_5": "Hate green governance",
+            "stance_desc_5": 0,
+            "stance_6": "Mosquitoes, cockroaches, and the DPP",
+            "stance_desc_6": 0,
+            "stance_7": "Never support the Taiwan Independence Party!!",
+            "stance_desc_7": 0,
+            "election": 20
+        }
+    }
+]
+
+campaignTrail_temp.state_issue_score_json = [
+    //台北市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191111,
+        "fields": {
+            "state": 268,
+            "issue": 32,
+            "state_issue_score": 0.22,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191112,
+        "fields": {
+            "state": 268,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191113,
+        "fields": {
+            "state": 268,
+            "issue": 34,
+            "state_issue_score": 1,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191114,
+        "fields": {
+            "state": 268,
+            "issue": 35,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191115,
+        "fields": {
+            "state": 268,
+            "issue": 36,
+            "state_issue_score": 0.1,
+            "weight": 0.5
+        }
+    },
+    //新北市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191116,
+        "fields": {
+            "state": 267,
+            "issue": 32,
+            "state_issue_score": 0.15,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191117,
+        "fields": {
+            "state": 267,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191118,
+        "fields": {
+            "state": 267,
+            "issue": 34,
+            "state_issue_score": 0.65,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191119,
+        "fields": {
+            "state": 267,
+            "issue": 35,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191120,
+        "fields": {
+            "state": 267,
+            "issue": 36,
+            "state_issue_score": 0.0,
+            "weight": 0.5
+        }
+    },
+    //桃园市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191121,
+        "fields": {
+            "state": 269,
+            "issue": 32,
+            "state_issue_score": 0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191122,
+        "fields": {
+            "state": 269,
+            "issue": 33,
+            "state_issue_score": 0.10,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191122,
+        "fields": {
+            "state": 269,
+            "issue": 34,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191123,
+        "fields": {
+            "state": 269,
+            "issue": 35,
+            "state_issue_score": 0.75,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191124,
+        "fields": {
+            "state": 269,
+            "issue": 36,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    //新竹市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191125,
+        "fields": {
+            "state": 265,
+            "issue": 32,
+            "state_issue_score": 0.4,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191126,
+        "fields": {
+            "state": 265,
+            "issue": 33,
+            "state_issue_score": -0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191127,
+        "fields": {
+            "state": 265,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191128,
+        "fields": {
+            "state": 265,
+            "issue": 35,
+            "state_issue_score": 0.65,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191129,
+        "fields": {
+            "state": 265,
+            "issue": 36,
+            "state_issue_score": 0.35,
+            "weight": 0.5
+        }
+    },
+    //基隆市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191130,
+        "fields": {
+            "state": 270,
+            "issue": 32,
+            "state_issue_score": 0.5,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191131,
+        "fields": {
+            "state": 270,
+            "issue": 33,
+            "state_issue_score": 0.1,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191132,
+        "fields": {
+            "state": 270,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191133,
+        "fields": {
+            "state": 270,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191134,
+        "fields": {
+            "state": 270,
+            "issue": 36,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    //新竹县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191135,
+        "fields": {
+            "state": 264,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191136,
+        "fields": {
+            "state": 264,
+            "issue": 33,
+            "state_issue_score": 0.45,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191137,
+        "fields": {
+            "state": 264,
+            "issue": 34,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191138,
+        "fields": {
+            "state": 264,
+            "issue": 35,
+            "state_issue_score": 0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191139,
+        "fields": {
+            "state": 264,
+            "issue": 36,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    //苗栗縣
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191140,
+        "fields": {
+            "state": 266,
+            "issue": 32,
+            "state_issue_score": 0.85,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191141,
+        "fields": {
+            "state": 266,
+            "issue": 33,
+            "state_issue_score": 0.55,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191142,
+        "fields": {
+            "state": 266,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191143,
+        "fields": {
+            "state": 266,
+            "issue": 35,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191144,
+        "fields": {
+            "state": 266,
+            "issue": 36,
+            "state_issue_score": 0.85,
+            "weight": 0.5
+        }
+    },
+    //宜兰县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191145,
+        "fields": {
+            "state": 263,
+            "issue": 32,
+            "state_issue_score": -0.45,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191146,
+        "fields": {
+            "state": 263,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191147,
+        "fields": {
+            "state": 263,
+            "issue": 34,
+            "state_issue_score": 0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191148,
+        "fields": {
+            "state": 263,
+            "issue": 35,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191149,
+        "fields": {
+            "state": 263,
+            "issue": 36,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    //台中市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191150,
+        "fields": {
+            "state": 262,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191151,
+        "fields": {
+            "state": 262,
+            "issue": 33,
+            "state_issue_score": 0,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191152,
+        "fields": {
+            "state": 262,
+            "issue": 34,
+            "state_issue_score": 0.55,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191154,
+        "fields": {
+            "state": 262,
+            "issue": 35,
+            "state_issue_score": 0.35,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191155,
+        "fields": {
+            "state": 262,
+            "issue": 36,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    //南投县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191156,
+        "fields": {
+            "state": 258,
+            "issue": 32,
+            "state_issue_score": 0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191157,
+        "fields": {
+            "state": 258,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191158,
+        "fields": {
+            "state": 258,
+            "issue": 34,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191159,
+        "fields": {
+            "state": 258,
+            "issue": 35,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191160,
+        "fields": {
+            "state": 258,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //花莲县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191161,
+        "fields": {
+            "state": 255,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191162,
+        "fields": {
+            "state": 255,
+            "issue": 33,
+            "state_issue_score": 0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191163,
+        "fields": {
+            "state": 255,
+            "issue": 34,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191164,
+        "fields": {
+            "state": 255,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191165,
+        "fields": {
+            "state": 255,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //台东县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191166,
+        "fields": {
+            "state": 254,
+            "issue": 32,
+            "state_issue_score": 0.55,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191167,
+        "fields": {
+            "state": 254,
+            "issue": 33,
+            "state_issue_score": 0.15,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191168,
+        "fields": {
+            "state": 254,
+            "issue": 34,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191169,
+        "fields": {
+            "state": 254,
+            "issue": 35,
+            "state_issue_score": -0.33,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191170,
+        "fields": {
+            "state": 254,
+            "issue": 36,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    //彰化县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191171,
+        "fields": {
+            "state": 260,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191172,
+        "fields": {
+            "state": 260,
+            "issue": 33,
+            "state_issue_score": -0.85,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191173,
+        "fields": {
+            "state": 260,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191174,
+        "fields": {
+            "state": 260,
+            "issue": 35,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191175,
+        "fields": {
+            "state": 260,
+            "issue": 36,
+            "state_issue_score": 0,
+            "weight": 0.5
+        }
+    },
+    //云林县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191176,
+        "fields": {
+            "state": 259,
+            "issue": 32,
+            "state_issue_score": -0.4,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191177,
+        "fields": {
+            "state": 259,
+            "issue": 33,
+            "state_issue_score": -0.85,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191178,
+        "fields": {
+            "state": 259,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191179,
+        "fields": {
+            "state": 259,
+            "issue": 35,
+            "state_issue_score": -0.85,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191180,
+        "fields": {
+            "state": 259,
+            "issue": 36,
+            "state_issue_score": -0.45,
+            "weight": 0.5
+        }
+    },
+    //澎湖
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191181,
+        "fields": {
+            "state": 261,
+            "issue": 32,
+            "state_issue_score": 0,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191182,
+        "fields": {
+            "state": 261,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191183,
+        "fields": {
+            "state": 261,
+            "issue": 34,
+            "state_issue_score": -0.9,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191184,
+        "fields": {
+            "state": 261,
+            "issue": 35,
+            "state_issue_score": -0.75,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191185,
+        "fields": {
+            "state": 261,
+            "issue": 36,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    //嘉义县
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191186,
+        "fields": {
+            "state": 256,
+            "issue": 32,
+            "state_issue_score": -0.75,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191187,
+        "fields": {
+            "state": 256,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191188,
+        "fields": {
+            "state": 256,
+            "issue": 34,
+            "state_issue_score": -0.15,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191189,
+        "fields": {
+            "state": 256,
+            "issue": 35,
+            "state_issue_score": -0.9,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191190,
+        "fields": {
+            "state": 256,
+            "issue": 36,
+            "state_issue_score": -0.75,
+            "weight": 0.5
+        }
+    },
+    //嘉义市
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191191,
+        "fields": {
+            "state": 257,
+            "issue": 32,
+            "state_issue_score": -0.25,
+            "weight": 1
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191192,
+        "fields": {
+            "state": 257,
+            "issue": 33,
+            "state_issue_score": -0.75,
+            "weight": 2
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191193,
+        "fields": {
+            "state": 257,
+            "issue": 34,
+            "state_issue_score": 0.25,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191194,
+        "fields": {
+            "state": 257,
+            "issue": 35,
+            "state_issue_score": -0.6,
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "campaign_trail.state_issue_score",
+        "pk": 191195,
+        "fields": {
+            "state": 257,
+            "issue": 36,
+            "state_issue_score": -0.25,
+            "weight": 0.5
+        }
+    },
+     //台南市
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191196,
+            "fields": {
+                "state": 251,
+                "issue": 32,
+                "state_issue_score": -0.85,
+                "weight": 1
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191197,
+            "fields": {
+                "state": 251,
+                "issue": 33,
+                "state_issue_score": -0.15,
+                "weight": 2
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191198,
+            "fields": {
+                "state": 251,
+                "issue": 34,
+                "state_issue_score": 0.55,
+                "weight": 0.5
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191199,
+            "fields": {
+                "state": 251,
+                "issue": 35,
+                "state_issue_score": 0.15,
+                "weight": 0.5
+            }
+        },
+        {
+            "model": "campaign_trail.state_issue_score",
+            "pk": 191200,
+            "fields": {
+                "state": 251,
+                "issue": 36,
+                "state_issue_score": -0.75,
+                "weight": 0.5
+            }
+        },
+         //高雄市
+             {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191201,
+                "fields": {
+                    "state": 252,
+                    "issue": 32,
+                    "state_issue_score": -0.55,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191202,
+                "fields": {
+                    "state": 252,
+                    "issue": 33,
+                    "state_issue_score": -0.15,
+                    "weight": 2
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191203,
+                "fields": {
+                    "state": 252,
+                    "issue": 34,
+                    "state_issue_score": 0.65,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191204,
+                "fields": {
+                    "state": 252,
+                    "issue": 35,
+                    "state_issue_score": 0.15,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191205,
+                "fields": {
+                    "state": 252,
+                    "issue": 36,
+                    "state_issue_score": -0.75,
+                    "weight": 0.5
+                }
+            },
+            //屏东县
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191206,
+                "fields": {
+                    "state": 253,
+                    "issue": 32,
+                    "state_issue_score": -0.5,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191207,
+                "fields": {
+                    "state": 253,
+                    "issue": 33,
+                    "state_issue_score": -0.25,
+                    "weight": 2
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191208,
+                "fields": {
+                    "state": 253,
+                    "issue": 34,
+                    "state_issue_score": 0.25,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191209,
+                "fields": {
+                    "state": 253,
+                    "issue": 35,
+                    "state_issue_score": 0,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191210,
+                "fields": {
+                    "state": 253,
+                    "issue": 36,
+                    "state_issue_score": -0.55,
+                    "weight": 0.5
+                }
+            },
+              //金门县
+              {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191211,
+                "fields": {
+                    "state": 271,
+                    "issue": 32,
+                    "state_issue_score": 1,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191212,
+                "fields": {
+                    "state": 271,
+                    "issue": 33,
+                    "state_issue_score": 1,
+                    "weight": 1
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191213,
+                "fields": {
+                    "state": 271,
+                    "issue": 34,
+                    "state_issue_score": -0.75,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191214,
+                "fields": {
+                    "state": 271,
+                    "issue": 35,
+                    "state_issue_score": -0.25,
+                    "weight": 0.5
+                }
+            },
+            {
+                "model": "campaign_trail.state_issue_score",
+                "pk": 191215,
+                "fields": {
+                    "state": 271,
+                    "issue": 36,
+                    "state_issue_score": 1,
+                    "weight": 0.5
+                }
+            },
+                //连江县
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191216,
+                    "fields": {
+                        "state": 272,
+                        "issue": 32,
+                        "state_issue_score": 1,
+                        "weight": 1
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191217,
+                    "fields": {
+                        "state": 272,
+                        "issue": 33,
+                        "state_issue_score": 1,
+                        "weight": 1
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191218,
+                    "fields": {
+                        "state": 272,
+                        "issue": 34,
+                        "state_issue_score": -1,
+                        "weight": 0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191219,
+                    "fields": {
+                        "state": 272,
+                        "issue": 35,
+                        "state_issue_score": 0.25,
+                        "weight": 0.5
+                    }
+                },
+                {
+                    "model": "campaign_trail.state_issue_score",
+                    "pk": 191220,
+                    "fields": {
+                        "state": 272,
+                        "issue": 36,
+                        "state_issue_score": 1,
+                        "weight": 0.5
+                    }
+                },
+]
+campaignTrail_temp.candidate_issue_score_json = [
+    //赖清德
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 328,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 32,
+            "issue_score": -0.85 //深绿
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 329,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 33,
+            "issue_score": -0.75 //台湾本省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 330,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 34,
+            "issue_score": -0.35 //矿工之子
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 331,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 35,
+            "issue_score": 0.25 //年轻人支持度还行
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 332,
+        "fields": {
+            "candidate": 2001557,
+            "issue": 36,
+            "issue_score": -1 //我就是现任副总统啊
+        }
+    },
+    //侯友谊
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 333,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 32,
+            "issue_score": 0.15 //浅蓝，甚至蓝皮绿谷
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 334,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 33,
+            "issue_score": -0.9 //比赖清德更本省
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 335,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 34,
+            "issue_score": -0.5 //嘉义乡下卖猪肉的
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 336,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 35,
+            "issue_score": -0.25 //年轻人不喜欢的老蓝男
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 337,
+        "fields": {
+            "candidate": 2001591,
+            "issue": 36,
+            "issue_score": 0.25 //攻击性不强
+        }
+    },
+    //柯文哲
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 338,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 32,
+            "issue_score": -0.5 //我内心本质还是深绿的
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 339,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 33,
+            "issue_score": -0.75 //本省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 340,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 34,
+            "issue_score": 0.15 //家庭条件还可以
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 341,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 35,
+            "issue_score": 0.8 //阿北阿北我爱你
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 342,
+        "fields": {
+            "candidate": 2001622,
+            "issue": 36,
+            "issue_score": 0.5 //攻击性很强，但并不把下架民进党当第一目标
+        }
+    },
+     //郭台铭
+     {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 343,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 32,
+            "issue_score": 0.7 //深蓝
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 344,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 33,
+            "issue_score": 0.75 //外省人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 345,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 34,
+            "issue_score": 0.75 //城里人
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 346,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 35,
+            "issue_score": -0.25 //老蓝男
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 347,
+        "fields": {
+            "candidate": 2001653,
+            "issue": 36,
+            "issue_score": 0.4 //攻击性一般，下架民进党是说说听得口号
+        }
+    },
+]
+campaignTrail_temp.running_mate_issue_score_json = [
+  //萧美琴
+  {
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9343,
+    "fields": {
+        "candidate": 1002,
+        "issue": 32,
+        "issue_score": -0.7
+    }
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9344,
+    "fields": {
+        "candidate": 1002,
+        "issue": 33,
+        "issue_score": -0
+    }
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9345,
+    "fields": {
+        "candidate": 1002,
+        "issue": 34,
+        "issue_score": -0.25
+},
+},
+{
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9346,
+    "fields": {
+        "candidate": 1002,
+        "issue": 35,
+        "issue_score": 0.25 
+    }
+},
+    {
+    "model": "campaign_trail.candidate_issue_score",
+    "pk": 9347,
+    "fields": {
+        "candidate": 1002,
+        "issue": 36,
+        "issue_score": -0.5
+    }
+    },
+    //蓝白联票
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9348,
+        "fields": {
+            "candidate": 50001,
+            "issue": 32,
+            "issue_score": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9349,
+        "fields": {
+            "candidate": 50001,
+            "issue": 33,
+            "issue_score": 0
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9350,
+        "fields": {
+            "candidate": 50001,
+            "issue": 34,
+            "issue_score": 0
+    },
+},
+    {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9351,
+        "fields": {
+            "candidate": 50001,
+            "issue": 35,
+            "issue_score": 0.15 
+        }
+    },
+        {
+        "model": "campaign_trail.candidate_issue_score",
+        "pk": 9352,
+        "fields": {
+            "candidate": 50001,
+            "issue": 36,
+            "issue_score": 0.4
+        }
+        },
+        //赵少康
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93481,
+            "fields": {
+                "candidate": 50000,
+                "issue": 32,
+                "issue_score": 0.95
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93491,
+            "fields": {
+                "candidate": 50000,
+                "issue": 33,
+                "issue_score": 0.95
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93501,
+            "fields": {
+                "candidate": 50000,
+                "issue": 34,
+                "issue_score": 0.55
+        },
+    },
+        {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93511,
+            "fields": {
+                "candidate": 50000,
+                "issue": 35,
+                "issue_score": 0.1
+            }
+        },
+            {
+            "model": "campaign_trail.candidate_issue_score",
+            "pk": 93521,
+            "fields": {
+                "candidate": 50000,
+                "issue": 36,
+                "issue_score": 0.5
+            }
+            },
+            //韩国瑜
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 934812,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 32,
+                    "issue_score": 0.95
+                }
+            },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 934912,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 33,
+                    "issue_score": 0.95
+                }
+            },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935013,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 34,
+                    "issue_score": -0.25
+            },
+        },
+            {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935114,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 35,
+                    "issue_score": 0
+                }
+            },
+                {
+                "model": "campaign_trail.candidate_issue_score",
+                "pk": 935215,
+                "fields": {
+                    "candidate": 2020558,
+                    "issue": 36,
+                    "issue_score": 0.65
+                }
+                },
+                //柯志恩
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9348121,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 32,
+                        "issue_score": 0.15
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9349121,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 33,
+                        "issue_score": -0.75
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9350131,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 34,
+                        "issue_score": -0.15
+                },
+            },
+                {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9351141,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 35,
+                        "issue_score": 0.5
+                    }
+                },
+                    {
+                    "model": "campaign_trail.candidate_issue_score",
+                    "pk": 9352151,
+                    "fields": {
+                        "candidate": 2022055,
+                        "issue": 36,
+                        "issue_score": 0.42
+                    }
+                    },
+                    //赖佩霞
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93481211,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 32,
+                            "issue_score": 0.1
+                        }
+                    },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93491211,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 33,
+                            "issue_score": 0
+                        }
+                    },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93501311,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 34,
+                            "issue_score": 0.25
+                    },
+                },
+                    {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93511411,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 35,
+                            "issue_score": 0.15
+                        }
+                    },
+                        {
+                        "model": "campaign_trail.candidate_issue_score",
+                        "pk": 93521511,
+                        "fields": {
+                            "candidate": 50005,
+                            "issue": 36,
+                            "issue_score": 0.15
+                        }
+                        },
+                        //白蓝联票
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410110,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 32,
+                                "issue_score": -0.1
+                            }
+                        },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410111,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 33,
+                                "issue_score": 0
+                            }
+                        },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410112,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 34,
+                                "issue_score": 0
+                        },
+                    },
+                        {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410113,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 35,
+                                "issue_score": 0.75
+                            }
+                        },
+                            {
+                            "model": "campaign_trail.candidate_issue_score",
+                            "pk": 410114,
+                            "fields": {
+                                "candidate": 50003,
+                                "issue": 36,
+                                "issue_score": 0.25
+                            }
+                            },
+                            //吴欣盈
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241000,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 32,
+                                    "issue_score": 0
+                                }
+                            },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241001,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 33,
+                                    "issue_score": 0
+                                }
+                            },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241002,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 34,
+                                    "issue_score": 0
+                            },
+                           },
+                            {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241003,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 35,
+                                    "issue_score": 0.75
+                                }
+                            },
+                                {
+                                "model": "campaign_trail.candidate_issue_score",
+                                "pk": 11241004,
+                                "fields": {
+                                    "candidate": 25000,
+                                    "issue": 36,
+                                    "issue_score": 0.25
+                                }
+                        }
+    ]
+
+campaignTrail_temp.candidate_state_multiplier_json = [
+       //台南市
+       {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25191,
+        "fields": {
+            "candidate": 2001557,
+            "state": 251,
+            "state_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25192,
+        "fields": {
+            "candidate": 2001591,
+            "state": 251,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25693,
+        "fields": {
+            "candidate": 2001622,
+            "state": 251,
+            "state_multiplier": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25694,
+        "fields": {
+            "candidate": 2001653,
+            "state": 251,
+            "state_multiplier": 0.05
+        }
+    },
+    //嘉义市
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25691,
+        "fields": {
+            "candidate": 2001557,
+            "state": 256,
+            "state_multiplier": 0.3
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25692,
+        "fields": {
+            "candidate": 2001591,
+            "state": 256,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25693,
+        "fields": {
+            "candidate": 2001622,
+            "state": 256,
+            "state_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25694,
+        "fields": {
+            "candidate": 2001653,
+            "state": 256,
+            "state_multiplier": 0.05
+        }
+    },
+      //花莲县
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25591,
+        "fields": {
+            "candidate": 2001557,
+            "state": 255,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25592,
+        "fields": {
+            "candidate": 2001591,
+            "state": 255,
+            "state_multiplier": 0.366
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25593,
+        "fields": {
+            "candidate": 2001622,
+            "state": 255,
+            "state_multiplier": 0.18
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25594,
+        "fields": {
+            "candidate": 2001653,
+            "state": 255,
+            "state_multiplier": 0.1
+        }
+    },
+      //屏东
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25391,
+        "fields": {
+            "candidate": 2001557,
+            "state": 253,
+            "state_multiplier": 0.32
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25392,
+        "fields": {
+            "candidate": 2001591,
+            "state": 253,
+            "state_multiplier": 0.22
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25393,
+        "fields": {
+            "candidate": 2001622,
+            "state": 253,
+            "state_multiplier": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25294,
+        "fields": {
+            "candidate": 2001653,
+            "state": 253,
+            "state_multiplier": 0.05
+        }
+    },
+    //高雄
+      {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25291,
+        "fields": {
+            "candidate": 2001557,
+            "state": 252,
+            "state_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25292,
+        "fields": {
+            "candidate": 2001591,
+            "state": 252,
+            "state_multiplier": 0.21
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25293,
+        "fields": {
+            "candidate": 2001622,
+            "state": 252,
+            "state_multiplier": 0.13
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 25294,
+        "fields": {
+            "candidate": 2001653,
+            "state": 252,
+            "state_multiplier": 0.05
+        }
+    },
+    //台东
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252912,
+        "fields": {
+            "candidate": 2001557,
+            "state": 254,
+            "state_multiplier": 0.24
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252922,
+        "fields": {
+            "candidate": 2001591,
+            "state": 254,
+            "state_multiplier": 0.35
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252932,
+        "fields": {
+            "candidate": 2001622,
+            "state": 254,
+            "state_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.candidate_state_multiplier",
+        "pk": 252942,
+        "fields": {
+            "candidate": 2001653,
+            "state": 254,
+            "state_multiplier": 0.1
+        }
+    },
+        //嘉义市
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114514,
+            "fields": {
+                "candidate": 2001557,
+                "state": 257,
+                "state_multiplier": 0.35
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114515,
+            "fields": {
+                "candidate": 2001591,
+                "state": 257,
+                "state_multiplier": 0.23
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114516,
+            "fields": {
+                "candidate": 2001622,
+                "state": 257,
+                "state_multiplier": 0.15
+            }
+        },
+        {
+            "model": "campaign_trail.candidate_state_multiplier",
+            "pk": 114517,
+            "fields": {
+                "candidate": 2001653,
+                "state": 257,
+                "state_multiplier": 0.05
+            }
+        },
+        //南投
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 566666,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 258,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 666666,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 258,
+                        "state_multiplier": 0.31
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 6666666,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 258,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 66666666,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 258,
+                        "state_multiplier": 0.08
+                    }
+                },
+                //彰化
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 114514123,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 260,
+                        "state_multiplier": 0.35
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1145141234,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 260,
+                        "state_multiplier": 0.26
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 11451414,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 260,
+                        "state_multiplier": 0.19
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 21412412,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 260,
+                        "state_multiplier": 0.06
+                    }
+                },
+                //云林
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1111,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 259,
+                        "state_multiplier": 0.32
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2222,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 259,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 3333,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 259,
+                        "state_multiplier": 0.19
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 4444,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 259,
+                        "state_multiplier": 0.04
+                    }
+                },
+                //澎湖
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 5555,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 261,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 6666,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 261,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 7777,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 261,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 8888,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 261,
+                        "state_multiplier": 0.05
+                    }
+                },
+                //台中
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412241,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 262,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412411,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 262,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412412,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 262,
+                        "state_multiplier": 0.22
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 412511,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 262,
+                        "state_multiplier": 0.05
+                    }
+                },
+                //新竹县
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101001,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 264,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101002,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 264,
+                        "state_multiplier": 0.29
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101003,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 264,
+                        "state_multiplier": 0.26
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 101004,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 264,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //新竹市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010012,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 265,
+                        "state_multiplier": 0.285
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010022,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 265,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010032,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 265,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 1010042,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 265,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //苗栗
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2194,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 266,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2195,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 266,
+                        "state_multiplier": 0.35
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2196,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 266,
+                        "state_multiplier": 0.22
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 2197,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 266,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //新北市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12194,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 267,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12195,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 267,
+                        "state_multiplier": 0.27
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12196,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 267,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 12197,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 267,
+                        "state_multiplier": 0.12
+                    }
+                },
+                //台北市
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 268,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 268,
+                        "state_multiplier": 0.34
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 268,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 121975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 268,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //桃园
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 269,
+                        "state_multiplier": 0.26
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 269,
+                        "state_multiplier": 0.28
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 269,
+                        "state_multiplier": 0.21
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 221975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 269,
+                        "state_multiplier": 0.13
+                    }
+                },
+                //基隆
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321945,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 270,
+                        "state_multiplier": 0.25
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321955,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 270,
+                        "state_multiplier": 0.3
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321965,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 270,
+                        "state_multiplier": 0.16
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 321975,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 270,
+                        "state_multiplier": 0.1
+                    }
+                },
+                //金门
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19581,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 271,
+                        "state_multiplier": 0.05
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19582,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 271,
+                        "state_multiplier": 0.55
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19583,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 271,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 19584,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 271,
+                        "state_multiplier": 0.15
+                    }
+                },         
+                 //宜兰
+                 {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195813,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 263,
+                        "state_multiplier": 0.35
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195823,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 263,
+                        "state_multiplier": 0.2
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195833,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 263,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195843,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 263,
+                        "state_multiplier": 0.08
+                    }
+                },       
+                  //连江
+                  {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195812,
+                    "fields": {
+                        "candidate": 2001557,
+                        "state": 272,
+                        "state_multiplier": 0.05
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195822,
+                    "fields": {
+                        "candidate": 2001591,
+                        "state": 272,
+                        "state_multiplier": 0.55
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195832,
+                    "fields": {
+                        "candidate": 2001622,
+                        "state": 272,
+                        "state_multiplier": 0.18
+                    }
+                },
+                {
+                    "model": "campaign_trail.candidate_state_multiplier",
+                    "pk": 195842,
+                    "fields": {
+                        "candidate": 2001653,
+                        "state": 272,
+                        "state_multiplier": 0.15
+                    }
+                },      
+]
+
+campaignTrail_temp.answer_score_global_json = [
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13446,
+        "fields": {
+            "answer": 13440,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.0225
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13447,
+        "fields": {
+            "answer": 13441,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13448,
+        "fields": {
+            "answer": 13441,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13449,
+        "fields": {
+            "answer": 13440,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.0076
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13450,
+        "fields": {
+            "answer": 13442,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13451,
+        "fields": {
+            "answer": 13442,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13452,
+        "fields": {
+            "answer": 13442,
+            "candidate": 2001591,
+            "affected_candidate": 2001653,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13035,
+        "fields": {
+            "answer": 13030,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.011
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13051,
+        "fields": {
+            "answer": 13047,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13055,
+        "fields": {
+            "answer": 13048,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13056,
+        "fields": {
+            "answer": 13049,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13067,
+        "fields": {
+            "answer": 13059,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13071,
+        "fields": {
+            "answer": 13060,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.024
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13072,
+        "fields": {
+            "answer": 13060,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13079,
+        "fields": {
+            "answer": 13073,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13082,
+        "fields": {
+            "answer": 13075,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13083,
+        "fields": {
+            "answer": 13075,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13085,
+        "fields": {
+            "answer": 13076,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13086,
+        "fields": {
+            "answer": 13074,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13093,
+        "fields": {
+            "answer": 13087,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.175
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13094,
+        "fields": {
+            "answer": 13088,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13095,
+        "fields": {
+            "answer": 13087,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13096,
+        "fields": {
+            "answer": 13089,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13097,
+        "fields": {
+            "answer": 13089,
+            "candidate": 2001591,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.23
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13106,
+        "fields": {
+            "answer": 13100,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13107,
+        "fields": {
+            "answer": 13101,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13108,
+        "fields": {
+            "answer": 13102,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13114,
+        "fields": {
+            "answer": 13100,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": -1000
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13115,
+        "fields": {
+            "answer": 13101,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": -1000
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13116,
+        "fields": {
+            "answer": 13102,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": -1000
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13117,
+        "fields": {
+            "answer": 13102,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13126,
+        "fields": {
+            "answer": 13111,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.011
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13131,
+        "fields": {
+            "answer": 13127,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13137,
+        "fields": {
+            "answer": 13129,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13144,
+        "fields": {
+            "answer": 13139,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13146,
+        "fields": {
+            "answer": 13140,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13147,
+        "fields": {
+            "answer": 13139,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13149,
+        "fields": {
+            "answer": 13141,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13150,
+        "fields": {
+            "answer": 13141,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13152,
+        "fields": {
+            "answer": 13142,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.07
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13153,
+        "fields": {
+            "answer": 13142,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13187,
+        "fields": {
+            "answer": 13182,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13189,
+        "fields": {
+            "answer": 13183,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13197,
+        "fields": {
+            "answer": 13195,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13198,
+        "fields": {
+            "answer": 13195,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13200,
+        "fields": {
+            "answer": 13194,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13201,
+        "fields": {
+            "answer": 13194,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.055
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13209,
+        "fields": {
+            "answer": 13202,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13212,
+        "fields": {
+            "answer": 13203,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13213,
+        "fields": {
+            "answer": 13204,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13220,
+        "fields": {
+            "answer": 13216,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": 1000.35
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13221,
+        "fields": {
+            "answer": 13217,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": 1000.4
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13222,
+        "fields": {
+            "answer": 13216,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13223,
+        "fields": {
+            "answer": 13217,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13232,
+        "fields": {
+            "answer": 13226,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13233,
+        "fields": {
+            "answer": 13225,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13235,
+        "fields": {
+            "answer": 13227,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13240,
+        "fields": {
+            "answer": 13236,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13244,
+        "fields": {
+            "answer": 13237,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13245,
+        "fields": {
+            "answer": 13237,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13246,
+        "fields": {
+            "answer": 13238,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13247,
+        "fields": {
+            "answer": 13238,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13250,
+        "fields": {
+            "answer": 13248,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13257,
+        "fields": {
+            "answer": 13253,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13258,
+        "fields": {
+            "answer": 13253,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13259,
+        "fields": {
+            "answer": 13251,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13260,
+        "fields": {
+            "answer": 13252,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13268,
+        "fields": {
+            "answer": 13261,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13269,
+        "fields": {
+            "answer": 13261,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13273,
+        "fields": {
+            "answer": 13263,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13303,
+        "fields": {
+            "answer": 13299,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.13
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13305,
+        "fields": {
+            "answer": 13300,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.18
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13307,
+        "fields": {
+            "answer": 13301,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13317,
+        "fields": {
+            "answer": 13310,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13318,
+        "fields": {
+            "answer": 13309,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13326,
+        "fields": {
+            "answer": 13319,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": -10000
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13332,
+        "fields": {
+            "answer": 13322,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13333,
+        "fields": {
+            "answer": 13322,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13334,
+        "fields": {
+            "answer": 13322,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13335,
+        "fields": {
+            "answer": 13322,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13338,
+        "fields": {
+            "answer": 13323,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.3
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13339,
+        "fields": {
+            "answer": 13323,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": -10000
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13340,
+        "fields": {
+            "answer": 13323,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": -10000
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13341,
+        "fields": {
+            "answer": 13324,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -10000
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13342,
+        "fields": {
+            "answer": 13324,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.42
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13343,
+        "fields": {
+            "answer": 13324,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": -10000
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13352,
+        "fields": {
+            "answer": 13345,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13354,
+        "fields": {
+            "answer": 13346,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13355,
+        "fields": {
+            "answer": 13344,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13363,
+        "fields": {
+            "answer": 13357,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13365,
+        "fields": {
+            "answer": 13356,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.012
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13366,
+        "fields": {
+            "answer": 13358,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13372,
+        "fields": {
+            "answer": 13367,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.08
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13374,
+        "fields": {
+            "answer": 13368,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13375,
+        "fields": {
+            "answer": 13368,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13376,
+        "fields": {
+            "answer": 13368,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13379,
+        "fields": {
+            "answer": 13369,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13380,
+        "fields": {
+            "answer": 13369,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13381,
+        "fields": {
+            "answer": 13369,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13382,
+        "fields": {
+            "answer": 13370,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13389,
+        "fields": {
+            "answer": 13385,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13392,
+        "fields": {
+            "answer": 13384,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13393,
+        "fields": {
+            "answer": 13383,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13394,
+        "fields": {
+            "answer": 13383,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13413,
+        "fields": {
+            "answer": 13408,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13415,
+        "fields": {
+            "answer": 13409,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": -0.01
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13421,
+        "fields": {
+            "answer": 13398,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13422,
+        "fields": {
+            "answer": 13398,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.25
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13423,
+        "fields": {
+            "answer": 13397,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13424,
+        "fields": {
+            "answer": 13397,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.25
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13425,
+        "fields": {
+            "answer": 13396,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13426,
+        "fields": {
+            "answer": 13396,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.25
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13427,
+        "fields": {
+            "answer": 15783,
+            "candidate": 2001557,
+            "affected_candidate": 2001653,
+            "global_multiplier": -0.25
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13428,
+        "fields": {
+            "answer": 15783,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13433,
+        "fields": {
+            "answer": 15783,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13434,
+        "fields": {
+            "answer": 15782,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": -0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13435,
+        "fields": {
+            "answer": 15782,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.033
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 194000,
+        "fields": {
+            "answer": 1950002,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.033
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 194001,
+        "fields": {
+            "answer": 1950003,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "global_multiplier": 0.035
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1940021,
+        "fields": {
+            "answer": 13319,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 1940031,
+        "fields": {
+            "answer": 13322,
+            "candidate": 2001557,
+            "affected_candidate": 2001591,
+            "global_multiplier": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_global",
+        "pk": 13438,
+        "fields": {
+            "answer": 13436,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "global_multiplier": 0.015
+        }
+    }
+]
+
+campaignTrail_temp.answer_score_issue_json = [
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13023,
+        "fields": {
+            "answer": 13019,
+            "issue": 32,
+            "issue_score": -0.05,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13025,
+        "fields": {
+            "answer": 13020,
+            "issue": 36,
+            "issue_score": -0.05,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13027,
+        "fields": {
+            "answer": 13021,
+            "issue": 32,
+            "issue_score": -0.025,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13028,
+        "fields": {
+            "answer": 13021,
+            "issue": 36,
+            "issue_score": -0.03,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13034,
+        "fields": {
+            "answer": 13029,
+            "issue": 35,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13037,
+        "fields": {
+            "answer": 13030,
+            "issue": 36,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13040,
+        "fields": {
+            "answer": 13032,
+            "issue": 32,
+            "issue_score": -0.08,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13045,
+        "fields": {
+            "answer": 13041,
+            "issue": 36,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13052,
+        "fields": {
+            "answer": 13047,
+            "issue": 36,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13062,
+        "fields": {
+            "answer": 13057,
+            "issue": 32,
+            "issue_score": -0.1,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13064,
+        "fields": {
+            "answer": 13058,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13065,
+        "fields": {
+            "answer": 13058,
+            "issue": 33,
+            "issue_score": -0.07,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13068,
+        "fields": {
+            "answer": 13059,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13069,
+        "fields": {
+            "answer": 13059,
+            "issue": 33,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13080,
+        "fields": {
+            "answer": 13073,
+            "issue": 35,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13098,
+        "fields": {
+            "answer": 13089,
+            "issue": 32,
+            "issue_score": -0.15,
+            "issue_importance": 0.15
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13099,
+        "fields": {
+            "answer": 13089,
+            "issue": 36,
+            "issue_score": -0.15,
+            "issue_importance": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13110,
+        "fields": {
+            "answer": 13102,
+            "issue": 36,
+            "issue_score": -0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13121,
+        "fields": {
+            "answer": 13111,
+            "issue": 34,
+            "issue_score": -0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13122,
+        "fields": {
+            "answer": 13112,
+            "issue": 32,
+            "issue_score": -0.07,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13123,
+        "fields": {
+            "answer": 13113,
+            "issue": 34,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13124,
+        "fields": {
+            "answer": 13113,
+            "issue": 35,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13125,
+        "fields": {
+            "answer": 13112,
+            "issue": 36,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13132,
+        "fields": {
+            "answer": 13127,
+            "issue": 35,
+            "issue_score": -0.09,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13135,
+        "fields": {
+            "answer": 13128,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13136,
+        "fields": {
+            "answer": 13128,
+            "issue": 36,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13138,
+        "fields": {
+            "answer": 13129,
+            "issue": 35,
+            "issue_score": -0.1,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13154,
+        "fields": {
+            "answer": 13142,
+            "issue": 35,
+            "issue_score": 0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13191,
+        "fields": {
+            "answer": 13184,
+            "issue": 36,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13193,
+        "fields": {
+            "answer": 13185,
+            "issue": 32,
+            "issue_score": -0.08,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13210,
+        "fields": {
+            "answer": 13202,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13211,
+        "fields": {
+            "answer": 13202,
+            "issue": 36,
+            "issue_score": 0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13214,
+        "fields": {
+            "answer": 13204,
+            "issue": 32,
+            "issue_score": 0.05,
+            "issue_importance": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13215,
+        "fields": {
+            "answer": 13204,
+            "issue": 36,
+            "issue_score": 0.05,
+            "issue_importance": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13229,
+        "fields": {
+            "answer": 13224,
+            "issue": 35,
+            "issue_score": 0.09,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13270,
+        "fields": {
+            "answer": 13262,
+            "issue":32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13271,
+        "fields": {
+            "answer": 13262,
+            "issue": 36,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13350,
+        "fields": {
+            "answer": 13344,
+            "issue":32,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13351,
+        "fields": {
+            "answer": 13344,
+            "issue": 36,
+            "issue_score": -0.05,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13362,
+        "fields": {
+            "answer": 13356,
+            "issue": 36,
+            "issue_score": -0.1,
+            "issue_importance": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13364,
+        "fields": {
+            "answer": 13357,
+            "issue": 36,
+            "issue_score": -0.1,
+            "issue_importance": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13390,
+        "fields": {
+            "answer": 13385,
+            "issue":32,
+            "issue_score": -0.5,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13391,
+        "fields": {
+            "answer": 13385,
+            "issue": 36,
+            "issue_score": -0.8,
+            "issue_importance": 0.12
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13416,
+        "fields": {
+            "answer": 13410,
+            "issue":32,
+            "issue_score": -0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13417,
+        "fields": {
+            "answer": 13410,
+            "issue": 36,
+            "issue_score": -0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13420,
+        "fields": {
+            "answer": 13411,
+            "issue":32,
+            "issue_score": -0.15,
+            "issue_importance": 0.2
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13429,
+        "fields": {
+            "answer": 13396,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13430,
+        "fields": {
+            "answer": 13397,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13431,
+        "fields": {
+            "answer": 13398,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 13432,
+        "fields": {
+            "answer": 13395,
+            "issue": 32,
+            "issue_score": 0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 134320,
+        "fields": {
+            "answer": 1950004,
+            "issue": 32,
+            "issue_score": -0.1,
+            "issue_importance": 0.1
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_issue",
+        "pk": 134320,
+        "fields": {
+            "answer": 1950004,
+            "issue": 36,
+            "issue_score": -0.15,
+            "issue_importance": 0.1
+        }
+    },
+]
+
+campaignTrail_temp.answer_score_state_json = [
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13046,
+        "fields": {
+            "answer": 13042,
+            "state": 258,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13163,
+        "fields": {
+            "answer": 13155,
+            "state": 251,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13164,
+        "fields": {
+            "answer": 13155,
+            "state": 252,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.021
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13165,
+        "fields": {
+            "answer": 13155,
+            "state": 256,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13166,
+        "fields": {
+            "answer": 13155,
+            "state": 257,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13167,
+        "fields": {
+            "answer": 13156,
+            "state": 260,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.032
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13168,
+        "fields": {
+            "answer": 13156,
+            "state": 262,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.025
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13169,
+        "fields": {
+            "answer": 13156,
+            "state": 258,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.045
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13170,
+        "fields": {
+            "answer": 13157,
+            "state": 264,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13171,
+        "fields": {
+            "answer": 13157,
+            "state": 265,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13172,
+        "fields": {
+            "answer": 13157,
+            "state": 266,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13173,
+        "fields": {
+            "answer": 13157,
+            "state": 269,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13174,
+        "fields": {
+            "answer": 13158,
+            "state": 271,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13175,
+        "fields": {
+            "answer": 13158,
+            "state": 272,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13176,
+        "fields": {
+            "answer": 13158,
+            "state": 263,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13177,
+        "fields": {
+            "answer": 13158,
+            "state": 255,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13178,
+        "fields": {
+            "answer": 13158,
+            "state": 254,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13179,
+        "fields": {
+            "answer": 13158,
+            "state": 261,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13180,
+        "fields": {
+            "answer": 13158,
+            "state": 253,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13279,
+        "fields": {
+            "answer": 13274,
+            "state": 260,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13280,
+        "fields": {
+            "answer": 13274,
+            "state": 259,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13281,
+        "fields": {
+            "answer": 13274,
+            "state": 256,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13282,
+        "fields": {
+            "answer": 13274,
+            "state": 257,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13284,
+        "fields": {
+            "answer": 13275,
+            "state": 261,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13285,
+        "fields": {
+            "answer": 13275,
+            "state": 253,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13286,
+        "fields": {
+            "answer": 13275,
+            "state": 252,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.021
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13288,
+        "fields": {
+            "answer": 13276,
+            "state": 270,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13289,
+        "fields": {
+            "answer": 13276,
+            "state": 267,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13290,
+        "fields": {
+            "answer": 13276,
+            "state": 268,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.015
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13291,
+        "fields": {
+            "answer": 13277,
+            "state": 254,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13292,
+        "fields": {
+            "answer": 13277,
+            "state": 255,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13293,
+        "fields": {
+            "answer": 13277,
+            "state": 264,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13294,
+        "fields": {
+            "answer": 13277,
+            "state": 266,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13295,
+        "fields": {
+            "answer": 13277,
+            "state": 271,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13296,
+        "fields": {
+            "answer": 13277,
+            "state": 272,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13297,
+        "fields": {
+            "answer": 13277,
+            "state": 258,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.03
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13308,
+        "fields": {
+            "answer": 13301,
+            "state": 252,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": -0.05
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13353,
+        "fields": {
+            "answer": 13346,
+            "state": 255,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.04
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13403,
+        "fields": {
+            "answer": 13395,
+            "state": 267,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13404,
+        "fields": {
+            "answer": 13396,
+            "state": 251,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13405,
+        "fields": {
+            "answer": 13397,
+            "state": 262,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 13406,
+        "fields": {
+            "answer": 13398,
+            "state": 268,
+            "candidate": 2001557,
+            "affected_candidate": 2001557,
+            "state_multiplier": 0.02
+        }
+    },
+    {
+        "model": "campaign_trail.answer_score_state",
+        "pk": 134060,
+        "fields": {
+            "answer": 1950003,
+            "state": 268,
+            "candidate": 2001557,
+            "affected_candidate": 2001622,
+            "state_multiplier": -0.0255
+        }
+    }
+]
+
+campaignTrail_temp.answer_feedback_json = [
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13437,
+        "fields": {
+            "answer": 13436,
+            "candidate": 2001557,
+            "answer_feedback": "These medals were available in limited quantities, but they were snapped up in a flash."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13022,
+        "fields": {
+            "answer": 13019,
+            "candidate": 2001557,
+            "answer_feedback": "You can never go wrong for a DPP candidate to emphasize his love for Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13024,
+        "fields": {
+            "answer": 13020,
+            "candidate": 2001557,
+            "answer_feedback": "Better repair the rift you have with Tsai Ing-wen and her faction after the 2020 primary, you don't want the Green camp to split and lead to eventual defeat."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13026,
+        "fields": {
+            "answer": 13021,
+            "candidate": 2001557,
+            "answer_feedback": "Standard for a ruling party, bland response."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13033,
+        "fields": {
+            "answer": 13029,
+            "candidate": 2001557,
+            "answer_feedback": "Many young voters in 2020 chose to fall into Ko's arms this year, and to win them back you'll need more than just appealing to the differences between blue and green to sway them back."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13036,
+        "fields": {
+            "answer": 13030,
+            "candidate": 2001557,
+            "answer_feedback": "In Taiwan, skepticism about the United States is not considered mainstream public opinion. However, simply having good relations with the United States will not help the election. You need more."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13038,
+        "fields": {
+            "answer": 13031,
+            "candidate": 2001557,
+            "answer_feedback": "In a multi-person election, the most important thing is the base. If your base will not be poached by Ko or overwhelmed by Hou, you will get the position of president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13039,
+        "fields": {
+            "answer": 13032,
+            "candidate": 2001557,
+            "answer_feedback": "Voters' attitudes towards the DPP have been mixed over the years. Supporters believe that the DPP has done a good job, while opponents believe that the DPP has fallen into disgrace and needs political party alternation. But, President Tsai Ing-wen still has a certain degree of popularity and Support."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13043,
+        "fields": {
+            "answer": 13041,
+            "candidate": 2001557,
+            "answer_feedback": "Your help had paid off and she has been elected to the local legislator, hopefully she survives in the 2024 election!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13044,
+        "fields": {
+            "answer": 13042,
+            "candidate": 2001557,
+            "answer_feedback": "You personally dedicated your life to campaigning and supporting her in what was considered a precursor to the presidential election, and she was ultimately elected as a legislator."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13050,
+        "fields": {
+            "answer": 13047,
+            "candidate": 2001557,
+            "answer_feedback": "These small countries may be opportunistic, but your government cannot stop them from leaving, not only because of Beijing's economic diplomacy but also because of China's influence and vast market."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13053,
+        "fields": {
+            "answer": 13048,
+            "candidate": 2001557,
+            "answer_feedback": "Anyway, Honduras has already cut diplomatic ties with us, and Taiwan has lost one more diplomatic ally in the world, pointing out certain facts will not change this fact. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13054,
+        "fields": {
+            "answer": 13049,
+            "candidate": 2001557,
+            "answer_feedback": "Appealing to anti-China and pro-Taiwan sentiments has always been a strong suit of the Democratic Progressive Party, but this will not solve the diplomatic dilemma. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13061,
+        "fields": {
+            "answer": 13057,
+            "candidate": 2001557,
+            "answer_feedback": "Stating your victory goal is the first step in an election, but there is still a long way to go afterwards. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13063,
+        "fields": {
+            "answer": 13058,
+            "candidate": 2001557,
+            "answer_feedback": "The DPP has always considered itself as the vanguard against China, but your transformation is evidently a whitewashing of your past Taiwan independence tendencies and ideologies, which also demonstrates your move towards the center path. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13066,
+        "fields": {
+            "answer": 13059,
+            "candidate": 2001557,
+            "answer_feedback": "This is a slap in the face to your past identity as a \"pragmatic advocate for Taiwanese independence\" and a symbol of your transformation. To secure votes and avoid causing panic among voters due to the fear of Taiwanese independence, this move is both reasonable and sensible. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13070,
+        "fields": {
+            "answer": 13060,
+            "candidate": 2001557,
+            "answer_feedback": "Attacking the KMT might not be the best choice, as Ma Ying-jeou openly mentioned the Republic of China during this event, causing embarrassment to the CCP."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13077,
+        "fields": {
+            "answer": 13073,
+            "candidate": 2001557,
+            "answer_feedback": "This is certainly an effective and powerful move, quickly distancing oneself from others. However, cutting off others so quickly, there is no guarantee that one day you won't be cut off yourself."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13078,
+        "fields": {
+            "answer": 13074,
+            "candidate": 2001557,
+            "answer_feedback": "This is an effective and friendly method. Starting from now, educate your party members to put that thing in their pants."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13081,
+        "fields": {
+            "answer": 13075,
+            "candidate": 2001557,
+            "answer_feedback": "The woman accusing Fu Kun-chi disappeared quickly after being refuted by Fu Kun-chi, with no further information. Your pursuit has become a joke."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13084,
+        "fields": {
+            "answer": 13076,
+            "candidate": 2001557,
+            "answer_feedback": "Playing dead is not a good choice. As the fire burns hotter, more DPP members are being found to be related to sexual harassment..."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13090,
+        "fields": {
+            "answer": 13087,
+            "candidate": 2001557,
+            "answer_feedback": "A safe response, this won't cause any harm, but your campaign team believes that you can sway some votes here."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13091,
+        "fields": {
+            "answer": 13088,
+            "candidate": 2001557,
+            "answer_feedback": "clever choice. By not personally getting involved in the debate, the DPP's legislators and city council members in New Taipei City have already begun to question the ability of Mayor Hou You-yi's government and the truth of the events, bringing this incident into the political realm. The outcome of this move is yet to be observed."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13092,
+        "fields": {
+            "answer": 13089,
+            "candidate": 2001557,
+            "answer_feedback": "Many voters accuse you of politicizing the incident, especially during the election season. However, your personal involvement has indeed energized your base, and you must defeat Hou You-yi."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13103,
+        "fields": {
+            "answer": 13100,
+            "candidate": 2001557,
+            "answer_feedback": "It is true that Hou has started his presidential campaign without completing his second term. However, the difference between him and Han Kuo-Yu is that Hou has already served as the mayor for 4 years and has had more extensive experience as a vice mayor. The foundation he has in New Taipei will not be as weak as Han's."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13104,
+        "fields": {
+            "answer": 13101,
+            "candidate": 2001557,
+            "answer_feedback": "In the 2020 election, the DPP nearly captured all the youth supporters. However, the emergence of Ko Wen-je has significantly decreased your popularity among young people. You must bring them back as they could be an important group that helps you get elected."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13105,
+        "fields": {
+            "answer": 13102,
+            "candidate": 2001557,
+            "answer_feedback": "This would create a relatively balanced impact and competition between the two sides. If Ko Wen-je and Hou You-yi divide the pan-blue and swing voters while you maintain a solid base of core supporters, you will easily secure the position of president."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13118,
+        "fields": {
+            "answer": 13111,
+            "candidate": 2001557,
+            "answer_feedback": "I must remind you that achieving a non-nuclear homeland by 2025 is destined to be unattainable. If you continue to promote expensive green energy without using nuclear power, the rise in electricity prices will harm the DPP's ability to win future elections. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13119,
+        "fields": {
+            "answer": 13112,
+            "candidate": 2001557,
+            "answer_feedback": "These are the words you repeat over and over again, but your base really likes them, they will fully accept your statement."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13120,
+        "fields": {
+            "answer": 13113,
+            "candidate": 2001557,
+            "answer_feedback": "Continue building social housing is a good strategy, but the DPP government has had many opportunities and time in the past 8 years to address these issues, yet they have not been fully resolved. You may need to work harder to make efforts in combating high housing prices and hoarding properties. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13130,
+        "fields": {
+            "answer": 13127,
+            "candidate": 2001557,
+            "answer_feedback": "No matter what you do, TPP will always be critics and detractors. To be honest, your comments are quite plain and tasteless. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13133,
+        "fields": {
+            "answer": 13128,
+            "candidate": 2001557,
+            "answer_feedback": "Although your solo penetration into the enemy camp was a brave move, most of the people there sneered at the DPP government. You spoke amidst a chorus of boos and left the stage awkwardly."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13134,
+        "fields": {
+            "answer": 13129,
+            "candidate": 2001557,
+            "answer_feedback": "Critics continue to view the DPP government as arrogant and overbearing, but what does it matter as long as you win the election? "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13143,
+        "fields": {
+            "answer": 13139,
+            "candidate": 2001557,
+            "answer_feedback": "Referring to the memories of the martial law era may be a good tactic. However, in 2018, the DPP's leak of the \"East Depot\" conversation recording regarding Hou has already undermined your attacks against him, and some also believe that you are simply using the sacrifices of democracy pioneers to gain political capital."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13145,
+        "fields": {
+            "answer": 13140,
+            "candidate": 2001557,
+            "answer_feedback": "This could be the best point of attack. Hou You-yi has long been considered a top presidential candidate, and attacking him along with Han Kuo-yu can remind people of the summer of 2019."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13148,
+        "fields": {
+            "answer": 13141,
+            "candidate": 2001557,
+            "answer_feedback": "Many voters are tired of your anti-China rhetoric, but appealing to Taiwan's sovereignty and localization is something that all political parties are doing, just some are afraid to say it out loud."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13151,
+        "fields": {
+            "answer": 13142,
+            "candidate": 2001557,
+            "answer_feedback": "If Ko Wen-je is your real opponent in this election, then you must pay attention to his young voters, many of whom used to support the but have now abandoned it. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13159,
+        "fields": {
+            "answer": 13155,
+            "candidate": 2001557,
+            "answer_feedback": "You served as the mayor of Tainan for several years, and no matter what, the people of Tainan strongly support you. They hope that you can win over 50% or even 60% of the votes in Tainan this year!"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13160,
+        "fields": {
+            "answer": 13156,
+            "candidate": 2001557,
+            "answer_feedback": "Changhua County has been on the winning side in every election since 1996, and it is the most populous county in the country. Winning votes here would be very beneficial. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13161,
+        "fields": {
+            "answer": 13157,
+            "candidate": 2001557,
+            "answer_feedback": "With a large number of young people gathering in Hakka regions in recent years, the traditional strongholds of the Kuomintang seem to be not as solid as they used to be. However, the people in these areas are more likely to choose Ko Wen-je rather than you. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13162,
+        "fields": {
+            "answer": 13158,
+            "candidate": 2001557,
+            "answer_feedback": "These outlying islands and indigenous areas have very solid support for the Kuomintang. Though it may not be easy to change their voting preferences overnight, it would be beneficial to appear in these areas. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13186,
+        "fields": {
+            "answer": 13182,
+            "candidate": 2001557,
+            "answer_feedback": " Lai Ching-te appeared on the cover of the American 'Bloomberg Businessweek' with the headline \"He wants to lead Taiwan. But can he maintain peace?\""
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13188,
+        "fields": {
+            "answer": 13183,
+            "candidate": 2001557,
+            "answer_feedback": "The relationship between the United States and you has been emphasized time and time again. Although these are just routine clichés, as long as the voters believe it, isn't it? "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13190,
+        "fields": {
+            "answer": 13184,
+            "candidate": 2001557,
+            "answer_feedback": "You held a banquet for Taiwanese people in New York and San Francisco, hoping that they will come back to vote for you on January 13 next year. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13192,
+        "fields": {
+            "answer": 13185,
+            "candidate": 2001557,
+            "answer_feedback": "Paraguay is a steadfast ally of Taiwan, but with China's growing economic strength and influence, one day, this fortress of the ROC in South America may quietly crumble. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13196,
+        "fields": {
+            "answer": 13195,
+            "candidate": 2001557,
+            "answer_feedback": "You and your government are once again criticized for being indifferent and callous, but anyway, you don't want such petty matters to consume your time, right?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13199,
+        "fields": {
+            "answer": 13194,
+            "candidate": 2001557,
+            "answer_feedback": "You and your government need more reasonable rules, regulations, and punitive measures to achieve this. Remember, the DPP has been in power for 7 years, so all the people's dissatisfaction and anger towards their lives will naturally be vented on you. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13206,
+        "fields": {
+            "answer": 13202,
+            "candidate": 2001557,
+            "answer_feedback": "Once again, Taiwan has been expelled from an international organization during its term. Your government really needs to think carefully about how to save the diplomatic crisis. Or is it the case that if Taiwan loses all its diplomatic allies, it can achieve legal independence? "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13207,
+        "fields": {
+            "answer": 13203,
+            "candidate": 2001557,
+            "answer_feedback": "If you are so disgusted by the authoritarian Ortega government, why didn't you cut ties with it on your own before 2021? Acting out in impotent rage now only appears futile and serves no purpose."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13208,
+        "fields": {
+            "answer": 13204,
+            "candidate": 2001557,
+            "answer_feedback": "The connection between the Republic of China and Taiwan is a new phenomenon that emerged during Tsai Ing-wen's tenure in an effort to move towards a more centrist stance, but it will not resolve the diplomatic crisis. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13218,
+        "fields": {
+            "answer": 13216,
+            "candidate": 2001557,
+            "answer_feedback": "Mr. Vice President, you can have a good rest now. You can get up for the victory celebration on January 13th, and on May 20th next year, you can deliver your inaugural speech at the Presidential Office. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13219,
+        "fields": {
+            "answer": 13217,
+            "candidate": 2001557,
+            "answer_feedback": "Under your secret instructions, some deep-green Democratic Progressive Party members and local factions are stirring up support for Terry Gou's candidacy, providing him with more assistance. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13228,
+        "fields": {
+            "answer": 13224,
+            "candidate": 2001557,
+            "answer_feedback": "This is a solid red-meat policy aimed at young voters, however, the TPP and KMT will continue to criticize the expenses and lack of fiscal discipline caused by your policy. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13230,
+        "fields": {
+            "answer": 13225,
+            "candidate": 2001557,
+            "answer_feedback": "Paying attention to road traffic safety is the right choice; Taiwan is called \"Pedestrian Hell\" for good reasons. This can also reduce the country's mortality rate. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13231,
+        "fields": {
+            "answer": 13226,
+            "candidate": 2001557,
+            "answer_feedback": "Focusing on achieving progressive values is good and will not attract opposition from the opposition party. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13234,
+        "fields": {
+            "answer": 13227,
+            "candidate": 2001557,
+            "answer_feedback": "What you said is all true, but it's already challenging for Taiwanese elementary school students to learn various domestic languages, let alone adding English on top of that. The bilingual policy is not successful and has faced widespread criticism from the education sector. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13239,
+        "fields": {
+            "answer": 13236,
+            "candidate": 2001557,
+            "answer_feedback": "You know what? What you're saying sounds like a radical advocate for Taiwanese independence. Perhaps your dreams from decades ago have resurfaced?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13241,
+        "fields": {
+            "answer": 13237,
+            "candidate": 2001557,
+            "answer_feedback": "That's correct, the 1992 Consensus is indeed quite outdated. However, both sides' actions are just aimed at strengthening their own support base. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13242,
+        "fields": {
+            "answer": 13238,
+            "candidate": 2001557,
+            "answer_feedback": "The number of times the Kuomintang has loudly proclaimed that the Republic of China is going to perish may be as numerous as the times the Democratic Progressive Party has called for Taiwan to return to authoritarian rule or fall under the rule of the Chinese Communist Party."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13249,
+        "fields": {
+            "answer": 13248,
+            "candidate": 2001557,
+            "answer_feedback": "In 2024, the Taiwan team will win the election, go Taiwan! "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13254,
+        "fields": {
+            "answer": 13251,
+            "candidate": 2001557,
+            "answer_feedback": "Everyone knows you speak for him with bad intentions, but your base really likes this routine. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13255,
+        "fields": {
+            "answer": 13252,
+            "candidate": 2001557,
+            "answer_feedback": "Haha, well, anyway, since he has nothing to do with you, it's unlikely to harm your voter base. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13256,
+        "fields": {
+            "answer": 13253,
+            "candidate": 2001557,
+            "answer_feedback": "You loudly speak out against China for Terry Gou, as if you were the one being audited for taxes yourself. This seems to have caused some backlash, after all, everyone knows that supporting Terry Gou, who is in opposition, is equivalent to supporting Lai Ching-te."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13264,
+        "fields": {
+            "answer": 13261,
+            "candidate": 2001557,
+            "answer_feedback": "This is true to some extent, but not many swing and opposition voters will listen to you. Of course, you don't want them to unite because then their poll numbers will surpass yours"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13267,
+        "fields": {
+            "answer": 13262,
+            "candidate": 2001557,
+            "answer_feedback": "Continue to strengthen your voter base. You are well aware that in a multi-candidate election, the voter base is the most important."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13272,
+        "fields": {
+            "answer": 13263,
+            "candidate": 2001557,
+            "answer_feedback": "Believe in  Taiwan! Your opponents will refer to it as BeLIEve Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13278,
+        "fields": {
+            "answer": 13274,
+            "candidate": 2001557,
+            "answer_feedback": "These areas have always been predominantly inhabited by people from Southern Min, with very few mainlanders, they will serve as your solid foundation and vote for you."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13283,
+        "fields": {
+            "answer": 13275,
+            "candidate": 2001557,
+            "answer_feedback": "Other than Penghu which is a swing district, there are also many supporters of the Democratic Progressive Party in these two southernmost regions of Taiwan, which can bring you over a million votes."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13287,
+        "fields": {
+            "answer": 13276,
+            "candidate": 2001557,
+            "answer_feedback": "Every candidate is eyeing the northern region, so the competition here will become very intense. The outcome of the election will largely depend on who wins the four million votes here. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13298,
+        "fields": {
+            "answer": 13277,
+            "candidate": 2001557,
+            "answer_feedback": "Perhaps a better tactic is to steal votes from the Kuomintang and Ko Wen-je? Attacking the enemy is equal to strengthening oneself. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13302,
+        "fields": {
+            "answer": 13299,
+            "candidate": 2001557,
+            "answer_feedback": "Your cutting speed is very fast, even extremely ruthless, but it quickly stops the bleeding caused by the incident. However, it will hurt you in any case. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13304,
+        "fields": {
+            "answer": 13300,
+            "candidate": 2001557,
+            "answer_feedback": "The opposition party is relentlessly pursuing you on this issue, engaging in wild discussions and criticisms on TV shows about Zhao's affair and the selfie he took with that Chinese woman. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13306,
+        "fields": {
+            "answer": 13301,
+            "candidate": 2001557,
+            "answer_feedback": "Allowing a city councilor to run for election in a different district has lowered the Democratic Progressive Party's chances of winning in that area, but Kaohsiung is a deep green stronghold, so she is unlikely to lose. Zhao has not been expelled from the party, but his political career is probably over."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13315,
+        "fields": {
+            "answer": 13310,
+            "candidate": 2001557,
+            "answer_feedback": "Anyway, even though the Democratic Progressive Party is behind in one-on-one battles, it still has a chance. Do you remember 2004? "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13316,
+        "fields": {
+            "answer": 13309,
+            "candidate": 2001557,
+            "answer_feedback": "This is a move that will surely boost your spirits. Everyone knows that high poll numbers do not necessarily mean high voter turnout. You still have a chance to win. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13325,
+        "fields": {
+            "answer": 13319,
+            "candidate": 2001557,
+            "answer_feedback": "the KMT has nominated media personality Zhao Shaokang as the vice president, while Ko Wen-je has chosen legislator Cynthia Wu as his running mate. The impact of these decisions is yet to be observed. so this race can now officially be confirmed as a three-way competition! "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13331,
+        "fields": {
+            "answer": 13322,
+            "candidate": 2001557,
+            "answer_feedback": "the KMT has nominated media personality Zhao Shaokang as the vice president, while Ko Wen-je has chosen legislator Cynthia Wu as his running mate. The impact of these decisions is yet to be observed, while Terry Gou decided to stay in the election. Now I can confidently address you as Mr. President! "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13336,
+        "fields": {
+            "answer": 13323,
+            "candidate": 2001557,
+            "answer_feedback": "This thing still happened, I knew the you wouldn't have such good luck. The opposition party has formed the Blue-White Coalition Ticket, with Hou You-yi as president and Ko Wen-je as vice president to challenge you. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13337,
+        "fields": {
+            "answer": 13324,
+            "candidate": 2001557,
+            "answer_feedback": " The first third-party government in Taiwan's history may be on the horizon...The KMT has decided that Hou You-yi will serve as the Vice President, Ko Wenje is the presidential candidate.The outcome on January 13 next year may not be what you had envisioned three months ago... "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13347,
+        "fields": {
+            "answer": 13344,
+            "candidate": 2001557,
+            "answer_feedback": "She has served as the representative to the United States for several years, which will increase public confidence in your government's ability to handle future relations with Taiwan's most critical ally. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13348,
+        "fields": {
+            "answer": 13345,
+            "candidate": 2001557,
+            "answer_feedback": "She can definitely help you secure more female votes and ensure the favor of highly educated elite professionals. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13349,
+        "fields": {
+            "answer": 13346,
+            "candidate": 2001557,
+            "answer_feedback": "Although Hualien is the stronghold of the Kuomintang, her presence can increase your chances of winning locally."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13359,
+        "fields": {
+            "answer": 13357,
+            "candidate": 2001557,
+            "answer_feedback": " \"On the Road\" immediately went viral on YouTube, gaining millions of views. This will be helpful for your campaign as people are keen to discuss the details in the video. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13360,
+        "fields": {
+            "answer": 13358,
+            "candidate": 2001557,
+            "answer_feedback": "The image of your family with your wife has touched some people, but it is not particularly eye-catching. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13361,
+        "fields": {
+            "answer": 13356,
+            "candidate": 2001557,
+            "answer_feedback": "Inciting fear against Han, those who truly dislike him among the 8.17 million voters will vote for you. However, this is something from a few years ago. His current level of hatred isn't that high anymore. If you are still the largest party, then he wouldn't be the President of the Legislative Yuan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13371,
+        "fields": {
+            "answer": 13367,
+            "candidate": 2001557,
+            "answer_feedback": "It's a strange feeling to see a man in his 60s crying on stage because of his own house; it doesn't evoke much sympathy from others. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13373,
+        "fields": {
+            "answer": 13368,
+            "candidate": 2001557,
+            "answer_feedback": "The opposition party continues to attack the illegal construction in your house, but it seems to have little effect. You can choose to keep it or use it for a public trust. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13377,
+        "fields": {
+            "answer": 13369,
+            "candidate": 2001557,
+            "answer_feedback": "you are getting anxious. Unfortunately, every candidate has their own real estate and property issues, why is our country wasting time on such matters?"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13378,
+        "fields": {
+            "answer": 13370,
+            "candidate": 2001557,
+            "answer_feedback": "You thought this could stop the bleeding, but dismantling it seemed to affect your approval ratings. This might not be that important, but you taking the initiative to show weakness indicates that you were aware of your guilt from the beginning. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13386,
+        "fields": {
+            "answer": 13383,
+            "candidate": 2001557,
+            "answer_feedback": "This is a direct confrontation between the KMT and the DPP policies, nuclear power versus green energy, pro-China versus anti-China. You mainly targeted Hou You-yi in this debate, but you were also attacked by Ko Wen-je at the same time. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13387,
+        "fields": {
+            "answer": 13384,
+            "candidate": 2001557,
+            "answer_feedback": "It seems like you view Ko Wen-je and his young supporters as your target to confront. Using red bait against him may not be effective, but it can help solidify your support base. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13388,
+        "fields": {
+            "answer": 13385,
+            "candidate": 2001557,
+            "answer_feedback": "These are undeniable facts, yet your statements regarding whether the Republic of China is a disaster or a protector have faced strong attacks from Ko Wen-je and the media... However, your deep green base can support this. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13399,
+        "fields": {
+            "answer": 13395,
+            "candidate": 2001557,
+            "answer_feedback": "You held your final campaign rally on the eve of the election at the stadium in New Taipei City, hoping that this can help you win in your hometown! "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13400,
+        "fields": {
+            "answer": 13396,
+            "candidate": 2001557,
+            "answer_feedback": "The citizens of Tainan City are excited and emotional because their mayor is about to become the president. Tomorrow is the decisive moment! "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13401,
+        "fields": {
+            "answer": 13397,
+            "candidate": 2001557,
+            "answer_feedback": "You held your final campaign rally on the eve of the election by the coast in Taichung City. The central region is crucial, hoping you can win over the populous city of Taichung! "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13402,
+        "fields": {
+            "answer": 13398,
+            "candidate": 2001557,
+            "answer_feedback": "You organized the final election campaign in the square in Taipei City, hoping that you will march into the Presidential Office tomorrow! "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13412,
+        "fields": {
+            "answer": 15782,
+            "candidate": 2001557,
+            "answer_feedback": "Hou Yi-yi responded with a slightly excited counterattack to your accusations, seeming somewhat rushed. This round is probably a win for you. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13414,
+        "fields": {
+            "answer": 15783,
+            "candidate": 2001557,
+            "answer_feedback": "It is undeniable that the Kuomintang relies on local factions in these areas. However, the Democratic Progressive Party also has its own factions in many places. In this aspect, the KMT and DPP are probably similar. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13418,
+        "fields": {
+            "answer": 15784,
+            "candidate": 2001557,
+            "answer_feedback": "Bringing up events from over a decade ago may not make your argument very convincing. The Kuomintang has proposed policies to strengthen military capabilities and expand forces, but in your base, it always seems like the DPP's policies are the best. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13419,
+        "fields": {
+            "answer": 15785,
+            "candidate": 2001557,
+            "answer_feedback": "Once again elevating the elections to the competition and conflict between China and Taiwan will strengthen your deep-green voter base"
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950009,
+        "fields": {
+            "answer": 1950001,
+            "candidate": 2001557,
+            "answer_feedback": "Ke Wen-je fiercely criticized you, saying that the DPP's path may be firm, but it leads Taiwan to a firm dead end. He also mentioned that you are not worthy to talk about his grandfather because you are merely using him as political capital."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950006,
+        "fields": {
+            "answer": 1950002,
+            "candidate": 2001557,
+            "answer_feedback": " \"The DPP is currently demonstrating what a red bait is, let me tell you, they always play this trick.\" Therefore, we need to establish a new politics in Taiwan."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950007,
+        "fields": {
+            "answer": 1950003,
+            "candidate": 2001557,
+            "answer_feedback": "Ko Wen-je believes that he has repaid a lot of debts for Taipei City, and having served as mayor for 8 years, he will not lose to you there."
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 1950008,
+        "fields": {
+            "answer": 1950004,
+            "candidate": 2001557,
+            "answer_feedback": " \"So, if the factions within the DPP divide the spoils, and the New Tide faction takes over the national governance, would that make various corruption and bribery even better? This is why we need to push for a coalition government and a cabinet system, democracy needs checks and balances!\" "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13443,
+        "fields": {
+            "answer": 13440,
+            "candidate": 2001557,
+            "answer_feedback": "This is a direct confrontation between the KMT and the DPP policies, nuclear power versus green energy, pro-China versus anti-China. You mainly targeted Hou You-yi in this debate, but you were also attacked by Ko Wen-je at the same time. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13444,
+        "fields": {
+            "answer": 13441,
+            "candidate": 2001557,
+            "answer_feedback": "It seems like you view Ko Wen-je and his young supporters as your target to confront. Using red bait against him may not be effective, but it can help solidify your support base. "
+        }
+    },
+    {
+        "model": "campaign_trail.answer_feedback",
+        "pk": 13445,
+        "fields": {
+            "answer": 13442,
+            "candidate": 2001557,
+            "answer_feedback": "Given that the competition has reached such a intense stage, it is evident that Terry Gou's candidacy will only weaken the opposition party further. You are merely pointing out this fact."
+        }
+    }
+]
+
+
+campaignTrail_temp.jet_data = [{}
+]
+
+
+campaignTrail_temp.candidate_image_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/William_Lai_Ching-te_20230814.jpg/800px-William_Lai_Ching-te_20230814.jpg";
+campaignTrail_temp.running_mate_image_url = "https://i.imgur.com/qZXcBwi.jpeg";
+campaignTrail_temp.candidate_last_name = "Lai";
+campaignTrail_temp.running_mate_last_name = "For DPP 2024";
+campaignTrail_temp.running_mate_state_id = '255';
+campaignTrail_temp.player_answers = [];
+campaignTrail_temp.player_visits = [];
+campaignTrail_temp.answer_feedback_flg = 1;
+campaignTrail_temp.game_start_logging_id = '3660822';
+
+const style_overwrite = document.createElement("style");
+style_overwrite.innerHTML = 
+`#campaign_sign {
+  background-color: #1B9431;
+  border-color: #4ade65;
+}
+#menu_container {
+  background-color: #c3c3c3;
+}
+#overall_result_container {
+  background-color: #c3c3c3;
+}
+#state_info h3 {
+  background-color: #ffffff;
+}
+#overall_result h3 {
+  background-color: #ffffff;
+}`
+;
+document.head.appendChild(style_overwrite);
+
+
+let style = document.createElement('style');
+style.type = 'text/css';
+style.id = 'dynamic-style';
+
+style.innerHTML = `
+  .inner_window_question h3 {
+    background-color: #e1e1e1;
+  }
+  .overlay_window h3 {
+    background-color: #b4b4b4;
+  }
+`;
+
+document.head.appendChild(style);
+
+
+function checkIfCanAddMap() {
+    map = document.getElementById("map_container");
+    
+    if(map) {
+        map.style.backgroundImage = "url('https://images.rawpixel.com/image_800/czNmcy1wcml2YXRlL3Jhd3BpeGVsX2ltYWdlcy93ZWJzaXRlX2NvbnRlbnQvbHIvdjk5Ni0wMDlfMS1rcm9pcjRkay5qcGc.jpg')"; 
+    }
+}
+
+setInterval(checkIfCanAddMap, 250);
+
+(function(e, t, n, r, i) {
+    function s(e, t, n, r) {
+        r = r instanceof Array ? r : [];
+        var i = {};
+        for (var s = 0; s < r.length; s++) {
+            i[r[s]] = true
+        }
+        var o = function(e) {
+            this.element = e
+        };
+        o.prototype = n;
+        e.fn[t] = function() {
+            var n = arguments;
+            var r = this;
+            this.each(function() {
+                var s = e(this);
+                var u = s.data("plugin-" + t);
+                if (!u) {
+                    u = new o(s);
+                    s.data("plugin-" + t, u);
+                    if (u._init) {
+                        u._init.apply(u, n)
+                    }
+                } else if (typeof n[0] == "string" && n[0].charAt(0) != "_" && typeof u[n[0]] == "function") {
+                    var a = Array.prototype.slice.call(n, 1);
+                    var f = u[n[0]].apply(u, a);
+                    if (n[0] in i) {
+                        r = f
+                    }
+                }
+            });
+            return r
+        }
+    }
+    var o = 1010,
+        u = 500,
+        a = 50;
+    var f = {
+        stateStyles: {
+            fill: "#333",
+            stroke: "#666",
+            "stroke-width": 1,
+            "stroke-linejoin": "round",
+            scale: [1, 1]
+        },
+        stateHoverStyles: {
+            fill: "#33c",
+            stroke: "#000",
+            scale: [1.1, 1.1]
+        },
+        stateHoverAnimation: 500,
+        stateSpecificStyles: {},
+        stateSpecificHoverStyles: {},
+        click: null,
+        mouseover: null,
+        mouseout: null,
+        clickState: {},
+        mouseoverState: {},
+        mouseoutState: {},
+        showLabels: true,
+        labelWidth: 20,
+        labelHeight: 15,
+        labelGap: 6,
+        labelRadius: 3,
+        labelBackingStyles: {
+            fill: "#333",
+            stroke: "#666",
+            "stroke-width": 1,
+            "stroke-linejoin": "round",
+            scale: [1, 1]
+        },
+        labelBackingHoverStyles: {
+            fill: "#33c",
+            stroke: "#000"
+        },
+        stateSpecificLabelBackingStyles: {},
+        stateSpecificLabelBackingHoverStyles: {},
+        labelTextStyles: {
+            fill: "#fff",
+            stroke: "none",
+            "font-weight": 300,
+            "stroke-width": 0,
+            "font-size": "10px"
+        },
+        labelTextHoverStyles: {},
+        stateSpecificLabelTextStyles: {},
+        stateSpecificLabelTextHoverStyles: {}
+    };
+    var l = {
+        _init: function(t) {
+            this.options = {};
+            e.extend(this.options, f, t);
+            var n = this.element.width();
+            var i = this.element.height();
+            var s = this.element.width() / o;
+            var l = this.element.height() / u;
+            this.scale = Math.min(s, l);
+            this.labelAreaWidth = Math.ceil(a / this.scale);
+            var c = o + Math.max(0, this.labelAreaWidth - a);
+            this.paper = r(this.element.get(0), c, u);
+            this.paper.setSize(n, i);
+            this.paper.setViewBox(-500, 0, c, u, false);
+            this.stateHitAreas = {};
+            this.stateShapes = {};
+            this.topShape = null;
+            this._initCreateStates();
+            this.labelShapes = {};
+            this.labelTexts = {};
+            this.labelHitAreas = {};
+            if (this.options.showLabels) {
+                this._initCreateLabels()
+            }
+        },
+        _initCreateStates: function() {
+            var t = this.options.stateStyles;
+            var n = this.paper;
+            var r = {
+                Tainancity:"m178.94 309.54c1.821 0.85976 1.9013 1.8004 3.9722 1.3601 0.52002 1.6719-1.5712 1.0502-1.4009 2.6113 0.8704 0.21983 2.3913 0.20091 2.5009 1.2003 2.4514 1.3001-0.0196 1.501 0.46065 3.6413 2.191-0.12068 3.2917 1.4299 5.2733 1.8898 0.13963 1.4005-0.8306 1.1807-1.6207 1.8011-1.0903 0.85976-1.1105 1.2309-1.181 2.6706-0.0698 1.411-0.89063 5.8318 0.97023 6.032 0.0496 0.85128 0.0496 1.7515 0 2.6008-0.82081 0.37966-1.1705 1.4814-1.1105 2.3405 0.5807 0.0202 1.2006 0.03 1.7806 0.06 0.17029 0.33986 0.2897 0.71103 0.39083 1.0607 1.7114-0.20939 1.8902 1.5512 3.2813 1.8904 0.16051-0.81019 1.3415-1.1305 1.7219-0.3503 0.0692 0 0.55983-0.0104 0.61072 0 0.84039-1.4103 2.5114-1.3803 2.8611-3.2414 0.73077 1.1709 1.2312 1.6308 2.6314 1.7411 1.4909 0.10959 2.4716-0.39988 3.8418-0.0998 0.76079 1.1598 1.6618 0.69994 1.8817-0.36074 0.39931 0.31051 0.63942 0.76061 0.63029 1.3007-0.15986 0.0398-0.30014 0-0.45021 0.06-0.12984 1.3803-0.89063 1.4599-1.6501 2.4606-0.97023 1.2694-0.14094 1.9498-0.3804 3.1696-0.3308 1.6608-3.2924 3.1214-4.3331 4.6817-1.5007 2.2616-2.7815 3.6608-3.7217 6.3217-0.85083 2.4208-1.6612 4.5519-3.9122 5.5415-2.3711 1.0496-3.1919 3.0013-4.8727 4.8018-0.71055 0.74886-1.9209 1.7593-2.8317 2.1696-1.4204 0.63993-2.4814 0.69081-3.1815 2.3412-0.21009 0.50098-0.16051 1.4899-0.4502 1.8611-0.53047 0.68038-0.94022 0.39009-1.581 0.75996-1.0707 0.62036-1.4707 1.6112-2.281 2.6217-1.0505 1.291-1.0603 2.12-1.6906 3.5917-0.52068 1.2303-1.5509 2.2799-2.2915 3.3706-0.74056 1.0711-1.4707 2.1814-2.0312 3.1312-0.46065 0.77953 0.15007 1.1905-0.97088 1.3197-0.79015 0.0998-1.1705-0.12916-1.0603-0.96936-0.64008-0.0307-1.3108-0.0307-1.9509 0-1.2006 1.4703-2.7515 1.5004-4.0323 2.7711-1.0707 1.0705-0.46065 1.2303-2.0011 1.5695-0.89062 0.21005-2.3809 0.51991-2.1812-0.84019-1.8008-0.15982-3.432-0.77039-5.4827-0.69081-1.3604 0.0502-3.862-0.33008-4.8531 0.43053-1.3708-0.99153-4.3024-0.48011-4.8524-2.9113-1.641 0.95044-6.023-1.3503-7.784 0.42923-0.26034-1.9707-0.0803-4.4417-0.65052-5.7913-0.99045-2.3803-1.2103-4.501-3.1619-6.2114-2.0612-1.8102-4.8929-2.9609-6.513-5.122-1.4009-1.8806-2.9916-3.0216-5.3731-3.8415-5.5428-1.9009-6.4536-7.8024-2.5009-11.954 1.1608-1.2198 1.4811-1.2603 1.5007-3.2107 0.01-1.4606-0.20031-3.1207 0.15985-4.501 0.63029-2.3901 3.1521-3.9714 4.0225-6.3817 0.98067-2.7208-0.42019-5.6817 0.86062-8.4522 0.65051-1.4005 0.52002-2.7606 0.97022-4.1612 0.35038-1.1305 0.68053-0.7306 1.331-1.6308 0.52002-0.72016 0.39018-0.96087 0.49001-1.8813 0.21009-1.9198 0.97022-2.3601 1.7806-3.7815 1.4609 0.61123 2.4911 1.8709 4.0323 2.3008 0.1703 0.8702 0.81037 1.561 1.0603 2.4508 0.51024-0.0404 1.0903 0.09 1.611 0.0502 0.15007 1.9707 3.6819 4.7417 3.5618 1.1598 0.2499 0.3503 0.49001 0.45989 0.6603 0.96935 0.77057 0.0802 1.6012 1.1814 2.3111 1.0202 0.50045-0.11025 0.80059-1.1814 1.1608-1.6713 0.86062-1.1807 2.1108-1.7711 2.3613-3.4704 1.4211-1.5701 4.8028 0.42988 4.2822-2.8311-1.121-0.58122-0.30014-1.8513 0.65052-1.9113 0.98066-0.06 1.271 1.1403 2.6914 0.55121-0.30993-1.3614-1.2808-2.4221 0.31058-3.5512 1.4811-1.0405 2.8513 0.25897 2.7417-2.261 0.84038 0.0404 1.731 0.27006 2.6412 0.14025 1.5405-0.21984 0.94022-0.34965 1.9907-1.3001 1.3806-1.261 3.1521-1.0907 5.013-1.3705 1.611-0.24005 2.9316-1.0007 4.6626-1.0007 1.4707 0 3.9618 1.1102 5.0025-0.34965 0.97936 0.81476 2.5198 1.3144 3.6708 1.8546z",
+                Kaohsiungcity:"m156.17 440.89c0.0502 0.35029 0.20031 0.66993 0.12984 1.0502-0.0803-0.0111-0.15985 0-0.23032-0.0111-0.27991-0.50033-0.60027-0.33986-1.0309-0.58905-0.39996-0.24006-0.4502-0.63014-0.67009-0.96152-0.44042-0.67973-1.1105-1.3301-1.6312-1.9498-1.0707-1.291-2.0612-2.6908-3.0516-4.002-0.20031-0.27006-0.29035-0.8004-0.56047-0.93021-0.0202-0.06 0.01-0.12003-0.0202-0.17026-0.2499-0.34964-0.93043-0.3803-1.2404-0.63993 0.48022-0.15916 1.1608-0.0691 1.6808-0.0489-0.0202 0.17874 0.0803 0.30007 0.0803 0.47881 0.73077-0.0998 0.16051 0.93086 0.85083 0.96152 0.0202 0.0489-0.0104 0.12916 0.0202 0.17026 0.16964 0.14938 0.42998 0.17873 0.57026 0.30007 0.13963 0.12981 0.2897 0.47032 0.42998 0.63014 0.4502 0.49055 0.67009 0.78018 0.93043 1.3307 0.10961 0.2394 0.18986 0.5199 0.39017 0.72995 0.23033 0.24984 0.45021 0.2805 0.66031 0.47033 0.39018 0.36986 0.55068 0.78996 1.0603 1.06 0.12984 0.51012 0.52002 1.1103 0.78035 1.5408 0.0503 0.01 0.0998 0.01 0.15986 0.0196 0.0515 0.37052 0.29166 0.62036 0.69162 0.56035zm102.79-136.88c-0.15007 0-0.25968 0.0104-0.27012 0.0496-0.24011 0.69082-0.0502 1.1409 0.77057 1.3307 0.30992 1.6406 0.55982 2.8402 0.33994 4.6113-1.5203 0.24984-4.1014-0.3503-4.3226 1.5395-0.03 0.28116 0.51023 0.45011 0.51023 0.82063 0 0.77952-0.28969 0.71038-0.47043 1.2101-0.35038 0.93934-0.79014 1.5401-0.67009 2.6002 1.8015-0.20092 1.0309 0.68037 2.0109 1.3307 0.79015 0.53947 1.8413 0.33986 2.7717 0.39009-0.0692 0.3503 0.20096 0.81019 0.19052 1.0705 1.4609-0.61057 3.342 2.9113 3.1417 4.0412-1.0205 0.36987-1.1705 1.0705-0.95065 1.7704-0.8704 0.52056-2.052 0.29029-2.9818 0.6308-1.2006 0.42988-2.0409 1.3803-3.2115 1.9302-1.331 0.61122-2.4716 0.88129-3.832 1.2009-1.731 0.41031-2.2615 1.1507-3.3315 2.3412-0.7497 0.8291-1.4511 2.291-2.3411 2.9609-0.82929 0.61906-2.7012 0.25897-3.3113 1.2303-0.57026 0.92043 0.14028 3.2114-0.0202 4.3106-0.0698 0.54012-0.45021 0.92043-0.5011 1.4906-0.06 0.75996 0.29035 1.4514 0.17095 2.1703-0.28056 1.6204-1.6716 1.2616-2.3515 2.6608-0.30014 0.63014 0.21009 1.1807-0.35038 1.8011-0.39018 0.42075-1.4211 0.53034-1.9411 0.57013-0.27012 1.03 0.81037 1.291 1.611 1.5004 0.14028 2.6504 0.4104 5.9629-0.0998 8.5135-0.1703 0.91912-0.77057 2.0294-1.3604 2.8311-0.47043 0.63928-0.88997 0.75996-1.0498 1.5904-0.2101 1.0907 0.21988 0.88128 0.54025 1.5316 0.33015 0.66929 1.7604 2.621 0.96044 3.4808-0.89063 0.96087-2.9414-0.47098-3.462 1.1898-0.44108 1.4103 1.3108 2.0711 0.30013 3.6308-0.6205 0.95044-2.2419 1.6406-3.0118 2.4208-1.9809 2.0105-3.1514 6.702-1.6005 9.2728 0.24011-0.0189 0.55982 0.0802 0.79014 0.0502 0.53046 1.3999-0.06 3.1312 0.18009 4.6322 0.27012 1.6608 2.1212 2.0796 2.0305 3.651 1.9711-0.24005 1.7408 0.76061 1.8315 2.3308 2.0305 0.0189 1.3911 1.0705 0.28056 1.6497-0.0502-0.12916-0.11027-0.2394-0.18008-0.3503-0.74056-1.0796-3.5012-2.3901-4.7924-2.2799-1.4609 0.12916-2.3215 1.1298-3.5116 1.6797-1.2103 0.56035-2.1714 0.19048-2.0214 2.1409-2.251 0.10959-4.1125-0.60079-4.5021-3.1214-1.641-1.0705-2.9218-2.3105-4.8126-3.0209-1.1307-0.4201-1.7206-0.54012-2.9916-0.33007-1.2404 0.20091-1.5007 0.60013-2.4716 1.0202-0.30014 0.8702-1.4909 1.7293-2.071 2.5408-2.0011-2.0907-2.8122-4.2303-5.9936-3.561-1.38 0.28963-2.4409 1.2205-3.8013 1.7-1.1307 0.39074-2.9224 0.27006-3.8431 1.0802-0.90042 0.79062-1.0309 1.9707-1.8308 2.7104-0.71055 0.64972-1.791 1.9204-2.6314 2.3803-2.0312 1.1005-5.9232 0.28898-7.724-0.50098-1.0505-0.46054-2.3913-0.88064-3.6519-0.55056-1.5712 0.4214-1.4309 1.1703-1.3408 2.8409 0.0502 0.91064 0.73012 3.1996 0.33994 4.0014-0.45999 0.93021-1.1705 0.17874-1.6808 0.77887-0.35038 0.41097-0.15986 1.4814-0.15986 2.0516 0.01 2.7815 0 5.5617 0 8.3321 0 1.2101 0.2499 2.9309-0.36995 3.972-0.84038 1.4097-1.4707 1.079-1.4609 3.1996v4.3327c0 1.5604-0.39996 2.3706-0.68053 3.6602-0.58005 2.7815 0.28057 5.4221 0.64008 8.0118 0.18008 1.2407 0.39018 2.7411 0.2101 4.0014-0.32037 2.1514-1.2606 1.0007-2.3411 2.1709-1.3604 1.4814-0.50045 6.3817-0.50045 8.3321v0.21005c-0.92064-0.63993-1.301-0.42141-2.6614-0.54013-2.4213-0.23092-3.0118-2.5806-5.043-3.6308-1.4211-0.72995-2.1316-0.82911-3.2519-1.9107-0.96044-0.93086-2.4416-2.2009-3.2617-3.1918-0.2499-0.52055-0.8704-1.291-1.4309-1.5206 0.11027-0.53034 0.39018-0.50034 0.93043-0.47033 0.01 0.06 0 0.11024 0.0202 0.15982 0.03 0.0104 0.0698 0.0196 0.0998 0.03 0.0502 0.18982 0.15986 0.2805 0.2101 0.47032 0.2499 0.11024 0.69032 0.21005 0.86061 0.3914 0.24011 0.2394 0.2101 0.69994 0.50045 0.85911 0.28056 0.15982 0.91085-0.0189 1.1908-0.0496 0.46065-0.0404 0.72034 0.0404 1.181 0.14025 0.0104 0.69929 0.90041 0.25049 1.2508 0.7306 0.15007-0.97066-1.2208-1.2407-1.8713-1.7006-0.33994-0.24005-0.82016-0.45988-1.1105-0.74038-0.39997-0.39075-0.36995-0.78997-0.57026-1.2401-0.40976-0.8702-1.7108-0.54012-2.3809-1.3105-0.38039-0.42988-0.24011-0.88064-0.5807-1.3001-0.25968-0.33008-0.71054-0.60014-0.99045-0.93935-0.30993-0.36986-0.75035-0.66993-1.1307-1.0111-0.42019-0.39074-0.7001-0.91064-1.0303-1.3797-0.61071-0.83041-1.2006-1.6504-2.0116-2.231 0.42019-0.0307 1.331-0.17091 1.6912 0.03 0.40975 0.23027 0.36995 0.93086 0.55982 1.3803 0.38039 0.17026 1.4106 0.63015 1.3708 1.06 0.81037 0-0.35038-1.1011-0.56048-1.1898-0.19052-0.42075-0.23032-0.82975-0.49-1.1703-0.25969-0.33072-0.61007-0.48011-0.82995-0.86041-0.2499-0.44945-0.23032-0.57992-0.80058-0.84998-0.46-0.22048-0.86062-0.16047-1.3408-0.29028-0.81037-0.24006-1.5307-1.15-2.1714-1.6993-0.94021-0.81018-0.88084-1.3999-0.88084-2.6217v-2.1807c0-0.33073-0.0698-0.71038 0.1305-0.94 0.15985-0.19048 0.6603-0.23092 0.89062-0.42075 0.36017-0.31964 0.81037-1.06 0.91086-1.5206 0.15985-0.80105-0.29036-1-0.63029-1.6106-0.06-0.0307-0.12985-0.0496-0.18009-0.0698 0.39997-0.24984 0.70011 0.12981 0.96044 0.36073 0.40976 0.34965 0.47044 0.40966 1.1007 0.37965 0.0502-0.88976-0.0502-1.8891-0.38039-2.6706-0.97023-0.0907-0.88084 0.31051-1.1203 1.0405-0.50045 0.06-0.59049-1.3196-0.69032-1.73-0.16051-0.68103-0.74056-1.261-0.8704-1.9413-0.0698-0.39987 0.0698-0.77039-0.12984-1.1207-0.1703-0.30007-0.61072-0.45989-0.79015-0.75996-0.35037-0.61123 0.11027-1.2701-0.48022-1.8206 0.23033-1.4103-1.5307-2.2505-2.1616-3.1612-0.57026-0.82128-0.7001-1.6915-0.82995-2.6608-0.29035-2.0405-0.54024-1.5904-1.8713-2.9713-0.88084-0.91064-0.64008-1.3301-0.8306-2.6713-0.32036-2.2505-1.4811-4.1716-1.5105-6.4919-0.0202-2-0.53046-3.8911-1.3604-5.6517-1.1405-0.27006-1.581-1.4508-1.7806-2.9002 1.761-1.7802 6.1437 0.52055 7.784-0.42988 0.55003 2.4312 3.4816 1.9198 4.8524 2.9113 0.99046-0.76061 3.492-0.38031 4.8531-0.43054 2.0514-0.0796 3.6819 0.53034 5.4827 0.69147-0.20031 1.3601 1.2906 1.0496 2.1812 0.84019 1.5405-0.33986 0.93043-0.50098 2.0011-1.5701 1.2808-1.2707 2.8317-1.3007 4.0323-2.7711 0.64008-0.03 1.3108-0.03 1.9509 0-0.10962 0.84019 0.27012 1.0705 1.0603 0.97 1.121-0.12981 0.51023-0.54012 0.97088-1.3203 0.55982-0.94978 1.2906-2.06 2.0312-3.1312 0.74055-1.09 1.7708-2.1403 2.2915-3.3706 0.63029-1.471 0.64008-2.3008 1.6906-3.591 0.81037-1.0111 1.2103-2.0007 2.281-2.6223 0.64008-0.36922 1.0505-0.0796 1.5809-0.75996 0.29035-0.36922 0.24011-1.3601 0.45021-1.8611 0.7001-1.6504 1.761-1.7 3.1815-2.3405 0.91085-0.41031 2.1212-1.4214 2.8317-2.1703 1.6808-1.8011 2.5009-3.7515 4.8727-4.8018 2.251-0.99023 3.0614-3.1207 3.9122-5.5415 0.94021-2.6608 2.221-4.0614 3.7217-6.321 1.0407-1.561 4.0023-3.0216 4.3324-4.6824 0.24011-1.2198-0.58984-1.9002 0.38104-3.1696 0.76013-1.0007 1.5203-1.0802 1.6501-2.4606 0.15007-0.06 0.29035-0.0202 0.4502-0.06 0.0104-0.54012-0.23097-0.99088-0.63028-1.3007 0.01-0.0496 0.0189-0.10959 0.03-0.17026 0.12919-1.0496-0.43063-2.4306-0.71054-3.3308-0.65052-2.0509-1.3911-4.9316-0.64008-7.1521 0.8704-0.14025 2.8115-0.12916 3.6519 0.14025 1.5209 0.51012 0.67009 1.8513 1.9809 2.5114 2.8715 1.4508 2.482-2.7013 4.0121-3.8409 1.1405-0.85128 1.9809-0.11089 3.171-0.66145 0.35038-0.15982 1.9509-1.8402 2.1714-2.1305 0.65052-0.85063 0.5011-2.1207 1.4909-2.7515 0.98066-0.61971 2.6516-0.25963 3.8124-0.31964 0.28056-1.4306 0.39996-2.5506 1.821-3.1918 0.96109-0.42075 3.3315 0.25049 4.0519-0.39922 0.36995-0.33986 0.77122-2.8918 1.1105-3.6015 0.53046-1.1103 0.86061-2 1.2103-3.1514 0.38039-1.3105 0.82081-2.2805 2.1714-2.7593 1.2006-0.43053 3.0908 0.23941 4.0114-0.70059 0.21009-0.21983 0.36995-1.3601 0.6205-1.7202 0.27991-0.41031 0.93043-1.0802 1.3206-1.3418 1.0302-0.66928 2.4011-0.8004 3.5514-0.94978 1.1816-0.14025 1.9914-0.2094 2.6914-1.1298 0.79015 0.0802 1.821-0.27984 2.4018-0.88977 0.24989-0.0691 0.50044-0.12981 0.74055-0.18004 1.2208-0.24984 1.0903-0.11024 2.1714 0.36987 1.5509 0.69081 2.9316 0.59035 4.8022 0.69994 0.0104 0.33008 0.25055 0.55056 0.2101 0.93087 0.35037-0.0104 0.74055 0.27985 1.1307 0.23027 0.14942 0.98109-0.26033 1.7104-0.29035 2.6217 0.14028-0.0104 0.32037 0.0104 0.46065 0.0404 0.0176 0.12981-0.0124 0.30986-0.0124 0.45924z",
+                Pingtung:"m166.08 473.61c0.38039 0.47033 0.52002 0.84019 0.50045 1.4403-0.0398 0-2.1408 2.4514-2.3515 2.681-0.8704 0.88912-2.5212 1.7104-2.9016-0.16047 1.2808-0.74952 0.64008-2.0405 1.3206-3.1116 0.71054-1.1279 2.2615-0.91913 3.432-0.84933zm69.867-77.268c0.47044 1.2205-0.3693 2.9909 0.65052 4.0907 0.52002 0.57013 2.9218 1.4305 3.7119 1.7906 1.121 0.51012 1.121-0.18982 1.5007 1.1598 0.19052 0.6608 0.10961 1.9198 0.12984 2.5414 0.0692 1.8611-0.53046 2.5806-2.1016 3.4912 0.61137 1.8317 1.1307 5.6928-0.85017 7.1521-1.0107 0.75017-2.7613-0.18983-4.0121 0.32029-0.88997 0.36074-1.6605 1.4814-2.5414 2.1207-1.4106 1.0411-1.9607 1.03-3.802 1.2205-1.0603 0.10959-2.822-0.19047-3.5318 0.78997-0.73077 0.99153 0.25968 2.6413-0.1305 3.8722-0.39018 1.2205-1.6312 2.06-2.0005 3.3412-0.35038 1.2094-0.2499 1.8806-1.0002 2.9498-0.73077 1.0405-1.2906 1.76-1.701 2.8807-0.77057 2.0907-1.0303 4.201-1.1601 6.4828-3.0314 0.03 0.39932 5.3817 0.74056 6.1919 0.7001 1.6797 1.1608 5.4508 0.63029 7.0425-0.32037 0.96935-1.2006 2.1507-0.51024 3.4612 0.76079 1.4299 1.8015 0.21004 2.9616 1.0404 1.2704 0.90021 1.9013 5.1312 1.6808 6.6022-1.6612 0.0698-4.0114 0.74039-4.472 2.3601-0.25055 0.87085-0.0411 2.1011-0.18008 3.0013-0.10962 0.77105-0.46 1.6915-0.30014 2.471 0.48022-0.0802 0.8704 0.21983 1.2808 0.21983 0.45021 2.0516 2.0011 1.5401 3.5318 2.6419 1.671 1.1807 1.581 2.4808 1.4707 4.6406-2.2412 0.03-2.3711 1.6902-2.2817 3.5004 0.86061-0.0685 2.9414 0.40053 3.6421 0.82063 1.9711 1.1703-0.77058 1.8017-0.47044 3.1807 0.90042-0.12003 1.1908 0.50163 1.0002 1.3418 1.8511 0.0992 2.1212 0.57013 3.4712 1.1807 1.1908 0.53947 3.2421-0.0307 3.5318 1.6412 1.8008-0.23092 1.5907 1.9498 3.4418 0.99936 0.73077-0.38031 1.9711-1.7208 2.681-2.4508 0.33081 1.1598 0.67009 2.3608 0.39997 3.3608-0.2101 0.82062-0.6205 1.0907-0.71055 2.1207-0.09 0.91977-0.12984 1.7208-0.30013 2.5506-0.56048 2.7398 0.29035 6.411 0.0998 9.5931-0.98066 0.4201-1.2612 1.8206-0.97022 2.8611 0.38039 1.3601 0.94021 1.4292 2.4716 1.3601 0.09 0.48011 0.09 1.1403 0 1.6106-0.73077 0.6608-1.4511 0.59035-1.8113 1.531-0.33015 0.8702 0.0111 2.5617 0.0111 3.501 0 0.98044-0.27012 2.4103-0.0111 3.3406 0.32036 1.1011 1.2508 1.2101 0.98067 2.6308-0.61985 0.12981-1.2006 0.24006-1.7806 0.39988-0.0411 0.55056-0.21989 1.0404-0.21989 1.6002-1.5509 0.40966-0.93042 0.77104-1.4707 1.8702-0.70076 1.3908-0.68053 0.85976-2.3013 1.2003-2.5212 0.53034-2.0409 2.4814-2.0409 4.8011 0 1.8506-0.60028 4.9218 0.72033 6.2923 0.67988 0.69994 1.151 0.45989 1.6207 1.3712 0.29035 0.58971 0.38039 2.4808 0.30014 3.1507-1.7708 0.45989-1.8106-1.2309-2.7606-2.1905-0.51024-0.51991-0.95066-0.4899-1.3911-1.1207-0.34972-0.5199-0.4104-1.2198-0.82994-1.8004-1.0603-1.4703-1.8811-0.78018-3.5018-1.3608-0.71054-0.25962-1.2906-0.91977-1.9907-1.1814-0.59048-0.21983-1.3506-0.18982-1.9711-0.36008-0.79014-1.5003-4.5021-2.561-5.3327-0.44032-0.49001 1.2401 0.79014 1.6008 0.63029 2.8011-0.16965 1.3203-1.6606 1.3705-2.6712 1.8206-0.53046-0.78018-1.6605-1.4606-2.0011-2.1507-0.47956-0.97001-0.1592-2.7208-0.1592-3.8311 0-1.3007 0.1703-2.7208 0-4.0014-0.23097-1.7606-0.99111-1.5401-1.962-2.711-0.83973-1-0.69945-1.8891-1.0798-3.0809-0.20096-0.63079-0.65052-0.79061-0.63029-1.5506 0.03-0.82976 0.50958-0.75996 0.66944-1.501 0.12071-0.55056-0.25903-1.5095 0-2 0.51023-0.96087 0.56047-0.12068 1.331-0.66081 0.81038-0.55056 1.8511-2.1311 0.53046-2.8611-0.24011-0.39987-0.43063-0.99088-0.50109-1.4508 0.44041 0.0802 1.0107-0.12982 1.4518-0.0496 0.20944-1.2505 0.42933-2.4814 0.36016-3.8115-0.0998-1.8806-0.36995-1.8206-1.4707-3.0411-1.6906-1.8904-0.35038-4.8911-1.0309-7.2923-0.35038-1.2309-1.4909-1.8402-1.8008-3.1709-0.30013-1.291-0.13962-2.4599-0.54024-3.6608-0.8704-2.5695-3.1521-3.0007-4.3722-5.3014-0.60027-1.1292-0.46064-2.471-0.46064-3.8715 0-1.6112-0.46065-2.3608-1.0009-3.6713-0.84038-2.0405-2.0409-3.6817-3.7217-5.291-0.85082-0.82063-1.7304-1.2805-2.1108-2.381-0.54025-1.5395-0.65051-1.79-1.7108-3.1612-1.6508-2.1403-3.1019-2.7208-5.4632-4.0105-1.0714-0.5897-2.7117-0.83954-3.5018-1.8311-1.3904-0.17939-3.3518-0.50034-4.3722-1.2903-0.89063-0.7006-1.3108-1.8409-2.131-2.6719-1.7708-1.7906-4.8531-2.3797-6.0034-4.3706-0.72033-1.2401-0.95065-1.8617-2.1212-2.8709-0.2101-0.17026-0.39018-0.31051-0.55004-0.42075v-0.2094c0-1.9504-0.86061-6.852 0.50045-8.3321 1.0805-1.1703 2.0214-0.0202 2.3411-2.1709 0.18008-1.2603-0.03-2.7593-0.2101-4.0014-0.36017-2.591-1.2208-5.2316-0.64008-8.0118 0.28057-1.291 0.68053-2.1011 0.68053-3.6602v-4.3327c-0.0104-2.1207 0.62051-1.79 1.4609-3.1996 0.6205-1.0411 0.36995-2.7606 0.36995-3.972 0-2.7711 0.01-5.5519 0-8.3321 0-0.57013-0.19052-1.6412 0.15986-2.0516 0.51023-0.60014 1.2208 0.15003 1.6808-0.77888 0.39018-0.8017-0.2897-3.0907-0.33994-4.002-0.09-1.6712-0.23032-2.4208 1.3408-2.8402 1.2606-0.33007 2.6014 0.09 3.6519 0.55056 1.8008 0.78997 5.6935 1.6002 7.724 0.50099 0.84039-0.45989 1.9209-1.7306 2.6314-2.3803 0.80123-0.74039 0.93042-1.9198 1.8308-2.7111 0.92064-0.80953 2.7117-0.69016 3.8431-1.0796 1.3604-0.47946 2.4213-1.4103 3.802-1.7 3.1815-0.66994 3.9912 1.4703 5.993 3.561 0.58071-0.81019 1.7708-1.6706 2.071-2.5408 0.97022-0.4214 1.2306-0.82127 2.4716-1.0202 1.271-0.21005 1.8615-0.09 2.9916 0.33008 1.8909 0.71038 3.1717 1.9504 4.8126 3.0209 0.39083 2.5206 2.251 3.231 4.5021 3.1214-0.15007-1.9504 0.81037-1.5806 2.0214-2.1409 1.1908-0.54991 2.052-1.5506 3.5116-1.6797 1.2912-0.1109 4.0519 1.2003 4.7931 2.2799 0.0672 0.10763 0.12789 0.21787 0.17747 0.34703z",
+                Taidong:"m327.47 304.02c-0.32036 0.81019-0.64007 1.6302-0.96044 2.5004-0.7001 1.9204-0.23097 3.9309-0.55068 5.9518-0.27013 1.7417-1.1601 3.3412-1.4407 5.0627-0.25055 1.5904-0.0196 4.8415-1.181 6.0614-1.0903 1.1598-3.1417 1.2309-4.3122 2.6908-1.3108 1.6412-1.6508 2.9713-1.761 5.2519-0.0803 1.5708 0.36995 4.6217-0.50045 5.8116-0.76079 1.0607-2.852 0.77105-3.5723 2.3712-0.63095 1.4208-0.0698 3.651 0.0692 5.0712 0.29035 2.8611-0.1703 8.1527 3.7322 7.8129-1.0798 0.39009-1.35 1.6002-2.2308 2.1403-0.63029 0.39922-1.3004-0.0496-2.0116 0.50033-0.47956 0.36073-0.58983 1.1403-0.93042 1.3608-1.8211 1.1598-5.4827 0.12981-4.8126 3.9413 0.0502 1.7104-0.68053 3.561-1.331 4.8311-0.61072 1.1703-0.32037 2.4599-0.71055 3.621-0.42998 1.2805-1.4909 2.441-1.9607 3.732-0.44042 1.1807-0.36995 2.2199-1.0407 3.3216-1.301 2.1305-4.1621 2.5108-4.9229 4.8716-0.4502 1.3803-0.0907 2.3405-0.88084 3.591-0.59048 0.93021-1.0498 1.9504-1.7003 2.8611-0.42085 0.60013-0.98067 0.85063-1.2912 1.4814-0.25968 0.51991-0.10048 1.319-0.3693 1.8304-0.70075 1.2707-2.1114 0.97001-1.992 2.8409-2.2204 0.12003-6.4138-0.59035-7.4441 2.0607-1.0798 2.7698 0.82082 4.9603 1.6312 7.1319 0.71054 1.8898-0.31971 2.0411-1.5007 2.7111-1.5607 0.88063-1.1301 1.1403-1.331 2.9609-0.24989 2.2799-3.1619 3.1696-4.5223 5.1605-0.03 0.0502 0.01 0.39139-0.0104 0.48011-0.97023 0.75995-2.3913 1.1298-3.312 1.8904-0.93042 0.75996-1.2006 2.321-2.3313 2.9707-1.0107 0.59035-2.5212 0.14938-3.7021 0.6308-1.2208 0.50098-1.6312 1.5199-2.5009 2.5004-1.6012 1.8102-4.4022 2.1109-5.9232 3.9218-0.64008 0.74104-0.90041 2.3803-1.2103 3.2916-0.39931 1.2003-0.57026 2.4006-0.63029 3.7013-0.12005 2.5004-0.17029 4.3712-2.2014 5.8116-1.1203 0.78996-1.9202 0.91064-2.6308 1.9909-0.66095 0.99023-1.1908 2.1605-1.6716 3.3301-0.52003 1.2609-0.4202 2.5206-0.8704 3.8011-0.44042 1.2401-1.181 2.2805-1.5105 3.5408-0.63942 2.4821-0.44042 5.0327-1.181 7.4724-1.8308 0.47098-1.5607 4.6824-2.2713 6.203-0.88997 1.9002-1.2997 3.651-1.9111 5.5904-0.57026 1.8108-1.2208 4.4123-2.8017 5.5722-0.85017 0.6308-0.43977 2.3405-0.8293 3.6608-0.28121 0.91978 0.33016 7.2023 0.33016 8.1723 0 0.69016 0.24011 1.5004 0.47956 2.351-0.71054 0.72995-1.9502 2.0705-2.681 2.4508-1.8511 0.95043-1.6416-1.2303-3.4418-0.99936-0.28969-1.6719-2.3411-1.1011-3.5318-1.6412-1.35-0.61058-1.6201-1.0802-3.4712-1.1807 0.19052-0.84019-0.0998-1.4606-1.0002-1.3418-0.30013-1.379 2.4409-2.0105 0.47044-3.1807-0.70076-0.42009-2.7815-0.88911-3.6421-0.82062-0.09-1.8096 0.0411-3.4704 2.2817-3.5004 0.10962-2.1612 0.20031-3.4612-1.4707-4.6406-1.5307-1.1011-3.0816-0.59035-3.5318-2.6419-0.41041 0-0.80059-0.30007-1.2808-0.21983-0.15985-0.77953 0.19052-1.7 0.30014-2.471 0.14028-0.90021-0.0698-2.1305 0.18008-3.0014 0.46-1.6197 2.8115-2.2903 4.472-2.3601 0.21989-1.471-0.4104-5.702-1.6808-6.6022-1.1601-0.8291-2.2014 0.39074-2.9616-1.0405-0.69032-1.3105 0.18987-2.4906 0.51023-3.4612 0.53046-1.5904 0.0698-5.3628-0.63029-7.0425-0.33994-0.81019-3.772-6.1618-0.74056-6.1919 0.12919-2.2805 0.39018-4.3908 1.1601-6.4828 0.41041-1.1207 0.97023-1.8396 1.701-2.8807 0.75034-1.0705 0.65052-1.7404 1.0002-2.9498 0.3693-1.2805 1.611-2.1207 2.0005-3.3412 0.39083-1.2309-0.60028-2.8807 0.13049-3.8722 0.70989-0.98044 2.4716-0.68037 3.5318-0.78996 1.8406-0.19048 2.3913-0.17939 3.802-1.2205 0.88084-0.63927 1.6508-1.76 2.5414-2.1207 1.2508-0.50947 3.0027 0.42988 4.012-0.31964 1.9809-1.4599 1.4609-5.321 0.85018-7.1527 1.5712-0.91064 2.1714-1.6302 2.101-3.4912-0.0196-0.62036 0.0607-1.8806-0.12919-2.5414-0.38039-1.3497-0.38039-0.64971-1.5007-1.1598-0.79079-0.36008-3.1926-1.2205-3.7119-1.7906-1.0205-1.1011-0.18008-2.8702-0.65051-4.0907 1.1105-0.58057 1.7512-1.6308-0.28057-1.6497-0.0907-1.5701 0.14028-2.5708-1.8315-2.3308 0.0907-1.5701-1.7604-1.9902-2.0305-3.6511-0.24011-1.501 0.35038-3.231-0.18008-4.6322-0.23032 0.03-0.55069-0.0691-0.79015-0.0502-1.5509-2.5695-0.38039-7.2623 1.6005-9.2728 0.77057-0.77952 2.3913-1.4703 3.0118-2.4208 1.0107-1.561-0.74121-2.2205-0.30014-3.6302 0.52002-1.6615 2.5708-0.23092 3.462-1.1905 0.80059-0.85976-0.63028-2.8115-0.96044-3.4808-0.32036-0.65037-0.75034-0.44097-0.54024-1.5317 0.15985-0.8291 0.58004-0.94978 1.0498-1.5904 0.59048-0.80171 1.1908-1.9113 1.3604-2.8311 0.51024-2.5506 0.24011-5.8618 0.0998-8.5135-0.80058-0.2094-1.8811-0.47033-1.611-1.5004 0.52003-0.0404 1.5509-0.14938 1.9411-0.57013 0.55982-0.62036 0.0502-1.1709 0.35038-1.8011 0.67988-1.3999 2.071-1.0405 2.3515-2.6608 0.12005-0.72017-0.23098-1.4103-0.17095-2.1703 0.0502-0.57013 0.43063-0.95044 0.5011-1.4899 0.16051-1.1011-0.55004-3.3908 0.0202-4.3112 0.61072-0.97 2.4814-0.61122 3.3113-1.2303 0.89062-0.66993 1.5907-2.1318 2.3411-2.9609 1.0714-1.1905 1.6012-1.9309 3.3315-2.3405 1.3604-0.32029 2.5009-0.59036 3.832-1.2016 1.1705-0.54991 2.0109-1.5004 3.2115-1.9302 0.93043-0.33986 2.1114-0.11024 2.9818-0.6308 0.17943 0.65037 0.66031 1.3105 1.0309 1.7208 0.99046 1.1103 2.1401 2.0516 2.4905 3.7111 0.36082 1.7404 0.0111 2.8311 1.2508 4.2114 0.97023 1.0705 3.2617 0.81018 3.4118 2.09 1.4002 0.0907 4.1217-0.14938 5.133 0.69081 1.5209 1.2609 0.36016 3.1918 3.0014 3.3412 1.5509 0.09 3.3022-1.4508 4.8531-0.33986 1.3108 0.94979 1.4302 3.1996 1.5098 4.8115 0.81038 0.0489 1.6508 0.01 2.4514 0.06 0.06 1.03-0.03 2.1305 0.19052 3.1312 0.30014 1.3503 2.1414 2.1807 3.4816 2.03-0.33994 1.5095 0.63029 1.561 1.8315 1.501 0.21988 0.94 1.2208 1.4703 1.7408 2.2603 0.52002 0.79061 0.58918 1.9707 1.611 2.3908 2.131 0.89043 4.7226-0.91064 6.6533-1.03 0.11027-1.2694-0.28057-2.3712-0.14094-3.6413 0.0998-0.93934 0.9611-2.0105 0.9611-2.8696 0.0104-1.3203-1.2704-1.7606-1.2912-2.972-0.0196-1.2101 1.0603-2.2407 2.3013-2.0209 0.88084-2.3405 1.671-4.7117 2.8317-7.0118 0.63029-1.2505 0.03-2.6008 0.53046-3.8115 0.47044-1.1605 1.9914-1.3908 2.6308-2.4906 0.70011-1.2094 0.42998-2.6308 0.54025-4.0014 0.12071-1.4703 0.70989-2.2205 1.1705-3.501 0.15007-0.4201 0.0411-1.3503 0.48022-1.6406 0.50045-0.33007 1.5607 0.57013 2.2014-0.06 0.69031-0.69994 0.28969-2.6217 1.1503-3.471 1.0009-0.99153 2.5316-0.66993 1.5007-2.1709-0.30014-0.42988-2.1708-1.8304-2.6412-2.0202-0.10961-1.8709 0.12985-3.3914 0.84039-4.9414 1.2306-0.71038 0.7001-3.6308 2.2713-3.4012 0.68053-0.97001 2.4605-0.45011 2.2308-2.2707 1.0909-0.64972 2.9113-0.31964 3.9722 0.14025 0.41041 0.18004 1.1405 0.85128 1.5307 0.96087 0.62572 0.18004 1.1164-0.10894 1.7564-0.1396zm-3.9279 119.23-0.0202-0.18004c0.23097-0.12003 4.063-0.30985 4.3722-0.0189 1.5209-0.91064 2.4018-0.82975 2.6614 0.99088 0.15986 0.0404 0.29035 0.0196 0.45021 0.06-0.48022 0.80105-0.81037 1.7704-1.0002 2.7815-0.79015 0.12916-0.75035 0.21984-0.95066 0.82911 0.27013-0.0496 0.66031 0.0802 0.94022 0.0502-0.0607 0.78018 0.09 1.6302 0.33994 2.2694-1.5412 0.83041-3.4522-1.6706-5.1128-1.9902-0.21988-0.40053-0.29035-0.98044-0.17029-1.441 1.7003-0.91978-1.5509-2.3301-2.052-3.0307 0.1318-0.3105 0.29231-0.30007 0.5422-0.32029zm19.79 101.38c0.68053 1.6706 0.32037 2.231 0.33994 3.9518-1.301 0.17939-2.3222-0.39922-3.6121-0.33986-1.3611-2.1709-2.5616-3.0307-5.0025-3.171-0.60028-1.2609-2.6112-2.2407-3.573-3.4312-0.70989-0.88064-0.47043-2.1905-0.79014-3.201-0.27013-0.84019-1.7408-2.1005-1.3108-2.8109 0.8704-0.0802 1.5712 0.20026 2.4513 0.15982 0.0405 0.15916 0 0.30006 0.0502 0.44945 1.8106 0.0907 5.5428 0.55969 6.9834-0.41031 0.23098 0.81018 0.11027 0.33007 0.64008 0.8004 0.0104 0.58122 0.03 1.1905 0.0405 1.7802 0.15986 0.0404 0.30014 0.0104 0.46065 0.0502 0.2101 1.09-0.47043 1.1807-0.65052 1.6706-0.21988 0.61122-0.36995 1.1102-0.30014 1.9504 1.0903-0.18005 1.1105 0.85063 1.1608 1.6608 0.82994 0.03 0.68052 0.0496 1.0009 0.66994 0.70076-0.0398 1.4615 0.0307 2.1114 0.22048z",
+                Hualien:"m262.01 324.77c-0.21989-0.69994-0.0698-1.3999 0.95065-1.7704 0.20031-1.1298-1.6808-4.6517-3.1417-4.0411 0.0104-0.25897-0.25903-0.72017-0.19052-1.0705-0.93043-0.0496-1.9809 0.14938-2.7717-0.39009-0.98001-0.65037-0.20944-1.5317-2.0109-1.3307-0.12006-1.06 0.32036-1.6602 0.67009-2.6002 0.18008-0.50098 0.47043-0.43053 0.47043-1.2101 0-0.36921-0.54025-0.53947-0.50958-0.82062 0.21988-1.8898 2.8017-1.291 4.3226-1.5395 0.21988-1.7717-0.0307-2.972-0.33994-4.6113-0.82081-0.18983-1.0107-0.63993-0.77057-1.3307 0.0104-0.0404 0.12005-0.0496 0.27012-0.0496 0.2897-0.0196 0.72033-0.0104 0.84039-0.12981 0.20031-0.2094 0.15985-0.61057 0.47956-0.88977 0.8704-0.74104 0.48022-0.69081 1.7108-0.94978 0.72033-0.15004 1.4707-0.15004 2.1414-0.36987 0.14941-2.4906-2.191-1.9504-1.3108-4.3112 0.61985-1.6497 1.3304-3.3301 2.3802-4.8004 1.8713-2.6413 7.6137-2.561 10.085-0.72016 0.49001-0.7704 1.331-0.90021 2.0116-1.3405 0.10961-1.8311-0.2101-3.5715-0.0998-5.4417 1.6312-0.48011 1.4106-0.72017 1.7806-2.1709-0.27012 0.06-0.68053-0.0998-0.95065-0.0496-0.13963-0.78018-0.24011-1.6308 0.61136-1.8409 0.03-0.12003-0.0307-0.34899 0.06-0.43966 1.1601-0.5597 2.0514 0.60013 2.972 0.31963 0.48022-0.14025 1.4309-1.9002 1.5209-2.321 1.0198-0.71104 1.1908 0.20939 1.9411 0.20026 0.57026-0.0104 1.1014-0.32029 1.6716-0.42988 0.50045-0.71038 0.10961-1.3503 0.3693-2.1311 0.33994-1.0502 0.72033-0.5897 1.1712-1.3803 0.55982-1.0007-0.16051-2.3608 0.2499-3.441 0.39017-1 1.7003-1.7404 1.9111-3.0209 0.16051-0.9002-0.59049-1.5003-0.51023-2.3308 0.0907-0.8291 0.73011-1.2505 0.84038-2.3308 0.09-0.88064 0.0998-1.9707 0.01-2.8402-0.23946-2.1207-1.81-2.2805-2.0109-4.1612-0.2897-2.8213-0.2897-2.651-2.972-3.201-0.27991-1.4808 1.331-3.6113 2.7822-3.8311-0.17095-1.4103-0.24011-2.9211 0.21988-4.2812 0.53046 0 0.77971-0.2805 1.2808-0.39074 0.69031-1.3405 0.51023-3.06 1.1503-4.471 0.23097-0.5199 0.69031-0.65037 0.88083-1.1703 0.14094-0.3803 0.0411-0.93087 0.16051-1.3307 0.27013-0.84019 0.70011-1.2609 1.0303-1.9804 0.21988 0.0404 0.55003-0.0202 0.78036-0.0502 0.0698-1.3803-0.80059-5.8018 1.331-5.6615 0.1703-3.3816 0.51024-6.7822 0.33994-10.124-0.69945-0.0404-1.4204-0.01-2.1205-0.0502-0.12005-2.4808 0.64008-3.4312 1.3206-5.4717 0.42998-1.2903 0.75034-2.0607 1.3708-3.291 0.73011-1.4508 0.47108-2.4006 0.6205-3.8813 0.21988-2.2505 0.96109-1.0196 2.4611-1.8709 0.85996-0.47945 1.5405-1.6706 2.2112-2.4306 1.2912-1.4703 2.1812-4.9414 0.45999-6.1716-0.82994-0.59035-2.3313-0.90021-3.2513-1.5708-1.181-0.8702-1.0707-1.2903-2.8513-1.3105-0.23098-0.72017-0.3308-1.6902-0.0698-2.351 0.30013-0.72995 0.97022-0.77039 1.2208-1.2505 0.3804-0.70973 0.03-1.5304 0.32037-2.2199 0.42019-0.97979 0.4104-0.5199 1.3708-0.95043 1.6012-0.71038 2.4213-1.1814 3.6023-2.2205 1.2201-1.06 1.9411-0.93022 3.6721-1.0196 0.17943-0.80105 0.14028-1.6712-0.78036-1.8408-0.0998-1.1605 0.1305-1.5904 0.55069-2.1612 0.16964-0.21983 0.36995-0.47033 0.60028-0.8004 0.47108-0.67972 0.82994-2.3706 1.5209-2.9707 0.94087-0.82063 2.7326-0.0802 3.312-1.0307 0.59048-0.97979-0.35038-3.0607-0.01-4.1723 0.44042-1.4103 1.7304-1.4201 2.5205-2.4899 0.53046-0.74104-0.01-0.95043 0.82082-1.5108 0.49-0.33986 1.151-0.20026 1.7108-0.66994 0.78036-0.63014 1.7519-1.5095 2.1218-2.3301 0.50045-1.1403-0.30079-2.8317 0.20031-3.972 0.24011-0.54991 1.4504-1.7098 2.2412-2.1807 0.0411 0.0907 0.0907 0.18004 0.15007 0.27006 0.4104 0.60014 0.93956 0.39074 1.5712 0.59035 0.74056 0.23027 1.1705 0.87999 1.8811 1.2003 0.46064 0.21005 1.0009 0.27006 1.4302 0.54012 0.44107 0.27006 0.72033 0.59035 1.0805 0.93022 0.15986 0.15003 0.32037 0.25962 0.5011 0.39074 0.2897 0.18982 0.19052 0.21983 0.41041 0.0992 0.3693-0.19048 0.48022-0.66015 1.0407-0.50033 0.24011 0.0691 0.27013 0.21983 0.58005 0.24984 0.25055 0.0202 0.38039-0.0502 0.59049-0.0802 0.45021-0.0698 0.93043-0.06 1.3715 0.0411 0.61006 0.12916 1.1503 0.30985 1.7904 0.36921 0.41106 0.0404 0.84038 0 1.2508 0.0502 0.98067 0.0998 1.151 1.1905 1.761 1.8206 0.62051 0.63928 0.8306 1.3301 1.8106 1.4606 0.81037 0.10959 1.5809 0.01 2.3613 0.2094 0.39018 0.0998 0.82016 0.26027 1.2397 0.22048 0.26034-0.0307 0.47108-0.12981 0.74121-0.0907 0.23946 0.03 0.42019 0.15003 0.66944 0.12068-0.0998-0.25049-0.0398-0.53034-0.0803-0.82062-0.0502-0.47946-0.23032-0.45924-0.60027-0.80954-0.17943-0.17091-0.33015-0.28963-0.27013-0.55969 0.06-0.29029 0.03-0.14938 0.21989-0.14025 0.12984 0.0202 0.15006 0.18004 0.32036 0.17026 0.18987-0.0104 0.30014-0.19048 0.42998-0.31051 0.20031-0.20092 0.41041-0.65037 0.70076-0.72995 0.28904-0.0802 0.39018 0.21983 0.6205 0.10959 0.23946-0.10959 0.21988-0.63015 0.28904-0.84998 0.0901-0.27006 0.30014-0.53034 0.54025-0.66993 0.0502 0.24005 0.23098 0.48011 0.46065 0.53033 0.42019 0.11025 0.40975-0.1409 0.71054 0.23027 0.15986 0.20027 0.2897 0.78018 0.59049 0.58057 0.16964-0.11024 0.16964-0.61057 0.18987-0.80953 0.03-0.27006 0.0803-0.69994 0.0104-0.96087-0.11027-0.42989-0.44955-0.33986-0.74056-0.66016-0.19052-0.21004-0.19052-0.45988-0.33994-0.67972-0.2003-0.27984-0.55982-0.39009-0.6603-0.77039-0.20031-0.75017 0.49001-1.6308 1.2404-1.1305 0.32037 0.21984 0.68053 0.68038 0.95066 0.96022 0.33015 0.3503 0.63942 0.69995 0.98066 1.0411 1.1503 1.1507 0.0803-1.1011 1.2006-0.76061 0.24011 0.0802 0.36016 0.44032 0.55003 0.63015 0.38039 0.3803 0.90041 0.51011 1.2612 0.92043 0.36017 0.41031 0.66031 0.84997 1.1099 1.1598 0.35038 0.25049 0.66095 0.19048 1.0805 0.25049 0.46064 0.0691 0.53046 0.3105 0.90041 0.50033 0.39996 0.21005 0.96109-0.0404 1.3904 0.12003 0.29035 0.11024 0.59049 0.36073 0.8704 0.5199 0.53046 0.29028 0.99111 0.61123 1.5816 0.79062 0.46 0.14938 0.93043 0.12002 1.4204 0.12002 0.53046-0.01 0.92064 0.12982 1.4106 0.29029 0.61985 0.19048 1.4713 0.0196 2.0514 0.33986 0.33994 0.18983 0.60093 0.54012 0.93108 0.72995 0.2897 0.17026 0.58136 0.23027 0.90042 0.31051 0.49066 0.12981 1.5405 0.7606 2.022 0.3803 0.0196-0.01 0.0405-0.03 0.0405-0.0496 0.0796 0.42988 0.18987 0.96022 0.0411 1.3405-0.15007 0.43053-0.76078 0.27006-0.87105 0.88064-2.0905 1.3112-2.9414 2.9218-3.2219 5.4019-0.18987 1.7104-0.15985 2.2805-1.8811 2.8807-1.3708 0.48011-2.1904 0.8702-3.3518 1.6406 0.06 1.1305-1.0107 2.3908-1.9313 2.8311-0.57027 0.2805-1.2802 0.44032-1.8406 0.68037-0.95065 0.39009-1.0707 0.74952-1.7512 1.4508-0.99111 1.0196-1.4217 1.7606-1.5105 3.4006-0.0404 0.92043-0.33993 3.8011 0.61007 4.1416 0.57091 1.9615 0.39083 4.5115-1.2606 5.702-0.63943 0.4501-1.4707 0.72016-2.0612 1.1514-0.61071 0.44945-1.4511 1.3705-1.9411 1.9707-1.8504 2.2812-1.9307 8.5428-0.0698 10.763 0.39997 0.47032 1.0414 0.91064 1.5809 1.0502 0.97023 1.4508 1.7715 3.5506 0.62051 5.2016-0.36017-0.03-0.62051 0.16047-0.95066 0.17026-0.0496 0.1709-0.12919 0.29028-0.17029 0.46054-0.39997 0.0998-0.81037 0.19047-1.2097 0.29028-0.0998 0.23027-0.18987 0.21983-0.2897 0.45989-3.002 0.20026-1.7512 9.1221-1.8615 11.283-0.0907 1.8304-0.86062 3.8611-1.3611 5.5219-0.60028 1.9602-0.44042 3.8813-0.76079 5.972-0.17943 1.2303-1.0603 2.3706-1.8811 3.351-1.1601 1.4005-1.2397 2.1409-1.2397 4.0314 0 1.7508 0.68053 3.9818 0.12006 5.6322-0.53046 1.5806-1.9711 2.5004-2.4912 4.2512-1.0407 3.5708 0.0698 8.1723-1.5607 11.684-0.91085 1.9707-2.0807 2.2107-2.4513 4.5617-0.32037 2.0405 0.23032 4.2114 0.01 6.2623-0.21009 1.8611-1.4002 3.2805-1.761 4.9909-0.41041 1.9609-0.0796 3.9211-0.74056 5.762-0.59049 1.6706-2.1316 4.0907-0.12006 5.4913-0.57026 2.7411-1.4818 5.0418-2.4416 7.4926-0.64008 0.03-1.1307 0.31898-1.7519 0.13959-0.39018-0.10959-1.1203-0.77952-1.5307-0.96087-1.0603-0.45924-2.8813-0.78996-3.9723-0.14025 0.23097 1.8206-1.5503 1.3007-2.2308 2.2707-1.5712-0.23092-1.0407 2.6908-2.2713 3.4012-0.71054 1.5499-0.95065 3.0705-0.83973 4.9414 0.47043 0.18982 2.3411 1.5904 2.6412 2.0202 1.0309 1.501-0.5011 1.1814-1.5007 2.1709-0.86061 0.85063-0.45999 2.7711-1.151 3.471-0.63943 0.63015-1.7004-0.27006-2.2014 0.06-0.44042 0.28964-0.33015 1.2205-0.47957 1.6406-0.46064 1.2805-1.0505 2.0307-1.1705 3.501-0.11092 1.3712 0.1592 2.7906-0.54025 4.0014-0.64008 1.1011-2.1616 1.3301-2.6314 2.4906-0.5011 1.2094 0.0998 2.561-0.53046 3.8115-1.1601 2.3001-1.9502 4.6713-2.8317 7.0118-1.2397-0.21983-2.3215 0.81019-2.3006 2.0216 0.0196 1.2101 1.3004 1.6497 1.2906 2.9713 0 0.85977-0.86061 1.9302-0.96044 2.8702-0.13963 1.2694 0.25055 2.3712 0.14028 3.6406-1.9307 0.12068-4.5223 1.9204-6.6533 1.03-1.0198-0.4201-1.0903-1.6002-1.611-2.3908-0.52067-0.78996-1.5209-1.319-1.7408-2.2603-1.2006 0.06-2.1714 0.0104-1.8308-1.501-1.3415 0.14938-3.1821-0.67972-3.4822-2.03-0.21988-1.0007-0.12919-2.1011-0.19052-3.1312-0.80059-0.0502-1.641-0.0104-2.4513-0.06-0.0803-1.6112-0.20031-3.8618-1.5098-4.8115-1.5509-1.1102-3.3028 0.42988-4.8531 0.33986-2.6412-0.14938-1.4811-2.0803-3.0014-3.3412-1.0107-0.83954-3.7322-0.60014-5.133-0.69081-0.15007-1.2799-2.4416-1.0196-3.4118-2.09-1.2404-1.3803-0.89063-2.471-1.2508-4.2114-0.35037-1.6608-1.5013-2.6008-2.4911-3.7104-0.37778-0.41814-0.858-1.0783-1.0381-1.7287z",
+                ChiayiCity:"m184.85 297.29c0.06 1.2094-0.28056 1.4703-1.301 1.9994-0.12984 0.89042-0.33994 2.5317-1.6005 1.8017-0.42019-0.24005-0.55069-0.76061-1.0805-0.89042-0.39017-0.10959-1.2808-0.14938-1.671-0.09-0.75034 0.12003-1.4707 1.1005-1.9907 1.6706-0.51023 0.57013-1.4113 1.5506-2.3313 1.4005-0.48022-0.50164-0.2499-1.1709-0.67988-1.711-0.52002-0.64972-0.99046-0.55056-0.93043-1.5904-0.71054-0.0404-1.4309 0.0104-2.1414-0.03-0.0698-1.1011-1.1803-0.61057-1.8308-0.55056-0.98001 0.0992-1.4106-0.69994-0.27012-1.0404 0.0998-0.63993 0.76078-1.5904-0.39997-1.501-0.42019-0.53034-0.53046-1.4899-0.6205-2.1403-0.12984-0.97001-0.01-0.91978 0.94022-1.261 0.4502-0.17025 0.91085-0.42988 1.181-0.82062 0.0998-0.0104 0.21989 0.0104 0.30993 0 0.0502 0.33986 0.12005 0.66081 0.19052 0.98044 0.77057-0.0404 0.99045-0.63014 1.6605-0.82062 0.62051-0.17939 1.3911-0.0698 2.0612-0.0998-0.18009-1.3601 1.2606-0.94979 2.1714-1 0.0196-0.34899 0.17029-0.63014 0.42998-0.8291 0.33994 0.21983 0.26034 0.50033 0.48022 0.78018 0.20031 0.27985 0.63029 0.4488 0.79014 0.70973 0.49001 0.77952 0.03 1.2701 1.3004 1.1709 0.0998-0.29029 0.1703-0.57013 0.19053-0.89042 0.38039 0.03 1.5105 0.24005 1.7512 0.49054 0.32036 0.33008 0.24989 1.2101 0.33993 1.6497 0.93108 0.17026 1.3004 0.84019 2.3013 0.85976 0.03 0.4899 0.0398 0.93087 0.10961 1.3914 0.22967 0.17026 0.33994 0.2805 0.64008 0.36073z",
+                ChiayiCounty:"m205.81 336.38c-0.21988 1.0607-1.1216 1.5206-1.8817 0.36073-1.3708-0.30007-2.3515 0.2094-3.8418 0.0998-1.4002-0.11024-1.9013-0.57013-2.6314-1.741-0.35038 1.8611-2.0207 1.8311-2.8611 3.2414-0.0502-0.0104-0.54025 0-0.61071 0-0.38039-0.78018-1.5614-0.45988-1.7219 0.3503-1.3904-0.33986-1.5705-2.1011-3.2813-1.8904-0.0998-0.34965-0.22053-0.72017-0.39083-1.0607-0.5807-0.03-1.2006-0.0398-1.7806-0.06-0.0607-0.85912 0.2897-1.9609 1.1105-2.3405 0.0496-0.85063 0.0496-1.7508 0-2.6008-1.8615-0.20026-1.0414-4.6211-0.97023-6.032 0.0692-1.4397 0.09-1.8096 1.181-2.6706 0.79014-0.62036 1.761-0.39922 1.6207-1.8011-1.9816-0.45989-3.0816-2.0105-5.2733-1.8898-0.48022-2.1403 1.9914-2.3412-0.46064-3.6413-0.10962-0.99936-1.6312-0.98045-2.5009-1.2003-0.1703-1.561 1.9209-0.93935 1.4009-2.6112-2.071 0.44032-2.1512-0.50033-3.9723-1.3601-1.1503-0.54012-2.6915-1.0404-3.6721-1.8506-1.0407 1.4599-3.5318 0.34965-5.0025 0.34965-1.731 0-3.0516 0.76061-4.6626 1.0007-1.8609 0.27985-3.6317 0.10959-5.013 1.3705-1.0505 0.95044-0.45021 1.0802-1.9907 1.3001-0.91085 0.12982-1.8008-0.0998-2.6412-0.14025 0.10961 2.5206-1.2606 1.2205-2.7417 2.261-1.5907 1.1298-0.6205 2.1905-0.31057 3.5512-1.4204 0.58905-1.7108-0.61123-2.6915-0.55056-0.95065 0.06-1.7708 1.3294-0.65051 1.9106 0.52002 3.261-2.8618 1.2609-4.2822 2.8311-0.24989 1.7-1.5007 2.291-2.3613 3.471-0.36016 0.4899-0.6603 1.5604-1.1608 1.6706-0.71054 0.15982-1.5405-0.93934-2.3111-1.0196-0.17029-0.51012-0.40975-0.61971-0.6603-0.97 0.12005 3.5812-3.4118 0.81018-3.5618-1.1598-0.52003 0.0405-1.1007-0.0907-1.611-0.0502-0.2499-0.88912-0.89063-1.5806-1.0603-2.4508-1.5405-0.42989-2.5714-1.6908-4.0323-2.3001 0.03-0.0607 0.0698-0.12068 0.0998-0.17939 0.74056-1.3607-0.0404-3.7313 1.4811-4.471 0.21988-0.1109 0.48022-0.15982 0.7001-0.24006 0.30014-0.12133 0.42019-0.25962 0.67074-0.39074 0.10962-0.0607 0.76014-0.16047 0.82016-0.23092 0.67988-0.80106-2.3815-1.4201-2.6712-1.5199 1.8909-0.17025 6.6232-0.12068 4.6521-3.1814-0.36995-0.0411-0.55003 0.31051-0.80058 0.55969-0.53046-0.42074-1.2103-1.5506-0.93043-2.1011 0.20031-0.39987 0.58005-0.45989 0.56047-0.96935-0.0202-0.45011-0.33993-0.42988-0.0698-0.93087-0.48022-0.0104-0.86061-0.54012-0.81037-1.0104 0.06-0.62036 0.78036-0.88064 1.0505-1.3196 0.49001-0.79127 0.06-2.4019-1.0505-1.9309-0.44042 0.18983-0.44042 0.85977-1.1203 0.69081-0.53046-0.12981-0.70076-0.76061-0.44042-1.2309 0.35038-0.63993 0.78036-0.34965 1.3108-0.5199 0.7001-0.22114 0.38039-0.82128 0.38039-1.441 0-1.2401 0.88084-1.441 1.5607-2.2499 0.72033-0.86042 0.38039-2.0516-0.99046-1.5506-0.18987 0.0796-0.36995 0.31898-0.57026 0.37965-0.25968 0.0907-0.55003-0.0196-0.82016 0.0496-0.27012 0.0607-0.39996 0.33073-0.60027 0.39075-0.36995 0.11024-0.42019-0.0907-0.70076-0.15982-0.21988-0.06-0.63029 0.0104-0.82016-0.0998-0.42998-0.25049-0.17029-0.39922-0.30992-0.75996-0.20031-0.50098-0.73077-0.54012-0.94087-0.99087-0.27991-0.58971 0.21988-1.1905 0.36995-1.7104 0.0803-0.25962 0.0803-0.55969 0.20031-0.79061 0.13963-0.31051 0.36996-0.40966 0.50045-0.69081 0.47043-0.11025 0.58005 0.20091 0.96044 0.33072 0.33994 0.11025 0.80059 0.0405 1.1608 0.0405 0.58005 0 1.8909 0.25962 1.611-0.62036-0.12006-0.36008-0.66031-0.4201-0.55004-0.87999 0.06-0.27006 0.33994-0.35029 0.48022-0.59035 0.70011 0.45989 1.2006 0.95044 1.0505 2.0607 0.32036-0.0502 0.79014 0.12981 1.1105 0.06 0.42019 0.75996 2.9714 0.95044 3.862 1.1403 1.6508 0.35029 3.2317 0.85063 4.8224 1.1605 2.0312 0.39922 3.8724 0.40966 3.522-2.1709-0.0998-0.66994-0.89063-1.3601-0.98067-1.8617-0.14028-0.78997 0.38039-1.5304 0.50045-2.2805 0.33015-0.01 1.5607-0.21983 1.8113-0.03 0.63029 0.47098 0 1.0913 0.36996 1.6412 0.92064 1.3712 2.221 0.69081 1.9907-0.93021 1.9209-0.63993 1.1705-1.1403 2.101-2.7404 0.85082-1.441 1.6207-0.68038 3.342-0.82063-0.10049-0.63993-0.59049-1.1102-0.61072-1.7802 1.0407-0.09 2.161 0.18983 3.1214 0.4501 0.0405-2.2707 0.15007-2.651 2.3515-2.8122 1.4106-0.0998 3.0314-1.0405 2.7019-2.8004 0.88019-0.36008 1.9809-0.17939 2.9414-0.23027-0.2101-1.6615 1.9013-3.0516 3.3615-2.972 1.5007 0.0698 2.3515 2.9511 4.5125 1.6804 0.77057-0.4501 0.54025-1.3203 1.5307-1.6804 0.76013-0.27006 2.1512 0 2.9616 0 0.90041 0 1.9411 0.14025 2.8017-0.0398 0.96044-0.19048 1.38-0.86041 2.5114-0.60013 0.2499 1.3105 1.6207 1.8806 1.7206 3.1109 0.23098-0.0189 0.55004 0.0802 0.78036 0.06 0.80059 4.1514 4.6123 2.6112 7.694 3.3014 1.7114 0.39074 2.8115 1.291 4.8531 1.1703 1.7519-0.10959 3.1514-0.85976 4.9627-0.81019 0.35038 2.1514 0.06 3.1012 2.6614 2.4514 0.24011-0.49055 0.46064-0.47946 0.82994-0.79062 0.20096 2.0516 2.452 0.69994 3.5423 0.65037 1.4811-0.0692 3.6121 1.4103 5.0025 1 1.1007-0.33008 0.80059-0.71038 0.79015-1.8311 0-0.53034 0.09-2.0209-0.12071-2.5114-0.25903-0.62036-1.2306-0.4899-1.3604-1.3405-0.06-0.42988 0.64007-1.2003 1.1405-1.4305 0.2101 0.12068 0.5011 0.21983 0.89062 0.27006 1.2006 0.17026 2.5714-0.20026 3.9723-0.14025 0.0104 0.32029 0.19053 0.4899 0.2101 0.78018 0.75034 0.0502 1.5307 0.0202 2.2817 0.06 0.92064 0.68038 0.52002 1.4005 1.6906 1.8213 0.79014 0.27006 2.3111 0 3.1521-0.0404 0.0502-0.15004 0.01-0.29029 0.0502-0.45011 0 0 0.47957-0.0202 0.44955 0.0104 0.36995 0.66081 1.0903 1.3908 1.2012 2.1403 0.0692 0.55056-0.31123 1.9204-0.33994 2.6608-0.0502 0.98045-0.12985 1.6908-0.70011 2.4606-0.53046 0.7293-1.5007 0.77953-1.4511 1.8506 0.15986 0.0489 0.30014 0.0104 0.46065 0.0489 0.06 1.5904 0.70989 2.9811 1.01 4.4815 0.25055 1.2309 0.16051 3.7711 1.6508 4.1918 0.06 2.2499 0.52003 2.2805 2.6915 2.3001 1.6201 0.0196 3.0516 0.45011 4.6417 0.31116 0.39997-2.242 7.5844-0.54012 9.1849-0.44097 0 0-0.06 0.30007-0.0802 0.30007 0.0698 0.22049 0.28056 0.36074 0.29035 0.63993 0.45999-0.0698 0.94021-0.21005 1.4002-0.33008-0.58071 0.61058-1.6116 0.97001-2.4018 0.88977-0.7001 0.91978-1.5098 0.99088-2.6914 1.1298-1.151 0.14938-2.5212 0.27985-3.5514 0.94978-0.39084 0.26028-1.0414 0.93087-1.3206 1.3412-0.2499 0.36073-0.41041 1.501-0.6205 1.7208-0.92064 0.93934-2.8115 0.27006-4.0114 0.69994-1.3506 0.47946-1.791 1.4508-2.1714 2.76-0.35038 1.1507-0.67988 2.0411-1.2103 3.1514-0.33994 0.71038-0.74056 3.261-1.1105 3.6015-0.72033 0.64971-3.0908-0.0196-4.0519 0.39987-1.4204 0.63993-1.5398 1.76-1.821 3.1918-1.1601 0.06-2.8317-0.30007-3.8124 0.31899-0.99046 0.63145-0.84039 1.9009-1.4909 2.7522-0.21988 0.28898-1.821 1.9707-2.1714 2.1305-1.1901 0.55056-2.0305-0.18982-3.171 0.66081-1.5307 1.1403-1.1412 5.291-4.0121 3.8415-1.3108-0.6608-0.45999-2-1.9809-2.5114-0.84038-0.27006-2.7815-0.2805-3.6519-0.14025-0.75035 2.2205-0.01 5.1012 0.64008 7.1521 0.27991 0.90086 0.83973 2.2812 0.71054 3.3308-9e-3 0.0626-0.0189 0.12264-0.0287 0.17222zm-22.262-37.091c1.0198-0.53033 1.3604-0.78996 1.301-1.9994-0.30014-0.0802-0.41106-0.19048-0.64008-0.36008-0.0698-0.46054-0.0803-0.90151-0.10961-1.3914-1.0009-0.0196-1.3708-0.69081-2.3013-0.85976-0.09-0.43967-0.0202-1.3196-0.33993-1.6497-0.24012-0.25049-1.3708-0.46054-1.7512-0.49054-0.0202 0.32029-0.09 0.60013-0.19053 0.89042-1.2704 0.0992-0.81037-0.3914-1.3004-1.1709-0.1605-0.25963-0.59048-0.42988-0.79014-0.70973-0.21988-0.28115-0.14028-0.56035-0.48022-0.78018-0.25969 0.20026-0.41041 0.47946-0.42998 0.8291-0.91085 0.0502-2.3515-0.36008-2.1714 1-0.67009 0.03-1.4407-0.0796-2.0612 0.0998-0.67009 0.19048-0.89062 0.77953-1.6605 0.82062-0.0698-0.31963-0.14028-0.63992-0.19052-0.98044-0.09 0.0104-0.2101-0.0104-0.30993 0-0.27012 0.39074-0.73077 0.65037-1.181 0.82063-0.95066 0.33986-1.0707 0.28963-0.94022 1.2603 0.09 0.65037 0.20031 1.6112 0.6205 2.1409 1.1608-0.0907 0.50045 0.85976 0.39997 1.5004-1.1405 0.33986-0.70989 1.1403 0.27012 1.0411 0.65052-0.0607 1.761-0.55121 1.8308 0.55057 0.71055 0.0398 1.4309-0.0104 2.1414 0.03-0.06 1.0405 0.41041 0.94 0.93043 1.5904 0.42998 0.53947 0.20031 1.2094 0.67988 1.7104 0.92064 0.14938 1.821-0.82976 2.3313-1.3999 0.52002-0.57013 1.2404-1.5506 1.9907-1.6706 0.39018-0.0607 1.2808-0.0196 1.671 0.09 0.53047 0.12982 0.66031 0.65037 1.0805 0.89042 1.2606 0.7293 1.4707-0.91194 1.6005-1.8024z",
+                Nantou:"m217.09 275.91c-0.88997-0.5199-0.50958-1.5506-1.671-2.351-1.581-1.0907-0.96044 0.88977-1.7806 1.79-0.74056 0.81019-2.9805-0.4899-3.0314 0.98109-1.4818 0.0692-2.7515-0.20091-4.1125-0.33986-0.39084-0.82975-0.2101-1.8206-0.57027-2.6106-1.121 0.36009-1.7806 2.1905-2.9316 1.9504-0.39997-2.0307-0.12071-3.3308 0.25968-5.1918 0.36082-1.7515 1.4909-2.7906 1.9118-4.4214 0.36017-1.3307-0.35038-1.3001-0.7001-2.2009-0.36017-0.91065-0.27991-1.6504-0.32037-2.6706-0.0404-0.66993-0.58005-2.351-0.18008-3.0013 0.47109-0.77952 1.5209-0.47032 2.4716-0.52055 0.10962-2.0607-0.15986-3.7913-0.63942-5.6406-0.26034-1.0202-0.54025-1.2505-1.0903-1.9805 0.18987 0 0.39997-0.03 0.57027-0.0502-0.0698-0.8004 0.51023-1.2003 0.88997-1.7802 1.7519-0.41031 2.972-0.95043 4.9425-1.0496-0.01-0.0698-0.01-0.39074 0-0.4501-0.49 0-0.82994-0.31051-1.2808-0.39009-0.03-0.4899-0.27991-0.90021-0.21988-1.4403-0.33994-0.33008-0.86062-0.59035-1.2808-0.66994 0.03 1.7515-3.8118 0.54013-4.0519-0.50033-1.6605-0.42988-1.4609-2.9107-2.7815-3.0509 0.50958-1.2707-0.21989-6.3021 1.2697-6.8422 0.0698-1.1403-0.09-2.3308 0.32036-3.351 0.21989-0.55056 0.71055-0.6608 0.8815-1.291 0.12005-0.47032 0-1.1605-0.0307-1.6406-0.23032 0.03-0.55004-0.0802-0.77971-0.0502-0.0907-1.561-0.55003-3.2708-0.33015-4.7815 3.1208 0.12003 3.2806-4.201 1.9411-6.002-0.47043 0.09-0.85017-0.19048-1.2704-0.21983-0.3693-4.1012 4.553-0.39009 5.8931-2.6706 0.28057 0.15982 0.58071 0.29029 0.91086 0.36922 1.2006 0.3105 2.9218-0.0104 4.1726-0.0104 1.8106 0 2.3913 0.31116 3.8424 0.80105 3.342 1.1396 4.6221-0.93086 6.4543-3.1814 0.66944-0.81997 1.5007-1.7704 1.8902-2.7704 0.42085-1.1011 0.62051-2.8813 1.6912-3.6413 0.82081-0.58057 1.9711-0.3503 2.942-0.39987 0.12005-2.4808-0.21989-5.0516 0.65051-7.3119 0.47957-1.2101 1.2906-1.9602 2.7019-1.3203 0.58005 0.25962 0.75034 0.97 1.3004 1.2003 0.73077 0.29029 0.82015-0.03 1.6808-0.17938 0.44955 1.1102-0.33081 2.9211 0.23032 3.9302 0.88084 1.5904 2.4011 0.48011 2.6314-0.96023 0.19052-1.1605-1.1105-3.321 0.84038-3.0007 1.3408 0.20939 1.121 1.8898 2.9616 1.4703 0.54025-1.1814 1.7708-1.1814 2.8409-1.6602 2.3613-1.09 4.4825-0.32029 7.234 0.0196 0.33994-1.0196 0.79015-1.8402 2.052-1.73 0.09-2.291 1.151-4.0111 3.631-4.1012 2.6014-0.09 3.6023-0.40053 5.6635-1.6712 1.8308-1.1298 2.3711-2.8702 3.9618-4.1612 1.5614-1.2799 4.4434-0.58905 6.4738-0.69929 0.12919-1.4814 0.0496-2.7411 1.3604-3.1409 1.0198-0.3105 2.9414-0.63014 4.0023-0.50033 0.55982 0.0802 1.0498 0.60992 1.6312 0.47033 0.42998-0.0998 0.81037-0.95044 1.5398-1.1305 0.70076-0.17939 1.4217-0.12916 2.1714-0.33986 0.66096-0.19048 0.84039-1.2205 1.3604-0.19048 0.72033 0.0404 1.5509 0.10046 2.2713 0.06 1.1405-0.0691 0.48022 0.48011 1.2006-0.69994 0.82016-1.3497 0.99111-2.6406 3.1417-2.3105-0.33994 2.1507 1.6201 1.0411 2.2204 2.1103 0.7001 0.12002 1.4818 0.0502 2.1108-0.15982 0.24011-2.0105 6.0934-0.0202 6.7936 1.0202-0.0802 0.19048-0.0502 0.28963-0.0698 0.47946 0.0196 0 0.03 0.0104 0.0502 0-0.42019 0.57013-0.65052 1-0.55069 2.1612 0.92064 0.17025 0.96044 1.0404 0.78036 1.8402-1.731 0.0907-2.452-0.0404-3.6728 1.0202-1.181 1.0404-2.0005 1.5101-3.6023 2.2205-0.96044 0.42988-0.95065-0.03-1.3708 0.95043-0.29035 0.69016 0.06 1.5101-0.32036 2.2199-0.2499 0.48011-0.92064 0.5199-1.2208 1.2505-0.26033 0.66081-0.16051 1.6308 0.0692 2.351 1.7806 0.0202 1.6716 0.44032 2.852 1.3105 0.92064 0.66993 2.4213 0.98044 3.2513 1.5708 1.7212 1.2303 0.82995 4.7013-0.45999 6.1716-0.67009 0.76061-1.3506 1.9504-2.2112 2.4306-1.5007 0.85128-2.2419-0.38031-2.4611 1.8709-0.14942 1.4814 0.10961 2.4312-0.62051 3.8813-0.61985 1.2303-0.94021 2.0007-1.3708 3.291-0.67988 2.0405-1.4407 2.9909-1.3206 5.4717 0.7001 0.0411 1.4211 0.0104 2.1205 0.0502 0.17095 3.3412-0.16964 6.7418-0.33994 10.124-2.1323-0.14025-1.2612 4.2812-1.331 5.6615-0.23097 0.03-0.56047 0.09-0.78035 0.0502-0.33016 0.72016-0.76079 1.1403-1.0303 1.9804-0.12005 0.39988-0.0202 0.95044-0.16051 1.3307-0.19052 0.5199-0.65051 0.65037-0.88084 1.1703-0.64007 1.4103-0.45999 3.1305-1.1503 4.471-0.5011 0.10959-0.75034 0.39074-1.2815 0.39074-0.45999 1.3608-0.39017 2.8702-0.21988 4.2812-1.4511 0.21983-3.0608 2.351-2.7815 3.8311 2.6817 0.54991 2.6817 0.3803 2.972 3.201 0.20097 1.8806 1.7715 2.0405 2.0109 4.1612 0.0907 0.8702 0.0802 1.9602-0.01 2.8402-0.11027 1.0802-0.75034 1.501-0.84039 2.3308-0.0802 0.83041 0.67009 1.4306 0.51024 2.3308-0.2101 1.2805-1.5209 2.0209-1.9111 3.0209-0.4104 1.0802 0.31058 2.441-0.25055 3.441-0.44955 0.78997-0.82994 0.33008-1.1705 1.3803-0.25904 0.77953 0.13049 1.4208-0.3693 2.1311-0.57092 0.10959-1.1014 0.42075-1.6716 0.42988-0.74969 0.0104-0.92064-0.91064-1.9411-0.20026-0.09 0.42075-1.0407 2.1807-1.5209 2.321-0.92064 0.2805-1.8113-0.88064-2.972-0.31964-0.0907 0.0907-0.03 0.31964-0.0607 0.43966-0.85017 0.21005-0.74969 1.0607-0.61072 1.8409 0.27013-0.0502 0.68053 0.10959 0.95066 0.0496-0.36995 1.4508-0.15007 1.6908-1.7806 2.1709-0.11027 1.8702 0.21009 3.6106 0.0998 5.4417-0.68053 0.44032-1.5209 0.57014-2.0116 1.3405-2.4716-1.8396-8.214-1.9198-10.085 0.72017-1.0498 1.4703-1.761 3.1507-2.3802 4.8004-0.8815 2.3608 1.4602 1.8206 1.3108 4.3112-0.67009 0.21984-1.4217 0.21984-2.1414 0.36987-1.2306 0.25897-0.84039 0.20874-1.7108 0.94978-0.32036 0.2805-0.28056 0.68038-0.48022 0.88977-0.12005 0.12068-0.55003 0.11025-0.84038 0.12981 0-0.14938 0.0307-0.33007 0.0111-0.45988-0.14028-0.03-0.32037-0.0502-0.46065-0.0405 0.03-0.91064 0.44042-1.6412 0.29035-2.6217-0.39083 0.0496-0.78036-0.24005-1.1307-0.23027 0.0411-0.3803-0.20031-0.60079-0.2101-0.93086-1.8713-0.10959-3.2513-0.0104-4.8022-0.69995-1.0805-0.48011-0.95065-0.6197-2.1714-0.36986-0.24011 0.0502-0.49 0.11024-0.74055 0.18004-0.46 0.12003-0.94022 0.25897-1.4002 0.33007-0.0104-0.2805-0.21989-0.42074-0.29035-0.63993 0.0202 0 0.0802-0.30006 0.0802-0.30006-1.6012-0.0992-8.7849-1.8011-9.1849 0.44097-1.5907 0.14025-3.0216-0.29029-4.6417-0.31116-2.1714-0.0196-2.6314-0.0502-2.6915-2.3001-1.4909-0.42074-1.4002-2.9609-1.6508-4.1918-0.30014-1.5003-0.95066-2.8911-1.01-4.4815-0.16051-0.0398-0.30014 0-0.46065-0.0489-0.0502-1.0711 0.92064-1.1213 1.4511-1.8506 0.57026-0.77104 0.65052-1.4814 0.70011-2.4606 0.03-0.74039 0.4104-2.1103 0.33994-2.6608-0.11027-0.74952-0.82995-1.4808-1.2006-2.1403 0.03-0.03-0.44955-0.0104-0.44955-0.0104-0.0411 0.16047 0 0.30007-0.0502 0.4501-0.84039 0.0405-2.3613 0.31051-3.1521 0.0405-1.1705-0.42075-0.77057-1.1409-1.6906-1.8213-0.75034-0.0398-1.5314-0.01-2.2817-0.06-0.0196-0.29028-0.20031-0.46054-0.21009-0.78017-1.4002-0.06-2.7717 0.31115-3.9723 0.14024-0.39083-0.0489-0.68053-0.14873-0.89063-0.26875z",
+                Yunlin:"m204.7 249.7c0.55004 0.72995 0.82929 0.96022 1.0903 1.9805 0.47957 1.8506 0.7497 3.5806 0.63943 5.6406-0.95066 0.0502-2.0005-0.25897-2.4716 0.52055-0.39932 0.65037 0.14028 2.3308 0.18008 3.0014 0.0411 1.0196-0.0405 1.7606 0.32037 2.6706 0.35037 0.90021 1.0603 0.8702 0.7001 2.2009-0.42085 1.6308-1.5503 2.6706-1.9118 4.4214-0.38039 1.8611-0.6603 3.1612-0.25968 5.1918 1.151 0.24006 1.8106-1.5904 2.9316-1.9504 0.36017 0.78997 0.17943 1.7802 0.57026 2.6106 1.3604 0.14025 2.6308 0.41032 4.1125 0.33986 0.0502-1.471 2.2908-0.17025 3.0314-0.98109 0.82147-0.90021 0.20097-2.88 1.7806-1.79 1.1608 0.8004 0.78036 1.8304 1.671 2.351-0.50045 0.23092-1.2006 1.0007-1.1405 1.4305 0.12984 0.84998 1.1014 0.72017 1.3604 1.3405 0.2101 0.49055 0.12071 1.9804 0.12071 2.5114 0.01 1.1207 0.30992 1.501-0.79015 1.8311-1.3904 0.41031-3.522-1.0705-5.0025-1-1.0903 0.0496-3.342 1.3999-3.5416-0.65037-0.36996 0.31116-0.59049 0.30007-0.8306 0.79062-2.6014 0.64971-2.3111-0.30007-2.6614-2.4514-1.8113-0.0496-3.2115 0.7006-4.9627 0.81019-2.0409 0.12068-3.141-0.77953-4.8531-1.1703-3.0816-0.69016-6.8934 0.85063-7.694-3.3008-0.23032 0.0196-0.55003-0.0802-0.78036-0.0607-0.0992-1.2303-1.4707-1.8004-1.7206-3.1109-1.1307-0.25962-1.5509 0.41032-2.5114 0.60014-0.86061 0.17939-1.902 0.0398-2.8017 0.0398-0.81037 0-2.2014-0.27006-2.9616 0-0.9911 0.36009-0.76078 1.2303-1.5307 1.6804-2.1616 1.2707-3.0118-1.6106-4.5125-1.6804-1.4609-0.0802-3.5723 1.3105-3.3615 2.972-0.96044 0.0502-2.0612-0.13046-2.9414 0.23027 0.33015 1.7606-1.2912 2.7013-2.7019 2.8004-2.2014 0.15982-2.3111 0.54012-2.3515 2.8122-0.96044-0.26027-2.0807-0.54012-3.1214-0.4501 0.0202 0.66994 0.51024 1.1403 0.61072 1.7802-1.7212 0.14025-2.4912-0.62036-3.342 0.82063-0.93043 1.6002-0.18009 2.1005-2.101 2.7404 0.23033 1.6197-1.0707 2.3001-1.9907 0.93021-0.36996-0.54991 0.25968-1.1703-0.36996-1.6412-0.25055-0.18982-1.4811 0.0202-1.8113 0.0307-0.12006 0.74952-0.64008 1.4899-0.50045 2.2799 0.09 0.50164 0.88084 1.1905 0.98067 1.8617 0.35038 2.5806-1.4909 2.5708-3.522 2.1709-1.5907-0.31116-3.1717-0.81019-4.8224-1.1605-0.89063-0.18983-3.4418-0.38031-3.862-1.1403-0.32037 0.0698-0.79015-0.11024-1.1105-0.06 0.15006-1.1102-0.35038-1.6008-1.0505-2.0607 0.0405-0.0496 0.06-0.11024 0.0803-0.18004 0.26033-1.0705-0.55004-0.88912-0.95066-1.5304-0.0502-0.0104-0.11026 0-0.1605-0.0196-0.0503-0.87085-0.06-1.8011-0.01-2.6804 0.0405-0.71038 0.27991-0.36987 0.50045-0.81019 0.21988-0.45988-0.21989-0.63993-0.4202-0.88977-0.57026-0.71038-0.38039-1.6908-0.33015-2.621 0.0202-0.52056 0.30014-0.66994 0.36995-1.0607 0.0803-0.40966-0.24011-0.75017-0.31057-1.1403-0.0803-0.48011 0.0202-1.0405-0.01-1.5304-0.36995-0.13047-1.151-0.74104-1.0505-1.2107 0.0998-0.5199 0.85082-0.27006 1.1105-0.80105 0.18008-0.36922 0.0104-1.2505 0.0104-1.6797 0-0.72017 0.32036-0.94 0.50044-1.5708 0.18009-0.62036 0.4202-1.0098 0.88084-1.5101 0.49001-0.53034 0.6205-0.84019 0.85996-1.5095 0.24011-0.66993 0.39018-1.09 0.45021-1.7906 0.0398-0.56035 0.27012-0.89043 0.64008-1.3007 0.57026-0.62036 2.2112-1.6008 1.7206-2.6308-0.21989-0.45989-0.45021-0.48989-0.48022-1.1403-0.03-0.4201 0.0998-0.97979-0.0803-1.3601-0.21009-0.44945-0.48022-0.3803-0.85082-0.30985-0.32037 0.06-0.20031 0.36008-0.57026 0.10959-0.18009-0.12068-0.27992-0.33986-0.26034-0.56034 0.12005-0.97979 1.8413-0.62036 2.5016-0.70973 0.0398-0.8702-0.15007-1.7404-0.18008-2.6008-0.0398-0.99022 0.20031-1.2505 0.70076-2 0.81037-0.0404 2.681 0.30007 3.1214-0.44032-0.0998-0.52055-0.20031-0.99088-0.20031-1.561 0-0.27985-0.0803-0.69016 0.0802-0.93021 0.18009-0.27007 0.55069-0.27007 0.73077-0.50034-0.6603-0.30007-0.88084 0.2505-1.181 0.66994-0.27991 0.39987-0.81037 0.75996-1.0205 1.1905-0.45021 0.12003-0.72033 0.63993-1.121 0.87999-0.32037 0.19047-0.67988 0.12068-0.99046 0.25049-0.24011 0.0998-0.42019 0.30007-0.67987 0.30007-0.09-0.68038-0.59049-1.2101-1.0205-1.7215-0.51024-0.6197-0.47043-1.0796-0.49001-1.8806 0.21988 0.51011 0.70011 1.0307 1.3004 0.93999 0.52002-0.0907 0.59049-0.54991 0.78036-1.0007 0.38039-0.89042 0.47043-1.8904 0.42019-2.8807-0.68053 0.0698-1.0309 0.24984-1.5105 0.74038-0.46065 0.45989-0.78036 0.58057-1.3506 0.8702-0.09-0.50033 0.74055-1.0307 1.1105-1.2903 0.47043-0.33986 0.68053-0.7306 1.1307-1.0711 0.39018-0.28898 0.89063-0.74952 1.3708-0.9002 0.88084-0.28964 1.3206-0.57013 1.9711-1.2094 0.6205-0.62036 1.2906-1.1703 2.1616-1.4005 0.75034-0.21005 3.3015 0.46054 2.9414-1-0.15007-0.60014-0.88084-0.63928-0.24011-1.3001 0.27991-0.2805 0.67009-0.36987 1.0603-0.39075 0.30014 0.12068 0.74056 0.18005 1.1307 0.11025 0.67009 2.0516 3.5919 0.81997 4.3918 2.2805 2.3411 0.66015 4.3226 0.86042 6.9736 0.86042 1.1908 0 2.681 0.24984 3.8418 0.01 1.4009-0.30007 1.9013-1.2903 3.1319-0.20026 0.97023-2.0516 1.7708-1.8102 4.0323-1.8102 0.92064 0 1.8308-0.06 2.6216 0.21005 1.0407 0.35029 1.241 0.9002 2.5212 0.82062-0.0398 0.27006 0.11027 0.66994 0.06 0.94 0.20031 0.20026 0.20031 0.01 0.33015 0.33986 1.581 0.0907 2.4611 0.06 3.6317 0.69081 0.99045 0.53034 1.7212 1.3307 2.6614 1.6608 2.651 0.90999 5.593 0.20939 8.3543 0.33986 0.4104 0.0202 1.4818-0.0189 1.8413 0.16047 0.47043 0.23092 0.73012 1.06 1.1908 1.3105 0.91085 0.47097 2.7417 0.48011 3.802 0.53034 1.6801 0.0802 3.3818 0.17025 5.0626 0.14938 1.9111-0.0189 2.0214-0.0802 3.141 1.4814 0.0215 0.0157 0.0313 0.0359 0.0418 0.0555z",
+                Penghu:"m30.865 336.76c0.46065 0.0698 0.20031 0.18004-0.06003 0.3503-0.51023 0.33986-0.21988 1.15-0.59049 1.6504-0.15007 0.20026-0.32036 0.4788-0.49001 0.64906-0.23032 0.21005-0.47043 0.0907-0.7001 0.25114-0.28056 0.20027-0.14028 0.50947-0.2499 0.8004-0.09004 0.24006-0.27012 0.39988-0.32036 0.66994-0.04045 0.24006 0.0098 0.50033-0.33015 0.50033-0.1703-0.21983-0.40975-0.47032-0.60028-0.69016-0.15986-0.19047-0.56048-0.33072-0.6603-0.53034-0.10962-0.23027 0.1305-0.58904 0.16051-0.80953 0.02023-0.18982 0.02023-0.52055-0.06981-0.69081-0.21988-0.41031-0.76078-0.48989-1.0009-0.90021-0.03001-0.0698-0.05024-0.19047-0.09983-0.24005-0.09983-0.0998-0.18987-0.0405-0.30014-0.11024-0.1703-0.09-0.25968-0.4488-0.47043-0.45989 0.45021 0 0.90041-0.03 1.3506-0.0405 0.32036 0 0.39018-0.0411 0.61072-0.21983 0.23032-0.19048 0.2897-0.18004 0.64008-0.18004 0.48022 0 0.95065 0.0404 1.3708-0.12003 0.20031-0.0698 0.36016-0.0502 0.56047-0.0998 0.27012-0.0607 0.15986-0.22049 0.33994-0.31116 0.10896 0.4214 0.56961 0.48076 0.90955 0.53099zm9.855-23.999c0.12006 0.36008 0.21988 0.66015 0.06981 1.06-0.15986 0.4214-0.55004 0.48011-0.59049 0.96087-0.02023 0.42075 0.24011 0.69994 0.4104 1.0496-0.73077 0.11024-4.3827 0.0907-4.3925-0.78996 0.33015-0.0202 0.60028-0.19048 0.6603-0.50034 0.80058-0.41031 1.3904-1.1905 1.3108-2.0803-0.09983-0.0104-0.2101-0.0307-0.31058-0.0307-0.55982-0.66015-0.09004-0.97-0.09983-1.6497 0-0.54013-0.64008-1.3412 0.26034-1.6713 0.13963-0.03 0.33994 0.17026 0.48022 0.17939 0.11027 0.78997 0.51023 0.0998 0.85082 0.15982 0.81037 0.12981 0.2499 0.25049 0.58005 0.75017 0.1703 0.25898 0.73077 0.42989 0.82016 0.60014 0.24011 0.4201-0.2101 0.85063-0.24011 1.06-0.06916 0.55186 0.03067 0.38226 0.19052 0.90216zm4.2326 0.90021c0.01957 0.25962 0.06981 0.21005-0.1703 0.34964-0.12006 0.0607-0.29035 0.12134-0.43063 0.18004-0.53046 0.25898-0.40975-0.20091-0.85017-0.24983-0.31058-0.0411-0.20031 0.18982-0.33015 0.33986-0.08025 0.11024-0.11027 0.0998-0.2101 0.17025-0.09983 0.0613-0.24011 0.16047-0.36995 0.24006-0.0098 0.22048 0.08025 0.55056-0.1703 0.65036-0.36995 0.12982-0.40975-0.33007-0.45999-0.55056-0.50045 0.03-0.43063-0.69994-0.43063-1.0404 0.33015 0 0.6603 0.0104 0.99046-0.0111 0.09004-0.25898 0.08025-0.57013 0.06003-0.85911-0.11027-0.0111-0.23032-0.0998-0.24011-0.22049-0.04045-0.3105 0.24011-0.14025 0.38039-0.25962 0.11027-0.0998 0.03001-0.27007 0.11027-0.34965 0.10962-0.0907 0.39997 0 0.49001 0.12981 0.20031 0.31051-0.1703 0.55056 0.33994 0.60014 0.19052 0.0196 0.42019-0.12981 0.5807-0.09 0.14028 0.03 0.15007 0.14938 0.2499 0.20874 0.09983 0.0613 0.2101 0.0111 0.30014 0.10046 0.1703 0.15134 0.15072 0.46185 0.16051 0.66146zm0.24011-20.209c-0.21988 0.4201-0.13963 0.91978-0.16964 1.3901-0.90041 0.0502-1.6012 0.2805-2.4213 0.20027-0.42019-0.0489-0.7399-0.16961-1.1503 0-0.32036 0.13046-0.09983 0.63993-0.73077 0.55121-0.0398-0.18004-0.15986-0.21983-0.20031-0.39074-0.21988 0.0411-0.50045-0.0607-0.72033-0.03-0.06003-0.6308 0.71054-0.60079 0.6603-1.1507 0.73012 0.17874 1.7108-0.22048 2.3913-0.42988 0.77057-0.25049 1.4909-0.2107 2.3411-0.14025zm0.26034-23.275c0.19052 0.0998 0.19052 0.8402 0.09004 1.09-0.6603 1.6112-2.3913 0.72016-3.7419 1.2609-0.02023 0.74952-0.0098 0.82975 0.30014 1.4299 0.30014 0.55056 0.36995 0.75017 0.33015 1.4606-0.04045 0.95044 0.15986 2.7019-1.2103 2.6106-0.14028 0.53034 0.98002 1.8011-0.25055 1.8409-0.01957 0.33986-0.12006 0.90021-0.01957 1.2401 0.09983 0.3105 0.43977 0.45989 0.57026 0.75995 0.44042 1.0705-0.38039 1.1807-1.2208 1.1403 0.02023-0.12068-0.0398-0.2805-0.01957-0.39075-0.76078-0.0404-1.7512-0.53034-2.4018-0.09 0.30014 1.3405-1.6207 0.0496-1.611 1.06-0.69032-0.0802-1.0805 0.32029-1.8008 0.25049-0.39997-0.98044 0.06981-1.1102 0.75034-1.5095 0.58005-0.33986 0.27012-0.3803 0.57026-0.81018 0.2101-0.31116 0.1703-0.52056 0.72033-0.58122 0.30992 0.51012 0.51023 0.61971 1.0505 0.60079 0.26034-0.0111 1.1412-0.27006 1.331-0.42075 0.60028-0.50099 0.67009-2.1507 0.38039-2.9211-1.3911 0-1.4009-1.3412-0.08026-0.86041 0.03001-0.61123-0.03001-0.92043 0.32036-1.3803 0.33015-0.44032 0.76078-0.42075 0.85082-1.09-0.14028 0.03-0.33994-0.0502-0.48022-0.03 0.02023-0.11024-0.0398-0.28115-0.02023-0.39074-0.24011-0.0404-0.47043-0.16047-0.73012-0.11024 0.27012-0.8004-0.2499-1.9198 0.09004-2.6406 0.85017-0.0104 0.70989-0.25049 0.98002-0.85063 0.2101-0.44032 0.61072-0.66015 0.75034-1 0.36995-0.8004-0.18008-0.69016 0.75034-1.0802 0.45021-0.19048 0.86061-0.46054 1.3108-0.65037l0.03001 0.0698c0.1305-0.01 0.27012-0.01 0.40062 0.0104-0.2101 0.36074-0.39018 0.6608-0.63029 1.0111-0.29035 0.39922-0.69032 0.39922-0.51024 1.0496 0.77057-0.0502 1.3708 0.57013 2.2412 0.3503 0.21923-0.0587 0.71902-0.52838 0.90955-0.42858zm8.5742-4.4032c-0.23032 1.3803 1.641 2.2205 1.5007 3.8109-0.36995 0.0202-0.76078 0.0104-1.1405 0.0307-0.26034 0.38031-0.32036 1.2401-0.2499 1.7208 0.84039-0.19048 0.82995 0.8004 0.39018 1.1703-0.63029-0.0404-0.50045 0.63014-0.47043 1.0802 1.5307 0.03 1.2912 1.1005 1.2208 2.4208-0.4104 0.03-0.89063-0.2805-1.2306-0.48989-0.7001-0.45011-0.29035-0.48011-0.59049-1.2505-0.39018-1.0411-1.761-0.57013-1.3206-1.9915 0.54025-0.09 0.33015-1.1096 0.31058-1.5806-0.86061 0.0411-0.49001-0.77953-0.75034-1.2603-0.16051-0.29029-0.53046-0.33986-0.65052-0.66994-0.09983-0.24984 0-0.72016-0.01957-0.99023-0.8704-0.26027-2.191-0.63014-2.0814 0.63928-0.53046-0.0196-0.44042 0.52056-0.74056 0.78018-0.50045-0.3803-0.69032-0.93935-1.331-0.65037 0.09004-0.06 0.01044-0.16047 0.08025-0.27984h0.09004c0.31058-0.76061-0.38039-1.1905-0.32036-1.9009 0.56048 0.10959 0.84039-0.36987 1.4009-0.43054 0.54025-0.0691 1.2306 0.0998 1.8211 0.0698-0.04045-0.15982 0.06003-0.39987 0.03001-0.56035 0.41041-0.03 1.0309 0.17026 1.0805-0.33007 0.7001-0.21005 0.84039 0.41031 1.3408 0.63014 0.52981 0.22179 1.0505-0.058 1.6305 0.032zm1.592-17.163c0.09004 0.40966 0.1703 0.78997 0.16051 1.2205-0.18008-0.0411-0.45021 0.0691-0.64008 0.03-0.04045 0.78996-0.31058 0.85976-0.67009 1.3999-0.23032 0.33986-0.15007 1.4606-0.91085 1.2401 0.02023-0.1396-0.08025-0.18004-0.09983-0.24005-0.0098-0.66016-0.10962-1.3503 0.27012-1.9009 0.30014-0.44031 1.1307-0.55056 1.1405-1.1703-0.32036-0.06-0.52002-0.33987-0.59049-0.66994-0.39018 0.0411-0.65052-0.20026-0.64008-0.57992 0.78036-0.21005 1.1803 0.78018 1.9803 0.67059zm0.75687 4.9772c0.27012 0.19048 1.1405 1.0007 1.0009 1.4208-0.14028 0.42988-1.4811 0.24984-1.8511 0.39988-0.5807 0.24005-1.0603 0.92043-1.2306 1.5708-0.39018-0.31116-0.47043-0.78996-0.42998-1.291-0.24011 0.0411-0.43063-0.10959-0.64008-0.10959-0.19052-0.63014 0.40975-0.54012 0.67009-0.9002 0.25968-0.36009 0.23032-0.60014 0.24011-1.0705 0.45999-0.0907 0.78036-0.80105 0.99046-1.1814 0.25968 0.75147 0.64986 0.75147 1.2501 1.1611zm9.1868 29.42c1.0309 0.25049 1.4211 0.16047 1.3904 1.4097-1.1608 0.0913-2.5812 1.0411-2.5009-0.88912-1.3506-0.0698-2.8415-0.14025-4.1523-0.0907-0.82016 0.0307-1.2704 0.22049-1.5007 0.91064-0.2499 0.72017 0.02023 1.1207-0.82995 1.4208-0.30014 0.11024-0.64008-0.0405-0.92064 0.0998-0.35038 0.17939-0.45021 0.52055-0.73012 0.74952-0.46065 0.39074-1.0009 0.33986-1.3408 0.84019-0.75034 1.1103 0.81037 2.8918-0.08026 3.9818-0.30992 0.37965-0.89063 0.25897-1.4204 0.23027-0.43063-1.561-2.0011 0.12068-3.1019 0.17939-0.61072 0.0404-1.4009-0.14939-1.5907-0.82976-0.14028-0.50033 0.42998-1.2394-0.06003-1.7704-0.49001-0.55056-1.2404 0.0998-1.8308-0.50033-0.47043-0.47032-0.21988-1.1605-0.77057-1.5617-0.44042-0.31899-1.5509 0.0698-1.7708-0.64972-0.18987-0.58056 0.55069-0.82062 0.6205-1.3412 0.43063-0.20027 0.30014-0.66015 0.5807-1 1.2103-0.33007-0.02023 2.3412 1.3108 2.1703 0.27991 0.72016 0.75034 1.0104 0.69032 1.8904 0.52002 0.14938 0.8704-0.0998 0.8306-0.63993 1.6207-0.0796 0.81037 0.53034 1.2508 1.6412 1.0407 0.20026 1.2906-0.66994 1.2508-1.561 0.67988 0.0496 2.9616 1.6204 2.5512 0.0111-0.0398-0.19048-0.45999-0.27007-0.48022-0.52121-0.04045-0.47946 0.30014-0.45924 0.50045-0.66929 0.27012-0.30006 0.49001 0.0496 0.51023-0.59035 0-0.12981-0.28056-0.63014-0.36016-0.74039-1.1007-1.3901-2.101 0.20092-3.1417 0.33073-0.97023 0.12003-2.6216-0.76061-2.4911-1.9009 0.68053-0.0691 1.7108 1.2101 2.2412 0.24006 0.65052-1.2101-1.0407-1.4703-1.7408-1.2401-0.09004 0.48011-0.59049 0.31116-1.0107 0.31964 0.15007-0.88977 0.31058-1.1801 1.151-1.6002 0.12006-0.68038-0.98067-1.6106-0.6603-2.0607 0.2499-0.33986 2.0311-0.01 2.4716 0-0.33994-0.90021 0.33994-0.85911 1.0205-0.82911 0.03001 0.66929-0.18008 1.9994 0.36995 2.471 0.09983 0.09 1.0303 0.30007 1.1405 0.26941 0.67009-0.17939 0.39997-0.36987 0.44042-0.94 0.10962-1.6902 0.96044-0.33986 1.5705-1.15 0.64008-0.84084-0.65052-1.4703-0.85017-1.9009-0.12006-0.03-0.1703-0.06-0.2499-0.0998 0.45021-0.12002 0.82016-0.67972 1.4302-0.50033 0.53046 0.16047 0.35038 0.88977 1.2306 0.4899-0.12006-0.74104 0.91085-1.1403 1.2808-0.4899 0.16051 0.28963-0.36016 0.99023-0.42998 1.3405-0.09004 0.4501-0.09983 1.3001 0 1.7508 0.10962 0.48011 0.58005 1.1514 1.0903 0.50099-0.26034-0.36987-0.18008-1.5506-0.06981-1.9413 0.27991-1.0196 0.88084-0.30007 1.8008-0.41031 0.06982-1.3999-0.16051-2.1709 1.5007-1.8898 0.09983 0.67972 0.33015 1.1292 0.36016 1.8898 0.2499-0.03 0.55069 0.0502 0.81037 0.03 0.06981 0.0802 0.09004 0.0907 0.1703 0.17091-0.04045 0.19048 0.02023 0.45989 0.02023 0.72016 0.76078-0.0802 0.23032-1.1605 0.39997-1.6608 0.24011-0.66016 0.76078-0.51991 1.4909-0.48011 0.02023 0.4501-0.15007 1.2205 0.01044 1.6504 0.23032 0.59035 0.52002 0.57991 0.59049 1.3307 0.09722 1.1285-0.05285 2.2884 0.0072 3.409z",
+                Changhua:"m211.1 246.37c-0.01 0.0607-0.01 0.3803 0 0.4501-1.9711 0.0998-3.1919 0.63928-4.9425 1.0496-0.38039 0.58057-0.96044 0.98044-0.88997 1.7802-0.17095 0.0202-0.38039 0.0502-0.57026 0.0502-0.0111-0.0202-0.0202-0.0411-0.0411-0.06-1.1203-1.561-1.2306-1.501-3.141-1.4814-1.6808 0.0202-3.3824-0.0692-5.0632-0.14938-1.0603-0.0502-2.8918-0.0607-3.8013-0.53034-0.46064-0.24984-0.72033-1.0802-1.1908-1.3105-0.36017-0.18004-1.4309-0.14025-1.8413-0.16047-2.7606-0.12981-5.7033 0.57013-8.3543-0.33986-0.94022-0.33008-1.671-1.1298-2.6614-1.6608-1.1705-0.63014-2.0514-0.60014-3.6317-0.69016-0.12984-0.33007-0.12984-0.13959-0.33015-0.33986 0.0502-0.26941-0.0998-0.66928-0.06-0.93934-1.2802 0.0802-1.4805-0.47033-2.5212-0.82063-0.79015-0.27006-1.7004-0.21004-2.6216-0.21004-2.2608 0-3.0614-0.24006-4.0323 1.8102-1.2306-1.0907-1.731-0.0998-3.1319 0.20027-1.1608 0.24005-2.651-0.01-3.8418-0.01-2.6517 0-4.6326-0.20091-6.9736-0.86041-0.80059-1.4606-3.7217-0.23093-4.3918-2.2805-0.39018 0.0698-0.8306 0.01-1.1307-0.11024 0.18009-0.01 0.36996-0.01 0.54025 0 0.60028 0.03 1.4309 0.27006 1.8909-0.21983 0.48022-0.53034-0.18008-0.72017-0.32036-1.3503-0.20031-0.90021 0.59048-1.6008 1.4309-1.561 0.11027-0.69081 0.0803-0.91065 0.8306-0.93022 0.6205-0.0202 1.5105 0.17026 2.0514-0.12981 0.4502-0.25049 0.84038-1.0502 1.0903-1.4814 0.30014-0.53033 0.20031-1.1102 0.42998-1.6406 0.53046-1.2205 1.4309-2.1103 2.2112-3.1312 0.33015-0.43967 0.60028-1.1011 0.77057-1.6204 0.06-0.21004 0.0202-0.57013 0.12984-0.75017 0.19053-0.30985 0.36996-0.23027 0.50045-0.60992 0.10962-0.31051 0.06-0.94 0.06-1.2603-1.1007-0.29028-2.071-0.40053-1.3506-1.6608 0.54025-0.95043 1.3806-1.7 1.731-2.8506 0.27012-0.89042 0.43063-1.8506 1.0009-2.6713 0.15985-0.23027 0.36016-0.36921 0.52002-0.63927 0.12984-0.23093 0.12005-0.48011 0.35037-0.63015 0.50045-0.32029 1.3911 0.30007 1.8811-0.0698 0.33993-0.25049 0.39017-1.0907 0.48022-1.4703 0.15985-0.66994 0.35037-1.3503 0.78035-1.8898 0.58071-0.72016 1.181-1.1807 1.3206-2.1103 0.14028-0.88064 0.7001-1.3712 1.3604-1.9407 0.48022-0.42074 1.9711-0.97 2.131-1.5101 0.88083-0.15004 2.6014-0.66994 2.4213-1.8709-1.0002-0.0802-2.131 0.11024-3.1717 0.0502-0.80058-0.0404-0.78036-0.21983-0.71054-0.95044 0.0502-0.44031-0.0405-1.09 0.0803-1.5506 0.28057-1.1305 1.761-1.1605 2.7613-1.2505 0.57026-0.0502 1.0707-0.26028 1.611-0.31116 0.56047-0.0496 1.1412 0 1.6912 0 0.61071 0 1.5809 0.21005 1.9209-0.42923 0.27991-0.53034 0.0196-1.3412-0.06-1.8709-0.0998-0.65037 0.12984-1.09 0.26034-1.7006 0.13963-0.5897 0.09-1.3196 0.06-1.9302-0.53046-0.0202-1.0309-0.06-1.5607-0.0691-0.77057-0.0104-0.71054 0.0802-0.75034 0.8004-0.06 0.0202-0.11027 0-0.1703 0.0202-0.0202 0.33986 0 0.70059-0.0202 1.0496-0.64007-0.09-0.28056 1.1011-0.44042 1.4906-0.84038 0.0502-1.9914-0.21984-2.8011 0.0111-0.57026 0.1696-0.40061 0.69929-0.95065 0.99022-0.15007 0.0802-0.45021 0.0404-0.61071 0.09-0.2897 0.0907-0.3804 0.33987-0.73012 0.29029 0.21988-1.1703 1.1608-1.4208 1.8511-2.2407 0.76078-0.91065 1.4407-1.8506 2.251-2.7104 0.7001-0.74039 1.5007-1.5108 2.2713-2.2812 0.33015-0.33008 0.67988-0.72017 0.92064-1.1403 0.29035-0.53034 0.36016-1.0502 0.81037-1.4906 1.0205-1.0007 3.0216-0.43053 4.4322-0.51011 0-0.53947 0.06-0.5199-0.12005-0.99023-0.45021-1.2603 0.92064-1.4403 1.4002-2.3608 0.27012-0.53034 0.2003-1.2701 0.71054-1.7202 0.96109-0.85063 2.7913-0.50033 4.0121-0.31116-0.0405-0.12002-0.0803-0.23027-0.12071-0.31963 0.0803 0.03 0.15986 0.0691 0.24011 0.11024 0.0803 1.3497 0.11027 2.2903 0.54025 3.4612 0.42084 1.15 1.0714 1.8402 1.5007 2.8409 0.49001 1.1703 0.0907 2.9002 0.7001 3.9713 0.72033 1.2505 2.0312 0.78997 3.1019 1.2303 0.09 0.68037 0.67009 0.81018 1.331 0.66015-0.0692 0.32029 0.12984 0.80105 0.06 1.1102 1.1405 0.58122 2.0011 1.0502 3.3028 1.2003 1.4106 0.15982 2.6712-0.0802 3.9723 0.36073-0.09 1.8004 0.58005 1.8102 1.2404 3.1012 0.58984 1.15 0.3804 3.0007 2.2706 2.5604-0.11027 0.46054 0.0202 0.21983-0.28056 0.51012-0.0803 0.96022-0.93043 1.5604-1.0303 2.471-0.11027 0.98044 0.33994 2.1005 0.36017 3.1403 0.64007 0.03 1.3108 0.03 1.9509 0-0.0802-0.38031 0.1305-0.91 0.0502-1.2903 2.1512 0.25962 3.2017 2.6106 5.0626 3.621-1.3408 2.2805-6.2631-1.4306-5.8931 2.6706 0.42084 0.03 0.80123 0.30986 1.2704 0.21983 1.3408 1.8004 1.181 6.1221-1.9418 6.002-0.21988 1.5101 0.24011 3.2212 0.3308 4.7815 0.23033-0.03 0.55004 0.0802 0.77971 0.0502 0.03 0.47945 0.15007 1.1703 0.03 1.6406-0.17029 0.63015-0.6603 0.74039-0.88084 1.291-0.4104 1.0196-0.24989 2.2107-0.32036 3.351-1.4909 0.54012-0.76078 5.5715-1.2697 6.8422 1.32 0.14025 1.1203 2.621 2.7815 3.0509 0.24011 1.0404 4.0825 2.2512 4.0519 0.50033 0.42019 0.0802 0.93956 0.33986 1.2808 0.66994-0.06 0.54012 0.19052 0.95043 0.21988 1.4403 0.45151 0.0776 0.79145 0.38813 1.2821 0.38813z",
+                Taichung:"m182.09 177.11c-0.03-0.84997-0.10962-2.0907 0.38039-2.8004 0.42998-0.63015 1.5209-1.4606 2.3515-1.5206-0.0411-0.8004 0.47957-1.09 0.0496-1.8604-0.27012-0.4899-0.80058-0.80106-1.2097-1.1814 1.2397 0.63993 2.5707 0.71038 2.6712 2.4814 0.33015 0.0398 0.57026-0.20092 0.80124-0.36987 0.11027-0.91065 0.26947-1.0202 1.121-1.0705 0.21988-0.97979-0.93108-0.39988-1.0603-1.291-0.74121-0.12982-1.5209-0.21005-2.2817-0.20027 0.82995 0 1.3108-0.48989 1.8713-1 0.3693-0.33986 0.39932-0.29028 0.47957-0.81018 0.06-0.36009 0.0907-0.74039 0.0502-1.1103-0.0692-0.03-0.11027-0.0502-0.18008-0.0802 0.43063 0.0104 1.1307-0.0802 1.701-0.06 0.96044 0.0411 0.76078 0.11024 1.0009 0.8702 0.40975-0.01 0.81037-0.09 1.1705-0.25897 0.0405-0.33073 0.31058-1.1703 0.12005-1.4103-0.0803-0.0998-0.52002-0.15003-0.6603-0.21004-0.24011-0.10959-0.32036-0.32029-0.75034-0.30986 0.41105-0.44097 1.6207 0.0992 1.9809-0.30007 0.56047-0.63079-0.17943-1.9504 0.0411-2.6719 0.2897-0.96936 1.4909-1.5206 2.0801-2.2701 0.97022-1.2205 0.17094-2.591 0.80123-3.8813 0.39018-0.78018 1.1105-1.15 1.761-1.7306 0.60028-0.54012 1.1803-1.2394 1.5698-1.9504 0.32037-0.57991 0.97088-1.1598 1.1816-1.7704 0.24011-0.65036 0.16051-1.1102 0.63942-1.6908 0.8306-1.0104 2.0716-1.4906 2.7019-2.6106 0.0196-0.03 0.0404-0.0691 0.06-0.0998 1.4106 1.1305 1.5105 2.7815 2.5512 4.2114 1.0707 1.4514 2.8709 1.9707 4.0917 3.6217 1.121 1.5003 2.0612 2.351 3.4627 3.591 0.74969 0.66015 1.0407 1.5506 1.9907 1.9602 1.0909 0.47946 1.7212 0.06 2.8017 0.8702 1.7806 1.3405 3.2017 3.2714 5.163 4.4912 2.1212 1.3203 4.9829 0.7006 6.834 2.1807 0.88084 0.70973 1.4609 1.8702 2.4318 2.5806 1.0798 0.78018 2.0605 0.41031 3.4522 0.20092 2.4514-0.36987 5.4821 0.50946 7.6737-0.33073 3.2017-1.2198 0.0998-4.6211 1.6201-6.882 1.4413-2.1096 4.6423 0.0998 6.3831 0.3803 2.2119 0.36008 5.7333-0.30007 7.174 1.8702 0.35038 0.53034 0.15985 1.2505 0.53046 1.7704 0.2499 0.3503 0.93956 0.48011 1.2508 0.74039 1.2306 1.0307 1.4407 1.5708 3.1919 1.4305 0.14028-0.69994 0.63029-1.1507 0.88084-1.7802 1.5907-0.0307 1.5405-1.3803 2.482-1.7006 1.2306-0.41031 1.5712 0.8402 2.6712 0.68038 0.33994-0.0502 2.0514-1.0104 2.3313-1.1703 1.32-0.78997 0.55917-1.0502 1.3708-2.1409 0.36995-0.50033 1.1014-0.33007 1.4609-0.69016 0.38039-0.3803 0.33015-0.8702 0.63029-1.2101 0.89062-1.03 1.151-0.84019 2.542-1.1292 2.3006-0.47098 3.1514-1.2505 4.2013-3.3021 2.221-0.39922 2.052-1.0705 2.1616-3.1703 0.69032-0.12067 1.4602-0.0202 2.1212 0.15917 0.31058 1.501 0.70011 2.8618 2.5205 1.6804 1.1014-0.72995 1.1412-2.03 2.6419-2.561 0.47044-1.1703-0.0802-2.6106 0.39018-3.7809 0.81038 0.0404 1.4106-0.39988 1.9411-0.87999v0.1396c1.6208 0.0802 3.4627 0.0802 5.043-0.15982 1.32-0.20092 2.4905-0.84019 3.4118-1.7802 0.0411 0.03 0.0803 0.0502 0.12071 0.0698 0.2499 0.15982 0.51023 0.28963 0.7001 0.5199 0.20031 0.25962 0.26948 0.60014 0.42998 0.87998 0.33081 0.60014 0.2101 1.1703 0.2101 1.8506-0.01 0.35029-0.0502 0.65036-0.2101 0.92043-0.14941 0.25962-0.35037 0.48011-0.42998 0.78017-0.0607 0.24984-0.18008 0.74039-0.0698 1.0007 0.11027 0.30007 0.49001 0.45989 0.74056 0.63928 0.28056 0.21004 0.44042 0.52055 0.68053 0.78018 0.29035 0.32029 0.42998 0.29028 0.8704 0.29028 0.83059 0 2.0109-0.20092 2.7019 0.17026 0.31971 0.18004 0.91085 0.29028 1.121 0.57991 0.17029 0.23092 0.0998 0.76061 0.0998 1.0411 0 0.82062-0.0202 1.6908 0.82929 2.0111 0.38039 0.14025 0.90041 0.17939 1.3206 0.12003 0.49-0.0691 0.55003-0.3105 0.85017-0.66015 0.2499-0.29028 0.56047-0.3803 0.89062-0.58122 0.41041-0.2394 0.68053-0.21983 1.1412-0.30985 0.50045-0.0998 1.0107-0.12003 1.5607-0.12003 0.35038 0 0.39996 0 0.65051-0.15982 0.16051-0.11024 0.26034-0.28115 0.46065-0.33986 0.48022-0.12981 1.0505-0.12981 1.5307-0.0992 0.73012 0.03 0.85083 0.2094 1.2808 0.76061 0.24011 0.30986 0.25968 0.17939 0.61071 0.30007 0.5807 0.20027 0.70076 0.61971 0.79015 1.1703 0.03 0.20027 0.0802 0.38031 0.14941 0.5597-0.79014 0.47097-2.0005 1.6308-2.2412 2.1814-0.50045 1.1396 0.30014 2.8311-0.20031 3.9713-0.36995 0.81997-1.3415 1.7-2.1212 2.3301-0.56048 0.47098-1.2208 0.33073-1.7114 0.66994-0.82995 0.56035-0.2897 0.77039-0.82081 1.5108-0.79015 1.0705-2.0801 1.0796-2.5205 2.4899-0.33993 1.1103 0.60028 3.1918 0.01 4.1723-0.58005 0.95044-2.3711 0.2094-3.312 1.0307-0.69032 0.60014-1.0498 2.291-1.5209 2.9707-0.23032 0.33007-0.43063 0.58056-0.60028 0.8004-0.0202 0.0104-0.03 0-0.0502 0 0.0196-0.19048-0.0104-0.28963 0.0698-0.47946-0.70011-1.0411-6.5534-3.0307-6.7936-1.0202-0.63029 0.21005-1.4106 0.27985-2.1108 0.15982-0.60027-1.0705-2.5616 0.0411-2.2204-2.1103-2.1512-0.33008-2.3222 0.96087-3.1417 2.3105-0.72033 1.1807-0.06 0.63079-1.2006 0.69994-0.72033 0.0411-1.5509-0.0202-2.2706-0.06-0.52067-1.03-0.70011 0-1.3611 0.19048-0.74969 0.21004-1.4707 0.16047-2.1708 0.33986-0.73012 0.18004-1.1105 1.0307-1.5405 1.1305-0.5807 0.1396-1.0707-0.39009-1.6312-0.47032-1.0603-0.13047-2.9818 0.18982-4.0023 0.50033-1.3115 0.39987-1.2312 1.6602-1.3604 3.1409-2.0312 0.11024-4.9125-0.58057-6.4732 0.69929-1.5907 1.291-2.1323 3.0307-3.9625 4.1618-2.0612 1.2694-3.0614 1.5806-5.6628 1.6706-2.482 0.09-3.5423 1.8102-3.6317 4.1012-1.2606-0.11024-1.7108 0.70973-2.052 1.7306-2.7515-0.33986-4.8727-1.1103-7.234-0.0202-1.0707 0.47945-2.3006 0.47945-2.8409 1.6602-1.8406 0.4201-1.6207-1.2603-2.9616-1.4703-1.9509-0.32029-0.65052 1.8402-0.84039 3.0007-0.23032 1.4403-1.7512 2.5506-2.6314 0.96087-0.55983-1.0111 0.21988-2.8206-0.23033-3.9309-0.86061 0.14938-0.95065 0.47033-1.6808 0.18004-0.55003-0.23092-0.72033-0.93999-1.3004-1.2009-1.4113-0.63928-2.221 0.10959-2.7019 1.3203-0.8704 2.261-0.53046 4.8318-0.65052 7.3119-0.97023 0.0502-2.1212-0.18004-2.9414 0.39988-1.0714 0.76061-1.271 2.5408-1.6919 3.6413-0.39018 0.99936-1.2201 1.9498-1.8902 2.7711-1.8315 2.2499-3.1123 4.3216-6.4543 3.1807-1.4511-0.48989-2.0305-0.80105-3.8424-0.80105-1.2508 0-2.9714 0.32029-4.1726 0.0111-0.3308-0.0802-0.63094-0.21005-0.91085-0.36987-1.8608-1.0104-2.9113-3.3608-5.0625-3.621 0.0803 0.38031-0.12984 0.91064-0.0502 1.2903-0.63943 0.03-1.3108 0.03-1.9509 0-0.0196-1.0405-0.47043-2.1605-0.36016-3.1403 0.0998-0.91064 0.95065-1.5101 1.0302-2.471 0.30014-0.29029 0.1703-0.0502 0.28057-0.51012-1.8902 0.44032-1.6801-1.4103-2.2706-2.5604-0.66096-1.291-1.331-1.3007-1.2404-3.1012-1.301-0.44097-2.5616-0.20091-3.9723-0.36073-1.301-0.14938-2.1616-0.61971-3.3022-1.2003 0.0692-0.3105-0.12984-0.78996-0.0607-1.1102-0.6603 0.15003-1.2404 0.0202-1.331-0.66015-1.0707-0.43967-2.3809 0.0202-3.1019-1.2303-0.61007-1.0711-0.20945-2.8011-0.69946-3.9714-0.43063-1.0007-1.0805-1.6908-1.5013-2.8409-0.42932-1.1703-0.45999-2.1103-0.54024-3.4612-0.0796-0.0411-0.15921-0.0802-0.23946-0.11024-0.60028-1.2303-2.0612-0.78018-3.0614-1.5206-0.55069-0.40053-0.86061-0.63993-1.5007-0.84019-0.60027-0.18004-0.96044-0.33008-1.4811-0.67059 0.33015-0.12003 0.64008-0.25897 0.92064-0.45989 0.50045-0.3803 0.48022-0.58057 0.6205-1.1005 0.11027-0.4501 0.26034-0.72995 0.46065-1.1305 0.15007-0.30985 0.17029-0.8004 0.48022-0.99022-0.06 0.57013-0.0196 1.3999 0.06 1.9811 0.12005 0.7704 0.67987 0.90021 0.88018 0.12003 0.15007-0.57991-0.20031-1.4606 0.44042-1.6902 0.51024-0.18004 1.4217 0.21983 1.9209 0.30985 0.14029-0.57013 0.0502-1.0404 0.0803-1.6197 0.0202-0.56034 0.16051-1.1213 0.17029-1.6804-0.33994-0.0698-0.53046 0.27006-0.72033 0.51012-0.44042 0.55056-0.32036 0.50033-0.90041 0.44031-0.87562-0.10437-0.94609 0.2655-1.2958 1.0359z",
+                Yilan:"m393.17 81.6c0.64987 0.54012 1.0505 1.2003 1.0002 2.0405-0.0404 0.04044-0.0692 0.0698-0.12005 0.12068-1.1014 0.06915-3.342 0.46054-3.2519-1.1011-0.20031-0.06001-0.4104-0.12981-0.60027-0.21005-0.0104-0.03979-0.0104-0.06915-0.0104-0.10959h0.0196c0.36995 0.06067 0.81037 0.12981 1.2103 0.10959 0.18987-0.39922 0.11027-0.87998 0.53046-1.12 0.4613-0.25962 0.89193 0 1.2221 0.27006zm-72.209 76.407c-0.0692-0.17938-0.12006-0.36008-0.14942-0.55969-0.0907-0.55056-0.21009-0.97-0.79014-1.1709-0.35038-0.12003-0.36995 0.0104-0.61072-0.30007-0.43063-0.55056-0.55068-0.72995-1.2808-0.76061-0.48022-0.03-1.0505-0.03-1.5307 0.0998-0.20096 0.06-0.30013 0.23092-0.46064 0.33986-0.2499 0.15982-0.30014 0.15982-0.65052 0.15982-0.55003 0-1.0603 0.0196-1.5614 0.12002-0.45999 0.09-0.73011 0.0692-1.1412 0.30986-0.33015 0.20091-0.63943 0.29028-0.88998 0.58122-0.30013 0.3503-0.36016 0.5897-0.85082 0.66015-0.42019 0.06-0.93956 0.0202-1.32-0.12003-0.85017-0.32029-0.82994-1.1905-0.82994-2.0111 0-0.2805 0.0698-0.81019-0.0992-1.0411-0.21009-0.28898-0.80123-0.39922-1.1216-0.57992-0.69032-0.36986-1.87-0.17025-2.7012-0.17025-0.44042 0-0.58005 0.03-0.8704-0.29029-0.24011-0.25962-0.39996-0.57013-0.68053-0.78018-0.2499-0.17938-0.63029-0.33986-0.74056-0.63927-0.10961-0.26028 0.0104-0.75018 0.0692-1.0007 0.0803-0.30007 0.28056-0.5199 0.43063-0.78018 0.15986-0.27006 0.20096-0.57078 0.2101-0.92043 0-0.67972 0.12005-1.2505-0.2101-1.8506-0.16051-0.27984-0.23032-0.62036-0.43063-0.87998-0.19053-0.23092-0.44956-0.36008-0.69945-0.5199 0.39017-0.73061 0.31971-1.8311 0.79014-2.5708 0.27012-0.41031 0.77057-0.36922 1.0107-0.66015 0.2101-0.24984 0.24011-0.80106 0.39018-1.1305 0.24011-0.57013 0.73012-1.7404 1.2103-2.06 0.47043-0.32029 0.90041-0.0698 1.3904-0.25114 0.63942-0.23027 0.29035-0.5199 0.74056-0.84998 0.0998-0.71038 0.53046-0.62036 1.0107-0.81997 0.75034-0.31116 0.5807-0.17026 0.75034-1.0007 0.30014-1.4103 1.0107-0.84997 2.1616-1.2603 0.31057-1.1011-0.23033-1.7515 0.93108-2.2505 0.91998-0.40966 1.2508-0.33986 1.0798-1.4906-0.15986-1.1103-1.1301-3.7313-0.34973-4.6915 0.39018-0.47946 1.1705-0.44032 1.6312-0.95044 0.74969-0.85911 0.0692-0.95043-0.35038-1.6902-0.16051-0.28963-0.24011-0.66928-0.24011-1.0705-0.0104-1.06 0.50045-2.3105 1.3708-2.6217 0.71054-0.24984 1.1608-0.01 1.7114-0.72017 0.46-0.60013 0.44042-1.3001 0.65052-2.0105 0.41041-1.4208 1.4609-1.8709 2.5714-2.681 0.21988-0.66928 0.57026-1.9009 0.27991-2.5004-0.30993-0.66015-0.72033-0.46054-0.45999-1.2394 0.12005-0.33008 0.47043-0.77105 0.71054-1.0307 0.67009-0.74039 2.3411-0.88129 3.5618-0.95044 0.2101 0 0.39997-0.0111 0.57026-0.0202 0.88149-0.0404 1.2704-0.06 2.0011-0.43053 0.58005-0.28898 1.0805-0.77953 1.7708-0.92043 0.70989-0.14025 1.5307 0.0607 2.1812-0.20026 0.35038-0.14025 0.63029-0.4201 0.98067-0.54991 0.2897-0.0998 0.67988-0.0802 0.92064-0.23093 0.86061-0.50033 0.54025-1.7802 1.0714-2.5108 0.53959-0.76061 2.4905-0.91064 3.432-0.90021 1.2208 0 1.5907-0.40966 1.5098-1.6602 2.7026 0.12003 2.7326-2.0705 1.9711-4.0712-0.33016-0.87998-0.44042-1.7508 0-2.6908 0.33015-0.69016 1.2097-1.8304-0.0503-2.2603 0-0.12068 0.0405-0.26028 0.0503-0.33986 0.0692-1.4299 2.3613-1.6197 3.3518-1.6497 1.1105-0.04045 0.85017-0.20092 1.0002-1.1709 0.0998-0.60014 0.36017-1.1096 0.85083-1.4808 1.0302-0.76061 2.7913-0.69016 4.0721-0.77039 1.3806-0.08024 2.7515-0.02022 4.1524-0.09067 0.0398-0.69016-0.12071-1.5506 0.33015-2.1005 0.36995-0.44945 1.151-0.63014 1.6012-0.97 0.49-0.36922 0.81037-1 1.1705-1.4299 0.65052-0.78018 2.3006-1.7306 3.312-1.9302 1.3408-0.26028 2.7404 0.21983 3.9416-0.48011 1.1601-0.66015 1.6116-1.6106 2.9009-2.0105 0.29035-0.56035 0.86061-0.66994 0.75034-1.3007-0.0998-0.57992-0.7001-0.62036-0.38039-1.4208 1.4009-0.0098 0.94021-1.7202 1.4106-2.5004 1.2097-0.24984 2.3913-0.3503 3.6525-0.3503 0.53047 0 1.2808 0.0698 1.7004-0.23027 0.3693-0.26028 0.68053-0.72016 1.1405-1.0202 0.58071-0.36987 2.0801-1.2003 2.2315-1.9107 0.21989-1.06-1.0805-1.9805-2.1414-1.9413-0.42998-1.4403 0.26033-2.0796 1.1712-3.0711 1.1014-1.1703 2.2608-0.84019 3.8215-0.91064 0.6603-0.04044 1.4296-0.02022 2.0801-0.15004 0.82081-0.14938 1.0805-0.60014 1.5705-1.12 0.84039-0.91064 2.0912-1.5206 3.2722-1.6504 0.46-0.04958 1.4309-0.01957 1.8517-0.23027 0.56961-0.2805 0.60028-0.88064 1.2312-1.1305 1.2006-0.47033 2.2008 0.42988 3.3916 0.36987-0.11027 0.30007-0.15007 0.66015-0.0998 1.1103-1.4106-0.05023-2.882 0.66015-4.1432 1.2094-0.39931 0.17091-1.181 0.32029-1.3708 0.69081-0.19053 0.39009 0.15985 1.0796-0.44042 1.2394-0.0202 0.03001 0 0.0698-0.0104 0.10959-0.4215 0.28115-0.64008 0.6608-1.0303 0.97066-0.36995 0.31051-0.71054 0.91064-1.2103 0.96022-0.42084 0.4899-0.93108 1.0202-1.6312 1.1605-0.39018 0.08024-0.50045 0.08024-0.82929 0.33008-0.25969 0.20092-0.68053 0.42988-0.8306 0.75017-0.2897 0.63014 0.16051 1.4808 0.16051 2.1311-0.0104 0.6608-0.65052 1.3203-1.1705 1.6602-0.24011 0.17091-0.52067 0.30007-0.72033 0.50098-0.18987 0.19048-0.49001 0.41031-0.68053 0.63014-0.4489 0.53034-0.84039 1.1298-1.3604 1.5701-0.47957 0.41031-1.0107 0.98044-1.4413 1.4403-0.47892 0.53034-0.88932 0.8291-1.0407 1.5604-0.12984 0.63014-0.49 1.1103-0.76013 1.6902-0.31058 0.6608-0.53046 1.4103-0.82081 2.0907-0.60028 1.3901-0.47043 2.9811-0.58984 4.5219-0.0502 0.61058-0.09 1.2805-0.25903 1.8402-0.12984 0.45989-0.2512 0.85063-0.3308 1.3301-0.0796 0.50098-0.18987 0.97066-0.28057 1.4305-0.27012 1.3307-0.0502 2.7906-0.0502 4.1514 0 1.2303 0.2101 2.5702 0.51024 3.7509 0.27012 1.0705 1.1014 2.1703 1.6312 3.0901 0.27991 0.46054 0.40976 0.69081 0.44042 1.2101 0.03 0.44945 0.0796 0.85976 0.1703 1.291 0.12984 0.69081 0.36995 1.3999 0.3308 2.1207-0.03 0.60014-0.0411 1.2205-0.0411 1.8402 0 0.60013 0.0496 1.1814 0.0802 1.7802 0.0196 0.48989 0.26947 0.93021 0.31971 1.4208 0.0405 0.36008-0.0998 0.67972-0.0411 1.0496 0.12136 0.74104 0.72033 1.2909 0.93173 1.9915 0.28904 0.93021 0.17878 1.7 0.79014 2.4899 0.47044 0.61057 0.68053 1.501 1.3708 1.9009 0.65052 0.38031 1.1014 0.5199 1.8413 0.66081 0.20879 0.0404 0.39997 0.14024 0.61985 0.17025-0.0111 0.31051 0.23946 1.2205-0.36995 1.1207-0.2101-0.0404-0.33015-0.35029-0.50045-0.47032-0.2101-0.15004-0.30014-0.15004-0.58135-0.16047-0.49001-0.01-1.0407-0.0998-1.4106 0.24984-0.34973 0.33007-0.28057 0.8702-0.2499 1.3307 0.25969 0.12981 0.45999 0.36986 0.74056 0.47032 0.20944 0.0698 0.44107 0.0698 0.66095 0.17091 0.0992 0.15982 0.21989 0.33986 0.30014 0.50033 0.12006-0.0998 0.21989-0.21004 0.30014-0.33986 0.18987-0.0196 0.39083 0.0196 0.57026 0.0907 0.0104 0.28049-0.17943 1.1403 0.12071 1.2094 0.18987 0.32029-0.14028 0.36987-0.3693 0.43054-0.48022 0.12068-0.51024 0.03-0.56048 0.61057-0.0998 1.09-0.03 2.1898 0.03 3.2805 0.68053-0.17026 0.4502 1.4005 0.4502 1.8011 0 0.68038 0.28057 1.7097-0.50109 1.9602-0.72034 0.21983-1.4511 0.06-2.1212 0.57078-0.28904 0.2094-0.52067 0.40966-0.88084 0.47032-0.54024 0.09-1.0407 0.0196-1.3715 0.57992-0.25055 0.42075-0.22054 1.0307-0.1703 1.5101 0.0411 0.33986 0.0998 0.66994 0.30014 0.93935 0.25968 0.35029 0.68053 0.29028 0.95065 0.55121 0.25969 0.24005 0.1703 0.63014 0.25969 0.96022 0.14028 0.53034 0.39018 0.78018 0.82081 1.1207 0.17943 0.14025 0.82016 0.72995 0.84038 0.92043 0.0398 0.31116-0.73077 0.32029-0.99176 0.33008-1.4707 0.0698-2.3606 1.2407-3.4411 2.1318-0.31971 0.25897-0.88084 0.57992-1.0714 0.95044-0.20031 0.3803-0.1703 1.0104-0.30014 1.4208-0.63942 0.06-1.181 1.1807-1.6305 1.6308-0.35038 0.33986-0.63094 0.66993-0.90107 1.0802-0.20031 0.30986-0.53046 0.60014-0.70989 0.91-0.17029 0.32029-0.25968 0.74038-0.39083 1.0907-0.14028 0.36987-0.2101 0.81997-0.24011 1.2101-0.0796 0.96022-0.06 1.9504-0.25968 2.8702-0.18987 0.8702-0.27013 1.7306-0.31058 2.6308-0.0411 0.75017-0.31971 1.3105-0.73012 1.9204-0.49001 0.71038-0.82081 1.3503-0.8704 2.2505-0.0405 0.8702-0.25055 1.6706-0.25055 2.5512 0 0.63015-0.0411 1.2505-0.0496 1.8696-0.0104 0.36074 0.15986 1.0502-0.0998 1.3307 0 0.0202-0.0196 0.0411-0.0405 0.0502-0.48022 0.38031-1.5314-0.24984-2.0214-0.3803-0.31971-0.0802-0.61137-0.14025-0.90107-0.31051-0.33015-0.18983-0.58983-0.54012-0.93108-0.72995-0.58005-0.32029-1.4302-0.15003-2.0514-0.33986-0.49001-0.16047-0.88084-0.30007-1.4106-0.28963-0.49001 0-0.96109 0.03-1.4204-0.12068-0.59048-0.17939-1.0505-0.50033-1.5816-0.78997-0.27991-0.15982-0.58005-0.40966-0.8704-0.5199-0.42933-0.15982-0.99045 0.09-1.3904-0.12003-0.3693-0.18982-0.44042-0.42988-0.90041-0.50098-0.4202-0.06-0.73012 0-1.0805-0.24984-0.44955-0.31051-0.74969-0.75017-1.1099-1.1605-0.36082-0.41032-0.88084-0.54013-1.2612-0.92043-0.18987-0.19048-0.30992-0.55056-0.55003-0.63015-1.1203-0.33986-0.0502 1.9113-1.2006 0.76061-0.33994-0.33986-0.65052-0.69016-0.98067-1.0404-0.27013-0.27985-0.63029-0.74039-0.95066-0.96022-0.75034-0.50099-1.4407 0.3803-1.2404 1.1298 0.0998 0.3803 0.46065 0.48989 0.6603 0.77105 0.15007 0.21983 0.15007 0.47032 0.33994 0.67972 0.2897 0.31964 0.63029 0.23027 0.74056 0.66015 0.0698 0.25962 0.0196 0.69016-0.0104 0.96022-0.0202 0.20092-0.0202 0.69994-0.18987 0.81019-0.30014 0.20026-0.43063-0.38031-0.59049-0.58057-0.30013-0.36987-0.29035-0.12068-0.71054-0.23093-0.23098-0.0502-0.41041-0.28963-0.46065-0.53033-0.24011 0.13959-0.4502 0.39922-0.54024 0.66928-0.0692 0.21983-0.0503 0.74104-0.2897 0.85063-0.23033 0.11024-0.33015-0.19048-0.61985-0.10959-0.29035 0.0802-0.5011 0.53034-0.70076 0.7293-0.12984 0.12068-0.24011 0.30007-0.42998 0.31116-0.17029 0.01-0.19052-0.15004-0.32036-0.17026-0.19053-0.0104-0.16051-0.15004-0.21989 0.14025-0.06 0.27006 0.0907 0.39009 0.27013 0.55904 0.36995 0.3503 0.55003 0.33008 0.60027 0.81019 0.0411 0.29028-0.0202 0.57013 0.0803 0.81997-0.2499 0.03-0.42998-0.09-0.66944-0.12003-0.27013-0.0404-0.48022 0.06-0.74121 0.09-0.42019 0.0411-0.85017-0.12003-1.2397-0.21983-0.78036-0.20027-1.5509-0.0998-2.3613-0.21005-0.98002-0.12981-1.1908-0.81997-1.8106-1.4599-0.61071-0.6308-0.7797-1.7215-1.761-1.8206-0.41041-0.0502-0.83973-0.0111-1.2508-0.0502-0.63943-0.06-1.181-0.24005-1.7904-0.36986-0.44107-0.0992-0.92064-0.11025-1.3715-0.0405-0.2101 0.03-0.33994 0.0992-0.59049 0.0802-0.30992-0.03-0.33994-0.18004-0.58005-0.25049-0.56047-0.15917-0.67009 0.31115-1.0407 0.50098-0.21988 0.12003-0.12071 0.09-0.41041-0.0998-0.18008-0.13047-0.33994-0.24006-0.5011-0.39009-0.36016-0.33986-0.63942-0.66016-1.0798-0.93022-0.42998-0.27006-0.97023-0.33007-1.4309-0.54012-0.71055-0.32029-1.1405-0.97001-1.8811-1.2003-0.63094-0.20091-1.1608 0.01-1.5712-0.59035-0.0574-0.0855-0.10701-0.17548-0.14746-0.2655z",
+                HsinchuCounty:"m293.48 147.63c0.0196-0.71104-0.09-1.4514-0.0502-2.1514 0.03-0.55969 0.18987-1.1807 0.0698-1.73-0.12005-0.56034-0.58005-0.84019-0.91085-1.2707-0.2897-0.38031-0.67009-0.63015-1.0002-0.96023-0.67988-0.71103-1.2312-1.5812-1.9118-2.2805-0.60027-0.61123-1.2704-1.1102-1.7604-1.8011-0.55982-0.80041 0.47043-1.3705 0.19052-2.1403-0.25968-0.66993-1.0002-1.1703-1.5705-0.70973-0.69097 0.57013-1.5509 0.16961-2.2315 0.69016-0.30014 0.23027-0.52002 0.57079-0.88084 0.66015-0.36017 0.0907-0.88997 0.0111-1.2508 0-0.35038-0.01-0.66944-0.03-1.0002 0-0.39997 0.0411-0.58071 0.24006-0.93108 0.32029-0.47044 0.12003-0.61072-0.12981-0.95066-0.30985-0.34972-0.19048-0.72946-0.12068-1.1203-0.14025-0.69032-0.0307-1.0498-0.93086-1.7108-0.48011-0.25968 0.16961-0.38039 0.62036-0.61072 0.73974-0.18008 0.10045-0.82015 0.0502-1.0205 0-0.39018-0.10959-0.43064-0.51012-0.76079-0.69995-0.30014-0.19048-0.6205-0.06-0.90041 0.11025-0.21988 0.12981-0.3693 0.28963-0.55004 0.48011-0.24011 0.26027-0.47043 0.35029-0.79014 0.53033-0.30014 0.16961-0.44042 0.24984-0.67988 0.4899-0.24011 0.23027-0.33015 0.33986-0.6603 0.3803-0.69097 0.0692-1.3604-0.0607-1.8615-0.39074-0.52067-0.3503-1.1705-0.0691-1.791-0.24984-0.15985-0.2805-0.44955-0.47032-0.58005-0.78996-0.14028-0.3503-0.0802-0.75017-0.13049-1.1207-0.0998-0.66994-0.74056-1.3901-0.2499-2.0516 0.23032-0.32029 0.54025-0.36008 0.91085-0.43967 0.53047-0.0998 0.36996-0.18004 0.60093-0.57013 0.20945-0.3503 0.58984-0.55056 0.66031-1.0104 0.0692-0.42009-0.24011-0.4501-0.5011-0.62036-0.2897-0.20026-0.61072-0.48989-0.84039-0.77039-0.23946-0.2805-0.50958-0.5199-0.80058-0.75996-0.3804-0.32029-0.89063-0.74039-1.3604-0.95043-0.0803-0.47033 0.76078-0.33987 1.0407-0.44032 0.32037-0.12068 0.53046-0.36074 0.58136-0.72017 0.10961-0.78018 0.3693-1.5003 0.85996-2.1305 0.35038-0.46054 0.39083-0.9002 0.70989-1.3307 0.27012-0.36008 0.65051-0.66015 0.55134-1.1703-0.15007-0.78018-1.0414-1.0502-1.2808-1.711-0.17095-0.47033 0.12919-0.69994-0.33994-1.0405-0.39018-0.27006-0.73011-0.25049-0.99045-0.66993-0.23098-0.36009-0.29035-0.74039-0.81037-0.59036-0.30014 0.09-0.99111 0.48011-1.0407 0.76061-0.22053-0.0802-0.39996-0.41031-0.55069-0.58057-0.24011-0.27006-0.52002-0.48989-0.7797-0.74038-0.65052-0.6308-1.3115-1.0104-2.2119-1.3301-0.58983-0.21005-0.81037-0.78996-1.4106-1.0111-0.14942-0.0496-0.3693-0.03-0.50045-0.0802-0.2101-0.0991-0.12984-0.0691-0.25968-0.30007-0.19053-0.31964-0.20031-0.39009-0.57027-0.50033-0.19052-0.41031 0-0.89042-0.09-1.3307-0.10961-0.50033-0.60027-0.3503-1.0805-0.36987-0.80059-0.0496-1.1099-0.69016-1.5607-1.2394-0.23098-0.27985-0.54025-0.47033-0.76078-0.76061-0.30993-0.39009-0.43977-0.88129-0.78036-1.2505-0.21989-0.23092-0.54025-0.3105-0.77971-0.51011-0.25968-0.21984-0.35038-0.54013-0.64007-0.69016-0.54025-0.2805-0.91086-0.0411-0.66031-0.81019 0.12984-0.39987 0.50045-0.62036 0.76013-0.96022 0.33016-0.44097 1.2508-1.4814 0.82995-2.1612-0.27012-0.44945-1.4811-0.43053-1.9111-0.29028-0.64008 0.21005-0.33994 1-1.1705 0.8702-0.78036-0.12003-0.76079-1.0104-1.5907-0.5897-0.2897 0.14025-0.39018 0.3105-0.70011 0.0991-0.18008-0.10959-0.39083-0.47946-0.42084-0.66015-0.0196-0.0202-0.0502-0.0404-0.0803-0.06 1.2612-1.0104 0.11027-3.2212 0.85148-4.5213 0.8293-0.29028 1.8008-0.15003 2.7215-0.20092 0.0496-0.97001-0.15007-2.1207 0.65051-2.8206 0.76079-0.66015 2.1408 0.02022 2.6112-0.91064 0.2499-0.4899 0.13963-0.93021 0.47957-1.4403 0.30014-0.4501 0.41041-0.63014 0.94022-0.7306 0.74055-0.15004 1.9711 0.66015 2.1812 1.3203 0.2897 0.01044 0.60028 0.01957 0.89063 0.03001 0.0398 0.20026 0.18987 0.31964 0.18987 0.54991 0.5807 0.46054 0.28056 1.0307 0.49001 1.6804 0.33015 1.0307 0.63029 0.27985 1.2397 0.08024 0.90106-0.28963 1.1712 0.09915 0.91085-1.1403-0.10962-0.53034-0.15986-1.3601-0.33994-1.9204-0.19052-0.60014-0.64986-0.91064-0.98067-1.4305-0.38039-0.60014-0.33015-1.1096-0.33015-1.8396 0-1.5101-0.65051-1.9909-1.84-2.7508-0.64008-0.41031-1.0603-1.0104-1.7519-1.2401-0.89063-0.30007-1.3708-0.0698-1.8406-0.99023-0.88084-0.06067-1.4602-0.21005-2.2204-0.45989-0.73077-0.23092-1.6207 0.0098-2.2921-0.36987-1.35-0.76061-1.4211-2.651-3.0216-2.8311 0.0404-0.06001 0.0698-0.11024 0.0404-0.19048 0.0992-2.471 1.9202-1.6008 2.9218-3.1709 0.4502-0.71038-0.03-1.9107 0.14028-2.7508 0.26034-1.2401 1.0205-2.3105 1.6312-3.3908 0.5011-0.85976 0.66096-1.9805 1.3115-2.6908 0.4202-0.44945 0.93043-0.78996 1.4407-1.12 0.47956 0.12981 1.1705 0.12981 1.5607 0.03979 0.61006-0.1396 0.82995-0.7293 1.4407-0.90021 0.63029-0.17939 1.1908 0.2805 1.8106 0.3803 0.8704 0.13046 1.35-0.24006 2.0807-0.39922 0.61072-0.12981 1.4707-0.01044 1.9907 0.27006 0.41041 0.21983 1.3806 0.8702 1.6606 1.1703 0.81037 0.88977 0.0202 2.9713 0.27012 4.1416 0.26034 1.2205 2.4716 1.09 3.5925 1.5708 0.66944 0.28898 1.0107 0.54991 1.8308 0.5199 0.69032-0.03001 1.3506-0.11024 2.071-0.0698-0.11027 0.54012-0.06 1.2003-0.23032 1.7404 0.0992-0.33008 1.4511 0.63993 1.4602 0.65037 0.70011 0.24006 1.9509 0.01044 2.7019 0.01044 0.71055 0 2.2204 0.33986 2.4213 1 0.0405 0.14025-0.24011 0.36074-0.17029 0.58057 0.0992 0.36008 0.3693 0.19048 0.47957 0.44032 0.15006 0.33986 0.15985 1.12 0.16964 1.5003 0.0111 0.66994-0.0496 0.84998-0.47957 1.3307-0.36995 0.40966-0.82016 0.42075-0.6603 1.1403 0.30014-0.03001 0.47957 0.0698 0.72033 0.19048 0.20031 0.09981 0.52002 0.67972 0.78036 0.85976 0.28969 0.20026 0.74969 0.39987 1.0798 0.5199 0.55069 0.19048 1.7108 0.14938 1.5907 1.0104 0.86061-0.1396 1.181 0.56035 1.331 1.2505 1.0407 0.33008 1.6808 1.5708 2.8918 1.3307 0-0.18004 0.14028-0.33986 0.11027-0.54991 0.53046-0.08024 1.0413 0.09915 1.5614 0.08024 0.03 0.66928-0.26034 1.6706 0.51023 1.8206 0.63942 0.12003 1.2606-0.72016 1.8308-0.75017 0.91085-0.03979 0.57091 0.92043 1.1705 1.3405 0.39018 0.27006 1.4002 0.43053 1.9013 0.51012-0.03 0.59035 0.01 1.3412 0.3693 1.8206 0.45021 0.60014 0.99111 0.29028 1.6312 0.67972 0.0998 0.06001 0.31058 0.3803 0.5011 0.50098 0.30014 0.20026 0.6205 0.33008 0.85082 0.4899 0.65052 0.44945 0.78036 0.55969 1.581 0.74039 1.3004 0.30007 2.2014 1.6706 1.9209 3.0914-0.12984 0.66015-0.67988 0.93021-0.82995 1.5003-0.15985 0.55969 0.0104 1.3803 0.18008 1.9009 0.21989 0.0502 0.12071 0.0802 0.2499 0.17026 0.11027-0.0202 0.27013 0.0202 0.39083 0.0202 0.41041 1.8004-1.3911 2.9707-0.72033 4.8115 0.12984 0 0.2499 0.03 0.38039 0 0.44042-0.48011 1.5509-0.51012 2.2713-0.39988 0.93957 0.1396 0.80059 0.50034 1.3108 1.1905 0.33994 0.45989 0.88084 0.76061 1.0198 1.3901 0.16051 0.71038 0 1.4703 0.18008 2.1507 0.39018 0.0202 1.6312-0.17939 1.9209 0.0802 0.31906 0.2805 0.17943 1.411 0.14942 1.8506-0.03 0.61123-0.14942 1.0502 0.2499 1.5708 0.45999 0.61057 0.80124 0.66994 0.76013 1.5904 1.4609-0.28898 0.30014 3.2812 0.33994 4.002 0.86061 0.50033 0.74056 1.7508 1.5809 2.2512 0.76079 0.01 1.2508 0.77039 1.8413 0.99023 0.73012 0.27984 1.8902 0.0502 2.6712-0.0502 0 0.39987 0.0802 0.78018 0.24011 1.0711 0.42019 0.74039 1.1007 0.82976 0.35038 1.6902-0.46065 0.50947-1.2404 0.47033-1.6312 0.95044-0.78036 0.96022 0.19052 3.5806 0.35038 4.6909 0.1703 1.1507-0.15986 1.0802-1.0805 1.4906-1.1608 0.50098-0.6205 1.1507-0.93042 2.2505-1.1516 0.41031-1.8622-0.15004-2.1616 1.2603-0.17029 0.8304 0 0.69081-0.74969 1.0007-0.48022 0.20026-0.91085 0.10959-1.0113 0.81997-0.44956 0.33008-0.0992 0.62036-0.74056 0.85063-0.49001 0.17939-0.92064-0.0698-1.3904 0.25049-0.48022 0.32029-0.97088 1.4906-1.2103 2.0607-0.14942 0.33008-0.17943 0.88064-0.39018 1.1298-0.24011 0.29028-0.74056 0.24984-1.0107 0.66015-0.47043 0.74104-0.39997 1.8402-0.79015 2.5708-0.0411-0.0202-0.0802-0.0404-0.1207-0.0698-0.91999 0.94-2.0905 1.5812-3.4118 1.7802-1.5809 0.24005-3.4222 0.24005-5.043 0.15982 6.5e-4 -0.0437 6.5e-4 -0.0939 6.5e-4 -0.14351z",
+                HsinchuCity:"m239.48 98.926c0.2101-0.57078 0.27012-0.55121 0.82995-0.91064 0.30013-0.19048 0.85996-0.51012 1.1209-0.81019 0.25904-0.30007 0.20031-0.63014 0.30993-0.98044 0.0803-0.27006 0.24011-0.77953 0.11027-1.0802-0.14942-0.36008-0.63029-0.4201-0.91086-0.60014-0.24989-0.14025-0.58135-0.4899-0.42084-0.8291 0.0998-0.20092 0.28056-0.12068 0.39083-0.29028 0.09-0.14938 0.03-0.46054 0.03-0.63014 0-0.71038-0.0502-1.4501 0-2.1611 0.0196-0.34965 0.10962-0.5897 0.24011-0.8702 0.12006-0.26941 0.39018-0.4201 0.55069-0.66015 0.18987-0.31051 0.21989-0.7006 0.40976-1.0196 0.21988-0.3803 0.47956-0.4501 0.51023-0.91064 0.0196-0.33986-0.03-0.68037 0.0803-1.0007 0.11027-0.30985 0.3693-0.5199 0.5396-0.78996 0.20096-0.30985 0.41106-0.4899 0.64008-0.74039 0.23032-0.24006 0.42019-0.53034 0.6205-0.84019 0.38039-0.55969 0.42019-1.4103-0.25969-1.7306-0.30013-0.14025-0.63029-0.21983-0.95065-0.24984 0.06-0.4899 2.5616-0.16047 3.0314-0.27985 0.03-0.06001 0.0692-0.0998 0.09-0.14025 1.6005 0.17939 1.6716 2.0705 3.0216 2.8311 0.67009 0.3803 1.5614 0.1396 2.2921 0.36987 0.75948 0.24984 1.3408 0.39922 2.2204 0.45989 0.47109 0.91978 0.95066 0.69016 1.8406 0.99023 0.69032 0.23027 1.1105 0.83041 1.7512 1.2401 1.1908 0.76061 1.8406 1.2401 1.8406 2.7508 0 0.72995-0.0502 1.2394 0.33015 1.8396 0.33015 0.52055 0.79014 0.83041 0.98067 1.4305 0.18008 0.56035 0.23097 1.3908 0.33993 1.9204 0.25969 1.2394-0.0104 0.85063-0.91085 1.1403-0.61006 0.20026-0.9102 0.95044-1.2397-0.08024-0.21009-0.65037 0.09-1.2205-0.49001-1.6804 0-0.23092-0.15006-0.3503-0.18986-0.54991-0.29036-0.01109-0.60028-0.02022-0.89063-0.03001-0.2101-0.6608-1.4407-1.4703-2.1812-1.3203-0.53046 0.0998-0.64008 0.27985-0.94021 0.7306-0.33994 0.51012-0.23033 0.95044-0.48022 1.4403-0.47044 0.93021-1.8511 0.24984-2.6112 0.91064-0.80059 0.69994-0.60028 1.8506-0.65052 2.8206-0.91999 0.05023-1.8902-0.09002-2.7215 0.20092-0.74055 1.3001 0.40976 3.5108-0.85082 4.5212-0.42019-0.29028-1.1608-0.33007-1.7206-0.33007-0.8306 0-1.2912-0.14025-1.2808-1.0411 0-0.63928-0.03-1.1298-0.4104-1.6197-0.14094-0.18004-0.41106-0.36986-0.51024-0.54991-0.12984-0.21983-0.0907-0.50098-0.16964-0.74104-0.69097-0.19048-1.1105 1.4103-1.791 1.5401-0.31123 0.06-1.0903 0.03-1.3715-0.09-0.40062-0.15004-0.44955-0.44032-0.91085-0.46054-0.0111-0.06002-0.0202-0.11024 0-0.15004 0.0189-0.20026 0.20944-0.2805 0.3693-0.4201 0.24272-0.2094 0.27273-0.28963 0.37256-0.54926z",
+                Miaoli:"m246.9 103.34c0.03 0.0202 0.06 0.0404 0.0803 0.06 0.03 0.18004 0.24011 0.54991 0.42019 0.66015 0.31123 0.21005 0.41106 0.0411 0.70076-0.0992 0.82994-0.42075 0.81037 0.47032 1.5907 0.5897 0.82994 0.12981 0.53046-0.66015 1.1705-0.8702 0.42998-0.14025 1.641-0.16047 1.9111 0.29028 0.42084 0.67973-0.50045 1.7202-0.82995 2.1612-0.25968 0.33986-0.63094 0.5597-0.76013 0.96022-0.2512 0.7704 0.12005 0.53034 0.6603 0.81019 0.29035 0.14938 0.38039 0.47032 0.63943 0.69016 0.24011 0.20026 0.56047 0.27984 0.78036 0.51011 0.33993 0.36922 0.47043 0.86042 0.78035 1.2505 0.21989 0.29028 0.53046 0.48011 0.76079 0.76061 0.44955 0.54991 0.76078 1.1905 1.5607 1.2394 0.48022 0.0202 0.97088-0.12916 1.0805 0.36987 0.09 0.44032-0.0998 0.92043 0.09 1.3307 0.36995 0.10959 0.38039 0.18004 0.57026 0.50033 0.12985 0.23093 0.0502 0.20092 0.25969 0.30072 0.13049 0.0496 0.35038 0.03 0.50044 0.0796 0.60028 0.22048 0.82016 0.80105 1.4106 1.0111 0.90042 0.31964 1.5607 0.69929 2.2112 1.3301 0.26034 0.25049 0.54025 0.47032 0.78036 0.74039 0.15007 0.17025 0.33015 0.50033 0.55004 0.58056 0.0502-0.27984 0.74121-0.66928 1.0414-0.76061 0.52002-0.14938 0.5807 0.23093 0.80971 0.59036 0.26034 0.42009 0.60093 0.39987 0.99111 0.66993 0.47044 0.33986 0.1703 0.57013 0.33994 1.0405 0.24011 0.66015 1.1307 0.93021 1.2815 1.711 0.0992 0.51012-0.28122 0.81019-0.55134 1.1703-0.31906 0.42988-0.36017 0.8702-0.70989 1.3307-0.49001 0.63015-0.74969 1.3497-0.86062 2.1305-0.0496 0.36009-0.25968 0.60014-0.5807 0.72017-0.27991 0.0991-1.1203-0.03-1.0407 0.44032 0.47043 0.21004 0.98067 0.63014 1.3604 0.95043 0.29035 0.24006 0.55982 0.48011 0.80058 0.75996 0.23098 0.2805 0.55004 0.57013 0.84039 0.77039 0.25968 0.17026 0.57026 0.20092 0.5011 0.62036-0.0698 0.45989-0.45021 0.66015-0.66096 1.0104-0.23032 0.39074-0.0692 0.47033-0.60028 0.57013-0.3693 0.0802-0.68053 0.12068-0.91085 0.43967-0.49001 0.6608 0.14942 1.3803 0.2499 2.0516 0.0502 0.36921-0.01 0.77039 0.13049 1.1207 0.12919 0.32029 0.4202 0.51012 0.58005 0.78996 0.6205 0.18004 1.2704-0.0998 1.791 0.24984 0.50045 0.33008 1.1705 0.46054 1.8609 0.39075 0.3308-0.0411 0.42084-0.15004 0.66095-0.38031 0.24011-0.24005 0.38039-0.32029 0.67988-0.48989 0.31971-0.18005 0.55003-0.27007 0.79014-0.53034 0.17943-0.19048 0.33016-0.3503 0.55004-0.48011 0.28056-0.17026 0.60027-0.30007 0.90041-0.11025 0.33015 0.19048 0.36996 0.59036 0.76079 0.69995 0.20031 0.0502 0.84038 0.10045 1.0205 0 0.23032-0.12003 0.34972-0.57013 0.61071-0.73974 0.6603-0.4501 1.0205 0.44945 1.7108 0.48011 0.39017 0.0196 0.77057-0.0502 1.1203 0.14025 0.33994 0.17939 0.48022 0.42923 0.95066 0.30986 0.35037-0.0802 0.53046-0.27985 0.93042-0.3203 0.33081-0.03 0.65052-0.01 1.0009 0 0.36016 0.0111 0.89062 0.0907 1.2508 0 0.36016-0.09 0.5807-0.42988 0.88084-0.66015 0.68053-0.5199 1.5405-0.12002 2.2315-0.69016 0.57026-0.46054 1.3108 0.0398 1.5698 0.70973 0.28121 0.7704-0.74969 1.3405-0.19052 2.1409 0.49 0.69016 1.1608 1.1898 1.761 1.8004 0.67988 0.69929 1.2306 1.5702 1.9118 2.2805 0.33015 0.33007 0.71054 0.58056 1.0002 0.96022 0.33015 0.43053 0.79015 0.71038 0.91085 1.2707 0.12006 0.54991-0.0404 1.1703-0.0698 1.73-0.0405 0.69995 0.0698 1.4403 0.0502 2.1514-0.53046 0.47946-1.1307 0.91977-1.9411 0.87998-0.47108 1.1703 0.0803 2.6106-0.39083 3.7809-1.5007 0.53034-1.5398 1.8311-2.6412 2.561-1.8211 1.1814-2.2112-0.17939-2.5212-1.6804-0.6603-0.17939-1.4302-0.27985-2.1212-0.15917-0.10962 2.1005 0.0607 2.7704-2.161 3.1703-1.0505 2.0516-1.9013 2.8311-4.2019 3.3021-1.3904 0.28898-1.6501 0.0991-2.5414 1.1292-0.30013 0.33986-0.24989 0.83041-0.63029 1.2101-0.36081 0.36008-1.0903 0.19048-1.4609 0.69016-0.81038 1.0907-0.0502 1.3503-1.3715 2.1409-0.28057 0.16048-1.9914 1.12-2.3306 1.1703-1.1014 0.15982-1.4407-1.0907-2.6719-0.68037-0.93956 0.32029-0.88997 1.6706-2.4814 1.7-0.2499 0.6308-0.74056 1.0802-0.88084 1.7802-1.7519 0.14025-1.9607-0.39988-3.1926-1.4306-0.31058-0.25962-1.0002-0.39009-1.2508-0.74039-0.3693-0.5199-0.17943-1.2401-0.53046-1.7704-1.4407-2.1709-4.9627-1.5101-7.1739-1.8702-1.7408-0.2805-4.9425-2.4899-6.3832-0.3803-1.5209 2.261 1.5809 5.6615-1.6201 6.882-2.191 0.8402-5.2224-0.0404-7.6744 0.33073-1.3911 0.2094-2.3711 0.58057-3.4522-0.20091-0.96958-0.71038-1.5509-1.8709-2.4311-2.5806-1.8511-1.4808-4.7128-0.85976-6.834-2.1807-1.9613-1.2205-3.3824-3.1507-5.163-4.4912-1.0805-0.81019-1.7108-0.39074-2.8017-0.8702-0.95065-0.40966-1.2404-1.3001-1.9913-1.9602-1.4002-1.2401-2.3411-2.0907-3.462-3.5917-1.2208-1.6497-3.0216-2.1696-4.0917-3.621-1.0414-1.4299-1.1405-3.0809-2.5512-4.2114 0.58984-0.96935 1.6312-1.7202 2.5414-2.4599 0.47044-0.39074 1.1908-0.75017 1.5614-1.2003 0.38039-0.46054 0.17943-0.91064 0.33994-1.4305 0.2897-0.92043 1.1705-1.4906 1.5607-2.3608 0.4502-1.0007 0.91085-1.6908 1.5614-2.6008 0.30013-0.42923 0.49-1.15 0.55982-1.6602 0.11027-0.84019 0.11027-1.1403 0.69097-1.8096 0.54025-0.63993 0.63942-0.99088 0.67988-1.8004 0.06-1.2309 0.5807-2.5617 0.88083-3.762 0.36996-1.4703 1.6312-2.1005 2.4109-3.381 0.50045-0.83041 0.61072-1.7906 1.1705-2.651 0.36995-0.55904 0.92064-1.5206 1.5607-1.6602 1.0413-0.24006 4.1928 1 3.7824-1.2394-0.54025-0.22048-0.92064 0.12916-1.4106 0.0992-0.0411-0.23027 0.5807-1.1298 0.74056-1.4103 0.30013-0.53034 0.68053-0.92043 0.86061-1.5304 0.33994-1.1305 0.65051-1.9407 1.6201-2.6706 0.70076-0.53034 1.562-1.3007 2.5218-1.4403 1.1803-0.18004 2.3802-0.39988 3.5618-0.50099 0.59049-0.06 1.2103 0.0202 1.8008-0.01 0.2499-1.3503 1.2208-2.621 2.5009-3.1312 0.0907-0.98045 1.0505-1.1103 1.5809-1.7802 0.49001-0.6197 0.44107-1.2805 0.49001-2.0803 0.0607-0.81997 0.53046-1.4703 1.0805-2.0307 0.44042-0.44032 0.97088-1.3307 1.562-1.5401-0.0202 0.04044-0.0111 0.09067 0 0.15004 0.45999 0.0202 0.50958 0.30985 0.91085 0.46054 0.27991 0.12003 1.0603 0.14938 1.3715 0.09 0.68053-0.12981 1.1007-1.7306 1.7904-1.5401 0.0803 0.24006 0.0404 0.52056 0.17029 0.74104 0.0992 0.17939 0.3693 0.36922 0.50958 0.54991 0.3804 0.4899 0.41106 0.98044 0.41106 1.6204-0.0111 0.90021 0.44956 1.0405 1.2808 1.0405 0.56112-5e-3 1.301 0.0346 1.7212 0.32486z",
+                Taipei:"m351.36 53.383c0.0104 0.32029 0.0104 0.65037 0 0.97066-0.52002-0.02022-1.0407 0.06915-1.5705 0.09915-0.25968 0.01044-0.5807-0.06001-0.82994 0.02022-0.20031 0.0698-0.4202 0.36008-0.56048 0.39987-0.50045 0.14938-0.96044-0.11024-1.5307-0.09067-0.63029 0.03066-0.92064 0.32029-1.4909 0.44097-0.90042 0.19048-2.3313-0.39987-3.141 0.17026-0.20096 0.1396-0.10962 0.44032-0.28056 0.63014-0.15986 0.17026-0.42933-0.05023-0.58984 0.26028-0.35038 0.66928 0.3693 0.87998 0.82016 1.0196 0.0692 1.2805-1.0303 5.092 1.0909 4.8318 0.06 0.3503 1.3004 0.54991 1.6605 0.66994 0.25968 0.96935-0.47043 0.77953-1.151 0.81997-0.82995 0.05023-0.77123 0.41031-1.4106 0.66928-0.59049 0.22048-1.2208-0.2394-1.761-0.31964-0.61071-0.09981-1.3708 0.23027-1.5098-0.59035-0.67009 0.13046-1.0414 0.65037-1.7414 0.57013-0.55004-0.06001-0.85996-0.47032-1.1601-0.92043-0.47108-0.67972-1.3506-1.6804-1.2704-2.5708-0.3804 0.02022-0.8704-0.03001-1.1705-0.2394-0.39997-0.2805-0.25969-0.74104-0.47044-0.94-0.72033-0.66994-1.4609 0.47032-1.9117 0.83041-0.01-1.2009 1.791-2.1905 0.74121-3.3412-0.44107-0.48011-0.97023-0.68037-1.4009-1.1703-0.44042-0.50098-0.60028-0.96087-1.3604-0.90021-0.82016 0.06001-1.0505 0.72016-1.4909 1.2505-0.61072 0.74039-0.79015 0.88977-1.3604 0.09981-0.46065-0.63928-0.42019-0.95044-0.55982-1.681-0.0907-0.43967-0.61137-1.1801-0.59049-1.5904 0.06-1.06 2.2308-1.06 2.8115-2.0209 0.59049-0.94 0.61137-2.8011 0.61137-3.9818 0-1.2205-0.73077-2.1507-1.5816-2.9811-0.41041-0.39922-0.69032-0.8004-1.2501-1.0196-0.57091-0.21983-1.2404-0.10959-1.8315-0.24984-0.52002-0.12981-1.0603-0.20092-1.5607-0.39987-0.84038-0.32029-0.75034-0.42075-0.79014-1.1905-0.0202-0.54991-0.19053-1.2903 0.03-1.8095 0.0992-0.23092 1.2306-1.0202 1.2208-0.69081 0.0405-0.8004-0.2101-1.7606 0.42998-2.2407 0.7001-0.53034 1.331-0.10959 1.2612-1.3999 1.0309-0.06001 1.2097 0.12981 1.4909-0.85063 0.16051-0.57992 0.28056-0.97 0.65052-1.5003 0.28904-0.42075 0.67987-1.1011 1.1803-1.2609 0.54025-0.17026 1.4211 0.01957 1.9914 0 0.19052-1.1703-0.0802-1.8102 1.3415-1.8206 0.5807-0.01044 1.0002-0.06915 1.4902-0.25962 0.24011-0.09067 0.89062-0.3803 1.0205-0.57013 0.2101-0.36008-0.1605-1.06 0.0502-1.4403 0.21989-0.39074 0.89063-0.4899 1.1301-0.80105 0.18008-0.23027 0.36082-1.03 0.64007-1.1703 0.58005-0.28963 0.96045 0.42075 1.3904 0.65037-0.33994 1.6308 0.90041 1.8617 2.191 1.9309 0.60028 1.5003-0.03 3.3308 0.76013 4.822 0.14942 0.27006 0.50958 0.50033 0.61072 0.7293 0.15007 0.36987 0.0202 0.86042 0.06 1.2707 0.0698 0.85063 0.53046 1.2401 1.151 1.7704 0.20944 0.77105 0.85996 0.80105 0.85082 1.8206-0.0111 1.1011-0.69097 0.98044-1.0909 1.8311-0.10962 0.21983-0.13963 0.82976-0.0803 1.0907 0.14029 0.51012 0.0104 0.30007 0.66944 0.40966 0.78036 0.12981 1.3917 0.60014 2.1512 0.68037 0.0307 1.0405 1.1908 0.69994 1.4309 1.6504 0.2499 0.93935-0.48022 2.9707-1.0002 3.6706-0.85083 1.1507-0.63029 1.0705-0.33015 2.4208 0.32036 1.4808 2.0011 2.8011 3.2519 3.3301 0.53047 0.23092 1.1007 0.3803 1.7512 0.42075 0.76666 0.04175 1.1966-0.49838 1.8974-0.23875z",
+                Newtaipei:"m400.14 55.204c1.2012 4.4117-4.7722 2.1905-5.6935 4.7613-1.1901 0.06001-2.1904-0.84019-3.3909-0.36987-0.6316 0.25049-0.66161 0.85063-1.2319 1.1305-0.4202 0.21005-1.3911 0.18004-1.8511 0.23092-1.181 0.12916-2.4318 0.74039-3.2722 1.6497-0.49001 0.5199-0.7497 0.97001-1.5705 1.12-0.65051 0.12981-1.4211 0.1109-2.0801 0.15003-1.562 0.0698-2.7221-0.25962-3.8215 0.91064-0.91085 0.99023-1.6012 1.6308-1.1712 3.0711 1.0609-0.04044 2.3613 0.88064 2.1414 1.9407-0.15007 0.71038-1.6508 1.5401-2.2315 1.9107-0.46 0.30007-0.77122 0.76061-1.1405 1.0202-0.42085 0.30007-1.1705 0.23027-1.7004 0.23027-1.2612 0-2.4416 0.09981-3.6526 0.3503-0.47043 0.78018-0.0104 2.4906-1.4106 2.5004-0.31972 0.80105 0.28056 0.84084 0.38039 1.4208 0.11027 0.6308-0.46 0.74104-0.75035 1.3007-1.2906 0.39988-1.7408 1.3503-2.9009 2.0105-1.2012 0.69994-2.6008 0.21983-3.9416 0.48011-1.0113 0.20026-2.6614 1.15-3.312 1.9302-0.36082 0.42988-0.67988 1.06-1.1705 1.4305-0.4502 0.33986-1.2312 0.5199-1.6012 0.96935-0.4502 0.54991-0.29035 1.4103-0.33015 2.1005-1.4009 0.0698-2.7717 0.01044-4.1523 0.09067-1.2808 0.08024-3.0418 0.0098-4.0721 0.77039-0.49 0.36987-0.75034 0.88064-0.85082 1.4814-0.15007 0.96935 0.11027 1.1298-1.0002 1.1703-0.99046 0.03001-3.282 0.21983-3.3518 1.6497-0.0104 0.08024-0.0502 0.21983-0.0502 0.33986 1.2606 0.42988 0.38039 1.5701 0.0502 2.2603-0.44042 0.94-0.33015 1.8108 0 2.6908 0.76078 2.0007 0.73077 4.1912-1.9711 4.0712 0.0803 1.2505-0.28905 1.6602-1.5098 1.6602-0.94021-0.01-2.8924 0.14025-3.4327 0.9002-0.53046 0.72995-0.20944 2.0105-1.0707 2.5108-0.24011 0.15003-0.63029 0.13046-0.92064 0.23092-0.35038 0.12981-0.63029 0.40966-0.98066 0.54991-0.65052 0.26027-1.4707 0.06-2.1812 0.20026-0.69097 0.1409-1.1908 0.6308-1.7708 0.92043-0.73077 0.36987-1.1203 0.39074-2.0011 0.43053-0.1703 0.0104-0.36017 0.0202-0.57026 0.0202 0.01-0.92043 0.0398-1.8409-0.0104-2.7508-0.94022 0.11024-0.91086-0.74039-1.6312-1.1814-0.42084-0.24984-0.54024-0.33986-1.0205-0.4201-0.36016-0.0502-0.85017 0.11024-1.151-0.0998-0.64007-0.42989-0.21988-1.3301-0.54025-1.9602-0.26033-0.51011-0.72033-1.0307-1.0407-1.5206-0.75035-1.15-1.4511-2.1605-1.8615-3.501-0.17029-0.57013-0.21988-1.3197-0.33015-1.9198-0.20031-0.98044-0.14028-1.2009 0.60028-1.6412 1.0603-0.63014 1.3715-1.9302 2.7215-2.1201 0.31123-0.2805 0.29035-0.76061 0.2499-1.2205-2.3411 0.1409-0.99959-2.6504-1.7304-3.6811-0.39997-0.57013-1.3004-0.06001-1.6906-0.99023-1.1105 0.12003-1.6612-1.8709-2.2315-2.4514-0.68053-0.69016-2.7019-1.5806-3.5919-0.7306-0.44956 0.43053-0.30014 1.0711-1.1601 1.2505-0.81037 0.17091-1.331-0.58057-1.9209-0.91978-1.3108-0.74104-2.5009-0.59035-3.9918-0.68037-0.21988-1.0502 2.0612-1.3007 2.7319-1.3307 0.03-0.44097 0.0803-0.82976-0.21988-1.1814-0.2101-0.24984-0.91086-0.21983-1.0805-0.57992-0.43063-0.89042 1.6808-1.1403 1.3408-1.9909-0.24989-0.61058-1.1705 0.08024-1.6207-0.23092-0.36017-0.25962-0.38039-1.2303-0.33994-1.6602-0.12005 0-0.28056-0.04044-0.39018-0.03001-0.35038-0.30007-0.39083-1.0007-0.76078-1.2407-0.31123-0.20026-1.0205 0.01109-1.3415-0.24006-0.69031-0.53034 0.0405-1.4808-0.0104-2.4103-0.30992-0.01044-0.63029-0.01044-0.91085-0.0698 0.0202-0.14025 0.0411-0.90021 0.11092-0.93021 0.23946-0.09981 0.44956-0.23092 0.72033-0.27006 0.15007-0.3803 0.19052-1.1807 0.01-1.4906-0.30993-0.54012-0.72033-0.14025-1.0707-0.4899-0.42998-0.42988 0-1.1005 0.39997-1.2603 0.36016-0.15003 1.1007 0.01044 1.4909-0.01044 0.12005-0.77953-0.33994-1.2805-0.49001-1.9909-0.14093-0.71038-0.19052-1.5095-0.16051-2.2505 0.0104-0.33986-0.0802-1.0705 0.0992-1.3405 0.30014-0.4501 0.44107-0.21005 0.90041-0.33008 0.74121-0.18983 1.3115-0.30007 2.1016-0.1396 1.1301 0.23027 3.0118 0.57013 4.1523 0.14938 1.1301-0.43053 0.74056-2 2.4011-1.9407 0.19052-0.39987 0.77057-0.82976 1.1705-1 0.0398-0.54012 0.03-0.8702-0.30014-1.2603-0.18987-0.21983-0.72033-0.21005-0.84039-0.57013-0.32036-0.96087 1.3604-1.0307 1.9711-1.0007-0.03-0.92043-0.58984-1.0405-0.88019-1.7606-0.31058-0.74039-0.09-1.8004 0.12984-2.4599-0.0411-0.01044-0.09-0.02022-0.14028-0.03001-0.0405-0.2805-0.0998-0.55056-0.19052-0.81019-0.99111-0.24006-0.94022-0.55969-1.0002-1.5003-0.31123-0.0698-0.54025-0.2805-0.5807-0.58057-1.1712-0.12003-2.052-0.54991-3.2422-0.60014-0.76078-0.02022-1.6012-0.44032-2.071-0.93021-0.30992-0.32029-0.33015-0.63993-0.53046-0.98044-0.32036-0.53034-0.5011-0.44032-0.90041-0.75017-0.68053-0.51012-1.3611-0.90021-1.6808-1.6602-1.0303-0.02022-2.0912-0.05023-3.1417-0.11024-0.0692-0.20026-0.18008-0.24984-0.20031-0.47033-0.36995-0.29028-0.5807-0.67972-1.0714-0.8702-0.47957-0.19048-1.0002-0.0411-1.4407-0.36987-0.66031-0.5199-0.42933-1.9107-0.39932-2.8109 0.21989-0.01044 0.39018-0.02022 0.46065-0.05023 0.42933-0.15003 1.7512-0.15982 2.5505-0.33008 1.8817-0.39074 3.5729-0.15003 5.5128-0.24006 0.86061-0.0411 1.5007-0.17026 2.2419-0.76061 1.0198-0.81019 1.32-1.3705 2.7515-2.0007 0.0404-0.21983 0.90041-0.28963 1.0009-0.50033 1.9809-1.1011 6.8738-4.0509 2.7815-5.702 1.5307-0.33986 0.9102-1.3105 1.4609-2.3105 0.47043-0.86042 1.7512-1.6106 2.2112-2.3007 0.94022-1.4299 1.9509-3.2603 1.8413-5.4006 0-0.13046 2.4311-0.0698 2.6712-0.18004 1.2103-0.60014 1.0002-1.3601 1.7806-2.2603 1.3408-1.5604 3.402-2.561 4.5523-4.3112 1.2508 0.01109 4.703 0.96087 3.4816-1.4899 0.67009 0.33986 0.53046-0.05023 1.0205 0.66015 1.38 0.08024 3.8418 0.53034 4.6521-0.62036 0.80058 0.63014 1.0407 0.69016 2.0214 0.4501 0.12071 0.21983-0.0202 0.44032 0.0803 0.66928 1.2006 0.20092 1.7408 1.0202 2.7117 1.5401 1.2606 0.66994 0.59048 0.66015 2.251 0.74952 0.06 0.97 1.3708 1.6804 1.7003 2.5917 0.42085 1.1801 0.12985 2.8604 0.33994 4.1201 0.55917-0.12003 1.3604 0.20092 1.9202 0.08024-0.25903 2.2805 1.5712 2.6308 1.581 4.6713 0.96109 0.04044 1.962 0.04044 2.9224 0 0.69032-1.0007 2.071-0.93021 2.9916-1.9302 0.1703 2.2603-1.9613 3.1709-2.1616 4.9322 0.0502-0.4899 1.5105 0.7704 2.4716 1.6308-1.1399 0.53034-1.9307 1.0796-2.9505 1.7208-0.47043 0.29028-0.43063 1.2094-1.0505 1.4508-0.66944 0.25962-1.9907-0.01044-2.7215 0.03001-0.65052 1.8409-2.3913 1.4103-4.0023 1.501-0.12984 0.40966-0.12984 1.2603 0 1.6706 0.58071-0.14938 1.3708 0.0411 1.9209-0.17026 0.09 1.711-0.26034 6.0209 2.0005 6.002 0.03 0.27985-0.03 0.65037 0.0802 0.92043 0.42998-0.02022 1.0009 0.14938 1.4211 0.07958 0.42085 1.1403 1.4511 1.5708 2.5512 0.81019-0.21009 0.15982-0.43063 0.55056-0.7797 0.78018 0-0.01957 0.0796 0.55056 0.06 0.58057 1.4504-0.30007 2.5708 0.5199 2.5009 2.0007 2.0801 0.12003 3.5619 1.0405 5.5323 1.2205 0.47108 0.05023 1.0107 0.44945 1.6912 0.33008 0.60027-0.09981 0.48022-1.06 1.0414-1.2101 1.2697-0.34965 2.7515 0.58057 3.2121-1.0405 0.36017-1.2603-0.95065-2.1709-1.9711-2.3001 0.0998-1.8311-0.13963-3.1312-1.4504-4.2218 1.0498-0.24006 1.8406-1.1103 2.9009-1.2505 1.2012-0.16047 2.0605 0.78996 3.4712 0.47098-0.09-0.63993 0.33994-1.1103 0.33015-1.6713 0.3308 0.0698 0.84038-0.12003 1.1705-0.08024 0.0613-0.32029 0.39148-1.09 0.42149-1.4208v-0.03001c0.36017 0.01044 0.73012 0.01957 1.0805 0.03001-0.12136 0.55969 0.20031 1.3607 0.0796 1.9204 1.1099 0.07958 1.6612-0.84019 2.2504-0.92043 1.271-0.15982 1.8622 0.33008 2.7117 0.46054 1.4211 0.23027 4.7526-0.42075 5.043 1.2094 1.1405 0.18983 2.6216 0.39009 2.7515-0.92043 0.53046 0.06001 1.4811-0.28898 1.7108-0.28898-0.42084 0.74039-0.33015 1.5695-0.21009 2.4599 0.23097 0.0698 0.44042 0 0.67074 0.08024 0.36017 1.4299-2.5714 5.9316 0.2499 6.002 0.24011 1.1801 0.7908 1.7202 0.98067 2.9009 0.14028 0.85976-0.2101 2.4899-0.15007 3.5206 2.4115 1.5701 4.2535 0.91064 7.1739 1.0802 0.41106 1.1507 2.512 0.84084 3.6225 0.71038zm-48.785-0.84998c0.0104-0.32029 0.0104-0.65037 0-0.97066-0.69946-0.25962-1.1301 0.2805-1.9013 0.24006-0.65052-0.0411-1.2201-0.19048-1.7512-0.42075-1.2508-0.53034-2.9316-1.8506-3.2519-3.3301-0.30014-1.3503-0.52002-1.2701 0.33015-2.4208 0.52068-0.69994 1.2508-2.7313 1.0002-3.6706-0.24011-0.95044-1.4002-0.61123-1.4302-1.6504-0.76013-0.08024-1.3715-0.55056-2.1512-0.68037-0.66096-0.10959-0.53046 0.09981-0.67009-0.40966-0.06-0.26028-0.03-0.8702 0.0802-1.0907 0.40062-0.85063 1.0805-0.72995 1.0909-1.8311 0.01-1.0196-0.64008-1.0496-0.85083-1.8206-0.6205-0.53034-1.0805-0.91978-1.151-1.7704-0.0405-0.41031 0.0907-0.90021-0.06-1.2707-0.0998-0.23027-0.46064-0.45924-0.61071-0.7293-0.79015-1.4906-0.15986-3.3216-0.76013-4.822-1.2912-0.06915-2.5316-0.30007-2.191-1.9309-0.43063-0.23027-0.81037-0.93935-1.3904-0.65037-0.28056 0.14025-0.46065 0.94-0.64008 1.1703-0.23945 0.31116-0.91085 0.41031-1.1301 0.80105-0.2101 0.3803 0.15986 1.0802-0.0502 1.4403-0.12984 0.19048-0.78036 0.47946-1.0198 0.57013-0.49066 0.19048-0.91085 0.24984-1.4909 0.25962-1.4211 0.01044-1.151 0.65037-1.3415 1.8206-0.57027 0.01957-1.4511-0.17026-1.9914 0-0.50045 0.15982-0.89063 0.84019-1.1803 1.2609-0.36995 0.53034-0.49001 0.92043-0.65051 1.5003-0.28057 0.98044-0.46 0.78996-1.4909 0.85063 0.0692 1.2909-0.56047 0.8702-1.2606 1.3999-0.64008 0.47946-0.39084 1.4403-0.43064 2.2407 0.0104-0.33008-1.1203 0.46054-1.2208 0.69081-0.21989 0.5199-0.0502 1.2603-0.03 1.8095 0.0398 0.77039-0.0502 0.8702 0.79015 1.1905 0.50044 0.20026 1.0407 0.27006 1.5607 0.39988 0.59049 0.14025 1.2612 0.03001 1.8315 0.24984 0.55982 0.21983 0.84038 0.62036 1.2508 1.0196 0.85017 0.83041 1.5809 1.7606 1.5809 2.9811 0 1.1807-0.0202 3.0411-0.61137 3.9818-0.5807 0.96022-2.7515 0.96022-2.8115 2.0209-0.0202 0.41031 0.50044 1.1507 0.59048 1.5904 0.14029 0.7306 0.0992 1.0411 0.55983 1.681 0.57026 0.78996 0.75034 0.63993 1.3604-0.0998 0.44042-0.53034 0.67009-1.1905 1.4909-1.2505 0.76078-0.06067 0.92064 0.39922 1.3604 0.90021 0.43063 0.4899 0.9611 0.69016 1.4009 1.1703 1.0498 1.15-0.75034 2.1396-0.74121 3.3412 0.45021-0.36074 1.1908-1.501 1.9118-0.83041 0.2101 0.20026 0.0692 0.66015 0.47043 0.94 0.30014 0.2094 0.79015 0.25962 1.1705 0.2394-0.0803 0.89042 0.80124 1.8904 1.2704 2.5708 0.30013 0.4501 0.61071 0.86042 1.1608 0.92043 0.7001 0.08024 1.0707-0.43967 1.7408-0.57013 0.13963 0.82062 0.90041 0.4899 1.5098 0.59035 0.54025 0.08024 1.1705 0.54012 1.761 0.31964 0.64008-0.25897 0.58071-0.61971 1.4106-0.66928 0.68053-0.04044 1.4106 0.14938 1.151-0.81997-0.36017-0.12068-1.6012-0.32029-1.6606-0.66994-2.1212 0.25962-1.0198-3.5512-1.0909-4.8318-0.45021-0.14025-1.1705-0.3503-0.82016-1.0196 0.1605-0.31116 0.43063-0.09067 0.58983-0.26028 0.17095-0.18983 0.0803-0.4899 0.28057-0.63014 0.81037-0.57013 2.2412 0.02022 3.141-0.17026 0.57026-0.12068 0.85996-0.41031 1.4909-0.44097 0.57027-0.01957 1.0309 0.24006 1.5307 0.09067 0.14093-0.0411 0.36081-0.33008 0.56047-0.39988 0.2499-0.08024 0.57026-0.01044 0.82995-0.02022 0.53372-0.03066 1.0537-0.12068 1.5744-0.10046z",
+                Taoyuan:"m324.59 106.65c0.0502 0.91065 0.0202 1.8304 0.0104 2.7508-1.2208 0.0691-2.8918 0.21005-3.5619 0.95044-0.24011 0.25962-0.59048 0.69994-0.71054 1.0307-0.26034 0.78018 0.15007 0.57991 0.45999 1.2394 0.29035 0.60079-0.06 1.8311-0.27991 2.5004-1.1105 0.81019-2.1616 1.2609-2.5714 2.681-0.2101 0.71038-0.19053 1.4103-0.65052 2.0105-0.55069 0.71038-1.0009 0.47033-1.7114 0.72017-0.8704 0.3105-1.3806 1.561-1.3708 2.621-0.78035 0.0998-1.9418 0.33008-2.6719 0.0502-0.58984-0.21983-1.0798-0.98044-1.8406-0.99088-0.84039-0.50033-0.72033-1.7508-1.5809-2.2505-0.0405-0.72017 1.1209-4.291-0.33994-4.002 0.0411-0.92043-0.30014-0.97979-0.76013-1.5904-0.39997-0.5199-0.28057-0.96087-0.2499-1.5708 0.03-0.43967 0.16964-1.5701-0.15007-1.8506-0.2897-0.25963-1.5307-0.06-1.9202-0.0802-0.18008-0.67972-0.0202-1.4403-0.18008-2.1507-0.13963-0.63014-0.67988-0.93021-1.0198-1.3901-0.51023-0.69081-0.36995-1.0502-1.3115-1.1905-0.72033-0.11025-1.8308-0.0802-2.2706 0.39987-0.12984 0.03-0.2499 0-0.38039 0-0.67009-1.8409 1.1301-3.0111 0.72033-4.8115-0.12005 0-0.27991-0.0411-0.39018-0.0202-0.12984-0.09-0.03-0.12068-0.2499-0.17026-0.17029-0.52055-0.33993-1.3412-0.18008-1.9009 0.15007-0.57013 0.70011-0.84019 0.82995-1.501 0.28056-1.4208-0.6205-2.79-1.9209-3.0907-0.80059-0.18004-0.93043-0.28963-1.581-0.74104-0.23097-0.15917-0.55068-0.28898-0.85082-0.4899-0.19052-0.12003-0.39997-0.44032-0.5011-0.50033-0.63943-0.39009-1.181-0.08024-1.6312-0.67972-0.36016-0.48011-0.39931-1.2303-0.3693-1.8206-0.50109-0.08024-1.5105-0.24006-1.9013-0.51012-0.60028-0.4201-0.26034-1.3803-1.1705-1.3405-0.57026 0.03001-1.1908 0.8702-1.8315 0.75017-0.77057-0.15004-0.47957-1.1514-0.50958-1.8206-0.52068 0.01957-1.0309-0.16047-1.5614-0.08024 0.03 0.2094-0.11027 0.36922-0.11027 0.54991-1.2097 0.24006-1.8511-1.0007-2.8918-1.3307-0.15007-0.69081-0.47109-1.3901-1.331-1.2505 0.12006-0.86042-1.0414-0.81997-1.5907-1.0104-0.33015-0.12068-0.79015-0.32029-1.0805-0.5199-0.25968-0.18004-0.5807-0.75996-0.7797-0.85976-0.24011-0.12003-0.42085-0.21983-0.72033-0.19048-0.15986-0.72016 0.29035-0.7306 0.66095-1.1403 0.42933-0.48011 0.49001-0.66015 0.47957-1.3307-0.01-0.3803-0.0196-1.1605-0.16964-1.5003-0.11027-0.24984-0.38039-0.08024-0.48022-0.44032-0.0692-0.21983 0.21009-0.44097 0.17095-0.58057-0.20097-0.66015-1.7108-1.0007-2.422-1.0007-0.74969 0-2.0005 0.23092-2.7012-0.0098-0.0104-0.01044-1.3611-0.98044-1.4609-0.65037 0.17094-0.54012 0.1207-1.2003 0.23097-1.7404-0.72033-0.04044-1.3806 0.0411-2.071 0.0698-0.82081 0.03001-1.1608-0.23092-1.8315-0.5199-1.121-0.48011-3.3309-0.3503-3.5919-1.5708-0.2499-1.1703 0.54025-3.2505-0.27012-4.1423-0.27991-0.30007-1.2508-0.95044-1.6606-1.1703-0.52002-0.27985-1.3806-0.39922-1.9907-0.27006-0.73077 0.16047-1.2103 0.53034-2.0814 0.39987-0.61985-0.09981-1.1803-0.55904-1.81-0.3803-0.61137 0.17026-0.8306 0.76061-1.4407 0.90021-0.39083 0.09067-1.0805 0.09067-1.5614-0.03979 0.45999-0.30007 0.92064-0.60014 1.2704-0.99088 0.60028-0.66015 1.9307-2.561 2.2308-3.4514 0.47043-1.3901-0.39018-4.4208 1.271-4.7313 0.49-2.7411 2.2608-4.6909 4.6326-6.002 2.1714-1.2003 5.133-1.0104 5.9532-3.6706 0.66096-0.04958 0.82016-0.44945 1.4217-0.58057 0.0692-4.3014 8.9037-0.39009 9.8347-3.9211 2.512-0.54012 4.6221-2.5708 6.9534-3.6113 3.0118-1.3405 4.6025-0.98044 7.5145-1.9302 0.35038-0.10959 1.3806-0.0998 1.9914-0.12003-0.03 0.90021-0.25968 2.291 0.39931 2.8109 0.44108 0.33008 0.9611 0.18004 1.4407 0.36987 0.49 0.19048 0.7001 0.57992 1.0714 0.8702 0.0202 0.21983 0.12984 0.27006 0.20031 0.47032 1.0505 0.06001 2.1114 0.09002 3.1417 0.11024 0.32036 0.75996 1.0009 1.15 1.6808 1.6602 0.39996 0.30985 0.5807 0.21983 0.90041 0.75017 0.20031 0.33986 0.21988 0.66015 0.53046 0.98044 0.47044 0.4899 1.3108 0.91064 2.071 0.93021 1.1908 0.05023 2.0716 0.48011 3.2421 0.60014 0.0405 0.30007 0.27013 0.51012 0.5807 0.57992 0.06 0.94065 0.01 1.2609 1.0002 1.501 0.09 0.25962 0.14941 0.53034 0.19052 0.80953 0.0502 0.01044 0.0992 0.02022 0.14028 0.03001-0.21988 0.6608-0.44042 1.7215-0.12984 2.4606 0.2897 0.72017 0.85017 0.84019 0.88084 1.7606-0.61137-0.03001-2.2921 0.04044-1.9711 1.0007 0.12006 0.36008 0.65052 0.34965 0.84039 0.57013 0.33015 0.39009 0.33994 0.72017 0.30014 1.2603-0.40062 0.17026-0.98067 0.60014-1.1705 1-1.6605-0.06067-1.2704 1.5095-2.4011 1.9407-1.1405 0.42075-3.0223 0.08024-4.1523-0.14938-0.79015-0.16047-1.3604-0.05023-2.101 0.1396-0.46064 0.12003-0.60092-0.12068-0.90106 0.33008-0.17943 0.27006-0.09 1-0.0992 1.3405-0.03 0.74039 0.0196 1.5401 0.16051 2.2505 0.14942 0.71038 0.61072 1.2094 0.49001 1.9909-0.39083 0.02022-1.1307-0.14025-1.4909 0.01044-0.39997 0.15982-0.82995 0.82976-0.39997 1.2603 0.35038 0.3503 0.76078-0.05023 1.0707 0.4899 0.18008 0.31051 0.14093 1.1103-0.01 1.4906-0.27012 0.03979-0.48022 0.1696-0.72033 0.27006-0.0698 0.03001-0.0907 0.78996-0.11027 0.93021 0.28057 0.06001 0.60028 0.06001 0.91086 0.0698 0.0502 0.93021-0.67988 1.8806 0.0104 2.4103 0.32036 0.24984 1.0302 0.04044 1.3415 0.24006 0.3693 0.24006 0.41041 0.94 0.76078 1.2407 0.10962-0.01109 0.27013 0.03001 0.39018 0.03001-0.0404 0.42988-0.0202 1.3999 0.33994 1.6602 0.44956 0.31051 1.3708-0.3803 1.6201 0.23027 0.33994 0.85128-1.7708 1.1011-1.3408 1.9915 0.1703 0.36008 0.8704 0.33008 1.0805 0.57992 0.30013 0.3503 0.25055 0.74039 0.21988 1.1807-0.67009 0.03001-2.9511 0.28115-2.7319 1.3307 1.4909 0.09067 2.681-0.06001 3.9918 0.68037 0.59049 0.33986 1.1105 1.09 1.9209 0.92043 0.85996-0.17939 0.71054-0.81997 1.1601-1.2505 0.89062-0.84998 2.912 0.0411 3.5925 0.7306 0.56961 0.57992 1.1203 2.5708 2.2308 2.4508 0.39018 0.93021 1.2906 0.42075 1.6906 0.99088 0.73077 1.0307-0.61072 3.8207 1.7304 3.6811 0.0411 0.46054 0.0607 0.94-0.2499 1.2205-1.35 0.18983-1.6605 1.4906-2.7215 2.1201-0.74056 0.44032-0.80059 0.66015-0.60028 1.6406 0.10962 0.60014 0.15986 1.3503 0.33015 1.9204 0.41041 1.3405 1.1105 2.351 1.8615 3.501 0.31971 0.4899 0.7797 1.0104 1.0407 1.5206 0.32037 0.63014-0.0998 1.5304 0.54025 1.9602 0.30014 0.21005 0.79015 0.0502 1.151 0.0998 0.48022 0.0802 0.60028 0.17025 1.0205 0.42009 0.71577 0.44684 0.6851 1.2975 1.626 1.1872z",
+                Keelung:"m354.05 44.801c-1.1007 0.76061-2.131 0.33008-2.5505-0.81019-0.42085 0.0698-0.99176-0.09915-1.4217-0.08024-0.10962-0.26941-0.0502-0.63928-0.0803-0.91978-2.2615 0.01892-1.9111-4.2916-2.0005-6.002-0.55069 0.2094-1.3415 0.01957-1.9209 0.17026-0.12984-0.40966-0.12984-1.2603 0-1.6706 1.611-0.09067 3.3518 0.33986 4.0023-1.501 0.73077-0.04044 2.052 0.23092 2.7215-0.03001 0.6205-0.24006 0.58135-1.1598 1.0505-1.4508 1.0205-0.63993 1.8106-1.1905 2.9511-1.7208 0.46064 0.42988 0.80972 0.76061 0.82016 0.77039 1.4811 1.0502 2.6621 1.0705 4.6326 1.1801 0.4502 1.8617-0.28057 2.7906-0.14942 4.4423 0.68053-0.86042 1.7004-1.4005 1.7304-2.6908 2.4611-1.3203 4.0525 1.6706 6.6742 0.7306-0.11027 0.4899 0.17878 1.2003 0.0796 1.6902 0.52068 0.02022 1.0498 0.03001 1.5907 0.05023v0.03001c-0.03 0.33008-0.36016 1.1005-0.42084 1.4208-0.33015-0.04044-0.84039 0.15004-1.1705 0.08024 0.0104 0.56035-0.42084 1.0307-0.33015 1.6706-1.4106 0.32029-2.2706-0.63014-3.4718-0.47032-1.0603 0.14025-1.8511 1.0104-2.9009 1.2505 1.3108 1.0907 1.5503 2.3908 1.4511 4.2212 1.0198 0.13046 2.3306 1.0411 1.9711 2.3007-0.46064 1.6204-1.9418 0.69016-3.2121 1.0405-0.55982 0.15003-0.44042 1.1103-1.0407 1.2101-0.68053 0.12003-1.2208-0.2805-1.6912-0.33008-1.9711-0.18004-3.4516-1.1011-5.5323-1.2205 0.0698-1.4814-1.0505-2.3007-2.5009-2.0007 0.0196-0.03001-0.06-0.60014-0.06-0.58057 0.34907-0.23027 0.56896-0.62036 0.77971-0.78018z",
+                Kinmen:"m41.675 107.89c-0.0762 4e-3 -0.14595 0.0243-0.18718 0.0468-0.0375 0.0225-0.0711 0.0402-0.0936 0.0702l-0.0468 0.0936c-0.05235 0.16473-0.0159 0.38094-0.0234 0.53817-0.77124 0.0375-1.3965-0.23867-2.1526-0.16379-0.17222 0.015-0.27516 0.0412-0.32758 0.0936-0.015 8e-3 -9e-3 9e-3 -0.0234 0.0234-0.09735 0.11235-0.102 0.2967-0.30418 0.49137-0.21714 0.20217-0.453 0.4034-0.46797 0.72537-0.0075 0.41931 0.2527 0.74409 0.1404 1.1933-0.09735 0.34443-0.40246 0.4268-0.51478 0.74877-0.08985 0.2471 0.015 0.66641 0 0.93596-0.0225 0.3669-0.1095 0.46984-0.49137 0.51477-0.15724 0.0225-0.32666 0.0524-0.49138 0-0.09735-0.0225-0.24522-0.1563-0.32757-0.16379-0.75626-0.0973-0.35661 1.154-0.3042 1.521 0.045 0.34443-0.0135 0.56532-0.1404 0.84236-0.1422 0.32946-0.03375 0.42867-0.0936 0.79557-0.045-7e-3 -0.0795 0-0.117 0-0.03 0.10485-0.1011 0.16098-0.0936 0.28078-0.38936 0.0748-0.53722-0.27891-0.88916-0.23398-0.0225 0.11235 0.07485 0.23959 0.1872 0.37438 0.03 0.0375 0.072 0.0795 0.117 0.117 0.15723 0.1497 0.32384 0.27611 0.42117 0.35097 0.0375 0.0225 0.087 0.0552 0.117 0.0702 0.1422 0.0599 0.26301 0.0468 0.39778 0.0468 0.09735 8e-3 0.20778 0.0328 0.32758 0.0702 0.11235 0.0375 0.21434 0.10485 0.30418 0.1872 0.05235 0.0375 0.1029 0.0954 0.1404 0.1404 0.0375 0.0448 0.0795 0.0954 0.117 0.1404l0.0702 0.0468 0.0468 0.0702c0.1797 0.1797 0.39498 0.30699 0.70197 0.18719 0.35192-0.1347 0.1161-0.47265 0.28078-0.77216 0.22462-0.41182 0.906-0.78433 1.3103-0.88917 0.21789-0.0598 0.66546-0.25176 0.91256-0.117 0.23211 0.1497 0.1104 0.43898 0.1404 0.67857 0.0075 0.0748 0.0411 0.1347 0.0936 0.1872 0.015-0.0225 0.0243-0.0318 0.0468-0.0468 0.1497-0.1497 0.41368-0.27705 0.60837-0.37438 0.25458-0.1347 0.5026-0.33975 0.77217-0.44459 0.07485-0.26206-0.10395-0.43615-0.35098-0.42117-0.11235-0.45675-0.0468-0.63364 0.32758-0.86577 0.31448-0.20965 0.58497-0.3697 0.95936-0.44457 0.36688-0.0823 0.69354-0.0795 1.0529 0.0702 0.2995 0.11985 0.55222 0.34349 0.88916 0.35099 0.1497-0.20966 0.0486-0.47079 0.0936-0.72537 0.015-0.12735-0.04215-0.20685 0.0702-0.30419 0.09735-0.0898 0.25272 0.0206 0.32758-0.0468 0.26208-0.20965 0.045-0.94999 0.1872-1.2869 0.0225-0.0448 0.0243-0.072 0.0468-0.117 0.0375-0.0899 0.0795-0.19842 0.117-0.28078 0.0225-0.0448 0.0477-0.0795 0.0702-0.117 0.03-0.0523 0.072-0.0795 0.117-0.117 0.11985-0.11235 0.24615-0.19374 0.35098-0.35099 0.22462-0.37438 0.0543-1.0389 0.0468-1.4507-0.2471-0.0225-0.57 0.0263-0.77217-0.0936-0.05235-0.03-0.1188-0.072-0.16378-0.117-0.03-0.03-0.0636-0.0561-0.0936-0.0936-0.05985-0.0748-0.09645-0.1591-0.1638-0.23398-0.03-0.0375-0.0795-0.0795-0.117-0.117-0.4268-0.3594-0.98836-0.45674-1.3103-0.93596-0.0225-0.0375-0.0243-0.0881-0.0468-0.1404-0.0225-0.0524-0.0636-0.10395-0.0936-0.16378-0.0375-0.0824-0.0645-0.18158-0.117-0.23399-0.0225-0.0225-0.0477-0.0318-0.0702-0.0468-0.18718-0.11235-0.59433-0.0468-0.81896-0.0468-0.15162 0-0.47348-0.0594-0.70197-0.0468zm32.666-14.206c-0.71882-0.05985 0.19842 0.96028 0.28078 1.1699v0.0234c0.03 0.07485 0.0468 0.17596 0.0468 0.28078 0 0.21714-0.0468 0.45114-0.0468 0.60837 0 0.3669 0.0402 0.51946-0.30418 0.63177-0.20217 0.06735-0.3332 0.08805-0.46798 0.1404-0.05235 0.0225-0.10395 0.0327-0.16378 0.0702-0.03 0.015-0.0561 0.0477-0.0936 0.0702-0.10485 0.06735-0.21526 0.13575-0.32758 0.2106-0.11235 0.08235-0.22276 0.15818-0.32758 0.21058-0.1422 0.06735-0.29482 0.0702-0.44458 0.0702-0.05235 0.0075-0.11145 0-0.16378 0-0.06735 0-0.14325 9e-3 -0.21058 0.0234-0.0375 0.0075-0.0795 9e-3 -0.117 0.0234-0.25458 0.07485-0.44085 0.21058-0.72537 0.21058-0.07485 0.12735-0.1338 0.30513-0.1638 0.51478-0.04485 0.45675 0.06645 1.0408 0.35098 1.3103 0.0375 0.0375 0.072 0.0711 0.117 0.0936 0.0075 0.0075 0.0159 0 0.0234 0 0.04485 0.015 0.0954 0.0393 0.1404 0.0468v-0.117c0-0.015-0.0075-0.0318 0-0.0468v-0.0234c-0.0075-0.0075 0.0075-0.0159 0.0234-0.0234-0.0075-0.0075-0.0075-0.0159 0-0.0234-0.0075-0.0225-0.01515-0.0318 0-0.0468-0.0075-0.03 9e-3 -0.0711 0.0234-0.0936 0.0075-0.03-0.0075-0.0402 0-0.0702 0-0.015 0.01605-0.0234 0.0234-0.0234v-0.0468c0.0225-0.07485 0.04035-0.14325 0.0702-0.2106 0.0225-0.06735 0.0477-0.12735 0.0702-0.18718 0.015-0.0225 0.0159-0.0711 0.0234-0.0936 0.08235-0.0075 0.19281-0.0075 0.32758 0 0.05985 0 0.13575-0.0075 0.2106 0 0.0375 0 0.072 0.0234 0.117 0.0234 0.0225 0 0.0318-0.0075 0.0468 0 0.0375 0 0.0795-0.0075 0.117 0 0.08985 0.0075 0.19936 0.0318 0.30418 0.0468l0.0936 0.0234h0.0234c0.05985 0.0075 0.10395 9e-3 0.16378 0.0234 0.05985 0.015 0.1347 0.0318 0.18718 0.0468 0.05235 0.0225 0.08805 0.0552 0.1404 0.0702 0.04485 0.015 0.1029 0.0402 0.1404 0.0702 0.05985 0.0225 0.0954 0.0561 0.1404 0.0936 0.045 0.03 0.0945 0.07215 0.117 0.117 0.045 0.06735 0.0777 0.12825 0.0702 0.21058v0.0234c-0.0075 0-0.0318-0.0159-0.0468-0.0234h-0.0231c-0.18718-0.015-0.42117 0.0216-0.60837-0.0234-0.22462-0.04485-0.33694-0.19467-0.56157-0.18718h-0.0702c-0.0375 0-0.0795 0.0159-0.117 0.0234-0.015 0.0075-0.0318 0.0234-0.0468 0.0234-0.0375 0.015-0.0636 0.0243-0.0936 0.0468-0.06735 0.05985-0.09735 0.1535 0 0.28078 0.0075 0.015 0.0318 9e-3 0.0468 0.0234 0.08235 0.05985 0.19188 0.0543 0.30418 0.0468 0.10485 0 0.21246 0.0135 0.25738 0.1404 0.0225 0 0.0477 0.01575 0.0702 0.0234 0.0225-0.0075 0.0318-0.0075 0.0468 0 0.10485 0.31448 0.12825 0.45861 0.0234 0.79556l-0.0234 0.0936c-0.03 0.0973-0.04965 0.18345-0.117 0.28079-0.05985 0.0823-0.18999 0.12075-0.25738 0.2106l-0.0468 0.0468c-0.0075 0.015 0 0.0243 0 0.0468-0.0075 0.0448-0.0075 0.0881 0 0.1404 0.04485 0.16473 0.19094 0.32571 0.28078 0.46797 0.11235 0.17221 0.19188 0.46705 0.30418 0.63177l0.0468 0.0468c-0.03-7e-3 -0.0402-0.0159-0.0702-0.0234-0.0375-8e-3 -0.087-9e-3 -0.117-0.0234-0.05985-0.0225-0.11145-0.0561-0.16378-0.0936-0.0375-0.015-0.0636-0.0243-0.0936-0.0468-0.35193-0.25458-0.44178-0.67482-0.56158-1.1465-0.22462-0.0974-0.14595-0.27237-0.28078-0.44459l-0.0702-0.0702-0.0234-0.0468c-0.0375-0.03-0.1029-0.0477-0.1404-0.0702-0.08235-0.0375-0.17595-0.0636-0.28078-0.0936-0.1422-0.0375-0.263-0.0486-0.39778-0.0936-0.04485-0.015-0.08805-0.0243-0.1404-0.0468 0 0-0.0234-0.0157-0.0234-0.0234-0.0225-0.015-0.0477-0.0168-0.0702-0.0468-0.015-0.0075-9e-3 -0.0318-0.0234-0.0468-0.0225-0.03-0.0477-0.04785-0.0702-0.0702-0.015-0.015-0.0318-0.0393-0.0468-0.0468-0.07485-0.04485-0.1769-0.04305-0.30418 0.0468-0.21039 0.1422-0.22725 0.48951-0.0468 0.63177 0.1497 0.11235 0.26114 0.0561 0.35098 0.0936l0.0468 0.0234c0.03 0.03 0.0561 0.058 0.0936 0.1404 0.1422 0.26957 0.2705 0.74034 0.2106 1.0998-0.015 0.0749-0.0477 0.12735-0.0702 0.18718-0.15724 0.015-0.30232 0.0402-0.44458 0.0702-0.1497 0.03-0.29482 0.0795-0.44458 0.117-0.08985 0.03-0.17595 0.0478-0.28078 0.0702-0.05235 8e-3 -0.1029 0.0318-0.1404 0.0468s-0.0636 0.0243-0.0936 0.0468c-0.0375 0.0225-0.0711 0.0402-0.0936 0.0702-0.015 0.0225-0.0318 0.0636-0.0468 0.0936-0.015 0.0448-0.0234 0.10395-0.0234 0.1638-0.0075 0.0748-7.5e-4 0.15255-0.0234 0.25739-0.0075 0.0449-0.0243 0.10395-0.0468 0.16378-0.07485 0-0.16004 8e-3 -0.25738 0h-0.1404c-0.0225 0-0.0552-7e-3 -0.0702 0-0.10485 8e-3 -0.18999 0.0252-0.25738 0.0702-0.03 0.015-0.0552 0.0402-0.0702 0.0702-0.1872 0.29951 0.1011 0.6168 0.28078 0.81897 0.0225 0.015 0.0552 0.0318 0.0702 0.0468 0.37438 0.4268 0.41182 0.96872 0.37438 1.5678-0.0075 0.0973-0.0075 0.18251-0.0234 0.25739-0.0075 0.0748-0.0243 0.14325-0.0468 0.21058-0.045 0.11985-0.11415 0.24803-0.23398 0.39779-0.0375 0.045-0.0795 0.087-0.117 0.117-0.03 0.0375-0.0636 0.0478-0.0936 0.0702-0.03 0.0225-0.0402 0.0552-0.0702 0.0702s-0.07965 0.0159-0.117 0.0234c-0.08235 0.0225-0.20124 0.0234-0.35098 0.0234-0.31448 1e-5 -0.66734-5e-3 -0.95936 0.0702-0.2995 0.0748-0.44739 0.22557-0.70197 0.39778-0.27704 0.19467-0.3126 0.25646-0.70197 0.23399-0.21714-0.32946-0.52881-0.25083-0.86576-0.28079-0.40432-0.03-0.4998-0.33132-0.88916-0.42118-0.08985-0.0225-0.18345-0.0393-0.28078-0.0468-0.23961-0.015-0.49324-1e-3 -0.72537-0.0468-0.61398-0.10485-1.0988-0.2499-1.638-0.63177-0.89103-0.62897-1.5668-1.5612-2.4802-2.1526-0.48669-0.32198-0.94156-0.32384-1.2635-0.79556-0.26206-0.41182-0.46518-0.85921-0.77216-1.2635-0.29952-0.40434-0.69356-0.92566-1.053-1.2402-0.55408-0.47172-0.87138-0.13755-1.0062 0.49138-0.614 0.03-1.1194-0.1236-1.5912 0.28079-0.44176 0.37438-0.8199 0.74782-1.4039 0.91255-0.89852 0.23961-1.856 1.7043-1.4741 2.7376 0.19468 0.48669 0.6065 0.32945 0.93596 0.56157 0.1347 0.0898 0.18532 0.19842 0.32758 0.28079 0.0225 8e-3 0.0477 0.0393 0.0702 0.0468 0.045 0.0225 0.0954 0.0318 0.1404 0.0468 0.045 0.0225 0.08805 0.0318 0.1404 0.0468 0.11235 0.03 0.22276 0.0542 0.32758 0.0468 0.0375-0.20217 6e-3 -0.3566-0.0702-0.49139-0.05235-0.10485-0.1422-0.20778-0.18718-0.32758-0.0075-0.0225-0.0159-0.0402-0.0234-0.0702l-0.0468-0.0936c-0.10485-0.19467-0.27237-0.47358-0.25738-0.60837 0.24708-0.0449 0.44644 0.0786 0.67856 0.0936 0.25458 0.03 0.36783-0.1329 0.58498-0.1404 0.38936-0.015 0.88728 0.73095 0.84236-0.0702h0.21058c0.22464 7e-3 0.44178 0.015 0.56158-0.18719 0.10485-0.1797-0.11235-0.57936 0.18718-0.63177 0.32198-0.0524 0.23025 0.44364 0.32758 0.60837 0.07485 0.11985 0.61866 0.4764 0.117 0.49137-0.18718 0.29202-0.25738 0.30606-0.25738 0.72537 0 0.41183 0.08985 0.68138-0.37438 0.74877h-0.0702c-0.12735 0.0225-0.32384 0.03-0.42118 0-0.1422-0.0524-0.27048-0.32853-0.39777-0.35098-0.1422-0.0225-0.21996 0.0272-0.2574 0.117-0.0075 0.015-0.0234 0.0243-0.0234 0.0468-0.0075 0.015-0.0234 0.0477-0.0234 0.0702-0.0225 0.1347-0.0168 0.28546-0.0468 0.39778-0.25458 0.015-0.51758 8e-3 -0.77216 0.0234-0.015 0.20966 0.16566 0.14505 0.21058 0.25739 0.015 0.03 0.0234 0.0636 0.0234 0.0936 0.0075 0.0225 0.0234 0.0477 0.0234 0.0702 0.0075 0.0523 0.0075 0.10395 0 0.16378v0.117c0 8e-3 0.0075 0.0159 0 0.0234 0.0075 0.0375-0.01575 0.0636-0.0234 0.0936-0.0225 0.23961-0.0711 0.45395-0.0936 0.67857-0.0375 0.5466 0.39966 1.0314 0.63177 1.4507 0.21714 0.39684 0.34443 0.58029 0.37438 1.0296 0.03 0.32196 0.117 0.58309 0.117 0.91255 0 0.26955 0.0162 0.54098 0.0234 0.79556 0.0075 0.35941 0.0234 0.69261 0.0234 1.0296 0 0.20966 0.0972 0.76374 0 0.93596-0.11235 0.19468-0.55408 0.26767-0.74877 0.32758-0.08235 0.0225-0.18344 0.0477-0.28078 0.0702-0.06735 0.015-0.11985 9e-3 -0.18718 0.0234-0.09735 0.0225-0.21434 0.0402-0.30418 0.0702-0.12735 0.0448-0.24522 0.11235-0.32758 0.18719-0.11235 0.11235-0.16098 0.27517-0.0936 0.51478 0.05985 0.23211 0.25458 0.47172 0.18718 0.74876 0 0.015 0.0075 0.0159 0 0.0234 0 0.03-0.0075 0.0477-0.0234 0.0702-0.0225 0.0448-0.07215 0.0954-0.117 0.1404-0.03 0.0225-0.0636 0.0552-0.0936 0.0702-0.0375 0.0225-0.072 0.0477-0.117 0.0702-0.06735 0.0448-0.12735 0.0795-0.18718 0.117-0.03 0.0225-0.0711 0.0477-0.0936 0.0702-0.29202 0.23212-0.33507 0.23961-0.70197 0.1872-0.08235-7e-3 -0.26206-9e-3 -0.37438-0.0234-0.0225 0-0.0318 7e-3 -0.0468 0-0.015-2e-5 -0.0318-0.0157-0.0468-0.0234-0.03-0.015-0.0552-0.0168-0.0702-0.0468-0.0075 7e-3 0-0.0157 0-0.0234-0.05985-0.0599-0.06555-0.11985-0.1404-0.1872-0.20216-0.18719-0.36128-0.27891-0.60837-0.23399-0.04485 8e-3 -0.08805 0.0318-0.1404 0.0468-0.0375 0.0973-0.09645 0.18158-0.16378 0.23399-0.0225 0.0225-0.0402 0.0318-0.0702 0.0468-0.12735 0.0898-0.28827 0.0918-0.46798 0.0468-0.08235-0.015-0.17502-0.0243-0.25738-0.0468-0.0225 0-0.0318-0.0162-0.0468-0.0234-0.08235-0.0225-0.17502-0.0552-0.25738-0.0702h-0.0234c-0.1422-0.0225-0.2939-0.0135-0.42118 0.0234-0.0375 0.015-0.0561 0.0318-0.0936 0.0468-0.0375 0.0225-0.0636 0.0168-0.0936 0.0468-0.04485 0.0375-0.1029 0.0879-0.1404 0.1404-0.15723 0.21715-0.14505 0.33882-0.0702 0.42118 0.05235 0.0524 0.14415 0.1029 0.234 0.1404 0.08985 0.03 0.19094 0.0561 0.28078 0.0936 0.24708 0.11235 0.59994 0.50636 0.77216 0.67857 0.0375 0.015 0.0795 0.0168 0.117 0.0468 0.045 0.03 0.0954 0.072 0.1404 0.117 0.26956 0.23961 0.5438 0.68699 0.67857 0.88916 0.05235 0.0748 0.0636 0.10395 0.0936 0.1638 0.015 0.015 0.0318 0.0402 0.0468 0.0702 0.0225 0.0599 9e-3 0.22836 0.0468 0.28078 0.03 0.03 0.0486 0.0627 0.0936 0.0702 0.04485 0.015 0.11145 0.0159 0.1638 0.0234h0.0234c0.04485 8e-3 0.0954 9e-3 0.1404 0.0234 0.03 7e-3 0.0477 0.0159 0.0702 0.0234 0.0225 7e-3 0.0318 0.0318 0.0468 0.0468 0.10485 0.0973 0.17408 0.23211 0.23398 0.37437 0.0375 0.0898 0.0636 0.20685 0.0936 0.3042 0.045 0.1422 0.08895 0.27704 0.16378 0.37437 0.05985 0.0824 0.16848 0.13485 0.28078 0.1872 0.11985 0.0448 0.23212 0.087 0.37438 0.117 0.13485 0.03 0.28641 0.0552 0.42118 0.0702 0.12735 0.015 0.26114 0.0318 0.35098 0.0468 0.03 0.12735 0.09735 0.23772 0.18718 0.32759 0.07485 8e-3 0.12735 0 0.1872 0 0.06735 0 0.1422 9e-3 0.18718 0.0234 0.0375 8e-3 0.0636-6e-3 0.0936 0.0234 0.05235 0.0375 0.0954 0.10485 0.1404 0.18718 0.0225 0.0448 0.0477 0.088 0.0702 0.1404 0.045 0.10485 0.0795 0.22277 0.117 0.32759 0.015 0.0524 0.0477 0.0954 0.0702 0.1404 0.05235 7e-3 0.087 0.0486 0.117 0.0936 0.09735 0.11985 0.16098 0.34723 0.28078 0.44458 0.25458 0.2396 0.2939 0.1694 0.60837 0.117 0.32946-0.0448 0.86109-0.20122 1.1232 0.0234 0.0225 0.015 0.0552 0.0402 0.0702 0.0702 0.0375 0.0524 0.0552 0.11235 0.0702 0.18719 0.15723 0.11985 0.43054 0.19749 0.65517 0.25738 0.03 0.015 0.0402 0.0159 0.0702 0.0234 0.03 7e-3 0.0711 0.0234 0.0936 0.0234 0.1347 0.03 0.2293 0.03 0.30418 0 0.015 0 0.0393-8e-3 0.0468-0.0234 0.0225-8e-3 0.0318-0.0243 0.0468-0.0468 0.05235-0.0674 0.0795-0.17782 0.117-0.32758 0.0375-0.015 0.0954-0.0234 0.1404-0.0234 0.10485-0.0225 0.19935-0.0309 0.30418-0.0234 0.10485 0 0.20684-7.5e-4 0.30418-0.0234 0.0225 0 0.0477 7e-3 0.0702 0 0.03-8e-3 0.0477-0.0161 0.0702-0.0234 0.0375-0.015 0.0795-0.0477 0.117-0.0702s0.0711-0.0402 0.0936-0.0702c0.20217-0.20216 0.26768-0.51758 0.32758-0.77216 0.15723-0.6664 0.14415-1.0436 0.60837-1.5678 0.39684-0.45675 0.52881-1.096 0.86576-1.5678 0.1497-0.20965 0.23118-0.4839 0.35098-0.67857 0.0375-0.0524 0.0795-0.0954 0.117-0.1404 0.08235-0.0824 0.1591-0.15163 0.23398-0.234 0.04485-0.0375 0.087-0.088 0.117-0.1404 0.0225-0.015 9e-3 -0.0477 0.0234-0.0702 0.1872-0.45673-0.0318-0.7029 0.51478-0.91255 0.23211-0.0974 0.30324-0.1161 0.46797-0.28079 0.43428-0.44176 0.58592-0.64113 1.1699-0.86575 0.32198-0.12735 0.5569-0.31167 0.81897-0.49139 0.17222-0.1347 0.35847-0.23772 0.53817-0.32758 0.35192-0.18719 0.73378-0.34161 1.1232-0.49137 0.61398-0.23961 1.082-0.4764 1.7782-0.49137 0.68138 0 1.3534-0.0748 2.0122-0.1872 0.63645-0.11235 1.183-0.23399 1.8718-0.23399 0.16473 0 0.31072 9e-3 0.46797 0.0234 0.1497 8e-3 0.31822 0.0168 0.46798 0.0468 0.07485 0.015 0.1347 0.0477 0.18718 0.0702 0.17222 0.0598 0.26582 0.13665 0.46798 0.23399 0.32944 0.1497 0.50634 0.1086 0.67856 0.46798 0.09735 0.1797 0.12825 0.41369 0.2106 0.60837 0.03 0.0598 0.0486 0.11145 0.0936 0.16379 0.04485 0.0523 0.10395 0.0795 0.16378 0.117 0.19468 0.0974 0.453 0.1179 0.65517 0.1404 0.15724 0.0225 0.34162-4e-3 0.49138 0.0468 0.1497 0.0598 0.2396 0.20497 0.37437 0.2574 0.15724 0.0523 0.32666 7.3e-4 0.49138 0.0234 0.03 0 0.0636 0.0159 0.0936 0.0234 0.0375 0.015 0.0636 0.0243 0.0936 0.0468 0.06735 0.0448 0.11985 0.0956 0.18718 0.1404 0.03 0.0225 0.0561 0.0552 0.0936 0.0702 0.15724 0.0898 0.31917 0.0824 0.49138 0.18718 0.1497 0.0824 0.20122 0.19749 0.35098 0.25739h0.0234l0.0234 0.1404c0.0075 0.0448 0.01605 0.0795 0.0234 0.117 0.015 0.0824 0.04875 0.17502 0.0936 0.25738 0.11985 0.23961 0.24522 0.36878 0.32758 0.60837 0.11235 0.28454 0.18063 0.52602 0.21058 0.79557 0.0075 0.0448 0.0234 0.0954 0.0234 0.1404 0.015 0.0898 0.0075 0.17595 0 0.28079-0.57656 0.20217-1.8064-0.30699-1.7316 0.56157 0.49419 0.0225 0.97246-0.0459 1.4741-0.0234 0.05985 0.41931-1.0333 0.20685-1.3103 0.30418-0.05235 0.20217 0.1245 0.28266 0.30418 0.32759 0.045 0.1347 0.0702 0.30231 0.0702 0.44458 0.30699-0.0375 0.57374-0.24241 0.86576-0.25738 0.26206-0.015 0.58965 0.1077 0.88916 0.0702 0.55334-0.0524 0.37083-0.1422 0.49138-0.56159 0.11985-0.42679 0.41276-0.29763 0.77216-0.32758 0.60651-0.0448 0.81054-0.70383 1.3571-0.93596 0.29202-0.11985 0.68325-0.0411 0.98276-0.0936 0.05985-8e-3 0.13485-0.0477 0.18718-0.0702 0.1497-0.0749 0.24054-0.19935 0.2106-0.49137-0.0225-0.20965-0.06555-0.30138-0.1404-0.42118-0.03-0.0448-0.0402-0.0647-0.0702-0.117l-0.0234-0.0234c-0.0225-0.0375-0.0318-0.0636-0.0468-0.0936-0.10485-0.16473-0.11235-0.18533 0-0.32759 0.015-0.0225 0.0243-0.0636 0.0468-0.0936 0.03-0.0449 0.0879-0.0954 0.1404-0.1404 0.2396-0.24709 0.61586-0.48201 0.79556-0.0702 0.33694 0.0973 0.57 0.15537 0.95936 0.1404 0.20966-0.24709 0.57375-0.61678 0.49138-1.0062-0.1497-0.0898-0.27986-0.20498-0.44458-0.25739-0.05235-0.12735-0.0375-0.27798 0-0.39778-0.16473-0.12735-0.53444-0.31355-0.63177-0.53817-0.08235-0.19467 7.5e-4 -0.64862 0.0234-0.86576 0.08985-0.74128 0.6636-0.80211 1.2401-0.58497-0.0225 0.22463 0.49138 0.27143 0.67857 0.23399 0.40434-0.0974 0.2527-0.40434 0.32758-0.74877 0.05985-0.25458 0.18158-0.48669 0.23398-0.74876 0.0075-0.03 0-0.0636 0-0.0936 0.0075-0.0748 0.0318-0.15912 0.0468-0.234 0.0075-0.03 9e-3 -0.0636 0.0234-0.0936 0.0075-0.015 0.0159-9e-3 0.0234-0.0234 0.05985-0.0898 0.2106-0.21432 0.2106-0.30418 0-0.45674-1.0923-0.1254-1.4741-0.51477-0.03-0.03-0.0786-0.072-0.0936-0.117-0.09735-0.2471 0.1125-0.54192 0-0.81896-0.09735-0.25458-0.41649-0.4165-0.49137-0.67857-0.1497-0.50916-0.05235-1.4732 0-2.0122 0.045-0.43428 0.28452-1.534 0.74876-1.6614 0.10485-0.23211 0.43522-0.34068 0.39778-0.65517-0.0075-0.10485-0.13005-0.24615-0.25738-0.35097-0.05235-0.0375-0.08805-0.0711-0.1404-0.0936-0.0225-8e-3 -0.0711-0.0159-0.0936-0.0234-0.05985-0.015-0.10395-0.0234-0.16378-0.0234-0.05985 0-0.11145 7e-3 -0.1638 0.0234-0.0225 8e-3 -0.0477 8e-3 -0.0702 0.0234-0.0225 0-0.0477 0.0159-0.0702 0.0234-0.05235 0.0225-0.1188 0.0477-0.16378 0.0702-0.1497 0.0748-0.263 0.1404-0.39778 0.1404-0.11985 0-0.25552-0.0459-0.39778-0.2106-0.06735-0.0824-0.12735-0.16659-0.18718-0.23398-0.05985-0.0824-0.1188-0.15911-0.1638-0.23399-0.05985-0.10485-0.1263-0.21528-0.16378-0.32758-0.03-0.10485-0.0318-0.2237-0.0468-0.35099-0.015-0.10485-0.03075-0.20029-0.0234-0.32758 0.03-0.614 0.25364-1.3272-0.39778-1.5444-0.05235-0.015-0.0954-0.0477-0.1404-0.0702-0.08235-0.0375-0.1422-0.0645-0.18718-0.117-0.20966-0.1872-0.19376-0.46611-0.1638-0.79557l0.0234-0.16379v-0.1872c0.0075-0.20216-0.0075-0.453 0.0234-0.65517 0.0075-0.06735 7.5e-4 -0.10395 0.0234-0.16378 0.11235-0.2995 0.3566-0.3828 0.30418-0.77217-0.05235-0.0075-0.1188-0.0159-0.16378-0.0234-0.0225 0-0.0318-0.0234-0.0468-0.0234-0.26956-0.015-0.51759 0.01785-0.77217 0.0702-0.16473 0.0375-0.31822 0.08055-0.46798 0.1404-0.03 0.015-0.0636 0.0393-0.0936 0.0468-0.05985 0.0225-0.12735 0.0402-0.18718 0.0702l-0.0702 0.0468c-0.11985 0.07485-9e-3 0.23306-0.23398 0.2106-0.1797-0.0075-0.36034-0.39591-0.39778-0.53817-0.03-0.0375-0.0327-0.0411-0.0702-0.0936-0.12735-0.0075-0.26206-0.0159-0.37438-0.0234-0.23211 0-0.43521-0.0135-0.58497-0.1404-0.08235-0.06735-0.1347-0.15351-0.18718-0.2808-0.04485-0.11985-0.0627-0.24708-0.0702-0.37437 0-0.06735 0.0075-0.12735 0-0.1872-0.015-0.06735-0.0318-0.12735-0.0468-0.18718-0.08985-0.28454-0.20498-0.497-0.2574-0.81897-0.0375-0.1797-0.1188-0.3828-0.16378-0.58497-0.015-0.05235-0.0159-0.11145-0.0234-0.16378-0.0075-0.07485-0.0075-0.15912 0-0.234v-0.1404c0.0075-0.11985 0.02265-0.26206 0-0.37437-0.0075-0.04485-0.01605-0.07215-0.0234-0.117-0.0375-0.1347-0.11415-0.26674-0.23398-0.30418-0.03-0.0075-0.072-0.015-0.117 0-0.015-0.0075-0.0318 0.0159-0.0468 0.0234l-0.0702 0.0234c-0.13485 0.08235-0.16473 0.30512-0.37438 0.32758-0.06735-0.16473-0.0243-0.35098-0.0468-0.53818-0.38187-0.1797-1.257 0.09825-1.6614 0.2106h-0.0234c-0.05985 0.0225-0.1029 0.0393-0.1404 0.0468h-0.0234c-0.16473 0.0375-0.24802 0.01785-0.39778-0.117-0.0375-0.03-0.072-0.0645-0.117-0.117h-0.0234c-0.16473-0.1497-0.36876-0.42962-0.60837-0.44458z",
+                Matsu:"m47.89 49.587c-0.5391 0.81864-0.3307 2.5646-0.0312 3.463-0.75874 0.08984-1.3228 0.52164-1.8719 1.0607 0.87854 1.6672-0.22714 1.5961-0.68638 2.9638-0.56906 1.6672 0.4917 2.5258 1.5599 3.2446 0.40934 0.27954 0.76624 0.68512 1.1856 0.90476 1.0383 0.46922 0.98962 0.07608 1.7783-0.09354 0.7288-0.18968 0.60276-0.31948 1.5911-0.24958 0.62896 0.02994 1.2292 0.46298 2.028 0.34318 0.39934-0.75874 1.4738-2.1078 2.4022-2.028 0.51914 1.6772 2.6594-0.27828 3.3382-0.71756 1.4876-0.98836 2.26-1.5712 2.0904-3.5878-1.797 0.08986-3.4904-0.45424-5.3974-0.37438-1.1381 0.04992-1.7571-0.1273-2.2464 0.81116-0.1198 0.22962-0.1572 0.47672-0.1872 0.68636l-0.0312 0.28078c0 0.03994-0.0212 0.08486-0.0312 0.1248-0.01 0.08986-0.012 0.1797-0.0312 0.24958-0.01 0.03994-0.012 0.09484-0.0312 0.1248-0.03 0.0599-0.065 0.10608-0.1248 0.156-0.1798 0.12978-0.52538 0.19468-1.1543 0.1248-0.1398-1.6972-0.2683-4.0908-2.7142-3.6814 0.32944-0.609 0.76498-1.0795 1.4039-1.2791 0.1598-0.16972 0.40708-0.72506 0.46798-0.90476 0.1598-0.32946-2.9376-1.4726-3.307-1.6223zm23.56-17.784c-0.38328 0.04264-0.8218 0.14792-1.2479 0.24958-0.21306 0.05082-0.42916 0.11702-0.62396 0.156-0.1948 0.03894-0.37314 0.05302-0.53038 0.0624-0.34942 0.02-0.85984-0.07238-1.2791-0.0624h-0.0312c-0.1698 0-0.31698 2e-3 -0.43678 0.0624-0.70882 0.26956-0.46922 0.52664-0.99836 0.93596-0.34442 0.24958-0.7213 0.5831-1.1231 0.87356s-0.82864 0.53786-1.2479 0.59278c-1.228 0.13978-1.807-0.80616-2.7454 0.31198-1.0882 1.2679 0.1548 1.9006 0.37438 3.0886 0.1198 0.6689-0.0212 0.95716-0.2808 1.2167-0.0698 0.0599-0.1386 0.12728-0.21838 0.18718-0.31948 0.24958-0.74252 0.54536-1.092 1.1543-0.1398 0.25958-0.2421 0.56532-0.31198 0.90476-0.02 0.1198-0.0524 0.25458-0.0624 0.37438-0.0598 0.58902 8e-3 1.2068 0.1872 1.7159 0.1598 0.04992 0.1872-0.04492 0.1872 0.1248 0.20966-0.02996 0.52914 0.09234 0.74876 0.0624-0.1572 0.84736 0.41046 1.3996 1.1232 1.2167 0.1018-0.02616 0.2059-0.06738 0.31198-0.1248-0.0486-0.1872-0.091-0.41458-0.1248-0.65516-0.23696-1.6842-0.0236-4.4052 1.8719-4.4926-0.0224-0.5441 0.0872-0.94332 0.28078-1.2479 0.0968-0.1523 0.20398-0.30146 0.34318-0.40558 0.69598-0.5206 1.8782-0.47422 3.0574-0.37438-0.0798 0.49918 0.1884 0.94468 0.21838 1.4039 1.797-0.7887 2.9938-1.7147 5.2102-0.93596 0.1872 0.38936-0.093 2.9332 0.49918 3.5254 0.0494 0.04932 0.125 0.07348 0.1872 0.09354s0.1106 0.0138 0.1872 0c0.153-0.02786 0.34192-0.1198 0.56156-0.31198 0.0674-0.0587 0.1122-0.13966 0.156-0.2184 0.0438-0.07876 0.1006-0.1542 0.1248-0.2496 0.1936-0.76316-0.191-2.0002-0.1248-2.839 8e-3 -0.10486 8e-3 -0.22142 0.0312-0.31198 0.024-0.09056 0.0812-0.14556 0.1248-0.2184 0.0436-0.07288 0.089-0.13552 0.156-0.1872 0.20096-0.15502 0.5154-0.22214 0.99836-0.1248 0.0798-0.45924 0.0798-1.1107 0-1.5599-0.76874-0.04992-3.01 0.68512-2.8702-0.34318 0.1598-0.99836 1.6186-0.7238 1.2791-2.371-1.1381 0.24958-1.1656-0.99836-2.184-1.2479-0.1798-0.04742-0.43086-0.0596-0.68636-0.03114z"
+                };
+            var i = {};
+            for (var s in r) {
+                i = {};
+                if (this.options.stateSpecificStyles[s]) {
+                    e.extend(i, t, this.options.stateSpecificStyles[s])
+                } else {
+                    i = t
+                }
+                this.stateShapes[s] = n.path(r[s]).attr(i);
+                this.topShape = this.stateShapes[s];
+                this.stateHitAreas[s] = n.path(r[s]).attr({
+                    fill: "#000",
+                    "stroke-width": 0,
+                    opacity: 0,
+                    cursor: "pointer"
+                });
+                this.stateHitAreas[s].node.dataState = s
+            }
+            this._onClickProxy = e.proxy(this, "_onClick");
+            this._onMouseOverProxy = e.proxy(this, "_onMouseOver"),
+            this._onMouseOutProxy = e.proxy(this, "_onMouseOut");
+            for (var s in this.stateHitAreas) {
+                this.stateHitAreas[s].toFront();
+                e(this.stateHitAreas[s].node).bind("mouseout", this._onMouseOutProxy);
+                e(this.stateHitAreas[s].node).bind("click", this._onClickProxy);
+                e(this.stateHitAreas[s].node).bind("mouseover", this._onMouseOverProxy)
+            }
+        },
+        _initCreateLabels: function() {
+            var t = this.paper;
+            var n = [];
+            var r = 860;
+            var i = 220;
+            var s = this.options.labelWidth;
+            var o = this.options.labelHeight;
+            var u = this.options.labelGap;
+            var a = this.options.labelRadius;
+            var f = s / this.scale;
+            var l = o / this.scale;
+            var c = (s + u) / this.scale;
+            var h = (o + u) / this.scale * .5;
+            var p = a / this.scale;
+            var d = this.options.labelBackingStyles;
+            var v = this.options.labelTextStyles;
+            var m = {};
+            for (var g = 0, y, b, w; g < n.length; ++g) {
+                w = n[g];
+                y = (g + 1) % 2 * c + r;
+                b = g * h + i;
+                m = {};
+                if (this.options.stateSpecificLabelBackingStyles[w]) {
+                    e.extend(m, d, this.options.stateSpecificLabelBackingStyles[w])
+                } else {
+                    m = d
+                }
+                this.labelShapes[w] = t.rect(y, b, f, l, p).attr(m);
+                m = {};
+                if (this.options.stateSpecificLabelTextStyles[w]) {
+                    e.extend(m, v, this.options.stateSpecificLabelTextStyles[w])
+                } else {
+                    e.extend(m, v)
+                }
+                if (m["font-size"]) {
+                    m["font-size"] = parseInt(m["font-size"]) / this.scale + "px"
+                }
+                this.labelTexts[w] = t.text(y + f / 2, b + l / 2, w).attr(m);
+                this.labelHitAreas[w] = t.rect(y, b, f, l, p).attr({
+                    fill: "#000",
+                    "stroke-width": 0,
+                    opacity: 0,
+                    cursor: "pointer"
+                });
+                this.labelHitAreas[w].node.dataState = w
+            }
+            for (var w in this.labelHitAreas) {
+                this.labelHitAreas[w].toFront();
+                e(this.labelHitAreas[w].node).bind("mouseout", this._onMouseOutProxy);
+                e(this.labelHitAreas[w].node).bind("click", this._onClickProxy);
+                e(this.labelHitAreas[w].node).bind("mouseover", this._onMouseOverProxy)
+            }
+        },
+        _getStateFromEvent: function(e) {
+            var t = e.target && e.target.dataState || e.dataState;
+            return this._getState(t)
+        },
+        _getState: function(e) {
+            var t = this.stateShapes[e];
+            var n = this.stateHitAreas[e];
+            var r = this.labelShapes[e];
+            var i = this.labelTexts[e];
+            var s = this.labelHitAreas[e];
+            return {
+                shape: t,
+                hitArea: n,
+                name: e,
+                labelBacking: r,
+                labelText: i,
+                labelHitArea: s
+            }
+        },
+        _onMouseOut: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("mouseout", e, t)
+        },
+        _defaultMouseOutAction: function(t) {
+            var n = {};
+            if (this.options.stateSpecificStyles[t.name]) {
+                e.extend(n, this.options.stateStyles, this.options.stateSpecificStyles[t.name])
+            } else {
+                n = this.options.stateStyles
+            }
+            t.shape.animate(n, this.options.stateHoverAnimation);
+            if (t.labelBacking) {
+                var n = {};
+                if (this.options.stateSpecificLabelBackingStyles[t.name]) {
+                    e.extend(n, this.options.labelBackingStyles, this.options.stateSpecificLabelBackingStyles[t.name])
+                } else {
+                    n = this.options.labelBackingStyles
+                }
+                t.labelBacking.animate(n, this.options.stateHoverAnimation)
+            }
+        },
+        _onClick: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("click", e, t)
+        },
+        _onMouseOver: function(e) {
+            var t = this._getStateFromEvent(e);
+            if (!t.hitArea) {
+                return
+            }
+            return !this._triggerEvent("mouseover", e, t)
+        },
+        _defaultMouseOverAction: function(t) {
+            this.bringShapeToFront(t.shape);
+            this.paper.safari();
+            var n = {};
+            if (this.options.stateSpecificHoverStyles[t.name]) {
+                e.extend(n, this.options.stateHoverStyles, this.options.stateSpecificHoverStyles[t.name])
+            } else {
+                n = this.options.stateHoverStyles
+            }
+            t.shape.animate(n, this.options.stateHoverAnimation);
+            if (t.labelBacking) {
+                var n = {};
+                if (this.options.stateSpecificLabelBackingHoverStyles[t.name]) {
+                    e.extend(n, this.options.labelBackingHoverStyles, this.options.stateSpecificLabelBackingHoverStyles[t.name])
+                } else {
+                    n = this.options.labelBackingHoverStyles
+                }
+                t.labelBacking.animate(n, this.options.stateHoverAnimation)
+            }
+        },
+        _triggerEvent: function(t, n, r) {
+            var i = r.name;
+            var s = false;
+            var o = e.Event("usmap" + t + i);
+            o.originalEvent = n;
+            if (this.options[t + "State"][i]) {
+                s = this.options[t + "State"][i](o, r) === false
+            }
+            if (o.isPropagationStopped()) {
+                this.element.trigger(o, [r]);
+                s = s || o.isDefaultPrevented()
+            }
+            if (!o.isPropagationStopped()) {
+                var u = e.Event("usmap" + t);
+                u.originalEvent = n;
+                if (this.options[t]) {
+                    s = this.options[t](u, r) === false || s
+                }
+                if (!u.isPropagationStopped()) {
+                    this.element.trigger(u, [r]);
+                    s = s || u.isDefaultPrevented()
+                }
+            }
+            if (!s) {
+                switch (t) {
+                case "mouseover":
+                    this._defaultMouseOverAction(r);
+                    break;
+                case "mouseout":
+                    this._defaultMouseOutAction(r);
+                    break
+                }
+            }
+            return !s
+        },
+        trigger: function(e, t, n) {
+            t = t.replace("usmap", "");
+            e = e.toUpperCase();
+            var r = this._getState(e);
+            this._triggerEvent(t, n, r)
+        },
+        bringShapeToFront: function(e) {
+            if (this.topShape) {
+                e.insertAfter(this.topShape)
+            }
+            this.topShape = e
+        }
+    };
+    var c = [];
+    s(e, "usmap", l, c)
+})(jQuery, document, window, Raphael)
+
+cyoAdventure = function (a) { 
+    //萧美琴
+    ans = campaignTrail_temp.player_answers[campaignTrail_temp.player_answers.length-1];
+    if ( ans == 13324  ) {
+        campaignTrail_temp.running_mate_image_url = 'https://i.imgur.com/JpqGVO0.jpg';
+        campaignTrail_temp.running_mate_last_name = 'Hsiao';
+        campaignTrail_temp.questions_json[28] = {
+          "model": "campaign_trail.question",
+          "pk": 195000,
+          "fields": {
+            "priority": 1,
+            "description": "Today, you will engage in a face-to-face debate showdown with the articulate TPP Chairman Ko Wen-je. You did not expect that a third-party candidate could possibly become the future president today, but you will not allow such a thing to happen, and the debate is your opportunity to outshine him. In what aspects do you plan to attack him? ",
+            "likelihood": 1
+          }
+        }
+    }
+    else if ( ans == 13319 ) {
+        campaignTrail_temp.running_mate_image_url = 'https://i.imgur.com/JpqGVO0.jpg';
+        campaignTrail_temp.running_mate_last_name = 'Hsiao';
+    }
+     if (ans == 13323 ){
+        campaignTrail_temp.running_mate_image_url = 'https://i.imgur.com/JpqGVO0.jpg';
+        campaignTrail_temp.running_mate_last_name = 'Hsiao';
+        campaignTrail_temp.questions_json[28] = {
+          "model": "campaign_trail.question",
+          "pk": 15781,
+          "fields": {
+            "priority": 1,
+            "description": "As the presidential debate kicks off, you go head-to-head with Mayor Hou on stage. He speaks Mandarin with a strong Taiwanese accent, interweaving Taiwanese phrases in his speech. Your eloquence and image are probably stronger than his. So, what issues do you primarily want to focus on during the debate?",
+            "likelihood": 1
+          }
+        }
+    }
+    if (ans == 13019 || 13020 || 13021 ){
+        campaignTrail_temp.election_json[0]["fields"].advisor_url = "https://i.imgur.com/DDLF2js.jpeg";
+    }
+    //四人辩论问题
+    if(ans == 13322){
+        campaignTrail_temp.running_mate_image_url = 'https://i.imgur.com/JpqGVO0.jpg';
+        campaignTrail_temp.running_mate_last_name = 'Hsiao';
+        campaignTrail_temp.questions_json[28] = {
+          "model": "campaign_trail.question",
+          "pk": 1950,
+          "fields": {
+            "priority": 1,
+            "description": "This year's presidential debate featured four candidates on stage for the first time. They were Hou, Ko, and the qualified candidate Guo, who secured candidacy by obtaining 940,000 citizen signatures. When facing the three other opposition candidates, what statement will you make?",
+            "likelihood": 1
+          }
+        }
+    }
+ //laipiliao
+    if (e.player_answers.includes(13357) && e.player_answers.includes(13370)) { 
+    unlockAchievement("On the Road To Laipiliao");  
+    }
+//Taiwan First
+    if (e.player_answers.includes(13019) && e.player_answers.includes(13049)  && e.player_answers.includes(13058)&& e.player_answers.includes(13112) && e.player_answers.includes(13204) && e.player_answers.includes(13236) && e.player_answers.includes(13253) && e.player_answers.includes(13300)) { 
+        getResults = function (out, totv, aa, quickstats) {
+            if( aa[0].candidate === 2001557 ) {
+                unlockAchievement("Taiwan First");
+            }
+        }
+    }
+    //Guo
+    if (e.player_answers.includes(13217) && e.player_answers.includes(13253) && e.player_answers.includes(13442)) { 
+     e.final_overall_results.sort((a, b) => b.popular_votes - a.popular_votes);   
+    getResults = function (out, totv, aa, quickstats) {
+            if( aa[3].candidate === 2001653 && quickstats[0] <= 1) {
+                unlockAchievement("Blue Spoiler");
+            }
+        }
+    }
+        // in-game achievements
+            getResults = function (out, totv, aa, quickstats) {
+              let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 268);
+              if( aa[0].candidate === 2001557 && stateResult.result[0].candidate == 2001557) {
+                  unlockAchievement("Sorry You are Not Taipei Mayor");
+                        }
+                  }
+          getResults = function (out, totv, aa, quickstats) {
+              let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 256);
+              let stateResulttwo = campaignTrail_temp.final_state_results.find((x) => x.state == 267);
+              if( aa[0].candidate === 2001591 && stateResult.result[0].candidate == 2001591 && stateResulttwo.result[0].candidate == 2001557) {
+                  unlockAchievement("New Home And Hometown");
+              }
+          }
+          getResults = function (out, totv, aa, quickstats) {
+              if( aa[0].candidate === 2001557 && quickstats[0] == 20 ) {
+                  unlockAchievement("Taiwanese independence Protégé");
+              }
+              }
+          getResults = function (out, totv, aa, quickstats) {
+              let stateResult = campaignTrail_temp.final_state_results.find((x) => x.state == 251);
+              if( aa[0].candidate === 2001591 || aa[0].candidate === 2001622 && quickstats[0] == 1 && stateResult.result[0].candidate == 2001557 ) {
+                  unlockAchievement("Reverse 817");
+              }
+          }
+          getResults = function (out, totv, aa, quickstats) {
+              if( aa[0].candidate === 2001557 && quickstats[0] <= 5 ) {
+                  unlockAchievement("Happy surprise");
+              }
+          }
+        //标题和背景
+           if ( ans == 13019 || ans == 13020 || ans == 13021 ){    
+            nct_stuff.themes[nct_stuff.selectedTheme].coloring_window = "#ffffff" 
+            nct_stuff.themes[nct_stuff.selectedTheme].coloring_title = "#4ade65" 
+            $(".container")[0].style.backgroundColor = "#6848ff" 
+            $("#game_window")[0].style.borderColor = "#99A0A8" 
+            $(".container")[0].style.backgroundColor = "#F4F4EE" 
+            $("#game_window")[0].style.borderColor = "#ffffff" 
+            $("#game_window")[0].style.backgroundImage = "url(https://i.imgur.com/560XCo8.png)" 
+            document.getElementById("header").src = "https://i.imgur.com/FvRpfn9.jpeg" 
+            document.body.background = "https://i.imgur.com/YQHN37t.jpeg"
+        }
+}
+
+campaignTrail_temp.multiple_endings=true
+
+// constructs endings based on header and pages
+construct = (a = 1) => {
+	
+    e.page = e.page + a < e.pages.length ? e.page + a : 0
+    let html = e.header;
+    html += e.pages[e.page] + "<br>";
+    if (e.page > 0) {
+    
+    html += `<button onclick='endingConstructor(a = -1)'>Back</button>`
+    }
+    if (e.page < e.pages.length - 1) {
+    
+    html += `<button onclick='endingConstructor(a = 1)'>Next</button>`
+    }
+    
+    for (i in e.executable) {
+    if (e.executable[i][0] == e.page) {
+        e.executable[i][1]();
+        
+    }
+    }  
+    return html;
+    }
+ 
+endingPicker = (out, totv, aa, quickstats) => {
+    //out = "win", "loss", or "tie" for your candidate
+    //totv = total votes in entire election
+    //aa = all final overall results data
+    //quickstat = relevant data on candidate performance (format: your candidate's electoral vote count, your candidate's popular vote share, your candidate's raw vote total)
+  
+    /*
+    e.header = "<h2></h2>"
+    e.pages = ["<p></p>",
+               "<p></p>"]
+    */
+  
+    // NORMAL ENDINGS
+  e.final_overall_results.sort((a, b) => b.popular_votes - a.popular_votes);
+  map = document.getElementById("map_container");
+
+  
+  if (aa[0].candidate === 2001557 && quickstats[1] > 39.3 && quickstats[1] < 46.0) {
+  used=false
+  if (used != true) {
+              setInterval(function () {
+                  used = true;
+                  imgg = document.getElementsByClassName("person_image")[0];
+                  if (imgg != null) {
+                      imgg.src =  "https://imgcdn.cna.com.tw/www/WebPhotos/800/20240113/2000x1333_wmky_495863372336_0.jpg";
+                  }
+              }, 100);
+          }
+  return "<div style='overflow-y:scroll;height:250px;'><h3>Miner's Son Triumphs! DPP Secures Over 40% Votes and Claims Presidency!</h3><p>The day has finally arrived! After a year of intricate and intense election campaigns, you have emerged victorious, leading in the polls. This marks a significant triumph for the Democratic Progressive Party (DPP) under President Tsai Ing-wen's leadership, securing your third term. The curse of party alternation every eight years since 1996 has been broken.</p><p>However, our representation in the Legislative Yuan is not as high. The Kuomintang (KMT) has successfully become the largest party in the Legislative Yuan with 54 seats (52+2), while the DPP falls to the second-largest with 51 seats. The Taiwan People's Party (TPP) is the third-largest party, and the New Power Party (NPP), which had seats in the last election, is now reduced to zero. Taiwan is now facing a unique political landscape with no single party holding a majority. In the next four years, you may encounter challenges in the legislature, requiring cooperation with the KMT or TPP to pass bills and potentially easing the burden of governance. Additionally, barring unexpected events, Han Kuo-yu is poised to become the Speaker of the Legislative Yuan as the KMT holds the majority.</p><p>Looking ahead to potential achievements during your term, party cooperation becomes a crucial consideration. Unlike the past, where the DPP held both the presidency and control of the legislature, challenges in governance may arise. The government, under Premier Lai Ching-te, must confront the increasing threat from a powerful China and escalating diplomatic crises. Just two days after your election, Nauru announced the termination of diplomatic ties with Taiwan, signaling a deepening diplomatic crisis. Each year, Taiwan loses more diplomatic allies, and our government can only condemn these actions. Furthermore, the lingering challenges of President Tsai Ing-wen's non-nuclear homeland policy by 2025 may prove insurmountable, leading to a likely increase in electricity prices due to continuous losses incurred by power companies in recent years. This could impact your political future. Regardless, you have won this battle, but the upcoming governance, 2026 local elections, and the 2028 presidential re-election may pose your greatest tests. Best of luck, President Lai Ching-te!</p></div>"  
+  
+} 
+  else if (aa[0].candidate === 2001557 && quickstats[1] < 39.3 && quickstats[1] > 35.0 ) {
+    used=false
+    if (used != true) {
+                setInterval(function () {
+                    used = true;
+                    imgg = document.getElementsByClassName("person_image")[0];
+                    if (imgg != null) {
+                        imgg.src =  "https://uc.udn.com.tw/photo/2024/01/13/realtime/28728303.jpg";
+                    }
+                }, 100);
+            }
+    return "<div style='overflow-y:scroll;height:250px;'><h3>Breaking DPP's Lowest Vote Record, Lai Ching-te Secures Presidency</h3><p>After a year-long presidential campaign, you have finally clinched the presidency. Despite the challenges along the way, you have successfully won the title of the 17th President of the Republic of China. However, your vote percentage is lower than that of President Chen Shui-bian in 2000. Your vote share falls short of expectations, influenced by the solid KMT voter base, loyal supporters, and Ko Wen-je taking away many votes from young voters. Nevertheless, you are the victor—neither of them is the president; you are.</p><p>However, in the Legislative Yuan, you are facing a challenging situation. Many young voters have thrown their party votes to the People's Party, securing 10 seats. With no party holding a majority, the KMT is the largest party with 51+2 seats, having a slim majority of 3 seats in the caucus. This situation may lead to Han Kuo-yu becoming the Speaker of the Legislative Yuan if no one defects or votes incorrectly.</p><p>Although you have successfully taken over the political legacy from President Tsai Ing-wen, the vote percentage is not satisfactory. 60% of the population wants to oust the DPP, and even among those who are somewhat satisfied with President Tsai Ing-wen, many did not vote for you. This indicates that you and your party are not the mainstream representation of the Taiwanese people, as claimed. The Lai Ching-te administration is destined for intense struggles between the legislature and the president. If you can regain some cities and counties in the local elections in 2026, you might seek re-election in 2028. Otherwise, after setting the record for a party ruling for three consecutive terms, you may become the first president unable to seek re-election.</p></div>    "
+  }
+  else if (aa[0].candidate === 2001591 && quickstats[1] > 40.0 && quickstats[1] < 46.0) {
+    used=false
+    if (used != true) {
+                setInterval(function () {
+                    used = true;
+                    imgg = document.getElementsByClassName("person_image")[0];
+                    if (imgg != null) {
+                        imgg.src =  "https://d1j71ui15yt4f9.cloudfront.net/wp-content/uploads/2023/12/03223725/20231203000125.jpg";
+                    }
+                }, 100);
+            }
+    return "<div style='overflow-y:scroll;height:250px;'><h3>Kuomintang Returns to Power! After 12 Years, KMT Finally Emerges Victorious!</h3><p>Perhaps it was a flaw in your campaign strategy, or maybe Zhao Shaokang provided significant support to Hou You-yi in the last one or two months of the election. It could also be the rejection of the DPP's governance shortcomings over the past 8 years by the voters. Or perhaps, it's a combination of these factors. The DPP fails to set a new record in Taiwan's history, succumbing to the 8-year curse. Six months ago, everyone was saying that the DPP would easily win the presidency amid opposition factionalism. However, reality proved otherwise. They could not foresee Hou You-yi winning this presidential election, let alone anticipate the substantial boost provided by Zhao Shaokang.</p><p>In the Legislative Yuan, the KMT successfully secures a majority with 56+2 seats, providing ample space for the Hou You-yi government to implement its policies. The DPP is relegated to the position of the second-largest party, obtaining only 48 seats. This means the KMT government can pass any legislation without hindrance, as the TPP holds only 7 seats and cannot stop them. Since 2016, the KMT has returned to power and gained a legislative majority. This is their triumph.</p><p>As for Taiwan's future, uncertainties loom. With the increasing threat from China, how the KMT government will address it remains unknown. What we do know is that you are now the Vice President of a limping duck, and your political future seems dim. Perhaps you can take a page from President Tsai Ing-wen, who, after losing in 2012, made a comeback in 2016. However, your age may not permit such a move, and if there are other contenders within the party, you may be overshadowed. You ultimately did not inherit Tsai Ing-wen's political legacy. The DPP's eight-year rule comes to an end...</p>    "
+  }
+  else if (aa[0].candidate === 2001591 && quickstats[1] < 40.0 && quickstats[1] > 35.0) {
+  used=false
+  if (used != true) {
+              setInterval(function () {
+                  used = true;
+                  imgg = document.getElementsByClassName("person_image")[0];
+                  if (imgg != null) {
+                      imgg.src =  "https://www.upmedia.mg/upload/article/20240112181616156933.jpg";
+                  }
+              }, 100);
+          }
+  return "<div style='overflow-y:scroll;height:250px;'><h3>DPP Sweats, KMT Overtakes DPP, Political Shift in Taiwan</h3><p>In a fierce multi-candidate election, until the day of the vote count, no one knew who the ultimate winner would be. In this election, both the Kuomintang (KMT) and the Democratic Progressive Party (DPP) were unsure who would have the last laugh. As the results drew closer, everyone held their breath. The counting started with the completion of votes in deep-blue counties, followed by deep-green ones, and finally landed in fiercely contested areas like New Taipei, Taipei, Taichung, and Changhua. Two hours into the counting, the KMT began to gradually widen the gap with the DPP. The scene at the KMT campaign headquarters was lively, echoing with cheers and laughter in the joy of victory. In contrast, the DPP headquarters was shrouded in the gloom of disappointment. They did not anticipate the success of Hou You-yi's campaign strategy, and losing the presidency was undoubtedly a heavy blow for the party. Hou You-yi's victory not only marked a breakthrough in political history but also signaled the KMT's reclaiming of executive power, ending the eight-year DPP rule.</p><p>In the distribution of seats in the Legislative Yuan, the KMT achieved a remarkable performance, winning 54 seats, with 2 independent legislators joining the KMT legislative caucus for collaboration. The DPP, on the other hand, could only secure 50 seats. This dominance in the Legislative Yuan positions the KMT as a powerful force, providing robust support for Hou You-yi's administration. Equally noteworthy is the TPP, securing 7 seats, successfully becoming an undeniable third force in the parliament.</p><p>As for the future of Taiwan, uncertainties linger, with increasing threats from China. How the KMT government will tackle these challenges remains an unknown variable. However, what we do know is that you have now become the Vice President, facing an uncertain political future. Perhaps you can learn from President Tsai Ing-wen, who, after losing the 2012 election, made a comeback in 2016. However, your age may not permit such a comeback, and if there are other contenders within the party, you might be overshadowed. Ultimately, you have not inherited Tsai Ing-wen's political legacy. The DPP's eight-year rule comes to an end... The future is always a mix of hope and disappointment. Good luck, Mr. Vice President.</p></div>"
+  map.style.backgroundImage = "url(https://i.imgur.com/Yzb7F9P.jpeg)"; 
+}
+else if (aa[0].candidate === 2001591 && quickstats[1] < 35.0) {
+    used=false
+    if (used != true) {
+                setInterval(function () {
+                    used = true;
+                    imgg = document.getElementsByClassName("person_image")[0];
+                    if (imgg != null) {
+                        imgg.src =  "https://pgw.udn.com.tw/gw/photo.php?u=https://uc.udn.com.tw/photo/2023/08/24/1/24423214.jpg&x=0&y=0&sw=0&sh=0&sl=W&fw=800&exp=3600";
+                    }
+                }, 100);
+            }
+    return "<div style='overflow-y:scroll;height:250px;'><h3>Historic Upset: Hou You-Yi Elected President with 35% Vote, Redefining Political Landscape</h3><p>In a fiercely contested multi-candidate election, the decisive day has finally arrived, with an air of uncertainty lingering until the last ballot is counted. In a stunning turn of events, Hou You-Yi clinched victory with a mere 35% of the vote, reshaping Taiwan's political landscape. This unexpected outcome left both the KMT and DPP in disbelief, marking a seismic shift in traditional political dynamics.</p><p>The atmosphere at the KMT campaign headquarters is filled with joy and astonishment. Hou You-Yi's unconventional strategies, coupled with the last-minute efforts of media personality Zhao Shaokang, played a crucial role in this unprecedented triumph. The KMT, after eight years as the opposition, has successfully made a comeback, signaling the end of the era dominated by the DPP.</p><p>As the results in the Legislative Yuan are unveiled, the KMT demonstrates an impressive performance, securing 52 seats, with an additional 2 independent legislators joining forces with the party. In contrast, the DPP only manages to secure 50 seats, indicating a significant setback. The People's Party, with 9 seats, emerges as a noteworthy third force in the political landscape.</p><p>Looking ahead, Taiwan faces uncertainties, especially in dealing with escalating threats from China. How the KMT government, led by President Hou You-Yi, will tackle these challenges remains a captivating unknown. The political future of the current Vice President appears dim, raising questions about the continuity of the DPP's political legacy. Whether Lai Ching-te can follow in the footsteps of President Tsai Ing-wen's resurgence in 2016 after the defeat in 2012 or if internal competitors will overshadow him remains an unsolved mystery.</p><p>Hou You-Yi's historic win with a modest 35% vote reveals a complex scenario. While successfully securing the presidency, it reflects the divided sentiments among the Taiwanese people. The DPP's dominant position is shattered, and the KMT must now address the expectations and concerns of a nation accustomed to different political narratives. The uncertainties ahead pose a challenging period for President Hou You-Yi and the KMT, but their unexpectedly historic upset has left an indelible mark on Taiwan's political history.</p></div>"
+    map.style.backgroundImage = "url(https://i.imgur.com/VjbWx3Q.jpeg)"; 
+  }
+else if (aa[0].candidate === 2001591 && quickstats[1] > 46.0 ) {
+    used=false
+    if (used != true) {
+                setInterval(function () {
+                    used = true;
+                    imgg = document.getElementsByClassName("person_image")[0];
+                    if (imgg != null) {
+                        imgg.src =  "https://media.zenfs.com/ko/chinatimes.com.tw/681833270e67620829c7ffa33a594f36";
+                    }
+                }, 100);
+            }
+    return "<div style='overflow-y:scroll;height:250px;'><h3>Historic Record: Hou You-Yi Secures Presidency with Over 46%, KMT Triumphs, Reshaping the Republic of China</h3><p>In this intense election, Hou You-Yi achieves a remarkable victory, winning the presidency with an impressive 46% of the vote, creating a historic chapter for the Kuomintang (KMT) and reshaping Taiwan's political landscape. This outcome signifies a major shift in Taiwan's political scenario, with the Democratic Progressive Party (DPP) suffering a severe setback. The KMT campaign headquarters exudes an atmosphere of joy and exhilaration. Hou You-Yi's robust support not only demonstrates his widespread recognition among voters but also reflects the electorate's trust in the KMT. The election showcases the KMT's successful return to power, ending an eight-year period in the opposition. Ko Wen-je's assistance brings millions votes to Hou You-Yi, while the DPP and Lai Ching-Te's campaign errors contribute to these results.</p><p>In the Legislative Yuan, the KMT secures a stunning victory with 56 seats, along with 2 independent legislators aligned with the KMT. This grants the KMT a clear majority in the legislature, providing robust support for Hou You-Yi's governance. In contrast, the DPP only manages to secure 48 seats, and the emerging TPP party gains prominence with 7 seats, establishing itself as a notable third force in the parliament. The KMT's absolute advantage in the Legislative Yuan will facilitate the effective implementation of policies.</p><p>This election is undoubtedly a significant defeat for the DPP. Voter dissatisfaction with its past governance and policy errors results in a substantial decline in votes. Particularly in diplomatic and economic policies, the DPP's performance faces widespread criticism. Taiwan's relationship with mainland China has always been a sensitive and crucial issue. The DPP appears to have made strategic errors in handling relations with the mainland, jeopardizing Taiwan's international standing. Additionally, in the economic sphere, many voters believe that the DPP's policies have led to rising unemployment and slowed economic growth, becoming crucial considerations in the voting process. Various policies, including energy and education, also influence the DPP's vote share.</p><p>As for Vice President Lai Ching-Te... Once, your approval ratings were the highest among several candidates; now, they lie overturned by Hou You-Yi. History does not favor second place, let alone a humiliating second place. This defeat is undoubtedly a shame and failure for the DPP. While the Tsai Ing-Wen government may be popular, that popularity did not transfer to you and left a burden. Following such a devastating loss, you may find it challenging to run for public office again, but at least you have served as vice president, haven't you? Best of luck to you.</p></div>"
+  }
+  else if (aa[0].candidate === 2001622 ) {
+  used=false
+  if (used != true) {
+              setInterval(function () {
+                  used = true;
+                  imgg = document.getElementsByClassName("person_image")[0];
+                  if (imgg != null) {
+                      imgg.src =  "https://images.chinatimes.com/newsphoto/2023-10-30/656/20231030001548.jpg";
+                  }
+              }, 100);
+          }
+  return "<div style='overflow-y:scroll;height:250px;'><h3>Ko Wen-je and Taiwan People's Party Triumph! Third Party Takes Power for the First Time, Bringing Tears of Joy to the Youth!!!</h3><p>It finally happened. Ko Wen-je and his Taiwan People's Party have won the presidency of the Republic of China, shocking the world. Major media outlets worldwide, including BBC in the UK, CNN in the US, Bloomberg, Yomiuri Shimbun in Japan, TASS in Russia, and even CCTV in China, are all covering the historic moment. For the first time in Taiwan's history, a third-party candidate secures the presidency. Ko Wen-je has indeed achieved what many young people had hoped for, leaving them teary-eyed but without regrets.</p><p>With the defeat of the Democratic Progressive Party (DPP), it is now apparent that Taiwan's political future might be characterized by long-term tri-party competition. The People's Party, seizing both the presidency and executive power in this election, also secures 13 seats in the legislature, including regional representatives. The Kuomintang (KMT) retreats to 50 seats, while the DPP holds 48 seats, and there are 2 independent seats aligned with the KMT. President Ko Wen-je is destined for a presidency that involves both fierce battles and collaborations with the legislature. In this regard, you, the legislators, hold the key power. Will you make him a president who can't pass any bills, or will you cooperate with him to secure more government positions? Only time will tell.</p><p>As for Vice President Lai Ching-te, it seems your political career has come to an end. The DPP's failure has reached a point where a third party, established just a few years ago, can surpass them. It's a disgrace and a significant failure. The political landscape in 2026 and 2028 remains uncertain, but Ko Wen-je will undoubtedly seek re-election. The DPP won't tolerate a candidate like you, who has faced defeat. You may consider retirement, perhaps in the US, to reunite with your family and enjoy a peaceful life.</p></div> "
+     }
+     else if (aa[0].candidate === 2001557 && quickstats[1] > 46.0 ) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://cdn.hk01.com/di/media/images/dw/20240112/822423439976435712294650.jpeg/DZO8aeGaT0u6zDkTim6YltXgdsj2Ey8DbXl0JW15dCU?v=w1280r16_9";
+                        }
+                    }, 100);
+                }
+        return "<div style='overflow-y:scroll;height:250px;'><h3>Team Taiwan scores a sweeping victory in 2024 as Lai Ching-te secures a landslide win</h3><p>When the lights at the Democratic Progressive Party (DPP) campaign headquarters lit up, no one anticipated such a massive triumph. The colossal TV screens displayed the faces of two doctors and a police officer, with blocks of green, blue, and cyan floating up and down. Initially, Kinmen, Matsu, Tainan, Kaohsiung—each stronghold fell into place. However, as the results in fiercely contested areas were confirmed surprisingly quickly, it became evident that the DPP had once again gained the trust of the people for the next term. Even before all votes were counted, you declared victory and held a press conference to deliver your winning remarks.</p><p>All potential advantages your opponents might have had in the legislature turned out to be a dream. The DPP maintained its majority with 57 seats against KMT's 50 and TPP's 6, ensuring smooth governance for the Lai Ching-te administration in the next 4 or even 8 years. South of the Zhuoshui River, not a single DPP legislator failed to win, even in traditionally blue areas.</p><p>Vice President Lai Ching-te, no, President Lai Ching-te, the Taiwanese people have proven with their votes that you are the most trustworthy among the candidates. Your resounding victory is like hitting a home run in baseball, bringing exhilarating cheers to the people of Taiwan. You have perfectly inherited the political legacy of President Tsai Ing-wen, and in 2026, the DPP is likely to reclaim some of the currently lost counties and cities, including Taichung and New Taipei. In 2028, you can easily seek re-election, and within the party, no one will question your leadership. Congratulations, President Lai Ching-te, and best of luck!</p></div>        "
+      }
+      else if (aa[0].candidate === 2001557 && quickstats[1] < 35.0 ) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://s.yimg.com/ny/api/res/1.2/YcsBFYsE8ED1HdbmlKDinw--/YXBwaWQ9aGlnaGxhbmRlcjt3PTY0MDtoPTQxOQ--/https://media.zenfs.com/ko/chinatimes.com.tw/bbfbb107137bcc4e005d08bdb427bd5e";
+                        }
+                    }, 100);
+                }
+        return "<div style='overflow-y:scroll;height:250px;'><h3>With a Low Vote Share, Lai Ching-te's Presidency Hangs on the Edge</h3><p>This election has proven to be exceptionally perilous for the Democratic Progressive Party (DPP), narrowly avoiding a loss as Lai Ching-te secured victory with a vote share below 35%. The fluidity of votes in a multi-candidate race prevented anyone from surpassing the 35% threshold, making Lai the candidate with the highest number of votes. Unlike France, the Republic of China lacks a second round of voting, making a president with such a low percentage a rarity. The DPP's victory was based on its solid base, but Lai Ching-te's vote share hovers dangerously close to the edge of defeat, with a cliff beneath his feet.</p><p>In the Legislative Yuan, governing is set to be an uphill battle for Lai. The Kuomintang (KMT) secured 51 seats, along with 2 independent legislators aligned with them, while the DPP only managed 48 seats. The Taiwan People's Party (TPP) garnered 12 seats, leaving Lai as the second-largest party but with little distinction from the third-largest. TPP could potentially collaborate with the KMT, making it difficult for Lai to pass any legislation and turning him into a handicapped president.</p><p>While Lai has won the presidency, his path to re-election is fraught with challenges. A vote share of just 35% is insufficient for victory in a blue-green contest. If he does not increase this figure to at least 45% by 2028, his chances of re-election are virtually nonexistent. He better hopes that the KMT and TPP do not form an alliance in 2028, and that he does not lose the currently DPP-governed deep-green counties and cities in 2026. It's not an implausible scenario, and his prospects for a smooth re-election in 2028 appear bleak. Nonetheless, best of luck!</p></div>"
+      }
+      //隐藏结局：2004重演。蓝白合输给民进党
+      else if (aa[0].candidate === 2001557 && quickstats[1] > 49.99 && quickstats[1] < 50.12 && aa[1].candidate === 2001591 ) {
+        used=false
+        if (used != true) {
+                    setInterval(function () {
+                        used = true;
+                        imgg = document.getElementsByClassName("person_image")[0];
+                        if (imgg != null) {
+                            imgg.src =  "https://pgw.udn.com.tw/gw/photo.php?u=https://uc.udn.com.tw/photo/2023/05/18/4/22127283.jpg&x=0&y=0&sw=0&sh=0&sl=W&fw=800&exp=3600";
+                        }
+                    }, 100);
+                }
+        return "<div style='overflow-y:scroll;height:250px;'><h3>Taiwan Election Deadlocked!</h3><p>Chairman Lai, something big has happened!</p><p>Your campaign office director, Yao Li-ming, hurriedly entered the hallway, finding you enjoying Taiwan's signature hand-shaken milk tea with extra sugar, evidently influenced by the locals in Tainan.</p><p>'Yao Director, what's the urgency?'</p><p>'Haven't you been watching? The vote count is at 95%, and there's still no winner declared!'</p><p>'I'm concerned about my health; high blood pressure, you know. What's going on?'</p><p>Yao quickly turned on the TV in your office, switching to SETN. Hou You-yi's and Lai Ching-te's images were swapping positions every half-minute, and their rankings kept changing. Each channel showed a different story, with Hou leading more on CTI, while Formosa TV and SETN favored Lai.</p><p>'Isn't there still 5% left? Let's wait until all votes are counted; I believe we'll win.'</p><p>One hour later, at the joint campaign headquarters of Hou You-yi and Ko Wen-je, the roar of car horns shattered the sky and everyone's hearts and ears.</p><p>'Everyone, please be quiet; President Hou can't speak in this noise.'</p><p>Hou You-yi stood silent on the stage.</p><p>'Chairman Ko, you go first.'</p><p>Ko Wen-je stepped forward, took the microphone, revealing an unprecedented solemnity in his expression.</p><p>'This is evidence of the DPP rigging the election. Their election staff used various methods, including disabling cameras, not singing the ballots, and much more. Our TPP and KMT supervisors have discovered many flaws in the electoral process, suspected of cheating... Please, everyone, look at the big screen.'</p><p>Hou You-yi added, 'The gap in our defeat is... very, very marginal. This slight difference is clouded in suspicion, raising many doubts. It gives the impression that this is an unfair election. We are preparing to file a lawsuit for the invalidation of the election.'</p><p>Supporters: 'Invalid! Invalid! Invalid!'</p><p>As the chants subsided, Hou You-yi continued, 'The second request is for the CEC to immediately seal all ballot boxes as a basis for future verification.'</p><p>Supporters: 'Verify! Verify! Verify!'</p><p>'If Taiwan really cannot lose, it's here. Everyone, right?'</p><p>Supporters: 'Yes!'</p><p>'Taiwanese people, democracy is our most effective weapon against the CCP. When we destroy this weapon, what other defenses do we have? Unfair elections not only make us hear about the doubts just mentioned but also clearly witness manipulative actions throughout the election. Everyone knows this, and we are using the most rational and gentle method to expose the deception carried out by Lai Ching-te and the DPP throughout this election. Let the whole world understand, shall we?'</p><p>Supporters: 'Go Hou-Ko! Go Hou-Ko!'</p><p>What happened in the world was unclear, but it was certain that Taiwan would once again enter bitter days of election violence and confrontation.</p></div>"
+      }
+      
+  }
+
+//立法院结局
+getResults = function (out, totv, aa, quickstats) {
+    map = document.getElementById("map_container");
+    if(aa[0].candidate === 2001557 && quickstats[1] > 39.3 && quickstats[1] < 46.0){
+        if(map) {
+            map.style.backgroundImage = "url('https://i.imgur.com/VjbWx3Q.jpg')"; 
+        }
+    }
+}
+
+getResults = function (out, totv, aa, quickstats) {
+    map = document.getElementById("map_container");
+    if(aa[0].candidate === 2001557 && quickstats[1] < 39.3 && quickstats[1] > 35.0 ){
+        if(map) {
+            map.style.backgroundImage = "url('https://i.imgur.com/JkXDEZo.jpg')"; 
+        }
+    }
+}
+getResults = function (out, totv, aa, quickstats) {
+    map = document.getElementById("map_container");
+    if(aa[0].candidate === 2001591 && quickstats[1] > 40.0 && quickstats[1] < 46.0){
+        if(map) {
+            map.style.backgroundImage = "url('https://i.imgur.com/JkXDEZo.jpg')"; 
+        }
+    }
+}
+
+getResults = function (out, totv, aa, quickstats) {
+    map = document.getElementById("map_container");
+    if(aa[0].candidate === 2001591 && quickstats[1] < 40.0 && quickstats[1] > 35.0){
+        if(map) {
+            map.style.backgroundImage = "url('https://i.imgur.com/Yzb7F9P.jpg')"; 
+        }
+    }
+}
+getResults = function (out, totv, aa, quickstats) {
+    map = document.getElementById("map_container");
+    if(aa[0].candidate === 2001591 && quickstats[1] < 35.0){
+        if(map) {
+            map.style.backgroundImage = "url('https://i.imgur.com/x4GCRjY.jpg')"; 
+        }
+    }
+}
+getResults = function (out, totv, aa, quickstats) {
+    map = document.getElementById("map_container");
+    if(aa[0].candidate === 2001591 && quickstats[1] > 46.0){
+        if(map) {
+            map.style.backgroundImage = "url('https://i.imgur.com/TOKXeGp.png')"; 
+        }
+    }
+}
+getResults = function (out, totv, aa, quickstats) {
+    map = document.getElementById("map_container");
+    if(aa[0].candidate === 2001622 ){
+        if(map) {
+            map.style.backgroundImage = "url('https://i.imgur.com/XFvSh3H.jpg')"; 
+        }
+    }
+}
+
+getResults = function (out, totv, aa, quickstats) {
+    map = document.getElementById("map_container");
+    if(aa[0].candidate === 2001557 && quickstats[1] > 46.0 ){
+        if(map) {
+            map.style.backgroundImage = "url('https://i.imgur.com/wFR9gBs.jpg')"; 
+        }
+    }
+}
+getResults = function (out, totv, aa, quickstats) {
+    map = document.getElementById("map_container");
+    if(aa[0].candidate === 2001557 && quickstats[1] < 35.0){
+        if(map) {
+            map.style.backgroundImage = "url('https://i.imgur.com/x4GCRjY.jpg')"; 
+        }
+    }
+}
+
+  setInterval(endingPicker, 250);
+  function changechart(){
+    if (document.getElementById("overall_vote_statistics")!=null) {
+    overallthing=document.getElementById("overall_vote_statistics").innerHTML;
+    overallthing.toString()
+    overallthing=overallthing.replace("Electoral Votes","Counties Won")
+    document.getElementById("overall_vote_statistics").innerHTML=overallthing
+    }
+
+    setInterval(changechart, 250);
+}
+
+//注释代码
+function getTooltips(str) {
+    let matches = [];
+
+    tooltipList.forEach((tooltip, index) => {
+        // Adjust the regex to match searchString potentially surrounded by “ and followed by optional punctuation
+       let regex = new RegExp(`(?<=\\b|\\s|^|“)${tooltip.searchString}(?=[.,;!?]?\\b|\\s|”|$)`, 'g');
+
+
+        let match;
+        while ((match = regex.exec(str)) !== null) {
+            matches.push({
+                start: match.index + (match[0].startsWith('“') ? 1 : 0), // Adjust for potential starting “
+                end: match.index + match[0].length - (match[0].endsWith('”') ? 1 : 0) - (match[2] ? 1 : 0), 
+                tooltipIndex: index
+            });
+        }
+    });
+
+    // Sort by starting position; if two start at the same position, longer match comes first
+    matches.sort((a, b) => a.start - b.start || b.end - b.start - (a.end - a.start));
+
+    // Filter out overlaps
+    for (let i = 0; i < matches.length - 1; ) {
+        if (matches[i + 1].start < matches[i].end) {
+            matches.splice(i + 1, 1); // Remove the next match since it overlaps
+        } else {
+            i++; // Move to next match
+        }
+    }
+
+    return matches;
+}
+function applyTooltips(str) {
+    const matches = getTooltips(str);
+    let result = '';
+    let lastIndex = 0;
+
+    matches.forEach(match => {
+        const tooltip = tooltipList[match.tooltipIndex];
+        result += str.slice(lastIndex, match.start);
+        result += `<span class='mytooltip'>${tooltip.searchString}<span class='mytooltiptext'>${tooltip.explanationText}</span></span>`;
+        lastIndex = match.end;
+    });
+
+    result += str.slice(lastIndex); // Add the remainder of the original string
+    return result;
+}
+
+function applyTooltipsToObject(obj) {
+    for (let key in obj) {
+        if (typeof obj[key] === 'string') {
+            obj[key] = applyTooltips(obj[key]);
+        } else if (typeof obj[key] === 'object') {
+            applyTooltipsToObject(obj[key]); // Recursive call
+        }
+    }
+}
+
+applyTooltipsToObject(campaignTrail_temp.questions_json);
+applyTooltipsToObject(campaignTrail_temp.answers_json);
+applyTooltipsToObject(campaignTrail_temp.answer_feedback_json);


### PR DESCRIPTION
Mod Name: ROC 2024
Best Place to Contact You:
DISCORD 
name: ussroaknoke

Description/Additional Info (Optional):
Election select Icon:https://i.imgur.com/InseU2v.png

This mod features four candidates, but only three have significant playability and competitiveness.

Due to an early withdrawal from the election, Terry Gou does not have a specially crafted set of 30 questions. Normally, he cannot win the election, but his story can still be experienced in full.

Both the KMT and the TPP have the possibility of forming a coalition by selecting Joint Tickets for the vice presidency, but there is still a risk of failure.
There are two types of Joint Tickets: Ko-Hou or Hou-Ko. The dominant party's name comes first. Selecting "XX-XX Joint Tickets" at the beginning of the game enables this feature. For example, Blue-white Tickets indicate Hou-Ko, while White-Blue Tickets indicate Ko-Hou.
Only the KMT and the TPP have additional vice presidential options. Choosing a different vice president eliminates all possibilities for Joint Tickets. However, each vice president choice has a different impact on your campaign activities and offers unique achievements. Enjoy playing!