### PR TITLE
2076 Ending

### DIFF
--- a/static/mods/2076_StephensonRichards.html
+++ b/static/mods/2076_StephensonRichards.html
@@ -117,16 +117,7 @@ construct = (a = 1) => {
       if (candImg) {
         candImg.remove()
       console.log("TRYING");
-        $("#final_results_description")[0].style = `
-          text-align:left;
-          width: 72%;
-        height:71%;
-          display: block;
-          margin-left: auto;
-          margin-right: auto;
-        overflow: auto;
-        `
-       console.log("RESULTS UPDATED");
+      console.log("RESULTS UPDATED");
       }
     }, 10)
     else if (e.image)
@@ -135,16 +126,7 @@ construct = (a = 1) => {
       if (candImg) {
         candImg.src = e.image;
       console.log("TRYING");
-        $("#final_results_description")[0].style = `
-          text-align:left;
-          width: 72%;
-        height:71%;
-          display: block;
-          margin-left: auto;
-          margin-right: auto;
-        overflow: auto;
-        `
-       console.log("RESULTS UPDATED");
+      console.log("RESULTS UPDATED");
       }		
     }, 10)
     


### PR DESCRIPTION
removed the scrollbars from the endings in the code 2, which is not really necessary due to the length of the text not needing for the ability to scroll up and down