### PR TITLE
Encase Mod Loader Description and Image into one Scrollable Div

### DIFF
--- a/static/css/community.css
+++ b/static/css/community.css
@@ -66,7 +66,7 @@
 .mod-desc {
     flex: 1;
   height: 100%;
-  overflow-y: clip;
+  overflow-y: scroll;
     text-align: center;
     font-size: 12px;
     width: 90%;

--- a/static/css/community.css
+++ b/static/css/community.css
@@ -60,11 +60,13 @@
 .mod-title p {
   padding:10px;
 }
-
+.mod-img-desc {
+    overflow-y: scroll;
+}
 .mod-desc {
     flex: 1;
   height: 100%;
-  overflow-y: auto;
+  overflow-y: clip;
     text-align: center;
     font-size: 12px;
     width: 90%;

--- a/static/js/modLoaderCode.js
+++ b/static/js/modLoaderCode.js
@@ -353,7 +353,8 @@ function createModView(mod, imageUrl, description, isCustom) {
   modView.innerHTML = `
     <div class="mod-title" ${theme ? `style="background-color:${theme.header_color};"` : ""}>
         <p ${theme ? `style="color:${theme.header_text_color};"` : ""}>${mod.innerText}</p>
-    </div><div>
+    </div>
+    <div class = "mod-img-desc">
     <img class="mod-image" src="${imageUrl}"></img>
     <div ${theme ? `style="background-color:${theme.description_background_color}; color:${theme.description_text_color};"` : ""} class="mod-desc" >${description}</div></div>
     <div class="hover-button-holder">

--- a/static/js/modLoaderCode.js
+++ b/static/js/modLoaderCode.js
@@ -353,9 +353,9 @@ function createModView(mod, imageUrl, description, isCustom) {
   modView.innerHTML = `
     <div class="mod-title" ${theme ? `style="background-color:${theme.header_color};"` : ""}>
         <p ${theme ? `style="color:${theme.header_text_color};"` : ""}>${mod.innerText}</p>
-    </div>
+    </div><div>
     <img class="mod-image" src="${imageUrl}"></img>
-    <div ${theme ? `style="background-color:${theme.description_background_color}; color:${theme.description_text_color};"` : ""} class="mod-desc" >${description}</div>
+    <div ${theme ? `style="background-color:${theme.description_background_color}; color:${theme.description_text_color};"` : ""} class="mod-desc" >${description}</div></div>
     <div class="hover-button-holder">
         <button ${theme ? `style="background-color:${theme.secondary_color};"` : ""} class="mod-play-button hover-button" onclick="loadModFromButton(\`${mod.value}\`)"><span ${theme ? `style="color:${theme.ui_text_color};"` : ""}>${PLAY}</span></button>
         <button ${theme ? `style="background-color:${theme.secondary_color};"` : ""} class="hover-button" onclick="toggleFavorite(event, \`${mod.value}\`)"><span ${theme ? `style="color:${theme.ui_text_color};"` : ""}>${favText}</span></button>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e76b8c25-b6b2-4cba-be92-de9927a10ea1)
Many mods look like the one on the far left, where you cannot read the description due to the image chosen. Even if this is not the case, other mods have a smaller space in which to read the descriptions.

![image](https://github.com/user-attachments/assets/0d77eae7-1d71-45ad-988d-63f21e338b83)

This update adds a scroll bar to encompass a new div class called ".mod-img-desc" which covers all of this.

Sadly, I could not remove the scroll bar from the original ".mod-desc" class. This is because it would make many mods look like this if they chose a unique description background color
![image](https://github.com/user-attachments/assets/80fb4c9f-00ac-40d2-8a90-e2edc188a174)

Its certain that with a lot more effort (or skill) on my part, this could be fixed. The easiest and most convenient way that I can find, is just to include the currently existing scroll bar. 

Despite this, it does fix the issue of unreadable descriptions which are caused by the images taking up their space.

Would be great if this was approved of, thanks!