### PR TITLE
Updating 2024 - Our Revolution mod

### DIFF
--- a/static/mods/2024 - Our Revolution_SandersHarris.html
+++ b/static/mods/2024 - Our Revolution_SandersHarris.html
@@ -5,7 +5,7 @@
 			"pk": 1000,
 			"fields": {
 				"priority": 0,
-				"description": "As you prepare to address the nation for the first time as President, the you feel the weight of history on your shoulders. This victory belongs to the millions who believed in you, who fought to elect you. You feel the anger and grief of a nation struggling to reconcile with itself after the divisive 2020 election and the tragedy of January 6. What speech did you choose to give?",
+				"description": "As you prepare to address the nation for the first time as President, you feel the weight of history on your shoulders. This victory belongs to the millions who believed in you, who fought to elect you. You feel the anger and grief of a nation struggling to reconcile with itself after the divisive 2020 election and the tragedy of January 6. What speech did you choose to give?",
 				"likelihood": 1
 			}
 		},
@@ -500,7 +500,7 @@
 			"pk": 28000,
 			"fields": {
 				"priority": 0,
-				"description": "The Israel-Palestine conflict has spread now with the Yemeni Houthis attacking commercial ships in the Red Sea. Though they claim to be avenging Palestine with attacks on Israeli or Western-aligned ships, their attacks have been indiscriminate in practice, causing economic disruption as vessels steer clear. How will you respond to this new threat, Mr. President?",
+				"description": "The Israel-Palestine conflict has spread now with the Yemeni Houthis attacking commercial ships in the Red Sea. Though they claim to be avenging Palestine with attacks on Israeli or Western-aligned ships, their attacks have been indiscriminate in practice, causing economic disruption as vessels steer clear. What will you tell America about this new threat, Mr. President?",
 				"likelihood": 1
 			}
 		},
@@ -761,7 +761,7 @@
 			"pk": 35400,
 			"fields": {
 				"priority": 0,
-				"description": "As you step onto the podium for the mid-summer debate, you prepare for Josh Hawley to try and seize your mantle as champion of the working class. With the media consumed by his picket-line performatism and debates about DEI and immigration, only you can cut through the noise and expose his false populism for what it is. What strategy do you employ?",
+				"description": "As you step onto the podium for the mid-summer debate, you prepare for Josh Hawley to try and seize your mantle as champion of the working class. With the media consumed by his picket-line performatism and debates about DEI and immigration, only you can cut through the noise and expose his false populism for what it is. What will you say on stage?",
 				"likelihood": 1
 			}
 		},
@@ -2069,7 +2069,7 @@
 			"pk": 17001,
 			"fields": {
 				"question": 17000,
-				"description": "The right to choose is under attack in a way we can't ignore, and we must push back. This is no time for compromises and half-measures; you will work with Schumer and Pelosi to fight for the Woman's Health Protection Act in Congress and codify the right to choose once and for all. You'll rally the Senate and the House, and if there are not 60 votes in the Senate, then the Senate must end the filibuster to pass it with 50 votes!"
+				"description": "The right to choose is under attack in a way we can't ignore, and we must push back. This is no time for compromises and half-measures; you will work with Schumer and Pelosi to fight for the Women's Health Protection Act in Congress and codify the right to choose once and for all. You'll rally the Senate and the House, and if there are not 60 votes in the Senate, then the Senate must end the filibuster to pass it with 50 votes!"
 			}
 		},
 		{
@@ -2077,7 +2077,7 @@
 			"pk": 17002,
 			"fields": {
 				"question": 17000,
-				"description": "As much as it pains you, you know the Woman's Health Protection Act won't pass. Working with Schumer and Pelosi, you'll push for votes on measures with broad public support - protecting abortion in the first trimester, in cases of rape and incest, securing travel for abortion, and guaranteeing birth control access. One vote at a time, you'll force Republicans to show America how out of touch they stand on women's rights."
+				"description": "As much as it pains you, you know the Women's Health Protection Act won't pass. Working with Schumer and Pelosi, you'll push for votes on measures with broad public support - protecting abortion in the first trimester, in cases of rape and incest, securing travel for abortion, and guaranteeing birth control access. One vote at a time, you'll force Republicans to show America how out of touch they stand on women's rights."
 			}
 		},
 		{
@@ -6054,7 +6054,7 @@
 			"fields": {
 				"state": 1102,
 				"issue": 110,
-				"state_issue_score": -0.2,
+				"state_issue_score": 0.1,
 				"weight": 1
 			}
 		},
@@ -6064,7 +6064,7 @@
 			"fields": {
 				"state": 1102,
 				"issue": 111,
-				"state_issue_score": 0.4,
+				"state_issue_score": 0.32,
 				"weight": 1.25
 			}
 		},
@@ -6095,7 +6095,7 @@
 				"state": 1102,
 				"issue": 114,
 				"state_issue_score": 1,
-				"weight": 1
+				"weight": 0.9
 			}
 		},
 		{
@@ -6134,7 +6134,7 @@
 			"fields": {
 				"state": 1103,
 				"issue": 113,
-				"state_issue_score": -0.6,
+				"state_issue_score": -0.75,
 				"weight": 1.5
 			}
 		},
@@ -6534,7 +6534,7 @@
 			"fields": {
 				"state": 1111,
 				"issue": 113,
-				"state_issue_score": -0.6,
+				"state_issue_score": -0.8,
 				"weight": 1
 			}
 		},
@@ -6815,7 +6815,7 @@
 				"state": 1117,
 				"issue": 111,
 				"state_issue_score": -0.45,
-				"weight": 0.75
+				"weight": 1
 			}
 		},
 		{
@@ -7104,7 +7104,7 @@
 			"fields": {
 				"state": 1123,
 				"issue": 110,
-				"state_issue_score": -0.1,
+				"state_issue_score": -0.2,
 				"weight": 0.75
 			}
 		},
@@ -7304,7 +7304,7 @@
 			"fields": {
 				"state": 1127,
 				"issue": 110,
-				"state_issue_score": 0.35,
+				"state_issue_score": 0.42,
 				"weight": 1.5
 			}
 		},
@@ -7314,7 +7314,7 @@
 			"fields": {
 				"state": 1127,
 				"issue": 111,
-				"state_issue_score": -0.35,
+				"state_issue_score": -0.47,
 				"weight": 1
 			}
 		},
@@ -7324,7 +7324,7 @@
 			"fields": {
 				"state": 1127,
 				"issue": 112,
-				"state_issue_score": 0.16,
+				"state_issue_score": 0.35,
 				"weight": 1
 			}
 		},
@@ -7334,7 +7334,7 @@
 			"fields": {
 				"state": 1127,
 				"issue": 113,
-				"state_issue_score": 0.16,
+				"state_issue_score": -0.15,
 				"weight": 1.5
 			}
 		},
@@ -7345,7 +7345,7 @@
 				"state": 1127,
 				"issue": 114,
 				"state_issue_score": 1,
-				"weight": 1.4
+				"weight": 1.0
 			}
 		},
 		{
@@ -7454,7 +7454,7 @@
 			"fields": {
 				"state": 1130,
 				"issue": 110,
-				"state_issue_score": 0.3,
+				"state_issue_score": 0.35,
 				"weight": 1.5
 			}
 		},
@@ -7464,7 +7464,7 @@
 			"fields": {
 				"state": 1130,
 				"issue": 111,
-				"state_issue_score": 0.2,
+				"state_issue_score": 0,
 				"weight": 1
 			}
 		},
@@ -7474,7 +7474,7 @@
 			"fields": {
 				"state": 1130,
 				"issue": 112,
-				"state_issue_score": 0.2,
+				"state_issue_score": 0.3,
 				"weight": 1
 			}
 		},
@@ -7484,7 +7484,7 @@
 			"fields": {
 				"state": 1130,
 				"issue": 113,
-				"state_issue_score": -0.1,
+				"state_issue_score": 0.1,
 				"weight": 1.5
 			}
 		},
@@ -7495,7 +7495,7 @@
 				"state": 1130,
 				"issue": 114,
 				"state_issue_score": 1,
-				"weight": 1.5
+				"weight": 1.2
 			}
 		},
 		{
@@ -7604,7 +7604,7 @@
 			"fields": {
 				"state": 1133,
 				"issue": 110,
-				"state_issue_score": -0.45,
+				"state_issue_score": -0.6,
 				"weight": 1
 			}
 		},
@@ -7734,7 +7734,7 @@
 			"fields": {
 				"state": 1135,
 				"issue": 113,
-				"state_issue_score": -0.7,
+				"state_issue_score": -0.8,
 				"weight": 1.25
 			}
 		},
@@ -7984,7 +7984,7 @@
 			"fields": {
 				"state": 1140,
 				"issue": 113,
-				"state_issue_score": -0.55,
+				"state_issue_score": -0.6,
 				"weight": 1
 			}
 		},
@@ -8034,7 +8034,7 @@
 			"fields": {
 				"state": 1141,
 				"issue": 113,
-				"state_issue_score": -0.5,
+				"state_issue_score": -0.6,
 				"weight": 1
 			}
 		},
@@ -8484,7 +8484,7 @@
 			"fields": {
 				"state": 1150,
 				"issue": 113,
-				"state_issue_score": -0.71,
+				"state_issue_score": -0.75,
 				"weight": 1
 			}
 		},
@@ -9051,7 +9051,7 @@
 			"fields": {
 				"candidate": 300,
 				"state": 1102,
-				"state_multiplier": 0.952
+				"state_multiplier": 0.975
 			}
 		},
 		{
@@ -9060,7 +9060,7 @@
 			"fields": {
 				"candidate": 300,
 				"state": 1103,
-				"state_multiplier": 1.64
+				"state_multiplier": 1.9
 			}
 		},
 		{
@@ -9069,7 +9069,7 @@
 			"fields": {
 				"candidate": 300,
 				"state": 1104,
-				"state_multiplier": 1.3
+				"state_multiplier": 1.34
 			}
 		},
 		{
@@ -9132,7 +9132,7 @@
 			"fields": {
 				"candidate": 300,
 				"state": 1111,
-				"state_multiplier": 0.72
+				"state_multiplier": 0.82
 			}
 		},
 		{
@@ -9141,7 +9141,7 @@
 			"fields": {
 				"candidate": 300,
 				"state": 1112,
-				"state_multiplier": 1.11
+				"state_multiplier": 1.13
 			}
 		},
 		{
@@ -9186,7 +9186,7 @@
 			"fields": {
 				"candidate": 300,
 				"state": 1117,
-				"state_multiplier": 1.82
+				"state_multiplier": 1.86
 			}
 		},
 		{
@@ -9303,7 +9303,7 @@
 			"fields": {
 				"candidate": 300,
 				"state": 1130,
-				"state_multiplier": 1.12
+				"state_multiplier": 1.068
 			}
 		},
 		{
@@ -9330,7 +9330,7 @@
 			"fields": {
 				"candidate": 300,
 				"state": 1133,
-				"state_multiplier": 0.72
+				"state_multiplier": 0.735
 			}
 		},
 		{
@@ -9348,7 +9348,7 @@
 			"fields": {
 				"candidate": 300,
 				"state": 1135,
-				"state_multiplier": 0.76
+				"state_multiplier": 0.81
 			}
 		},
 		{
@@ -9393,7 +9393,7 @@
 			"fields": {
 				"candidate": 300,
 				"state": 1140,
-				"state_multiplier": 0.87
+				"state_multiplier": 0.9
 			}
 		},
 		{
@@ -9402,7 +9402,7 @@
 			"fields": {
 				"candidate": 300,
 				"state": 1141,
-				"state_multiplier": 1.62
+				"state_multiplier": 1.72
 			}
 		},
 		{
@@ -9483,7 +9483,7 @@
 			"fields": {
 				"candidate": 300,
 				"state": 1150,
-				"state_multiplier": 0.57
+				"state_multiplier": 0.64
 			}
 		},
 		{
@@ -20969,7 +20969,7 @@
 			"fields": {
 				"answer": 31103,
 				"issue": 113,
-				"issue_score": 0.5,
+				"issue_score": 0.2,
 				"issue_importance": 12
 			}
 		},
@@ -21899,7 +21899,7 @@
 			"fields": {
 				"answer": 36003,
 				"issue": 111,
-				"issue_score": -0.25,
+				"issue_score": -0.2,
 				"issue_importance": 8
 			}
 		},
@@ -21929,7 +21929,7 @@
 			"fields": {
 				"answer": 36002,
 				"issue": 110,
-				"issue_score": 0.3,
+				"issue_score": 0.42,
 				"issue_importance": 4
 			}
 		},
@@ -21939,7 +21939,7 @@
 			"fields": {
 				"answer": 36002,
 				"issue": 113,
-				"issue_score": 0.16,
+				"issue_score": -0.15,
 				"issue_importance": 4
 			}
 		},
@@ -21959,7 +21959,7 @@
 			"fields": {
 				"answer": 44001,
 				"issue": 110,
-				"issue_score": 0.5,
+				"issue_score": 0.48,
 				"issue_importance": 5
 			}
 		},
@@ -21969,7 +21969,7 @@
 			"fields": {
 				"answer": 44001,
 				"issue": 111,
-				"issue_score": -0.25,
+				"issue_score": -0.2,
 				"issue_importance": 5
 			}
 		},
@@ -21979,7 +21979,7 @@
 			"fields": {
 				"answer": 44002,
 				"issue": 110,
-				"issue_score": 0.3,
+				"issue_score": 0.42,
 				"issue_importance": 5
 			}
 		},
@@ -21989,7 +21989,7 @@
 			"fields": {
 				"answer": 44002,
 				"issue": 113,
-				"issue_score": 0.16,
+				"issue_score": -0.15,
 				"issue_importance": 5
 			}
 		},
@@ -22009,7 +22009,7 @@
 			"fields": {
 				"answer": 44003,
 				"issue": 112,
-				"issue_score": -0.16,
+				"issue_score": -0.29,
 				"issue_importance": 5
 			}
 		},
@@ -22029,7 +22029,7 @@
 			"fields": {
 				"answer": 44004,
 				"issue": 112,
-				"issue_score": -0.1,
+				"issue_score": -0.26,
 				"issue_importance": 5
 			}
 		},
@@ -22039,7 +22039,7 @@
 			"fields": {
 				"answer": 44101,
 				"issue": 110,
-				"issue_score": 0.3,
+				"issue_score": 0.42,
 				"issue_importance": 3
 			}
 		},
@@ -22049,7 +22049,7 @@
 			"fields": {
 				"answer": 44101,
 				"issue": 111,
-				"issue_score": -0.25,
+				"issue_score": -0.47,
 				"issue_importance": 3
 			}
 		},
@@ -22059,7 +22059,7 @@
 			"fields": {
 				"answer": 44101,
 				"issue": 113,
-				"issue_score": 0.16,
+				"issue_score": -0.15,
 				"issue_importance": 3
 			}
 		},
@@ -22069,7 +22069,7 @@
 			"fields": {
 				"answer": 44102,
 				"issue": 111,
-				"issue_score": 0.4,
+				"issue_score": 0.32,
 				"issue_importance": 3
 			}
 		},
@@ -22089,7 +22089,7 @@
 			"fields": {
 				"answer": 44103,
 				"issue": 111,
-				"issue_score": 0.4,
+				"issue_score": 0.3,
 				"issue_importance": 3
 			}
 		},
@@ -22109,7 +22109,7 @@
 			"fields": {
 				"answer": 44101,
 				"issue": 112,
-				"issue_score": 0.16,
+				"issue_score": 0.35,
 				"issue_importance": 3
 			}
 		},
@@ -22119,7 +22119,7 @@
 			"fields": {
 				"answer": 44102,
 				"issue": 110,
-				"issue_score": -0.2,
+				"issue_score": 0.1,
 				"issue_importance": 3
 			}
 		},
@@ -22179,7 +22179,7 @@
 			"fields": {
 				"answer": 44104,
 				"issue": 112,
-				"issue_score": -0.1,
+				"issue_score": -0.26,
 				"issue_importance": 3
 			}
 		},
@@ -22189,7 +22189,7 @@
 			"fields": {
 				"answer": 44104,
 				"issue": 113,
-				"issue_score": -0.25,
+				"issue_score": -0.3,
 				"issue_importance": 3
 			}
 		},
@@ -50852,7 +50852,7 @@
 			"fields": {
 				"answer": 24301,
 				"candidate": 300,
-				"answer_feedback": "You push the aid through Congress, fifty billion dollars meant not for bombs, but for bread, hospitals, and homes. But the world isn't convinced; they're busy rearming, no longer trusting Washington to stand firm. Europe steps up, their aid generous but their eyes hard; they blame you for not doing more when it mattered most."
+				"answer_feedback": "Fifty billion for Ukrainian reconstruction scrapes through Congress. Your progressive wing grumbles about 'nation-building' while Tom Cotton calls it an \"expensive clean-up\" for a mess you should've prevented. At the G7, Scholz's keynote speech omits any mention of US leadership, while Macron briefs the press on Europe's need for 'strategic autonomy'."
 			}
 		},
 		{
@@ -52274,7 +52274,7 @@
 			"fields": {
 				"answer": 37203,
 				"candidate": 300,
-				"answer_feedback": "..."
+				"answer_feedback": "......"
 			}
 		},
 		{
@@ -53757,6 +53757,7 @@
 	stop_the_steal_loc=0
 	stop_the_steal_states=[]
 	faithless=false
+	left_angry=false //only for an ending song.
 	faithless_num=0
 	faithless_loc=0
 	faithless_states=[]
@@ -53790,6 +53791,9 @@
 				}
 				else if (!ending_2020) {
 					campaignTrail_temp.election_json[0].fields.advisor_url = "https://i.imgur.com/5BWx6ro.jpeg"; //happy Kamala
+				}
+				if (progressive_anger>=6) {
+					left_angry=true //setting here because left anger gets adjusted if you win by Bernie trying to talk them out of it, them being reluctant to throw a win.
 				}
 			}
 			else { //you lost, let's see if you should get blamed by someone for it.
@@ -54568,7 +54572,7 @@
 				
 			
 		}
-		if (faithless || stop_the_steal || (quickstats[0]<270 && e.final_overall_results.find(p=>p.candidate==301).electoral_votes<270)) { //election deadlocked somehow
+		if (faithless || stop_the_steal || (quickstats[0]<270 && e.final_overall_results.find(p=>p.candidate==301).electoral_votes<270 && NuclearWar==0)) { //election deadlocked somehow but not nuclear war
 			if (!ending_2020 && ticket_status==1) {
 				campaignTrail_temp.election_json[0].fields.advisor_url = "https://i.imgur.com/AfDHTn1.jpeg"; //protesting Bernie
 			}
@@ -54838,23 +54842,145 @@
 					corrr=`\n<h2>OUR REVOLUTION</h2><font id='wittyquote' size='3' color='white'><em>`+customquote+`</em></font>`
 				}
 				if (e.final_overall_results.find(p=>p.candidate==300).electoral_votes>=269 && won_house && senate_seats>=50 && senate_seats+party_econ_progressive+political_capital*0.5>=60) { //special music if you've gotten M4A done
-					song_change_resolved=true
-					const EndingSong = new Playlist();
-					const endSong = new Song("We Shall Overcome", "Harlem Boys Choir", "https://i.imgur.com/icevzpN.jpeg", "https://audio.jukehost.co.uk/YVfOVAH1vVW5eEYCcPP90sk8GXaIv6W5");
-					EndingSong.addSong(endSong);
-					changePlaylist(EndingSong);
+					if (e.difficulty_level_id>=5) {
+						ctsAchievement("The True Ending")
+						song_change_resolved=true
+						const EndingSong = new Playlist();
+						const endSong = new Song("Our Revolution", "Tony Tig", "https://i.imgur.com/vqwDsSE.jpeg", "https://audio.jukehost.co.uk/2VoDciGuogTI5lDlhTkQP6W3ptAgn2Y8");
+						EndingSong.addSong(endSong);
+						changePlaylist(EndingSong);
+					}
+					else {
+						song_change_resolved=true
+						const EndingSong = new Playlist();
+						const endSong = new Song("We Shall Overcome", "Harlem Boys Choir", "https://i.imgur.com/icevzpN.jpeg", "https://audio.jukehost.co.uk/YVfOVAH1vVW5eEYCcPP90sk8GXaIv6W5");
+						EndingSong.addSong(endSong);
+						changePlaylist(EndingSong);
+					}
 					ctsAchievement("The Holy Grail")
 					if (more_medicare_for_some) {
 						ctsAchievement("The Holier Grail")
 					}
-					if (e.difficulty_level_id>=5) {
-						ctsAchievement("The True Ending")
-					}
 				}
-				else if (ticket_status==1 &&opponent==13) { //Bernie defeated Rubio
+				else if (taiwan_war==1) { //win and PRC defeated via war, regardless of who you're playing as (i.e. Xi Jinping forced to resign. PRC future unspecified.)
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("国际歌", "唐朝", "https://i.imgur.com/wHhypAp.jpeg", "https://audio.jukehost.co.uk/xNDmj2kGMscSe3wE1rMs0SfdlFtUC0tE");
+					//Mandarin version of the Internationale is politically neutral in mainland PRC - used both by government at official events and by opposition (both at Tiananmen & at more recent lockdown/democracy protests.) Obviously the latter is why it gets picked. Picked the 唐朝 version as it wouldn't have pro-government vibes like many of the high-quality recordings.
+					//besides it feels appropriate to have at least one rendition of The Internationale in this mod. I don't think Bernie himself has made significant comment about the song, but it's likely he sung it regularly along the other kibbutz members at Sha'ar HaAmakim
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				//opponent-specific songs picked by Skittie unless specified otherwise
+				else if (ticket_status==1 && ukraine_strength>=24) { //win as Bernie and Ukraine liberated
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Seven Nation Army", "The White Stripes", "https://i.imgur.com/DhPVaGe.jpeg", "https://audio.jukehost.co.uk/S3m4rEjTKppwNLnFdWG7Hx4kolZelXH1");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ukraine_strength>=24) { //win as Kamala and Ukraine liberated
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Ще не вмерла України і слава, і воля", "Олекса́ндр Пономарьо́в", "https://i.imgur.com/RDeIdYI.jpeg", "https://audio.jukehost.co.uk/Cn7fyOoPmNil43g73mox9eYoS9R3gUqU"); //Slava Ukraini
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent==1 && quickstats[0]<=320) { //Bernie defeated Trump/Vance but with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Power To The People", "John Lennon", "https://i.imgur.com/QkQImcd.jpeg", "https://audio.jukehost.co.uk/hHlwkbJWO3gBQO0n3gfMOch6re4b1JKI");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent==2 && quickstats[0]<=320) { //Bernie defeated Trump/Burgum but with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Better World A-Comin'", "Woody Guthrie", "https://i.imgur.com/m5ytWBi.jpeg", "https://audio.jukehost.co.uk/G9VTxwld2sA78mUjMqOeJ5IVa9AUBFf2");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent==3 && quickstats[0]<=320) { //Bernie defeated Trump/Rubio but with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Turn! Turn! Turn!", "The Byrds", "https://i.imgur.com/EG818zH.jpeg", "https://audio.jukehost.co.uk/K4TNSKNyqDTaZab7NpbVfExMCAlVRe5I");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent==4 && quickstats[0]<=320) { //Bernie defeated Trump/Scott but with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("What's Going On", "Martin Gaye", "https://i.imgur.com/8EQ3zTJ.jpeg", "https://audio.jukehost.co.uk/YdrtvuvnbkyVSWeFpVidibuOjmixbhbJ");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent==5 && quickstats[0]<=320) { //Bernie defeated Trump Jr/Ramaswamy but with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Revolution", "The Beatles", "https://i.imgur.com/zFQUkSF.jpeg", "https://audio.jukehost.co.uk/iQNRnKfRnXGjjDZVUL7mTDupc4C9LQJ9");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent==6 && quickstats[0]<=320) { //Bernie defeated DeSantis/Burgum but with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("People Got To Be Free", "The Rascals", "https://i.imgur.com/mbURIlu.jpeg", "https://audio.jukehost.co.uk/QgrF7lZAkMbpNzguY5S0vwzMWCBlxWOr");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent==7 && quickstats[0]<=320) { //Bernie defeated Hawley/Vance but with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Working Class Hero", "John Lennon", "https://i.imgur.com/fC85CrN.jpeg", "https://audio.jukehost.co.uk/hFxQ3OvAkbpBPlscL36fZCSTFNLNyxgE");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent==11 && quickstats[0]<=320) { //Bernie defeated Vance/Trump Jr but with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Imagine", "John Lennon", "https://i.imgur.com/JL2GDoS.jpeg", "https://audio.jukehost.co.uk/epWTjw9BvBZ9d1JbcL6DedEdnbYRThet");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent==12 && quickstats[0]<=320) { //Bernie defeated Burgum/Trump Jr but with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("The Times They Are A Changin'", "Bob Dylan", "https://i.imgur.com/xT5PC4T.jpeg", "https://audio.jukehost.co.uk/rN85OrFQM8sFrEOzti0FB464gWPb01VR");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent==13 && quickstats[0]<=320) { //Bernie defeated Rubio but with 320 EVs or fewer. Recommended by Tannenberg.
 					song_change_resolved=true
 					const EndingSong = new Playlist();
 					const endSong = new Song("Como la Cigarra", "Mercedes Sosa", "https://i.imgur.com/JJMLvQv.jpeg", "https://audio.jukehost.co.uk/kYmLX7ut4E04C0hQE5tHmMQ5cPyA1eZ4");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent==14 && quickstats[0]<=320) { //Bernie defeated Scott but with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("A Change Is Gonna Come", "Sam Cooke", "https://i.imgur.com/Zax9ei3.jpeg", "https://audio.jukehost.co.uk/kFZKljqFbo3xxUkZoT0shkQAumVPssTn");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent==15 && quickstats[0]<=320) { //Bernie defeated Ramaswamy but with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Give the People What They Want", "The O'Jays", "https://i.imgur.com/wfijaB4.jpeg", "https://audio.jukehost.co.uk/Id5hCiqwfrolISTvpcvDhUEdLaJUSc8V");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent==16 && quickstats[0]<=320) { //Bernie defeated Burgum/Rubio but with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("The Revolution Starts Now", "Steve Earle", "https://i.imgur.com/QTTKtun.jpeg", "https://audio.jukehost.co.uk/C99Mt5f3cGhjdrLnkkQMXznQT1YUixGi");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent==17 && quickstats[0]<=320) { //Bernie defeated Vance/Cotton but with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Do You Hear The People Sing?", "Michael Maguire", "https://i.imgur.com/jOTyT2E.jpeg", "https://audio.jukehost.co.uk/8wvpydfEalQxIsMUD0BglQPbFMr2TA0h");
 					EndingSong.addSong(endSong);
 					changePlaylist(EndingSong);
 				}
@@ -54865,10 +54991,84 @@
 					EndingSong.addSong(endSong);
 					changePlaylist(EndingSong);
 				}
+				else if (left_angry) { //win as Kamala with left anger high. Recommended by Skittie.
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("I Just Threw Out the Love of My Dreams", "Weezer", "https://i.imgur.com/OrYPX2K.jpeg", "https://audio.jukehost.co.uk/MuIgTg9Br8AWgPwcz3Kg2MhrjIi32PsO");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				
+				//these opponent-specific ones recommended by Skittie, unless specified otherwise
+				else if (ticket_status>=2 && opponent>=1 && opponent<=4 && quickstats[0]<=320) { //Kamala defeated any Trump variation but with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Not Like Us", "Kendrick Lamar", "https://i.imgur.com/u4HTyxW.jpeg", "https://audio.jukehost.co.uk/rP0VFH05YAV6MvIIjXveLxsdylMGNB4z");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status>=2 && opponent==5 && quickstats[0]<=320) { //Kamala defeats Trump Jr with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("The Edge of Glory", "Lady Gaga", "https://i.imgur.com/CDfctSb.jpeg", "https://audio.jukehost.co.uk/CuwUcy63mkNgOsRnn4yZzI4R19rWQ7Zl");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status>=2 && opponent==6 && quickstats[0]<=320) { //Kamala defeats DeSantis with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Survivor", "Destiny's Child", "https://i.imgur.com/221kb7z.jpeg", "https://audio.jukehost.co.uk/vrVBpMQ3hzQCF81e6cq7MnmDLpnCsqN1");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status>=2 && opponent==7 && quickstats[0]<=320) { //Kamala defeats Hawley with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Unstoppable", "Sia", "https://i.imgur.com/z8BJidM.jpeg", "https://audio.jukehost.co.uk/ET2LFuhIlsk1cwPcAcg5jilwQD0B7Zvf");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status>=2 && (opponent==11 || opponent==17) && quickstats[0]<=320) { //Kamala defeats any Vance with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Karma", "Taylor Swift", "https://i.imgur.com/xJqXxC6.jpeg", "https://audio.jukehost.co.uk/J8vmX8E8LEnBeSXydPRV0p1gLegTmKzj");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status>=2 && (opponent==12 || opponent==16) && quickstats[0]<=320) { //Kamala defeats any Burgum with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Signed, Sealed, Delivered", "Stevie Wonder", "https://i.imgur.com/Mxxgdu8.jpeg", "https://audio.jukehost.co.uk/3ShqoHz4tORFurip60chBr95LagZfaGG");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status>=2 && opponent==13 && quickstats[0]<=320) { //Kamala defeats Rubio with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("California Dreamin'", "The Beach Boys", "https://i.imgur.com/l8RZrKS.jpeg", "https://audio.jukehost.co.uk/28krTJHaljlfXUZaooYoMmK7m41BCmvR");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status>=2 && opponent==14 && quickstats[0]<=320) { //Kamala defeats Scott with 320 EVs or fewer
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Ain't No Mountain High Enough", "Play", "https://i.imgur.com/orOkKXI.jpeg", "https://audio.jukehost.co.uk/tRQ7M74IP1VLGlaVTXLkBzc6kIFH4OiD");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status>=2 && opponent==15 && quickstats[0]<=320) { //Kamala defeats Vivek Ramaswamy with 320 EVs or fewer. Song picked by me.
+					song_change_resolved=true
+					const EndingSong = new Playlist();
+					const endSong = new Song("Singappenney", "A. R. Rahman", "https://i.imgur.com/Nm5Hsge.jpeg", "https://audio.jukehost.co.uk/qy0i9Xi4jLML9Y0NgEoXuuRJxYk71coG");
+					//I wanted a Tamil song because both are Tamil-speaking second-generation immigrants with at least one Tamil Brahmin parent. Kamala's mother was from Tamil Nadu; Ramaswamy's parents are from Kerala (but Tamil-speaking.)
+					//I am not familiar with any Tamil songs Kamala has specifically mentioned liking; I ended up going with a song by A.R. Rahman who's a giant in India - he endorsed her with a concert including it - and dedicated it specifically to her - in 2024. He'd definitely support her over Vivek (Ramaswamy, that is. Funnily enough, the song was actually written by Vivek... Vivek Velmurugan that is.)
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
 				else { //Freedom plays for Kamala win
 					song_change_resolved=true 
 					const EndingSong = new Playlist();
-					const endSong = new Song("Freedom", "Beyonce", "https://i.imgur.com/x5ooa2m.jpeg", "https://audio.jukehost.co.uk/reeFJNaRCAEzYiHEzqKKLddZ7loq6S9K");
+					const endSong = new Song("Freedom", "Beyoncé", "https://i.imgur.com/x5ooa2m.jpeg", "https://audio.jukehost.co.uk/reeFJNaRCAEzYiHEzqKKLddZ7loq6S9K");
 					EndingSong.addSong(endSong);
 					changePlaylist(EndingSong);
 				}
@@ -54988,7 +55188,7 @@
 				e.executable.push([0, (() => {e.image = e.image = 'https://i.imgur.com/ZPpAcX6.jpeg'})])
 			}
 		}
-		else if (quickstats[0]<270 && e.final_overall_results.find(p=>p.candidate==301).electoral_votes<270) { //you didn't win, your opponent didn't win (likely 269 tie; offhand chance of third-party winning votes.
+		else if (quickstats[0]<270 && e.final_overall_results.find(p=>p.candidate==301).electoral_votes<270) { //you didn't win, your opponent didn't win (likely 269 tie; offhand chance of third-party winning votes. Faithless electors is a separate ending.
 			if (!song_change_resolved) {
 				song_change_resolved=true
 				if (ticket_status==1) {
@@ -55001,19 +55201,8 @@
 					customquote = quotes[Math.floor((Math.random() * quotes.length))]
 					corrr=`\n<h2>OUR REVOLUTION</h2><font id='wittyquote' size='3' color='white'><em>`+customquote+`</em></font>`
 				}
-				if (opponent == 7) { //Elon DOGE ending song.
-					const EndingSong = new Playlist();
-					const endSong = new Song("I've Never Met a Nice South African", "Andy Roberts", "https://i.imgur.com/j7MqgHO.jpeg", "https://audio.jukehost.co.uk/rAiXWHZEh0zqJRz1xmU0UmWowLE8muCN");
-					EndingSong.addSong(endSong);
-					changePlaylist(EndingSong);
-				}
-				else if (ticket_status==1 &&opponent==13) { //Bernie lost to Rubio
-					const EndingSong = new Playlist();
-					const endSong = new Song("Ángel para un Final", "Silvio Rodríguez", "https://i.imgur.com/WXuwsAg.jpeg", "https://audio.jukehost.co.uk/GVObhh3VQIhXn90uidph3406rxB5Z6ie");
-					EndingSong.addSong(endSong);
-					changePlaylist(EndingSong);
-				}
-				else if (ticket_status>=2) { //Kamala lost
+				//no opponent-specific music here.
+				if (ticket_status>=2) { //Kamala lost
 					const EndingSong = new Playlist();
 					const endSong = new Song("Ain't No Way", "Aretha Franklin", "https://i.imgur.com/WMaFd14.jpeg", "https://audio.jukehost.co.uk/7MJsEjk1M8wT6QyEGqHCqA15r8ba1F9I");
 					EndingSong.addSong(endSong);
@@ -55092,15 +55281,121 @@
 					customquote = quotes[Math.floor((Math.random() * quotes.length))]
 					corrr=`\n<h2>OUR REVOLUTION</h2><font id='wittyquote' size='3' color='white'><em>`+customquote+`</em></font>`
 				}
-				if (opponent == 7) { //Elon DOGE ending song.
+				
+				if (taiwan_war==1) { //Loses after defeating PRC at war. Recommended by Irrintzi.
+					const EndingSong = new Playlist();
+					const endSong = new Song("團結的人民永遠不被擊敗", "再一次拒絕長大劇團", "https://i.imgur.com/GAUu3Xx.jpeg", "https://audio.jukehost.co.uk/yULHCFUV1zi3pF42h3OsLQjfEGnPatpr");
+					//Taiwanese protest song; very appropriate vibes.
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (taiwan_conquered==1) { //Loses after surrendering Taiwan. Great job, player. Recommended by Irrintzi.
+					const EndingSong = new Playlist();
+					const endSong = new Song("王傑", "亞細亞的孤兒", "https://i.imgur.com/ZYZgIdi.jpeg", "https://audio.jukehost.co.uk/YK8kah1tnucgGOs30b5bsoBglSXYI2wy");
+					//orphan of Asia, about Taiwan's identity crisis
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				//opponent-specific songs picked by Skittie unless specified otherwise
+				else if (ticket_status==1 && opponent == 1 && quickstats[0]>200) { //Bernie loses to Trump/Vance
+					const EndingSong = new Playlist();
+					const endSong = new Song("MAGA YMCA", "Mindy Robinson", "https://i.imgur.com/tKTmd6o.jpeg", "https://files.catbox.moe/kd4knj.mp3");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent == 2 && quickstats[0]>200) { //Bernie loses to Trump/Burgum
+					const EndingSong = new Playlist();
+					const endSong = new Song("America First", "Merle Haggard", "https://i.imgur.com/110F4wU.jpeg", "https://audio.jukehost.co.uk/DYVNHGjW3IHPbCkYHO9xc5TcOo0auXrZ");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent == 3 && quickstats[0]>200) { //Bernie loses to Trump/Rubio
+					const EndingSong = new Playlist();
+					const endSong = new Song("Born Free", "Kid Rock", "https://i.imgur.com/S4KeRWc.jpeg", "https://audio.jukehost.co.uk/IYPyvWhS9N4XOdyacceJDMAbq5JZXL2W");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent == 4 && quickstats[0]>200) { //Bernie loses to Trump/Scott
+					const EndingSong = new Playlist();
+					const endSong = new Song("Hold On, I'm Comin'", "Sam and Dave", "https://i.imgur.com/UUkHfjt.jpeg", "https://files.catbox.moe/ps1cgs.mp3");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent == 5 && quickstats[0]>200) { //Bernie loses to Trump Jr/Ramaswamy
+					const EndingSong = new Playlist();
+					const endSong = new Song("No More Mr. Nice Guy", "Alice Cooper", "https://i.imgur.com/Pnn6ct7.jpeg", "https://audio.jukehost.co.uk/UNQWfbb5LNNZoGxWWCIkPY8PiNIQy7iI");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent == 6 && quickstats[0]>200) { //Bernie loses to DeSantis/Burgum
+					const EndingSong = new Playlist();
+					const endSong = new Song("Nothin' But a Good Time", "Poison", "https://i.imgur.com/3pPafyD.jpeg", "https://audio.jukehost.co.uk/2AorboUTf5ASnFg5eHnyUamkvvn8jJOI");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 && opponent == 7 && quickstats[0]>200) { //Elon DOGE ending song. Picked by me.
 					const EndingSong = new Playlist();
 					const endSong = new Song("I've Never Met a Nice South African", "Andy Roberts", "https://i.imgur.com/j7MqgHO.jpeg", "https://audio.jukehost.co.uk/rAiXWHZEh0zqJRz1xmU0UmWowLE8muCN");
 					EndingSong.addSong(endSong);
 					changePlaylist(EndingSong);
 				}
-				else if (ticket_status==1 &&opponent==13) { //Bernie lost to Rubio
+				else if (ticket_status==1 &&opponent==11 && quickstats[0]>200) { //Bernie lost to Vance/Trump Jr
+					const EndingSong = new Playlist();
+					const endSong = new Song("You're Gonna Go Far, Kid", "The Offspring", "https://i.imgur.com/ev6Jaev.jpeg", "https://files.catbox.moe/u4so2i.mp3");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 &&opponent==12 && quickstats[0]>200) { //Bernie lost to Burgum/Trump Jr
+					const EndingSong = new Playlist();
+					const endSong = new Song("Every Small Town", "Ben Gallaher", "https://i.imgur.com/lad8czf.jpeg", "https://audio.jukehost.co.uk/H8kgLcmSKiZhe7ej5SwiywkX3fXo9E8l");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 &&opponent==13 && quickstats[0]>200) { //Bernie lost to Rubio. Picked by Tannenberg.
 					const EndingSong = new Playlist();
 					const endSong = new Song("Ángel para un Final", "Silvio Rodríguez", "https://i.imgur.com/WXuwsAg.jpeg", "https://audio.jukehost.co.uk/GVObhh3VQIhXn90uidph3406rxB5Z6ie");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 &&opponent==14 && quickstats[0]>200) { //Bernie lost to Scott
+					const EndingSong = new Playlist();
+					const endSong = new Song("Burn Rubber On Me", "The Gap Band", "https://i.imgur.com/D8G4Etr.jpeg", "https://audio.jukehost.co.uk/1hl6m7TIGmvhQUr0hAU25TW0K8vLNkzc");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 &&opponent==15 && quickstats[0]>200) { //Bernie lost to Ramaswamy
+					const EndingSong = new Playlist();
+					const endSong = new Song("Thunder", "Imagine Dragons", "https://i.imgur.com/mt5WGuD.jpeg", "https://audio.jukehost.co.uk/hjyrXrvVIkyIS0RBOAFJLfjVtAOuHoJa");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 &&opponent==16 && quickstats[0]>200) { //Bernie lost to Burgum/Rubio
+					const EndingSong = new Playlist();
+					const endSong = new Song("Only Here For A Little While", "Billy Dean", "https://i.imgur.com/kGnzJoo.jpeg", "https://audio.jukehost.co.uk/8oNxyjWMWLD5SyzDRtJ40H1TYOta58Lk");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status==1 &&opponent==17 && quickstats[0]>200) { //Bernie lost to Vance/Cotton
+					const EndingSong = new Playlist();
+					const endSong = new Song("I Won't Back Down", "Tom Petty & The Heartbreakers", "https://i.imgur.com/4h7GzTD.jpeg", "https://audio.jukehost.co.uk/3JoxbOrKTrOCOorOerKxKOmizu49ZGlC");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (quickstats[0]<=38) { //you won 38 or fewer EVs; opponents won 500+. Recommended by Skittie.
+					const EndingSong = new Playlist();
+					const endSong = new Song("The Ghost of Tom Joad", "Bruce Springsteen", "https://i.imgur.com/fjK9oFx.jpeg", "https://audio.jukehost.co.uk/7yt5Gab4oTaAy24laMqlFr2PPd75m10N");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status>=2 && opponent==1 && e.final_overall_results.find(p=>p.candidate==301).electoral_votes==312) { //Kamala lost to Trump/Vance; Trump/Vance has 312 EVs. Not necessarily wake-up-as-Kamala ending (maybe she's still stuck dreaming...). Not checking Kamala EVs because might have faithless electors.
+					const EndingSong = new Playlist();
+					const endSong = new Song("Donald Trump - Macarena", "Vek (AI generated)", "https://i.imgur.com/9EH6G2Y.jpeg", "https://audio.jukehost.co.uk/p8vmnW2EVTPQN0e2Q9qJ4tbxFlX71Rtr");
+					EndingSong.addSong(endSong);
+					changePlaylist(EndingSong);
+				}
+				else if (ticket_status>=2 && quickstats[0]>200) { //Kamala lost but not a landslide. Recommended by Skittie.
+					const EndingSong = new Playlist();
+					const endSong = new Song("For What It's Worth", "Billy Porter", "https://i.imgur.com/scqNhpc.jpeg", "https://audio.jukehost.co.uk/qDG2PbP47m9i26djXIJjshZ5xNakNhhd");
 					EndingSong.addSong(endSong);
 					changePlaylist(EndingSong);
 				}
@@ -56803,12 +57098,12 @@
 		else {
 			ending+=`</p><p>In addition, ${Object.keys(senate_close).length} `
 			if (Object.keys(senate_close).length==1) {
-				ending+=` seat`
+				ending+=` seat that did not change parties was`
 			}
 			else {
-				ending+=` seats`
+				ending+=` seats that did not change parties were`
 			}
-			ending+=` that did not change parties were decided by 5% or less:`
+			ending+=` decided by 5% or less:`
 			Object.keys(senate_close).forEach((item,index)=>{
 				if(item=="AZ" && !senate_lost) {//technically this condition checks for AZ SoS loss, not AZ governors loss (which should occur more often.) But Kari Lake is only mentioned as Governor if Mark Finchem is SoS, and mentioning either is mutually exclusive.
 					ending+=` Ruben Gallego barely defeated ${maga_trifecta.includes(1102) ? "Blake Masters" : "Kari Lake"} by ${roundToDecimals(senate_close["AZ"]*100,2)}% in Sinema's open Arizona seat`
@@ -56889,7 +57184,7 @@
 					ending+=` Maria Cantwell was narrowly re-elected by ${roundToDecimals(senate_close["WA"]*100,2)}% in Washington state`
 				}
 				else if (item=="WV") {
-					ending+=` Glen Elliott miraculously defeated Jim Justice in Manchin's open West Virginia seat by ${roundToDecimals(senate_close["WV"]*100,2)}%`
+					ending+=` Glenn Elliott miraculously defeated Jim Justice in Manchin's open West Virginia seat by ${roundToDecimals(senate_close["WV"]*100,2)}%`
 				}
 				else if (item=="WI") {
 					ending+=` Tammy Baldwin barely held on by ${roundToDecimals(senate_close["WI"]*100,2)}% in Wisconsin`
@@ -56945,7 +57240,7 @@
 			e.candidate_json[2].fields.first_name="Donald"
 			e.candidate_json[2].fields.last_name="Trump" 
 			vpTable["Donald Trump"]="JD Vance"
-			//-0.1/-0.5/-0.3/-0.75 (if running in 2020: D+4.3; D+16 EVs. Tipping point PA D+4.0. House tipping point D+3.8 Senate tipping point - MT R+2.4)
+			//-0.1/-0.5/-0.3/-0.75 (if running in 2020: D+4.5; D+16 EVs. Tipping point PA D+4.0. House tipping point D+3.9 Senate tipping point - MT R+2.8)
 			e.candidate_json[2].fields.state="Florida"
 			opponent_name="Donald Trump"
 			opponent_vp_name="JD Vance"
@@ -56990,6 +57285,7 @@
 			e.candidate_issue_score_json[22].fields.issue_score=0.6
 			e.candidate_issue_score_json[23].fields.issue_score=0.6
 			opponent_maga=true
+			e.candidate_json[2].fields.color_hex="#910c0c" //Trump color hex (also base hex) - resetting in case player has messed around with setting multiple opponents or something.
 		}
 		else if(OpponentValue==2) {
 			applySalience(110,0.075) //increases importance of econ in the election
@@ -57004,7 +57300,7 @@
 			e.candidate_json[2].fields.first_name="Donald"
 			e.candidate_json[2].fields.last_name="Trump" 
 			vpTable["Donald Trump"]="Doug Burgum" 
-			//-0.4/-0.4/-0.3/-0.55 (if running in 2020: D+0.4, D+12 EVs. Tipping point NV: D+0.3; House D+2.1; Senate tipping point MT: R+1.6)
+			//-0.4/-0.4/-0.3/-0.55 (if running in 2020: D+0.8, D+12 EVs. Tipping point PA: D+0.3; House D+2.1; Senate tipping point MT: R+2.0)
 			e.candidate_json[2].fields.state="Florida"
 			opponent_name="Donald Trump"
 			opponent_vp_name="Doug Burgum"
@@ -57047,11 +57343,12 @@
 			e.candidate_issue_score_json[20].fields.issue_score=0
 			e.candidate_issue_score_json[21].fields.issue_score=0.4
 			e.candidate_issue_score_json[22].fields.issue_score=0.4
-			e.candidate_issue_score_json[23].fields.issue_score=0.2
+			e.candidate_issue_score_json[23].fields.issue_score=0
 			applyMinorBoost(305,0.05,1102) //AZ for Sinema
 			applyMinorBoost(305,0.1,1120) //MA for Baker
 			applyMinorBoost(305,0.2) //nationwide
 			opponent_maga=true
+			e.candidate_json[2].fields.color_hex="#910c0c" //Trump color hex (also base hex) - resetting in case player has messed around with setting multiple opponents or something.
 		}
 		else if(OpponentValue==3) {
 			applySalience(111,0.075) //increases importance of globalism/foreign policy in the election
@@ -57065,7 +57362,7 @@
 			e.candidate_json[2].fields.first_name="Donald"
 			e.candidate_json[2].fields.last_name="Trump" 
 			vpTable["Donald Trump"]="Marco Rubio" 
-			// -0.3/+0.2/-0.5/-0.55 (if running in 2020: D+0.4, D+26 EVs. Tipping point PA: D+1.4. House D+2.0; Tipping point Senate - AZ R+1.5)
+			// -0.3/+0.2/-0.5/-0.55 (if running in 2020: D+0.9, D+26 EVs. Tipping point PA: D+1.4. House D+2.1; Tipping point Senate - AZ D+0.1)
 			e.candidate_json[2].fields.state="Florida"
 			opponent_name="Donald Trump"
 			opponent_vp_name="Marco Rubio"
@@ -57104,7 +57401,7 @@
 			vpTable["Joe Manchin"]="Condoleezza Rice"
 			e.candidate_json[5].fields.state="West Virginia"
 			e.candidate_json[5].fields.party="No Labels"
-			e.candidate_issue_score_json[20].fields.issue_score=0.2
+			e.candidate_issue_score_json[20].fields.issue_score=0.4
 			e.candidate_issue_score_json[21].fields.issue_score=0
 			e.candidate_issue_score_json[22].fields.issue_score=0
 			e.candidate_issue_score_json[23].fields.issue_score=0
@@ -57113,6 +57410,7 @@
 			applyMinorBoost(305,0.1,1100) //give a boost in AL to counteract the Deep South Penalty (Rice's home base)
 			applyMinorBoost(305,0.2) //general boost
 			opponent_maga=true
+			e.candidate_json[2].fields.color_hex="#910c0c" //Trump color hex (also base hex) - resetting in case player has messed around with setting multiple opponents or something.
 		}
 		else if(OpponentValue==4) {
 			applySalience(112,0.075) //increases importance of social policy in the election
@@ -57126,7 +57424,7 @@
 			e.candidate_json[2].fields.first_name="Donald"
 			e.candidate_json[2].fields.last_name="Trump" 
 			vpTable["Donald Trump"]="Tim Scott" 
-			//  -0.15/+0.1/-0.5/-0.7 (if running in 2020: D+1.7, D+26 EVs. House D+2.6. Tipping point Pennsylvania D+1.1; Tipping point Senate AZ D+0.4.)
+			//  -0.15/+0.1/-0.5/-0.7 (if running in 2020: D+1.9, D+26 EVs. House D+2.5. Tipping point Pennsylvania D+1.9; Tipping point Senate AZ D+1.8.)
 			e.candidate_json[2].fields.state="Florida"
 			opponent_name="Donald Trump"
 			opponent_vp_name="Tim Scott"
@@ -57174,6 +57472,7 @@
 			applyMinorBoost(305,0.01,1108) //At least Jolly is an actual politician.
 			applyMinorBoost(305,0.12) 
 			opponent_maga=true
+			e.candidate_json[2].fields.color_hex="#910c0c" //Trump color hex (also base hex) - resetting in case player has messed around with setting multiple opponents or something.
 		}
 		else if(OpponentValue==5) {
 			applySalience(111,0.15) //increases importance of globalism in the election
@@ -57185,7 +57484,7 @@
 			e.candidate_json[2].fields.first_name="Donald"
 			e.candidate_json[2].fields.last_name="Trump Jr." 
 			vpTable["Donald Trump Jr."]="Vivek Ramaswamy" 
-			// 0/-0.7/-0.7/-0.6 (D+6.9; D+92 EVs; NE-02 D+9.1; House D+8.1; Senate tipping point Montana D+0.8)
+			// 0/-0.7/-0.7/-0.6 (D+7.2; D+148 EVs; NE-02 D+9.2; House D+8.3; Senate tipping point Montana D+0.4)
 			e.candidate_json[2].fields.state="Florida"
 			opponent_name="Donald Trump Jr."
 			opponent_vp_name="Vivek Ramaswamy"
@@ -57236,28 +57535,29 @@
 			applyMinorBoost(305,0.02,1145) //Riggleman boost in Virginia
 			applyMinorBoost(305,0.12) 
 			opponent_maga=true
+			e.candidate_json[2].fields.color_hex="#730808" //Trump Jr color hex
 		}
 		else if(OpponentValue==6) {
 			applySalience(112,0.15) //increases importance of social issues in the election
-			worker_approval+=1.5 //normie Republican ticket 
+			worker_approval+=1.25 //normie Republican ticket 
 			dove_approval+=3 //normie Republican ticket
-			latino_approval-=2.75 //significant appeal to Latinos
+			latino_approval-=1.5 //significant appeal to Latinos
 			adversary_approval+=3 //you already look better in comparison
 			blob_approval-=3
 			e.candidate_json[2].fields.first_name="Ron"
 			e.candidate_json[2].fields.last_name="DeSantis" 
 			vpTable["Ron DeSantis"]="Doug Burgum" 
-			// -0.4/0.1/-0.7/-0.2 (D+6.1; D+148 EVs; ME-02 D+6.1; House tipping point D+3.8; Senate tipping point AZ D+4.8)
+			// -0.35/0.1/-0.7/-0.2 (D+6.0; D+116 EVs; PA D+7.4; House tipping point D+3.6; Senate tipping point AZ D+4.1)
 			e.candidate_json[2].fields.state="Florida"
 			opponent_name="Ron DeSantis"
 			opponent_vp_name="Doug Burgum"
 			opponent_last_name="DeSantis"
 			opponent_vp_last_name="Burgum"
 			opponent_slogan="Never Back Down!"
-			e.candidate_issue_score_json[5].fields.issue_score=-0.4
+			e.candidate_issue_score_json[5].fields.issue_score=-0.35
 			e.candidate_issue_score_json[6].fields.issue_score=+0.1
 			e.candidate_issue_score_json[7].fields.issue_score=-0.7
-			e.candidate_issue_score_json[8].fields.issue_score=-0.2
+			e.candidate_issue_score_json[8].fields.issue_score=-0.45
 			applyDrift(301,0.01,1108) //Florida
 			applyDrift(301,0.05,1133) //North Dakota
 			e.candidate_json[3].fields.first_name="Robert F."
@@ -57292,6 +57592,7 @@
 			applyMinorBoost(305,0.01,1131) //Boost Chavis in NY
 			applyMinorBoost(305,0.06) 
 			opponent_maga=false
+			e.candidate_json[2].fields.color_hex="#951633" //DeSantis color hex. Am told this is meant to reference RFK Jr's color in DSA.
 		}
 		else if(OpponentValue==7) {
 			applySalience(111,0.075) //increases importance of globalism in the election
@@ -57304,7 +57605,7 @@
 			e.candidate_json[2].fields.first_name="Josh"
 			e.candidate_json[2].fields.last_name="Hawley" 
 			vpTable["Josh Hawley"]="JD Vance" 
-			//+0.45/-0.6/-0.6/-0.5 (D+2.1; D+80 EVs; NV D+2.0; House tipping point D+3.2; Senate tipping point MT R+2.4)
+			//+0.45/-0.6/-0.6/-0.5 (D+2.6; D+80 EVs; PA D+1.7; House tipping point D+3.2; Senate tipping point MT R+2.8)
 			e.candidate_json[2].fields.state="Missouri"
 			opponent_name="Josh Hawley"
 			opponent_vp_name="JD Vance"
@@ -57349,6 +57650,7 @@
 			applyMinorBoost(305,0.1,1129) //Whitman boost in NJ
 			applyMinorBoost(305,0.12) 
 			opponent_maga=true
+			e.candidate_json[2].fields.color_hex="#bf5252" //Josh Hawley color hex
 		}
 		else if(OpponentValue==11) { //for assassination results, don't overwrite issue scores because keep the effect of previous attacks.
 			applySalience(111,0.15) //increases importance of globalism in the election
@@ -57361,7 +57663,7 @@
 			e.candidate_json[2].fields.first_name="J.D."
 			e.candidate_json[2].fields.last_name="Vance" 
 			vpTable["J.D. Vance"]="Donald Trump Jr." 
-			//+0.15/-0.7/-0.5/-0.5 (D+4.4; D+80 EVs. PA D+5.58; House D+4.1; Senate tipping point MT R+4.5)
+			//+0.15/-0.7/-0.5/-0.5 (D+4.8; D+80 EVs. PA D+5.7; House D+4.3; Senate tipping point MT R+4.9)
 			e.candidate_json[2].fields.state="Ohio"
 			opponent_name="JD Vance"
 			opponent_vp_name="Donald Trump Jr."
@@ -57373,6 +57675,7 @@
 			e.candidate_issue_score_json[8].fields.issue_score+=0.25
 			//home state effects don't change.
 			opponent_maga=true
+			e.candidate_json[2].fields.color_hex="#662828" //JD Vance color hex
 		}
 		else if(OpponentValue==12) {
 			applySalience(110,0.075) //econ more important
@@ -57385,7 +57688,7 @@
 			e.candidate_json[2].fields.first_name="Doug"
 			e.candidate_json[2].fields.last_name="Burgum" 
 			vpTable["Doug Burgum"]="Donald Trump Jr." 
-			//-0.6/+0.3/-0.2/-0.2 (D+3.4; D+60 EVs. PA D+4.2; 51 Senate seats; House D+2.7; Senate tipping point MO D+1.8)
+			//-0.6/+0.3/-0.2/-0.2 (D+3.4; D+60 EVs. PA D+4.0; 51 Senate seats; House D+2.7; Senate tipping point AZ D+2.4)
 			e.candidate_json[2].fields.state="North Dakota"
 			opponent_name="Doug Burgum"
 			opponent_vp_name="Donald Trump Jr."
@@ -57398,6 +57701,7 @@
 			applyMinorBoost(302,rfk_boost*0.25) //hey what happened to our MAGA candidate?
 			//home state effects don't change.
 			opponent_maga=false
+			e.candidate_json[2].fields.color_hex="#a83232" //Burgum color hex
 		}
 		else if(OpponentValue==13) {
 			applySalience(112,0.075) //increases importance of social issues in the election
@@ -57410,7 +57714,7 @@
 			e.candidate_json[2].fields.first_name="Marco"
 			e.candidate_json[2].fields.last_name="Rubio" 
 			vpTable["Marco Rubio"]="Donald Trump Jr." 
-			//-0.55/+0.4/-0.6/-0.2 (D+2.2; D+92 EVs; VA D+5, House D+4.5; 50 Senate seats - Senate tipping point AZ D+3.2%)
+			//-0.55/+0.4/-0.6/-0.2 (D+3.3; D+92 EVs; VA D+5, House D+4.6; 50 Senate seats - Senate tipping point AZ D+6.5%)
 			opponent_name="Marco Rubio"
 			opponent_vp_name="Donald Trump Jr."
 			opponent_last_name="Rubio"
@@ -57421,6 +57725,7 @@
 			e.candidate_issue_score_json[8].fields.issue_score+=0.35
 			//home state effects don't change.
 			opponent_maga=false
+			e.candidate_json[2].fields.color_hex="#bf1526" //Rubio color hex
 		}
 		else if(OpponentValue==14) {
 			worker_approval+=1.25 //ticket moves to right on econ 
@@ -57431,7 +57736,7 @@
 			e.candidate_json[2].fields.first_name="Tim"
 			e.candidate_json[2].fields.last_name="Scott" 
 			vpTable["Tim Scott"]="Donald Trump Jr." 
-			//-0.4/+0.3/-0.6/-0.5 (D+3.6; D+92 EVs; PA D+5.82; House D+2.4; Senate tipping point AZ R+0.9)
+			//-0.4/+0.3/-0.6/-0.5 (D+3.6; D+92 EVs; PA D+5.6; House D+2.4; Senate tipping point AZ D+0.7)
 			e.candidate_json[2].fields.state="South Carolina"
 			opponent_name="Tim Scott"
 			opponent_vp_name="Donald Trump Jr."
@@ -57444,6 +57749,7 @@
 			applyMinorBoost(302,rfk_boost*0.1) //hey what happened to our MAGA candidate?
 			//home state effects don't change.
 			opponent_maga=false
+			e.candidate_json[2].fields.color_hex="#d13838" //Scott color hex
 		}
 		else if(OpponentValue==15) {
 			worker_approval+=1.5 //ticket moves to right on econ 
@@ -57452,7 +57758,7 @@
 			e.candidate_json[2].fields.first_name="Vivek"
 			e.candidate_json[2].fields.last_name="Ramaswamy" 
 			vpTable["Vivek Ramaswamy"]="Lara Trump" 
-			//-0.3/-0.75/-0.7/-0.55 (D+8.4; D+148 EVs; NE-02 D+10.8; House D+9.7; 50 Senate seats - Senate tipping point MT D+2.3)
+			//-0.3/-0.75/-0.7/-0.55 (D+8.7; D+148 EVs; NE-02 D+10.8; House D+9.7; 50 Senate seats - Senate tipping point MT D+1.9)
 			e.candidate_json[2].fields.state="Ohio"
 			opponent_name="Vivek Ramaswamy"
 			opponent_vp_name="Lara Trump"
@@ -57464,42 +57770,44 @@
 			e.candidate_issue_score_json[8].fields.issue_score+=0.05
 			//home state effects don't change.
 			opponent_maga=true
+			e.candidate_json[2].fields.color_hex="#b21948" //Ramaswamy color hex
 		}
 		else if(OpponentValue==16) {
 			applySalience(112,-0.15) //decrease importance of social issues in the election
 			applySalience(110,0.075) //increases importance of econ issues in the election
 			applySalience(111,0.075) //increases importance of globalism in the election
-			worker_approval+=1.5 //ticket moves to right on econ 
+			worker_approval+=1.75 //ticket moves to right on econ 
 			dove_approval+=1.5 //ticket moves more globalist
-			latino_approval-=1 //ticket gets more moderate on immigration 
+			latino_approval-=2.25 //ticket gets more moderate on immigration 
 			adversary_approval+=1.5
 			blob_approval-=1.5
 			e.candidate_json[2].fields.first_name="Doug"
 			e.candidate_json[2].fields.last_name="Burgum" 
 			vpTable["Doug Burgum"]="Marco Rubio" 
-			//-0.7/+0.4/-0.3/0 (D+7.3; D+112 EVs; PA D+9.1; House D+4.3; 51 Senate seats - tipping point MO D+3.2)
+			//-0.7/+0.4/-0.3/0 (D+7.3; D+112 EVs; PA D+8.9; House D+4.4; 51 Senate seats - tipping point MD D+4.1)
 			e.candidate_json[2].fields.state="North Dakota"
 			opponent_name="Doug Burgum"
 			opponent_vp_name="Marco Rubio"
 			opponent_last_name="Burgum"
 			opponent_vp_last_name="Rubio"
-			e.candidate_issue_score_json[5].fields.issue_score+=-0.3
+			e.candidate_issue_score_json[5].fields.issue_score+=-0.35
 			e.candidate_issue_score_json[6].fields.issue_score+=0.3
 			e.candidate_issue_score_json[7].fields.issue_score+=0.4
-			e.candidate_issue_score_json[8].fields.issue_score+=0.2
+			e.candidate_issue_score_json[8].fields.issue_score+=0.45
 			//home state effects don't change.
 			applyMinorBoost(302,rfk_boost*0.25) //now they've gone even more establishment
 			opponent_maga=false
+			e.candidate_json[2].fields.color_hex="#a83232" //Burgum color hex
 		}
 		else if(OpponentValue==17) {
 			applySalience(112,-0.075) //social issues less important
 			applySalience(113,0.075) //immigration more important
 			worker_approval+=1.25 //ticket moves to right on econ 
-			latino_approval+=0.5 //ticket moves to right on immigration
+			latino_approval+=0.75 //ticket moves to right on immigration
 			e.candidate_json[2].fields.first_name="J.D."
 			e.candidate_json[2].fields.last_name="Vance" 
 			vpTable["J.D. Vance"]="Tom Cotton" 
-			//+0.2/-0.6/-0.4/-0.6 (D+1.3; D+14 EVs; PA D+1.0. House D+2.7; Tipping point: MT R+5.5)
+			//+0.2/-0.6/-0.45/-0.65 (D+2.8; D+16 EVs; PA D+2.7. House D+3.5; Tipping point: MT R+4.8)
 			e.candidate_json[2].fields.state="Ohio"
 			opponent_name="JD Vance"
 			opponent_vp_name="Tom Cotton"
@@ -57507,11 +57815,12 @@
 			opponent_vp_last_name="Cotton"
 			e.candidate_issue_score_json[5].fields.issue_score+=-0.25
 			e.candidate_issue_score_json[6].fields.issue_score+=0
-			e.candidate_issue_score_json[7].fields.issue_score+=0.2
-			e.candidate_issue_score_json[8].fields.issue_score+=-0.1
+			e.candidate_issue_score_json[7].fields.issue_score+=0.15
+			e.candidate_issue_score_json[8].fields.issue_score+=-0.15
 			applyDrift(301,-0.01,1124) //lose part of Hawley home state effect
 			applyDrift(301,0.01,1103) //Arkansas for Cotton home state effect
 			opponent_maga=true
+			e.candidate_json[2].fields.color_hex="#662828" //Vance color hex
 		}
 		
 		if (OpponentValue>=1 && OpponentValue<=7) {
@@ -57532,7 +57841,7 @@
 		}
 	}
 	function roundToDecimals(n, decimals) {
-		var log10 = n ? Math.floor(Math.log10(n)) : 0; //taking the log10 is how we find the order of magnitude of the number for the purpose of decimal places 
+		var log10 = n ? Math.floor(Math.log10(Math.abs(n))) : 0; //taking the log10 is how we find the order of magnitude of the number for the purpose of decimal places 
 		if (log10>=0) {
 			divider=Math.pow(10, decimals); 
 		}
@@ -57554,19 +57863,19 @@
 			CPolling = pop_vote.find(p=>p.candidate==305).percent //Centrists
 			if (boost_list[305][StateNum]>0) { //centrist boost in this specific state 
 				if (RPolling>CPolling*8 && DPolling>CPolling*8) {
-					applyMinorBoost(305,-0.012*boost_list[305][StateNum],1100+StateNum)
+					applyMinorBoost(305,-0.16*boost_list[305][StateNum],1100+StateNum)
 				}
 				else if (RPolling>CPolling*4 && DPolling>CPolling*4) {
-					applyMinorBoost(305,-0.09*boost_list[305][StateNum],1100+StateNum)
+					applyMinorBoost(305,-0.12*boost_list[305][StateNum],1100+StateNum)
 				}
 				else if (RPolling>CPolling*2 && DPolling>CPolling*2) {
-					applyMinorBoost(305,-0.06*boost_list[305][StateNum],1100+StateNum)
+					applyMinorBoost(305,-0.08*boost_list[305][StateNum],1100+StateNum)
 				}
 				else if (RPolling>CPolling*1.5 && DPolling>CPolling*1.5) {
-					applyMinorBoost(305,-0.03*boost_list[305][StateNum],1100+StateNum)
+					applyMinorBoost(305,-0.04*boost_list[305][StateNum],1100+StateNum)
 				}
 				else if (RPolling>CPolling && DPolling>CPolling) {
-					applyMinorBoost(305,-0.015*boost_list[305][StateNum],1100+StateNum)
+					applyMinorBoost(305,-0.02*boost_list[305][StateNum],1100+StateNum)
 				}
 				else if (CPolling>2*RPolling || CPolling>2*DPolling) { //hard cap is naturally done already in applyMinorBoost so don't need to check here
 					applyMinorBoost(305,0.04*boost_list[305][StateNum],1100+StateNum)
@@ -57580,19 +57889,19 @@
 			}
 			if (boost_list[302][StateNum]>0) { //RFK boost in this specific state 
 				if (RPolling>IPolling*8 && DPolling>IPolling*8) {
-					applyMinorBoost(302,-0.12*boost_list[302][StateNum],1100+StateNum)
+					applyMinorBoost(302,-0.16*boost_list[302][StateNum],1100+StateNum)
 				}
 				else if (RPolling>IPolling*4 && DPolling>IPolling*4) {
-					applyMinorBoost(302,-0.09*boost_list[302][StateNum],1100+StateNum)
+					applyMinorBoost(302,-0.12*boost_list[302][StateNum],1100+StateNum)
 				}
 				else if (RPolling>IPolling*2 && DPolling>IPolling*2) {
-					applyMinorBoost(302,-0.06*boost_list[302][StateNum],1100+StateNum)
+					applyMinorBoost(302,-0.08*boost_list[302][StateNum],1100+StateNum)
 				}
 				else if (RPolling>IPolling*1.5 && DPolling>IPolling*1.5) {
-					applyMinorBoost(302,-0.03*boost_list[302][StateNum],1100+StateNum)
+					applyMinorBoost(302,-0.04*boost_list[302][StateNum],1100+StateNum)
 				}
 				else if (RPolling>IPolling && DPolling>IPolling) {
-					applyMinorBoost(302,-0.015*boost_list[302][StateNum],1100+StateNum)
+					applyMinorBoost(302,-0.02*boost_list[302][StateNum],1100+StateNum)
 				}
 				else if (CPolling>2*RPolling || CPolling>2*DPolling) { //hard cap is naturally done already in applyMinorBoost so don't need to check here
 					applyMinorBoost(302,0.04*boost_list[302][StateNum],1100+StateNum)
@@ -57606,19 +57915,19 @@
 			}
 			if (boost_list[303][StateNum]>0) { //Green boost in this specific state
 				if (RPolling>GPolling*32 && DPolling>GPolling*32) {
-					applyMinorBoost(303,-0.12*boost_list[303][StateNum],1100+StateNum)
+					applyMinorBoost(303,-0.16*boost_list[303][StateNum],1100+StateNum)
 				}
 				else if (RPolling>GPolling*16 && DPolling>GPolling*16) {
-					applyMinorBoost(303,-0.09*boost_list[303][StateNum],1100+StateNum)
+					applyMinorBoost(303,-0.12*boost_list[303][StateNum],1100+StateNum)
 				}
 				else if (RPolling>GPolling*8 && DPolling>GPolling*8) {
-					applyMinorBoost(303,-0.06*boost_list[303][StateNum],1100+StateNum)
+					applyMinorBoost(303,-0.08*boost_list[303][StateNum],1100+StateNum)
 				}
 				else if (RPolling>GPolling*4 && DPolling>GPolling*4) {
-					applyMinorBoost(303,-0.03*boost_list[303][StateNum],1100+StateNum)
+					applyMinorBoost(303,-0.04*boost_list[303][StateNum],1100+StateNum)
 				}
 				else if (RPolling>GPolling*2 && DPolling>GPolling*2) {
-					applyMinorBoost(303,-0.015*boost_list[303][StateNum],1100+StateNum)
+					applyMinorBoost(303,-0.02*boost_list[303][StateNum],1100+StateNum)
 				}
 			}
 		}
@@ -57647,6 +57956,7 @@
 		e.candidate_json[0].fields.first_name='Kamala'
 		e.candidate_json[0].fields.last_name='Harris'
 		e.candidate_json[0].fields.state='California'
+		e.candidate_json[0].fields.color_hex="#2d1894" //Kamala color hex
 		
 		e.candidate_json[1].fields.first_name='Temporarily'
 		e.candidate_json[1].fields.last_name='Vacant'
@@ -57813,63 +58123,6 @@
 		ans = e.player_answers[e.player_answers.length-1];
 		noCounter += 1;
 		authenticity -=0.5; //Bernie checks out over time if he doesn't stay fired up.
-		if (party_unity>5 || party_unity<-5) { //soft cap
-			if (party_unity>5) {
-				party_unity=Math.max(party_unity*0.9,5)
-			}
-			else {
-				party_unity=Math.min(party_unity*0.9,-5)
-			}
-		}
-		if (political_capital>5 || political_capital<-5) {
-			if (political_capital>5) {
-				political_capital=Math.max(political_capital*0.9,5)
-			}
-			else {
-				political_capital=Math.min(political_capital*0.9,-5)
-			}
-		}
-		if (worker_approval>6 || worker_approval<-6) {
-			if (worker_approval>6) {
-				worker_approval=Math.max(worker_approval*0.95,6)
-			}
-			else {
-				worker_approval=Math.min(worker_approval*0.95,-6)
-			}
-		}
-		if (dove_approval>6 || dove_approval<-6) {
-			if (dove_approval>6) {
-				dove_approval=Math.max(dove_approval*0.95,6)
-			}
-			else {
-				dove_approval=Math.min(dove_approval*0.95,-6)
-			}
-		}
-		if (latino_approval>6 || latino_approval<-6) {
-			if (latino_approval>6) {
-				latino_approval=Math.max(latino_approval*0.95,6)
-			}
-			else {
-				latino_approval=Math.min(latino_approval*0.95,-6)
-			}
-		}
-		if (blob_approval>10 || blob_approval<-10) {
-			if (blob_approval>10) {
-				blob_approval=Math.max(blob_approval*0.95,10)
-			}
-			else {
-				blob_approval=Math.min(blob_approval*0.95,-10)
-			}
-		}
-		if (adversary_approval>10 || adversary_approval<-10) {
-			if (adversary_approval>10) {
-				adversary_approval=Math.max(adversary_approval*0.95,10)
-			}
-			else {
-				adversary_approval=Math.min(adversary_approval*0.95,-10)
-			}
-			adversary_approval*=0.95
-		}
 		applyInflation(inflation);
 		let pop_vote = e.current_results[0];
 		let DPolling = (pop_vote.find(p => p.pk === 300)).pvp
@@ -58853,6 +59106,7 @@
 			if (senate_lost==1) { //can't actually do the thing in the Senate
 				applyMultiplier(300,-0.01)
 			}
+			latino_approval-=1 //you're being more progressive on abortion than they prefer
 		}
 		else if (ans==17002) {
 			applySalience(111,-0.03)
@@ -58870,6 +59124,7 @@
 			applySalience(112,0.21) //attention goes from Ukraine to abortion 
 			party_unity+=1
 			political_capital-=1 //Manchin and Sinema don't like you insulting and going around them
+			latino_approval-=1 //you're being more progressive on abortion than they prefer
 		}
 		else if (ans==17004) {
 			applySalience(111,-0.03)
@@ -58880,6 +59135,7 @@
 			party_social_progressive+=1
 			r_radical+=1 //stacking the court
 			bipartisan-=1 //sort-of. 
+			latino_approval-=1 //you're being much more progressive on abortion than they prefer
 		}
 		else if (ans==18001) {
 			political_capital-=1 //you flubbed it publicly
@@ -59488,7 +59744,7 @@
 			dove_approval+=4
 			party_social_progressive+=4
 			r_radical+=1
-			if (ans==26103) {
+			if (ans==26104) {
 				dove_approval+=1 //you stuck with your policy
 			}
 		}
@@ -59746,11 +60002,13 @@
 			immigration_level=3 //immigrant flow increases
 		}
 		else if (ans==31103) {
-			//real-world values if you copy Biden exactly: 6.8 capital, 10 bipartisan, 6 r_radical and it still failed. Being nice and putting the threshold at 15 so that it just barely fails.
-			if (political_capital+bipartisan*2-r_radical*2>=15 && (e.player_answers.includes(26001) || e.player_answers.includes(26002) || e.player_answers.includes(26101) || e.player_answers.includes(261012))) { //player chose to arm Israel. 
+			//real-world values if you copy Biden exactly: 6.8 capital, 10 bipartisan, 6 r_radical and it still failed - values of 14.6.
+			//Toned down difficulty and improved this because it was essentially impossible beforehand, and not very rewarding for how absurdly hard it was.
+			if (political_capital+bipartisan*2-r_radical*2>=10 && (e.player_answers.includes(26001) || e.player_answers.includes(26002) || e.player_answers.includes(26101) || e.player_answers.includes(261012))) { //player chose to arm Israel. 
 				r_radical-=1 //less angry
+				political_capital+=2
 				party_unity+=2 //a win.
-				worker_approval+=0.5 //happy you're restricting the border
+				worker_approval+=1 //happy you're restricting the border
 				//the only option among these that does not lower Latino approval..
 				immigration_level=1 //with better enforcement funding, immigrant flow decreases
 			}
@@ -59761,7 +60019,7 @@
 				latino_approval-=1 //cutting the line
 				economy+=1
 				inflation+=0.25
-				applyMultiplier(300,-0.005) //you look ineffectual
+				applyMultiplier(300,-0.015) //you look ineffectual
 			}
 			party_social_progressive-=1
 			bipartisan+=1 //you still tried 
@@ -60286,44 +60544,45 @@
 			applySalience(111,0.06) //democracy and trust in the system suddenly more important
 			applySalience(112,0.06)
 		}
+		//starting at this point, opponent issue effects (and those only) of Bernie campaigning Qs are doubled. Watsonian reason is that campaigning is more effective when you're closer to the election. Doylist reason is that I wanted to encourage the player to keep Bernie around and keep the Kamala route from being too strong.
 		else if (ans==38001) { //Trump campaign
-			e.candidate_issue_score_json[7].fields.issue_score-=0.04 //move to the right on social
+			e.candidate_issue_score_json[7].fields.issue_score-=0.08 //move to the right on social
 			applySalience(112,0.06)
 			party_social_progressive+=1
 			party_unity+=0.2
 		}
 		else if (ans==38002) {
-			e.candidate_issue_score_json[5].fields.issue_score-=0.04 
+			e.candidate_issue_score_json[5].fields.issue_score-=0.08 
 			applySalience(110,0.06)
 			worker_approval+=0.5
 			party_unity+=0.2
 		}
 		else if (ans==38003) {
-			e.candidate_issue_score_json[7].fields.issue_score-=0.02 
+			e.candidate_issue_score_json[7].fields.issue_score-=0.04 
 			applySalience(112,0.03) //America doesn't care
 			party_unity+=0.1
 		}
 		else if (ans==38004) {
-			e.candidate_issue_score_json[7].fields.issue_score-=0.04 
+			e.candidate_issue_score_json[7].fields.issue_score-=0.08 
 			applySalience(112,0.06) //America does care
 			party_unity+=0.2
 		}
 		else if (ans==38101) { //Trump Jr campaign
-			e.candidate_issue_score_json[6].fields.issue_score-=0.015
-			e.candidate_issue_score_json[7].fields.issue_score-=0.015
+			e.candidate_issue_score_json[6].fields.issue_score-=0.03
+			e.candidate_issue_score_json[7].fields.issue_score-=0.03
 			applySalience(111,0.0225)
 			applySalience(112,0.0225)
 			party_unity+=0.15
 		}
 		else if (ans==38102) {
-			e.candidate_issue_score_json[7].fields.issue_score-=0.06 
+			e.candidate_issue_score_json[7].fields.issue_score-=0.12 
 			applySalience(112,0.09) 
 			party_unity+=0.3
 		}
 		else if (ans==38103 || ans==38104) {
-			e.candidate_issue_score_json[5].fields.issue_score-=0.06
+			e.candidate_issue_score_json[5].fields.issue_score-=0.12
 			if (ans ==38104) {
-				e.candidate_issue_score_json[5].fields.issue_score-=0.06 //makes this more painful for him
+				e.candidate_issue_score_json[5].fields.issue_score-=0.12 //makes this more painful for him
 				worker_approval+=0.5
 			}
 			applySalience(110,0.09) 
@@ -60331,37 +60590,37 @@
 			party_unity+=0.3
 		}
 		else if (ans==38201) { //campaign against Hawley
-			e.candidate_issue_score_json[5].fields.issue_score-=0.04 //as Hawley is slightly left of national center on econ, this attack moves him closer to the center and increases the prominence of his best issue. But you probably got the gist that billionaires donate more to him though.
+			e.candidate_issue_score_json[5].fields.issue_score-=0.08 //as Hawley is slightly left of national center on econ, this attack moves him closer to the center and increases the prominence of his best issue. But you probably got the gist that billionaires donate more to him though.
 			applySalience(110,0.06) 
 			worker_approval+=0.5
 			party_unity+=0.2
 		}
 		else if (ans==38202) { 
-			e.candidate_issue_score_json[6].fields.issue_score-=0.04 
+			e.candidate_issue_score_json[6].fields.issue_score-=0.08 
 			applySalience(111,0.06) 
 			worker_approval-=0.5
 			party_unity+=0.2
 			political_capital+=0.25
 		}
 		else if (ans==38203) { 
-			e.candidate_issue_score_json[7].fields.issue_score-=0.04 
+			e.candidate_issue_score_json[7].fields.issue_score-=0.08 
 			applySalience(112,0.06) 
 			party_unity+=0.2
 		}
 		else if (ans==38204) { 
-			e.candidate_issue_score_json[8].fields.issue_score-=0.04 
+			e.candidate_issue_score_json[8].fields.issue_score-=0.08 
 			applySalience(113,0.06) 
 			latino_approval+=0.5
 			party_unity+=0.2
 		}
 		else if (ans==38301) { //campaign vs DeSantis
-			e.candidate_issue_score_json[5].fields.issue_score-=0.04 
+			e.candidate_issue_score_json[5].fields.issue_score-=0.08 
 			applySalience(110,0.06) 
 			worker_approval+=0.5
 			party_unity+=0.2
 		}
 		else if (ans==38302) {
-			e.candidate_issue_score_json[6].fields.issue_score+=0.04 //moves DeSantis to right on globalism.
+			e.candidate_issue_score_json[6].fields.issue_score+=0.08 //moves DeSantis to right on globalism.
 			applySalience(111,0.06) 
 			dove_approval+=0.5
 			blob_approval-=1
@@ -60370,12 +60629,12 @@
 			political_capital-=0.25
 		}
 		else if (ans==38303) {
-			e.candidate_issue_score_json[7].fields.issue_score-=0.04 
+			e.candidate_issue_score_json[7].fields.issue_score-=0.08 
 			applySalience(112,0.12) 
 			party_unity+=0.2
 		}
 		else if (ans==38304) {
-			e.candidate_issue_score_json[8].fields.issue_score-=0.02
+			e.candidate_issue_score_json[8].fields.issue_score-=0.04
 			applySalience(113,0.03) //Americans don't really care. 
 			party_unity+=0.1
 		}
@@ -60638,199 +60897,200 @@
 			}
 			applyMinorBoost(303,0.0025+0.05*green_boost) //D votes go to Greens 
 		}
+		//opponent issue effects (and those only) of Bernie campaigning are doubled here too. Close to election so people are paying more attention (and I'm trying to avoid a situation in which it's better for the player to dispose of Bernie.)
 		else if (ans==42001) { //campaign vs Trump 
-			e.candidate_issue_score_json[7].fields.issue_score-=0.02
+			e.candidate_issue_score_json[7].fields.issue_score-=0.04
 			applySalience(112,0.03) 
 			party_unity+=0.1
 		}
 		else if (ans==42002) {
-			e.candidate_issue_score_json[5].fields.issue_score-=0.04 //Bernie is very good at making attacks on economics - every single one of his attacks there succeeds
+			e.candidate_issue_score_json[5].fields.issue_score-=0.08 //Bernie is very good at making attacks on economics - every single one of his attacks there succeeds
 			applySalience(110,0.06) 
 			party_unity+=0.2
 		}
 		else if (ans==42003) {
-			e.candidate_issue_score_json[8].fields.issue_score-=0.02 //Bernie is less conversant in making attacks on immigration and social policy (he is also further from the political median there.)
+			e.candidate_issue_score_json[8].fields.issue_score-=0.04 //Bernie is less conversant in making attacks on immigration and social policy (he is also further from the political median there.)
 			applySalience(113,0.03) 
 			party_unity+=0.1
 			latino_approval+=0.5
 		}
 		else if (ans==42004) {
-			e.candidate_issue_score_json[6].fields.issue_score-=0.04 //This is effective against some Trump tickets, and wholly backfires against others if Trump is comparatively pro-globalist.
+			e.candidate_issue_score_json[6].fields.issue_score-=0.08 //This is effective against some Trump tickets, and wholly backfires against others if Trump is comparatively pro-globalist.
 			applySalience(111,0.06) 
 			party_unity+=0.2
 			political_capital+=0.25
 		}
 		else if (ans==42101) {
-			e.candidate_issue_score_json[5].fields.issue_score-=0.04 
+			e.candidate_issue_score_json[5].fields.issue_score-=0.08 
 			applySalience(110,0.06) 
 			party_unity+=0.2
 		}
 		else if (ans==42102) {
-			e.candidate_issue_score_json[6].fields.issue_score+=0.04 
+			e.candidate_issue_score_json[6].fields.issue_score+=0.08 
 			applySalience(111,0.06) 
 			party_unity+=0.2
 			political_capital-=0.25
 		}
 		else if (ans==42103) {
-			e.candidate_issue_score_json[7].fields.issue_score-=0.02 //while DeSantis is extreme on social policy, he is also hard to attack on that.
+			e.candidate_issue_score_json[7].fields.issue_score-=0.04 //while DeSantis is extreme on social policy, he is also hard to attack on that.
 			applySalience(112,0.03) 
 			party_unity+=0.1
 		}
 		else if (ans==42104) {
-			e.candidate_issue_score_json[8].fields.issue_score-=0.04 
+			e.candidate_issue_score_json[8].fields.issue_score-=0.08 
 			applySalience(113,0.06) 
 			latino_approval+=1
 			party_unity+=0.2
 		}
 		else if (ans==42201) {
-			e.candidate_issue_score_json[5].fields.issue_score-=0.04 //I dunno what happens if you keep attacking Hawley on economics, it probably just helps him overall but maybe the global multipliers make up for it.
+			e.candidate_issue_score_json[5].fields.issue_score-=0.08 //I dunno what happens if you keep attacking Hawley on economics, it probably just helps him overall but maybe the global multipliers make up for it.
 			applySalience(110,0.06) 
 			party_unity+=0.2
 		}
 		else if (ans==42202) {
-			e.candidate_issue_score_json[6].fields.issue_score-=0.02 //Bernie is not very good at attacking someone for being too anti-war. It just goes against his ideological instincts.
+			e.candidate_issue_score_json[6].fields.issue_score-=0.04 //Bernie is not very good at attacking someone for being too anti-war. It just goes against his ideological instincts.
 			applySalience(111,0.03) 
 			political_capital+=0.25
 			party_unity+=0.1
 		}
 		else if (ans==42203) {
-			e.candidate_issue_score_json[7].fields.issue_score-=0.04 
+			e.candidate_issue_score_json[7].fields.issue_score-=0.08 
 			applySalience(112,0.06) 
 			party_unity+=0.2
 		}
 		else if (ans==42204) {
-			e.candidate_issue_score_json[8].fields.issue_score-=0.04 
+			e.candidate_issue_score_json[8].fields.issue_score-=0.08 
 			applySalience(113,0.06) 
 			latino_approval+=0.5
 			party_unity+=0.2
 		}
 		else if (ans==42301) {
-			e.candidate_issue_score_json[5].fields.issue_score-=0.06 //Trump Jr is just easy to attack
+			e.candidate_issue_score_json[5].fields.issue_score-=0.12 //Trump Jr is just easy to attack
 			applySalience(110,0.09) 
 			party_unity+=0.3
 		}
 		else if (ans==42302) {
-			e.candidate_issue_score_json[6].fields.issue_score-=0.06 
+			e.candidate_issue_score_json[6].fields.issue_score-=0.12 
 			applySalience(111,0.09) 
 			party_unity+=0.3
 			political_capital+=0.25
 		}
 		else if (ans==42303) {
-			e.candidate_issue_score_json[7].fields.issue_score-=0.03 
+			e.candidate_issue_score_json[7].fields.issue_score-=0.06 
 			applySalience(112,0.045) 
 			party_unity+=0.15
 		}
 		else if (ans==42304) {
-			e.candidate_issue_score_json[5].fields.issue_score=-0.06 //sort of attacking him for being pro-corporate.
+			e.candidate_issue_score_json[5].fields.issue_score=-0.12 //sort of attacking him for being pro-corporate.
 			applySalience(113,0.18) //America's watching the car crash 
 			party_unity-=2
 		}
 		else if (ans==42401) {
-			e.candidate_issue_score_json[5].fields.issue_score-=0.04
+			e.candidate_issue_score_json[5].fields.issue_score-=0.08
 			applySalience(110,0.06) 
 			party_unity+=0.2
 		}
 		else if (ans==42402) {
-			e.candidate_issue_score_json[6].fields.issue_score-=0.02
+			e.candidate_issue_score_json[6].fields.issue_score-=0.04
 			applySalience(111,0.03) 
 			political_capital+=0.25
 			party_unity+=0.1
 		}
 		else if (ans==42403) {
-			e.candidate_issue_score_json[7].fields.issue_score-=0.04
+			e.candidate_issue_score_json[7].fields.issue_score-=0.08
 			applySalience(112,0.06) 
 			party_unity+=0.2
 		}
 		else if (ans==42404) {
-			e.candidate_issue_score_json[8].fields.issue_score-=0.02
+			e.candidate_issue_score_json[8].fields.issue_score-=0.04
 			applySalience(113,0.03) 
 			party_unity+=0.1
 		}
 		else if (ans==42501) {
-			e.candidate_issue_score_json[5].fields.issue_score-=0.04
+			e.candidate_issue_score_json[5].fields.issue_score-=0.08
 			applySalience(110,0.06) 
 			party_unity+=0.2
 		}
 		else if (ans==42502) {
-			e.candidate_issue_score_json[6].fields.issue_score+=0.04
+			e.candidate_issue_score_json[6].fields.issue_score+=0.08
 			applySalience(111,0.06) 
 			party_unity+=0.2
 			political_capital-=0.25
 		}
 		else if (ans==42503) {
-			e.candidate_issue_score_json[7].fields.issue_score-=0.02
+			e.candidate_issue_score_json[7].fields.issue_score-=0.04
 			applySalience(112,0.03) 
 			party_unity+=0.1
 		}
 		else if (ans==42504) {
-			e.candidate_issue_score_json[5].fields.issue_score-=0.04 //sort of attacking him for being pro-corporate
-			e.candidate_issue_score_json[6].fields.issue_score+=0.04
+			e.candidate_issue_score_json[5].fields.issue_score-=0.08 //sort of attacking him for being pro-corporate
+			e.candidate_issue_score_json[6].fields.issue_score+=0.08
 			applySalience(111,0.06) 
 			applySalience(113,0.09) //watching the car crash
 			party_unity-=2
 			political_capital-=0.25
 		}
 		else if (ans==42601) {
-			e.candidate_issue_score_json[5].fields.issue_score-=0.04
+			e.candidate_issue_score_json[5].fields.issue_score-=0.08
 			applySalience(110,0.06) 
 			party_unity+=0.2
 		}
 		else if (ans==42602) {
-			e.candidate_issue_score_json[6].fields.issue_score+=0.04
+			e.candidate_issue_score_json[6].fields.issue_score+=0.08
 			applySalience(111,0.06) 
 			party_unity+=0.2
 			political_capital-=0.25
 		}
 		else if (ans==42603) {
-			e.candidate_issue_score_json[7].fields.issue_score-=0.04
+			e.candidate_issue_score_json[7].fields.issue_score-=0.08
 			applySalience(112,0.06) 
 			party_unity+=0.2
 		}
 		else if (ans==42604) {
-			e.candidate_issue_score_json[8].fields.issue_score-=0.02
+			e.candidate_issue_score_json[8].fields.issue_score-=0.04
 			applySalience(113,0.03) 
 			party_unity+=0.1
 		}
 		else if (ans==42701) {
-			e.candidate_issue_score_json[5].fields.issue_score-=0.04
+			e.candidate_issue_score_json[5].fields.issue_score-=0.08
 			applySalience(110,0.06) 
 			party_unity+=0.2
 		}
 		else if (ans==42702) {
-			e.candidate_issue_score_json[6].fields.issue_score+=0.04
+			e.candidate_issue_score_json[6].fields.issue_score+=0.08
 			applySalience(111,0.06) 
 			party_unity+=0.2
 			political_capital-=0.25
 		}
 		else if (ans==42703) {
-			e.candidate_issue_score_json[7].fields.issue_score-=0.04
+			e.candidate_issue_score_json[7].fields.issue_score-=0.08
 			applySalience(112,0.06) 
 			party_unity+=0.2
 		}
 		else if (ans==42704) {
-			e.candidate_issue_score_json[8].fields.issue_score=0.1 //moves his immigration score to 0.1
+			e.candidate_issue_score_json[8].fields.issue_score=0.2 //moves his immigration score to +0.2 (for immigration reform.)
 			applySalience(113,0.06) //watching the car crash as the pot calls the kettle black.
 			party_unity-=3
 		}
 		else if (ans==42801) { //Ramaswamy is also an easy punching bag, but you only get 1 question against him at most. (And Kamala doesn't even have time to go after her opponent.)
-			e.candidate_issue_score_json[5].fields.issue_score-=0.06 
+			e.candidate_issue_score_json[5].fields.issue_score-=0.12 
 			applySalience(110,0.09) 
 			party_unity+=1
 			party_unity+=0.3
 		}
 		else if (ans==42802) {
-			e.candidate_issue_score_json[6].fields.issue_score-=0.03 
+			e.candidate_issue_score_json[6].fields.issue_score-=0.06 
 			applySalience(111,0.045) 
 			political_capital+=0.25
 			party_unity+=0.15
 		}
 		else if (ans==42803) {
-			e.candidate_issue_score_json[7].fields.issue_score-=0.06 
+			e.candidate_issue_score_json[7].fields.issue_score-=0.12 
 			applySalience(112,0.09) 
 			party_unity+=0.3
 		}
 		else if (ans==42804) {
-			e.candidate_issue_score_json[5].fields.issue_score-=0.06 //you're basically attacking him for being pro-corporate.
+			e.candidate_issue_score_json[5].fields.issue_score-=0.12 //you're basically attacking him for being pro-corporate.
 			applySalience(113,0.18) //America's watching the car crash 
 			party_unity-=3
 		}
@@ -60978,8 +61238,8 @@
 			party_econ_progressive+=1
 			party_social_progressive+=1
 			political_capital-=1
-			worker_approval+=1 //progressive labor policy
-			latino_approval+=1 //progressive immigration 
+			worker_approval+=2 //progressive labor policy
+			latino_approval+=2 //progressive immigration 
 			ReplaceFeedback(3002,"AG Vanita Gupta translates your request into action, appointing Jack Smith as a special counsel to urgently investigate and prosecute Trump for the insurrection. The eruption from the right is as fierce as it's expected - calling you a Communist dictator, a tyrant locking up your political enemies. <i>Though the heavens fall, let justice be done.</i>") //enables Trump prosecution route
 		}
 		if (ans>2000 && ans<=2004 && cabinet_foreign_progressive==0) {
@@ -61360,7 +61620,7 @@
 						if (Math.ceil(Math.random() *100)<=25 && e.random_on) {
 							q24403_bad=1
 							if (e.tooltips_on) {
-								ReplaceFeedback(24403,`<span class=\'mytooltip\' style="background-color:darkblue;color:white">Beijing refuses to renounce conquest<span class=\'mytooltiptext\'><img src=https://i.imgur.com/UUyfVsl.jpeg><br><b>The PRC has a 25% chance to reject peace and escalate if asked to renounce reunification by force; 50% if also asked to return the Penghus. If randomness is off, this will never trigger.</b><br><i>Beaten and bloodied, the PRC refuses to submit to yet another Unequal Treaty - while beneath, the people rise, crying for an end to the madness.</i></span></span> of Taiwan, clinging to their pride even as the blockade strangles their ports. In the streets, young people rise in protest - demanding jobs, dignity, a future - and when the PLA is ordered to fire, the soldiers refuse and join the people. And for once, you dare to hope that a new China is being born from the ashes of the old.`)
+								ReplaceFeedback(24403,`<span class=\'mytooltip\' style="background-color:darkblue;color:white">Beijing refuses to renounce conquest<span class=\'mytooltiptext\'><img src=https://i.imgur.com/dGsQMq0.jpeg><br><b>The PRC has a 25% chance to reject peace and escalate if asked to renounce reunification by force; 50% if also asked to return the Penghus. If randomness is off, this will never trigger.</b><br><i>Beaten and bloodied, the PRC refuses to submit to yet another Unequal Treaty - while beneath, the people rise, crying for an end to the madness.</i></span></span> of Taiwan, clinging to their pride even as the blockade strangles their ports. In the streets, young people rise in protest - demanding jobs, dignity, a future - and when the PLA is ordered to fire, the soldiers refuse and join the people. And for once, you dare to hope that a new China is being born from the ashes of the old.`)
 							}
 							else {
 								ReplaceFeedback(24403,`Beijing refuses to renounce conquest of Taiwan, clinging to their pride even as the blockade strangles their ports. In the streets, young people rise in protest - demanding jobs, dignity, a future - and when the PLA is ordered to fire, the soldiers refuse and join the people. And for once, you dare to hope that a new China is being born from the ashes of the old.`)
@@ -61383,7 +61643,7 @@
 						if (Math.ceil(Math.random() *100)<=25 && e.random_on) {
 							q24503_bad=1
 							if (e.tooltips_on) {
-								ReplaceFeedback(24503,`<span class=\'mytooltip\' style="background-color:darkblue;color:white">Beijing refuses to renounce conquest<span class=\'mytooltiptext\'><img src=https://i.imgur.com/UUyfVsl.jpeg><br><b>The PRC has a 25% chance to reject peace and escalate if asked to renounce reunification by force; 50% if also asked to return the Penghus. If randomness is off, this will never trigger.</b><br><i>Beaten and bloodied, the PRC refuses to submit to yet another Unequal Treaty - while beneath, the people rise, crying for an end to the madness.</i></span></span> of Taiwan, clinging to their pride even as the blockade strangles their ports. In the streets, young people rise in protest - demanding jobs, dignity, a future - and when the PLA is ordered to fire, the soldiers refuse and join the people. And for once, you dare to hope that a new China is being born from the ashes of the old.`)
+								ReplaceFeedback(24503,`<span class=\'mytooltip\' style="background-color:darkblue;color:white">Beijing refuses to renounce conquest<span class=\'mytooltiptext\'><img src=https://i.imgur.com/dGsQMq0.jpeg><br><b>The PRC has a 25% chance to reject peace and escalate if asked to renounce reunification by force; 50% if also asked to return the Penghus. If randomness is off, this will never trigger.</b><br><i>Beaten and bloodied, the PRC refuses to submit to yet another Unequal Treaty - while beneath, the people rise, crying for an end to the madness.</i></span></span> of Taiwan, clinging to their pride even as the blockade strangles their ports. In the streets, young people rise in protest - demanding jobs, dignity, a future - and when the PLA is ordered to fire, the soldiers refuse and join the people. And for once, you dare to hope that a new China is being born from the ashes of the old.`)
 							}
 							else {
 								ReplaceFeedback(24403,`Beijing refuses to renounce conquest of Taiwan, clinging to their pride even as the blockade strangles their ports. In the streets, young people rise in protest - demanding jobs, dignity, a future - and when the PLA is ordered to fire, the soldiers refuse and join the people. And for once, you dare to hope that a new China is being born from the ashes of the old.`)
@@ -61853,14 +62113,13 @@
 				}
 			}
 			else if (e.question_number==29) { 
-				quotes = ["''I don’t think it’s appropriate for people to be coming across the border illegally'' ~ Bernie Sanders", ]
+				quotes = ["''I don’t think it’s appropriate for people to be coming across the border illegally.'' ~ Bernie Sanders", ]
 				customquote = quotes[Math.floor((Math.random() * quotes.length))]
 				corrr=`\n<h2>OUR REVOLUTION</h2><font id='wittyquote' size='3' color='white'><em>`+customquote+`</em></font>`
 				if (immigration_level==3) { //de facto open borders; Texas takes matters into its own hands with Eagle Pass
 					party_social_progressive+=1
 					worker_approval-=1 //driving down wages
-					latino_approval-=1 //skipping the line
-					//no inflation effect as the immigration helps alleviate labor shortage
+					//economic boost as the immigration helps alleviate labor shortage happens gradually in background
 					applySalience(113,0.3) //immigration is a big issue thanks to your decisions
 					e.questions_json[campaignTrail_temp.question_number+1] = tunnel(31000)
 				}
@@ -61878,10 +62137,14 @@
 				else { //LATAM immigrants protest that you denied asylum.
 					party_social_progressive-=1
 					worker_approval+=1 //wages up
-					latino_approval-=1 //stopping relatives from entering
-					//no inflation effect as the lack of migration exacerbates labor shortage
+					//economy penalty as lack of migration exacerbates labor shortage happens gradually in background
 					if (e.player_answers.includes(13104)) { //Sembrando Vida - i.e. you didn't crack down directly on refugees, you worked with AMLO to do so.
-						ReplaceQuestion(31200,"Morning breaks with the sound of chanting outside. \"You promised dignity, not deportation\", the voices cry outside the White House. Tens of thousands who once believed in you are burning their <i>Tio Bernie</i> shirts in piles. They call you a xenophobe in leftist clothing who conspired with AMLO against their countrymen to appease racists. What can you do to regain their trust?")
+						if (e.tooltips_on) {
+							ReplaceQuestion(31200,"Morning breaks with the sound of chanting outside. \"You promised dignity, not deportation\", the voices cry outside the White House. Tens of thousands who once believed in you are burning their <i>Tio Bernie</i> shirts in piles. They call you a xenophobe in leftist clothing who <span class=\'mytooltip\' style=\'background-color:darkblue;color:white;\'>conspired with AMLO against their countrymen to appease racists.<span class=\'mytooltiptext\'><img src=https://i.imgur.com/hiNxeaA.jpeg><br><b>You received this question due to convincing Mexico to stem the flow of migrants.</b><br><i>You convinced AMLO to stem the flow of migrants near the start of your term - not for the sake of cruelty, but to protect American wages and prevent the 1% from exploiting immigrants to avoid paying Americans fair wages. Your policies have been successful thus far, though its caused anger in the Latino community. They paraded the Bernie that slammed Obama and Trump's disastrous immigration policies, but now they see you as no different. In addition, while unions appreciate your commitment to protecting Americans wages from being depressed, economic reports are showing that a lack of immigrants is causing labor shortages, holding the economy back.</i></span></span>  What can you do to regain their trust?") //flavor text written by sabrinacarpenterfan333
+						}
+						else {
+							ReplaceQuestion(31200,"Morning breaks with the sound of chanting outside. \"You promised dignity, not deportation\", the voices cry outside the White House. Tens of thousands who once believed in you are burning their <i>Tio Bernie</i> shirts in piles. They call you a xenophobe in leftist clothing who conspired with AMLO against their countrymen to appease racists. What can you do to regain their trust?")
+						}
 					}
 					e.questions_json[campaignTrail_temp.question_number+1] = tunnel(31200)
 				}
@@ -61979,7 +62242,7 @@
 					// replacing result of terrible debate with global multiplier
 					political_capital-=2
 					party_unity-=2
-					quotes = ["''A presidential election is not an entertainment contest. It does not begin or end with a 90-minute debate'' ~ Bernie Sanders", ]
+					quotes = ["''A presidential election is not an entertainment contest. It does not begin or end with a 90-minute debate.'' ~ Bernie Sanders", ]
 					customquote = quotes[Math.floor((Math.random() * quotes.length))]
 					corrr=`\n<h2>OUR REVOLUTION</h2><font id='wittyquote' size='3' color='white'><em>`+customquote+`</em></font>`
 				}
@@ -62023,13 +62286,13 @@
 			}
 			else if (e.question_number==35) {
 				if (ans==36001) { //Bernie campaigns in West Mifflin
-					quotes = ["''Political violence of any kind or shape or form is unacceptable. It is un-American'' ~ Bernie Sanders", ]
+					quotes = ["''Political violence of any kind or shape or form is unacceptable. It is un-American.'' ~ Bernie Sanders", ]
 					customquote = quotes[Math.floor((Math.random() * quotes.length))]
 					corrr=`\n<h2>OUR REVOLUTION</h2><font id='wittyquote' size='3' color='white'><em>`+customquote+`</em></font>`
 					e.questions_json[campaignTrail_temp.question_number+1] = tunnel(37200) //you get assassination attempt.
 				}
 				else if (ticket_status>1) {
-					quotes = ["''We must reject political violence, we must also embrace a robust discussion about what is at stake in this election,'' ~ Kamala Harris", ]
+					quotes = ["''We must reject political violence, we must also embrace a robust discussion about what is at stake in this election.'' ~ Kamala Harris", ]
 					customquote = quotes[Math.floor((Math.random() * quotes.length))]
 					corrr=`\n<h2>OUR REVOLUTION</h2><font id='wittyquote' size='3' color='white'><em>`+customquote+`</em></font>`
 					ReplaceFeedback(37101,`You speak with conviction, not just to calm the nation, but to remind them of the strength that comes from unity: not fear, not violence, but justice. Then news breaks - ${opponent_last_name} is largely unhurt - but that image, his fist raised in defiance over his bloodied face, goes viral. Its meaning as a symbol cuts deep, even as it fuels the fire of division.`)
@@ -62038,7 +62301,7 @@
 					e.questions_json[campaignTrail_temp.question_number+1] = tunnel(37100) //Kamala responds
 				}
 				else {
-					quotes = ["''Political violence of any kind or shape or form is unacceptable. It is un-American'' ~ Bernie Sanders", ]
+					quotes = ["''Political violence of any kind or shape or form is unacceptable. It is un-American.'' ~ Bernie Sanders", ]
 					customquote = quotes[Math.floor((Math.random() * quotes.length))]
 					corrr=`\n<h2>OUR REVOLUTION</h2><font id='wittyquote' size='3' color='white'><em>`+customquote+`</em></font>`
 					ReplaceQuestion(37000, `You're in transit, on the way to another rally when an aide bursts into the room, face pale. They hold up a live video on their phone as they speak - there's gunshots at ${opponent_last_name}'s rally near Pittsburgh, it's an assassination attempt. You see the chaos on screen, a bloody figure dragged from the podium by Secret Service as you sit in stunned silence.`)
@@ -62262,7 +62525,7 @@
 			}
 			else if (e.question_number==37) { //dove approval check; simple enough.
 				if (ticket_status==1) {
-					quotes = ["''I’m not going to answer the question because I don’t like people disrupting me'' ~ Bernie Sanders", ]
+					quotes = ["''I’m not going to answer the question because I don’t like people disrupting me.'' ~ Bernie Sanders", ]
 					customquote = quotes[Math.floor((Math.random() * quotes.length))]
 					corrr=`\n<h2>OUR REVOLUTION</h2><font id='wittyquote' size='3' color='white'><em>`+customquote+`</em></font>`
 					if (dove_approval>=3+expectations) {
@@ -62418,7 +62681,7 @@
 			}
 			else if (e.question_number==40) {
 				if (ticket_status>=2) { //What would you have done differently from Bernie, Kamala?
-					quotes = ["''What can be, unburdened by what has been'' ~ Kamala Harris", ]
+					quotes = ["''What can be, unburdened by what has been.'' ~ Kamala Harris", ]
 					customquote = quotes[Math.floor((Math.random() * quotes.length))]
 					corrr=`\n<h2>OUR REVOLUTION</h2><font id='wittyquote' size='3' color='white'><em>`+customquote+`</em></font>`
 					e.questions_json[campaignTrail_temp.question_number+1] = tunnel(42900)
@@ -62459,7 +62722,7 @@
 			}
 			else if (e.question_number==41) { //Latino approval check
 				if (ticket_status==1) {
-					quotes = ["''This is the most consequential election in our lifetimes.... we cannot sit this election out. '' ~ Bernie Sanders", ]
+					quotes = ["''This is the most consequential election in our lifetimes.... we cannot sit this election out.'' ~ Bernie Sanders", ]
 					customquote = quotes[Math.floor((Math.random() * quotes.length))]
 					corrr=`\n<h2>OUR REVOLUTION</h2><font id='wittyquote' size='3' color='white'><em>`+customquote+`</em></font>`
 					if (latino_approval>=3+expectations*2) {
@@ -62584,6 +62847,63 @@
 		if (opponent>0 && e.question_number>32) { //opponents have been selected
 			applyOpponentFade();
 		}
+		if (party_unity>5 || party_unity<-5) { //soft cap applying after other effects
+			if (party_unity>5) {
+				party_unity=Math.max(party_unity*0.9,5)
+			}
+			else {
+				party_unity=Math.min(party_unity*0.9,-5)
+			}
+		}
+		if (political_capital>5 || political_capital<-5) {
+			if (political_capital>5) {
+				political_capital=Math.max(political_capital*0.9,5)
+			}
+			else {
+				political_capital=Math.min(political_capital*0.9,-5)
+			}
+		}
+		if (worker_approval>6 || worker_approval<-6) {
+			if (worker_approval>6) {
+				worker_approval=Math.max(worker_approval*0.95,6)
+			}
+			else {
+				worker_approval=Math.min(worker_approval*0.95,-6)
+			}
+		}
+		if (dove_approval>6 || dove_approval<-6) {
+			if (dove_approval>6) {
+				dove_approval=Math.max(dove_approval*0.95,6)
+			}
+			else {
+				dove_approval=Math.min(dove_approval*0.95,-6)
+			}
+		}
+		if (latino_approval>6 || latino_approval<-6) {
+			if (latino_approval>6) {
+				latino_approval=Math.max(latino_approval*0.95,6)
+			}
+			else {
+				latino_approval=Math.min(latino_approval*0.95,-6)
+			}
+		}
+		if (blob_approval>10 || blob_approval<-10) {
+			if (blob_approval>10) {
+				blob_approval=Math.max(blob_approval*0.95,10)
+			}
+			else {
+				blob_approval=Math.min(blob_approval*0.95,-10)
+			}
+		}
+		if (adversary_approval>10 || adversary_approval<-10) {
+			if (adversary_approval>10) {
+				adversary_approval=Math.max(adversary_approval*0.95,10)
+			}
+			else {
+				adversary_approval=Math.min(adversary_approval*0.95,-10)
+			}
+			adversary_approval*=0.95
+		}
 		
 		
 		if (ans >=45001) { //Nuclear war answer
@@ -62662,13 +62982,14 @@
 			}
 			e.global_parameter_json[0].fields.question_count = e.question_number+2 //end the game after next question.
 			const EndingSong = new Playlist();
-			const endSong = new Song("Star-Spangled Banner", "Jimmi Hendrix", "https://i.imgur.com/zykth93.jpeg", "https://audio.jukehost.co.uk/fdkvqrl1iZYmkiN8961JTkjQJZa1YVS6");
+			const endSong = new Song("Star-Spangled Banner", "Jimi Hendrix", "https://i.imgur.com/zykth93.jpeg", "https://audio.jukehost.co.uk/fdkvqrl1iZYmkiN8961JTkjQJZa1YVS6");
 			EndingSong.addSong(endSong);
 			changePlaylist(EndingSong);
 			quotes = ["''War, the human disease that has plagued mankind forever.'' ~ Bernie Sanders", ]
 			customquote = quotes[Math.floor((Math.random() * quotes.length))]
 			corrr=`\n<h2>OUR REVOLUTION</h2><font id='wittyquote' size='3' color='white'><em>`+customquote+`</em></font>`
 			e.election_json[0].fields.has_visits = 0 //so you don't get an awkward visit question while everything else changes.
+			e.election_json[0].fields.advisor_url="https://i.imgur.com/8THruOP.jpeg" //change advisor image to sad bernie
 		}
 		
 		updateSimplePopup();
@@ -62788,7 +63109,7 @@
 		if (ticket_status==1) {
 			authenticity_description=`
 		  <p><strong>
-			<span class="hover-value" data-tooltip="How much fire you've got in the belly">Fervor</span>: 
+			<span class="hover-value" data-tooltip="How much fire you've got in the belly. Thresholds are +8/-8">Fervor</span>: 
 			<span ${authenticity>=8 ? "style=\"color:#007D3E;\"" : authenticity<0 ? "style=\"color:#CC071E;\"" : ""} class="hover-value" data-tooltip="${
 			  authenticity <= -8 ? 'Burnt out and checked out' :
 			  authenticity <= 0 ? 'Frustrated and losing hope' :
@@ -62801,8 +63122,8 @@
 		else {
 			authenticity_description=`
 		  <p><strong>
-			<span class="hover-value" data-tooltip="How upset progressives are at you">Left anger</span>: 
-			<span ${progressive_anger<0 ? "style=\"color:#007D3E;\"" : progressive_anger>=3 ? "style=\"color:#CC071E;\"" : ""} class="hover-value" data-tooltip="${
+			<span class="hover-value" data-tooltip="How upset progressives are at you.">Left anger</span>: 
+			<span ${progressive_anger<=0 ? "style=\"color:#007D3E;\"" : progressive_anger>=3 ? "style=\"color:#CC071E;\"" : ""} class="hover-value" data-tooltip="${
 			  progressive_anger <= 0 ? 'Accepting' :
 			  progressive_anger <= 2 ? 'Resigned' :
 			  progressive_anger <= 4 ? 'Frustrated' :
@@ -62814,14 +63135,14 @@
 		//don't stop showing after election cycle begins because: Political capital still matters for epilogue (chance of M4A/etc.), party unity still matters for downballot results.
 		political_info=``
 		political_info+=`
-		  <p><strong><span class="hover-value" data-tooltip="How much the moderates are willing to give.">Political Capital</span>: 
+		  <p><strong><span class="hover-value" data-tooltip="How much the moderates are willing to give. Decays if more than +/-5">Political Capital</span>: 
 			<span ${political_capital>1 ? "style=\"color:#007D3E;\"" : political_capital<=-1 ? "style=\"color:#CC071E;\"" : "" } class="hover-value" data-tooltip="${
 			  political_capital<0 ? 'Owing the bastards' :
 			  political_capital==0 ? 'Hoping to bargain' :
 			  political_capital<=3 ? 'Got their ear' :
 			  'Holding the cards' 
 		}">${political_capital.toFixed(1)}</span></strong></p>`
-		political_info+=`<p><strong><span class="hover-value" data-tooltip="How much the party is unified.">Party Unity</span>: <span ${party_unity>2 ? "style=\"color:#007D3E;\"" : party_unity<=-2 ? "style=\"color:#CC071E;\"" : ""} class="hover-value" data-tooltip="${
+		political_info+=`<p><strong><span class="hover-value" data-tooltip="How much the party is unified. Decays if more than +/-5">Party Unity</span>: <span ${party_unity>2 ? "style=\"color:#007D3E;\"" : party_unity<=-2 ? "style=\"color:#CC071E;\"" : ""} class="hover-value" data-tooltip="${
 		  party_unity<=-5 ? 'Circular firing squad' :
 		  party_unity<=-2 ? 'Pulling different ways' :
 		  party_unity<=2 ? 'Fractures showing' :
@@ -62829,9 +63150,9 @@
 		  'With one voice' 
 		}">${party_unity.toFixed(1)}</span></strong></p>`
 		
-		base_support=`<p><strong><span class="hover-value" data-tooltip="How much your base approves.">Base support</span>:  `
+		base_support=`<p><strong><span class="hover-value" data-tooltip="How much your base approves. Decays if more than +/-6.">Base support</span>:  `
 		
-		base_support+=`<span class="hover-value" data-tooltip="America's conscience, demanding diplomacy over war." >Dove</span> <span ${dove_approval>=3+expectations ? "style=\"color:#007D3E;\"" : 			dove_approval<-3+expectations ? "style=\"color:#CC071E;\"" : "" } class="hover-value" data-tooltip="${
+		base_support+=`<span class="hover-value" data-tooltip="Peace activists. Support thresholds of +${3+expectations}/${-3+expectations}.">Dove</span> <span ${dove_approval>=3+expectations ? "style=\"color:#007D3E;\"" : 			dove_approval<-3+expectations ? "style=\"color:#CC071E;\"" : "" } class="hover-value" data-tooltip="${
 		  dove_approval>=3+expectations && dove_approval>=3 ? 'Fully satisfied' :
 		  dove_approval>=3 ? 'Expecting more' :
 		  dove_approval>=3+expectations ? 'Settling for you' :
@@ -62842,7 +63163,7 @@
 		  'Flat-out furious' 
 		}">${dove_approval.toFixed(1)}</span><br>`
 		
-		base_support+=`<span class="hover-value" data-tooltip="Working America's backbone of solidarity.">Worker</span> <span ${worker_approval>=3+expectations*2 ? "style=\"color:#007D3E;\"" : worker_approval<-3+expectations*2 ? "style=\"color:#CC071E;\"" : "" } class="hover-value" data-tooltip="${
+		base_support+=`<span class="hover-value" data-tooltip="Union workers. Support thresholds of +${3+expectations*2}/${-3+expectations*2}.">Worker</span> <span ${worker_approval>=3+expectations*2 ? "style=\"color:#007D3E;\"" : worker_approval<-3+expectations*2 ? "style=\"color:#CC071E;\"" : "" } class="hover-value" data-tooltip="${
 		  worker_approval>=3+expectations*2 && worker_approval>=3 ? 'Fully satisfied' :
 		  worker_approval>=3 ? 'Expecting more' : //would be satisfied but you promised big at the start 
 		  worker_approval>=3+expectations*2 ? 'Settling for you' : //would be neutral but you lowered expectations at the start.
@@ -62853,7 +63174,7 @@
 		  'Flat-out furious' 
 		}">${worker_approval.toFixed(1)}</span>/`
 		
-		base_support+=`<span class="hover-value" data-tooltip="Fighting for dignity, justice, and immigration reform.">Latino</span> <span ${latino_approval>=3+expectations*2 ? "style=\"color:#007D3E;\"" : latino_approval<-3+expectations*2 ? "style=\"color:#CC071E;\"" : "" } class="hover-value" data-tooltip="${
+		base_support+=`<span class="hover-value" data-tooltip="Hispanics and Latinos. Support thresholds of +${3+expectations*2}/${-3+expectations*2}.">Latino</span> <span ${latino_approval>=3+expectations*2 ? "style=\"color:#007D3E;\"" : latino_approval<-3+expectations*2 ? "style=\"color:#CC071E;\"" : "" } class="hover-value" data-tooltip="${
 		  latino_approval>=3+expectations*2 && latino_approval>=3 ? 'Fully satisfied' :
 		  latino_approval>=3 ? 'Expecting more' :
 		  latino_approval>=3+expectations*2 ? 'Settling for you' :
@@ -63108,4 +63429,3 @@
 		}
 		`;
 	document.head.appendChild(customStyling);
-

--- a/static/mods/2024 - Our Revolution_init.html
+++ b/static/mods/2024 - Our Revolution_init.html
@@ -42,7 +42,7 @@ campaignTrail_temp.election_json = [
 			
 			<br><br><b>Fervor</b> (internally called authenticity) - This goes up when Bernie gives in-character answers and goes down when he gives out-of-character answers; it also naturally decays over time. It's mainly checked on Q30 - you want to keep it at 8+ for that question. You really don't want it -8 or lower for Q30. Having it low can also result in a bad debate later - too many compromises makes Bernie bern out.
 			
-			<br><br><b>Political capital</b> - Affects your deal-making capability. This is limited to what your opposing party is willing to bargain on - no amount of political capital will convince Manchinema to remove the filibuster, or Rs to support things like the PRO Act, immigration reform, or M4A. Its utility usually goes down significantly starting in 2023, because Republicans are less willing to bargain with you - unless you go the full bipartisan route.
+			<br><br><b>Political capital</b> - Affects your deal-making capability. This is limited to what your opposing party is willing to bargain on - no amount of political capital will convince Manchinema to remove the filibuster, or Rs to support things like the PRO Act, immigration reform, or M4A. Its utility usually goes down significantly starting in 2023, because Republicans are less willing to bargain with you - unless you go the full bipartisan route. Full list of things you can get with it or that it contributes to: Minimum wage compromise with Rs (Q6), Medicare expansion to dental/vision (Q8), $600 billion in renewable investment in mini-GND (Q8), Bipartisan Infrastructure Law (Q10), not-IRA (Q18), rail worker compromise (Q20), compromise speaker with Rs (Q22) and potentially two grand bargains, bipartisan border bill (very hard), putting off TikTok ban until after election (also requires friendly House), and legislation (M4A, public option, codifying Roe) in the epilogue.
 			
 			<br><br><b>Party unity</b> - Primarily affects downballot results - each point gives +/- 0.5% margin-wise for downballot elections in non-presidential years. In 2024, each point will translate into a +/- 0.25% multiplier for you at the start of the campaign, and a +/-0.25% downballot effect at election. Party unity also affects how much support gets leeched from you to a strong Green Party or any third-party centrists, as well as the willingness of the party to support you if you try to get a Republican speaker.
 			
@@ -59,11 +59,11 @@ campaignTrail_temp.election_json = [
 			<br><p><b>Other mechanics</b>
 			
 			<br><br><b>The assassination</b> is conducted by Thomas Matthew Crooks, who shoots you as long as you show up in the greater Pittsburgh area for him to target (by campaigning in West Mifflin, PA.) Otherwise he shoots your opponent. From what we know of him - looking up public appearances of many prominent figures including both Biden and Trump - it seems clear that he was an equal-opportunity assassin who'd have targeted the first major-party candidate to show up near him. Being the assassination target will create a small backlash in favor of the victim, but this is intentionally small on both sides (up to a 2.5% margin swing) - partly because Trump's real-world one was small and partly because I did not want to incentivize the player to get Bernie killed.
-			<br><br>Surviving an assassination will help you recover from staying in after a bad debate (rally-to-the-flag effect); if you are the target of an assassination and replaced by Kamala, Kamala will get more political benefit from options that double down on supporting Bernie and it will cost her more to throw Bernie under the bus. Dying to an assassination after a bad debate, meanwhile, will fuel conspiracy theories that Kamala or the establishment was behind it, hurting the ticket.
+			<br><br>Surviving an assassination will help you recover from staying in after a bad debate (rally-to-the-flag effect); if you are the target of an assassination and replaced by Kamala, Kamala will get more political benefit from options that double down on supporting Bernie and it will cost her more to throw Bernie under the bus. Dying to an assassination after a bad debate, meanwhile, will fuel conspiracy theories that Kamala or the establishment was behind it, hurting the ticket and canceling out much of the sympathy boost.
 			
 			<br><br>The overall <b>2021 and 2022 election results</b> are determined by the national popular vote margin and party unity. Important state positions (both crucial governorship positions in 2022, state legislatures in 2022/2023, or each of the Senate races in 2024) are tracked behind the scenes and determined by local margins and party unity. They aren't publicly displayed because I realize that 99% of players do not care about who won the Virginia state legislature in 2023. It is impossible to do better than red ripple in the 2022 midterms - the Doylist explanation is that I did not want to write additional branching. The Watsonian explanation is that Bernie's voter base is akin to Obama's - intermittent and less willing to turn out in midterms.
 			
-			<br><br><b>Third party candidates</b> will see RFK Jr. disproportionately take votes from Republicans (however he will drop out and endorse any MAGA Republican), while centrists and Green Party candidates will predominately take votes from you. A viability mechanic means that third party candidates tend to fade over time (generally, 50% by the time of the election) so long as they are not serious candidates. However, if you do worse than a 3rd-party candidate in one state, they may start taking more votes instead - imagine that local figures see them as viable and begin endorsing them over time. Third-party votes do translate down into downballot votes too. 
+			<br><br><b>Third party candidates</b> will see RFK Jr. disproportionately take votes from Republicans (however he will drop out and endorse any MAGA Republican), while centrists and Green Party candidates will predominately take votes from you. A viability mechanic means that third party candidates tend to fade over time (generally, 2/3 by the time of the election) so long as they are not competitive candidates. However, if you do worse than a 3rd-party candidate in one state, they may start taking more votes instead - imagine that local figures see them as viable and begin endorsing them over time. Third-party votes do translate down into downballot votes too. 
 			
 			<br><br><b>Foreign interference</b> always occurs on Q40. The opinion of Russia+China towards the player are tracked over time, and depending on how strongly they feel, they may engage in anything from deepfakes to hacking (a la 2016) to social media interference from most to least impactful. Notably, banning Tiktok by the time foreign interference has happened (either getting it automatically banned via sanctions or war with the PRC, or getting it banned by Labor Day on the TikTok question) will roughly halve the impact of foreign interference. (I don't have any special knowledge about TikTok, but it's very clear that this is something that multiple world governments are very concerned about.)
 			
@@ -105,12 +105,12 @@ campaignTrail_temp.election_json = [
 			<br><br>Trump/Burgum: -0.4/-0.4/-0.3/-0.55
 			<br>Kennedy Jr/Ventura: 0.2/-0.6/0.4/0.6
 			<br>Stein/Benjamin: 0.6/-0.9/0.85/0.5
-			<br>Sinema/Baker: 0/0.4/0.4/0.2
+			<br>Sinema/Baker: 0/0.4/0.4/0
 			
 			<br><br>Trump/Rubio: -0.3/+0.2/-0.5/-0.55
 			<br>Baldwin/Broden: -0.8/-0.8/-0.8/-0.8
 			<br>Peltier/La Rivia: 0.9/-0.9/0.6/0.4
-			<br>Manchin/Rice: 0.2/0/0/0
+			<br>Manchin/Rice: 0.4/0/0/0
 			
 			<br><br>Trump/Scott: -0.15/+0.1/-0.5/-0.7
 			<br>Kennedy Jr/Rodgers: 0.6/-0.8/-0.2/-0.2
@@ -122,7 +122,7 @@ campaignTrail_temp.election_json = [
 			<br>Sawant/Romman: 0.7/-0.6/0.8/0.3
 			<br>Amash/Riggleman: -0.4/0/0.4/0
 			
-			<br><br>DeSantis/Burgum: -0.4/+0.1/-0.7/-0.2
+			<br><br>DeSantis/Burgum: -0.35/+0.1/-0.7/-0.45
 			<br>Kennedy Jr/Robbins: 0.6/-0.6/-0.2/-0.6
 			<br>Stein/Barrios: 0.7/-0.6/0.6/0.8
 			<br>Phillips/Chavis: 0.4/0.4/0.4/0.2
@@ -138,10 +138,10 @@ campaignTrail_temp.election_json = [
 			<br>Scott/Trump Jr: -0.4/+0.3/-0.6/-0.5
 			<br>Ramaswamy/Trump: -0.3/-0.75/-0.7/-0.55
 			<br>Burgum/Rubio: -0.7/+0.4/-0.3/0
-			<br>Vance/Cotton: +0.2/-0.6/-0.4/-0.6
+			<br>Vance/Cotton: +0.2/-0.6/-0.45/-0.65
 			
-			<br><br>Vance/Cotton is probably the single hardest opponent. Burgum/Rubio, Burgum/Trump Jr, and Ramaswamy/Trump are probably the easiest opponents.</p> 
-			<p><b>If you are having trouble winning the game and would like help</b>, here is a set to a list of answers that should give you re-election with randomness off, without too many compromises on Bernie's part from his ideals. It is not the best electoral result you can get, but it will likely get you Medicare for All, and is an example in case it helps. Visit Missouri every time.
+			<br><br>Vance/Cotton is probably the single hardest opponent. Burgum/Rubio, Burgum/Trump Jr, Trump Jr/Ramaswamy, and Ramaswamy/Trump are probably the easiest opponents.</p> 
+			<p><b>If you are having trouble winning the game and would like help</b>, here is a set to a list of answers that should give you re-election with randomness off, without too many compromises on Bernie's part from his ideals. It is not the best electoral result you can get, but it will get you Medicare for All, and is an example in case it helps. Visit Missouri every time.
 			<li>1. People fought tooth and nail to elect you - some of them <i>died</i> for you. That sacrifice will not, <i>must not</i> be in vain. </li>
 			<li>2. You were elected as President of America first and foremost; a domestic cabinet of progressives will push the bold change you promised.</li>
 			<li>3. You swore a sacred oath to defend the Constitution of the United States against all enemies, foreign and domestic</li>
@@ -187,7 +187,7 @@ campaignTrail_temp.election_json = [
 			<li>43. You've let them down, and you owe it to them to try and make things right.</li>
 			<li>44. It's freezing in Green Bay, Wisconsin, but the people are warm, glad to see you listen and care.<li>
 			</p>
-			<p><b>If you want to do better than the above</b> and achieve the True Ending - passing Medicare for All on hard difficulty - here is a set of answer IDs that will usually get you that. It requires much more compromises than on normal due to the higher difficulty. Visit Missouri every time, and either turn off randomness or restart if Sinema changes parties or the Supreme Court rules against you on the debt ceiling (both of those are unlikely): 1001, 2002, 3002, 4004, 5002, 6003, 7001, 8004, 9001, 10103, 11003, 12003, 13002, 14002, 15101, 16001, 17002, 18002, 19001, 20001, 21001, 22101, 23002, 24101, 25102, 26001, 27201, 28001, 29301, 30001, 31101, 32001, 33002, 34502, 35301, 36004, 37003, 38401, 39102, 40202, 41002, 42501, 43201, 44003</p>
+			<p><b>If you want to do better than the above</b> and achieve the True Ending - passing Medicare for All on hard difficulty - here is a set of answer IDs that will get you that with randomness off. It requires much more compromises than on normal due to the higher difficulty. Visit Missouri every time: 1001, 2002, 3002, 4004, 5002, 6003, 7001, 8004, 9001, 10103, 11003, 12003, 13002, 14002, 15101, 16001, 17002, 18002, 19001, 20001, 21001, 22101, 23002, 24101, 25102, 26001, 27201, 28001, 29301, 30001, 31101, 32001, 33002, 34502, 35301, 36004, 37003, 38401, 39102, 40202, 41002, 42501, 43201, 44003</p>
 			<br><p><b>Author commentary</b>
 			
 			<br><br>Rationale for certain design decisions: 
@@ -196,12 +196,17 @@ campaignTrail_temp.election_json = [
 			<li>With regards to nuclear war in-game: Realistically, almost all nuclear wars would almost certainly be much less abrupt than it currently comes off as in-game. It would generally involve a myriad of pathways - most commonly involving the use of single nuclear weapons (perhaps a tactical nuke) for intimidation, followed by a player escalation, followed by further escalation or so on. Fundamentally however, I wanted to avoid turning the game into Nuclear Response Simulator. Once a tactical nuke has been used, the game would be effectively over anyways.</li>
 			<li>With regards to Manchin and Sinema's presence in the mod. They are actually much more accommodating to the player in-game than they were in reality. For instance, it's quite likely that both would have vehemently opposed a stimulus much larger than IRL or a number of Cabinet choices (incl. SoS Barrbara Lee.) Manchin would almost certainly have also opposed attempts by Bernie to appoint a Fed chair dovish on inflation - he was very vocal on having the Fed focus on controlling inflation - which would likely have caused him to reject everyone but Powell. Furthermore, I allow the player to pass a Medicare expansion 2021 which both Sinema and Manchin were vehemently opposed to IRL despite Biden's best attempts. The Doylist reason for treating them this way is to try and give the player more agency and not leave them feeling completely hopeless; the Watsonian reason is that they're much more worried about what Bernie can do via executive action and are hence more willing to try and keep him working with them and reward him for compromising. </li>
 			<li>Regarding Israel's behavior in the mod: Hamas began planning Al-Aqsa Flood circa 2014 and decided to implement it following the 2021 clashes. It's unlikely that any U.S. decision could have averted it - in fact, U.S. withholding of arms would likely have encouraged an attack (akin to Hamas considering Israeli opposition protests to constitute an opportune time for their own attack.) While it is possible the date of the attack could have changed (e.g. if Iran and Hezbollah were willing in 2022 to join in), I avoided that possibility for simplicity. There are two possible pathways by which Bibi could be pressured to stop the war - namely, direct quid-pro-quo (i.e. you do XYZ - e.g. send arms, and Israel does ABC - e.g. stop attacking Gaza), or the pathway of Israeli munitions shortages leading to greater casualties, leading to political pressure, which eventually forces an end to the war (the Vietnam/Afghanistan pathway.) I concluded that the first was unlikely for the purpose of the mod though others could easily come to different interpretations. The shipments the U.S. sends Israel consists largely of things falling in the category of "nice to have" (e.g. additional munitions, aircraft parts, etc.) rather than "existentially necessary"; Netanyahu has refused pressure from the U.S. in the past (e.g. by the Obama administration over settlement policy), appears to be ideologically convinced that the continuation of Israeli settlement policy is necessary, and appears to strongly dislike the appearance of giving in to external pressure (incl. from the U.S.) for apparent fear of encouraging more in the future. Furthermore, the continuation of the Gaza war is necessary for his political survival and his governing coalition's existence (via Ben-Gvir until Gideon Sa'ar rejoined Likud), which is existentially necessary for him to put off the state inquiry into his own culpability in the attacks and sabotage the prosecution of him for corruption - either of which could result in catastrophic consequences for him. Netanyahu would also have the additional incentive that if Bernie loses re-election, he will almost certainly receive arms from whoever the new President is (and he would likely despise Bernie personally.) For this reason, I concluded that Netanyahu would likely try to continue the war as long as possible - in theory, he could potentially be persuaded at most to accept temporary humanitarian pauses to receive arms, but I did not think that would be a satisfying outcome for the average player and so it is not directly touched upon in-story. As a result, the main pressure point for Bibi to seek peace in-game is via increased casualties causing the war to become politically expensive, which is naturally a slow pathway.</li>
+			<li>Regarding the macroeconomic simulation in this mod: This mod attempts to adhere to mainstream orthodox economic thought. The aspect of it I find can be most confusing to players is the interaction of inflation and the economy. The average player may have formed their understanding of economics from 2008-2018 when the economy was recovering from the Great Recession, inflation was not a serious issue, and more spending was essentially a "free lunch" - there was literally no reason (other than ideology and worry about overreacting) not to do it in western nations like the United States. But this free lunch does not always exist - it only exists when the potential supply of the economy exceeds demand, so that giving people more money lets them spend it on things that wouldn't be bought/made otherwise, letting you employ more people. Otherwise you get inflation, which comes for two reasons - the first being when demand outstrips supply. Traditionally this happens when the economy is overheated (e.g. "too much money floating around too quickly for the amount of goods that can be produced.") In 2021-2023, this was due to supply chain crises, which very simplified means that "the amount of goods that can be produced and received is temporarily lower than expected", creating a paradigm in which you need to either deal with significant unemployment and no serious inflation, or have a decent economy with inflation. Bernie will not accept the former, almost all Fed chairs under almost all circumstances will not accept the latter. 
+			<br><br>Meanwhile, the second reason for inflation is essentially it getting baked into expectations and becoming persistent. If everyone expects prices and wages to go up 10% per year, workers will demand 10% pay hikes each year and corporations will raise prices 10% each year. Even when the initial reason is gone, it becomes "baked in." You can see inflation in this regard as essentially a tug-of-war between capital and labor, each hoping to get the better end of the deal. (Capital got the better end of the deal IRL.) To stop this, you either have to do some clever economic trickery - e.g. the Plano Real is a brilliant example in Brazil - or use brute force. Namely, engineer a giant recession that stops the economy in its tracks and sends inflation down, upon which you can undo the recession. This fear is the reason the Fed will not accept inflation more than temporarily.
+			<br><br>In any case, inflation is the reason that more spending is not always a "free lunch." When demand starts to outstrip supply, you give people more money but the total value of the money stays the same, in simplified terms. Even MMT accepts that too much spending is limited by inflation - they just have a different solution of preferring austerity (hiking taxes or cutting spending) to monetary policy via the Fed. During 2021-2023, MMTers (incl. Stephanie Kelton) did not recommend austerity because they did not believe the inflation to be persistent. While philosophically valid that full employment with inflation is preferable to a slow economy and recession without inflation as long as its temporary, it doesn't address the political problem of inflation.</li>
 			
 			<br><br>In so much as this mod has a <b>general message about American political systems</b> as a whole, it's to try and illustrate and explain the structures and incentives at play to explain why American politics is broken in the eyes of the majority. The system is set up to place all the visual responsibility in the person of the President, who has no actual ability to make legislation. Getting legislation requires Congress which they do not necessarily control. The House can be very difficult to win due to gerrymandering (though not in the present political paradigm); the Senate is often very skewed against one party or another in terms of the national margin needed to win it (especially true in the present political paradigm), and the filibuster adds only even greater barriers to achieving legislative change. This is a system that feels like it is meant to make legislative change extremely difficult while blaming everything on the person of the President - who has little power to actually do things - when it fails to happen.<br><br>Any would-be president must run on a legislative agenda, promising to e.g. accomplish Medicare for All (not just "Medicare for All if I get Congress sufficiently" - that's uninspiring.) But they don't actually have any power to do those things themselves - only yell at other people to do them, and stop those other people from doing things the President dislikes. The inevitable result is that they run for office making promises that they do not know if they can fulfill or not, and may of them end up inevitably not being fulfilled - not because they specifically failed as a person but because the system failed to allow them to do it. The increase in political polarization, expectations falling out of pace with what's likely achievable, etc. only further increases this problem. And even though the U.S. hates the existing system, they hate radical change - such as changing the existing system to make change easier - even more. And those activists strongly motivated by passing legislation (e.g. "Medicare for All") are not strongly motivated by the often-complicated pathway (e.g. "we need to moderate on social issues to be able to win Senate seats in socially conservative states to elect enough Senators willing to remove the filibuster and pass Medicare for All") to get said legislation.
 			
 			<br><br>In-so-much as this mod has a <b>commentary on the Biden administration's mistakes</b>, the specific thesis is <i>the Biden administration chose many options that were each individually reasonable in the short term that boiled down to not dramatically changing things or rocking the boat, but failed to fall into a coherent long-term strategy.</i> Part of this, of course, was that the Biden administration did not know what came next (as the player does), but also that the Biden administration made incorrect calculations that - e.g. not disarming Israel, as was in accord with general public opinion, was also the best choice for a Democratic candidate and that war opponents would essentially get over it. The intent of the Biden options available in the mod is that each of them is individually reasonable and defensible but will result in the real-world loss eventually. 
 			
-			<br><br>In-so-much as the mod has a <b>commentary on the office of the Presidency</b> and being an incumbent President, it is that being the President is exhausting, hard, infuriating, tiring, and complicated. This is especially true for anyone President in the age of 2021-2024, in which it seems like most nations have faced a significant anti-incumbent backlash. Frankly, I think Bernie would have done better in-office in 2016 (if he was able to win by enough to take the House and a significant Senate majority via coattails, as appeared possible from polling at the time) than 2020. His policy instincts (larger stimuluses and anti-interventionism) would have been especially suited for the Obama era, if only there existed any chance of him actually being elected President in 2008.</p>`, 
+			<br><br>In-so-much as the mod has a <b>commentary on the office of the Presidency</b> and being an incumbent President, it is that being the President is exhausting, hard, infuriating, tiring, and complicated. This is especially true for anyone President in the age of 2021-2024, in which it seems like most nations have faced a significant anti-incumbent backlash. Frankly, I think Bernie would have done better in-office in 2016 (if he was able to win by enough to take the House and a significant Senate majority via coattails, as appeared possible from polling at the time) than 2020. His policy instincts (larger stimuluses and anti-interventionism) would have been especially suited for the Obama era, if only there existed any chance of him actually being elected President in 2008.
+			
+			<br><br>If you enjoyed this mod, I strongly recommend both the game Suzerain (purchasable on Steam), and the online game Social Democracy by Red Autumn (https://red-autumn.itch.io/social-democracy), which I consider to be philosophically similar in spirit.</p>`, 
             "has_visits": 1,
             "no_electoral_majority_image": "../static/images/2012-no-majority.jpg"
         }
@@ -220,7 +225,7 @@ campaignTrail_temp.temp_election_list = [
  campaignTrail_temp.credits = "<button onclick='credits()'>Elyna</button>";
 
   window.credits = function() {
-    const creditsList = ["Mod mainly written and coded by Elyna (Seleucus on alternatehistory.com).", "", "Help from:", "TheNorthEast for ending slide #13 and the Left Opposition description.", "Tannenberg for achievement images (TBD).", "Skittie/C0SM0 for the Themes & for other Visual Help.", "Ronnie for advising writing revisions", "Pootmehoot for the Bernie Banner.", "mbierden for the Campaign Signs.", "u/ConsiderationOk3683 (burrito2045) for the candidate images (minus no running mate.)", "StrawberryMaster for visual design adjustments", "", "Various codes made by Mangolith, Thatchmaster, & DecStarG.", "", "Credit to the rest of the TCT community for assistance with the code and building a foundation of others to use."]
+    const creditsList = ["Mod mainly written and coded by Elyna (Seleucus on alternatehistory.com).", "", "Help from:", "TheNorthEast for ending slide #13 and the Left Opposition description.", "Tannenberg for achievement images (partially done).", "Skittie/C0SM0 for the Themes & for other Visual Help.", "Ronnie for advising writing revisions", "Pootmehoot for the Bernie Banner.", "mbierden for the Campaign Signs.", "u/ConsiderationOk3683 (burrito2045) for the candidate images (minus no running mate.)", "StrawberryMaster for visual design adjustments", "u/Macrohistorian for revised A24301 feedback and some tooltips","sabrinacarpenterfan333 for some tooltips", "", "Various codes made by Mangolith, Thatchmaster, & DecStarG.", "", "Credit to the rest of the TCT community for assistance with the code and building a foundation of others to use."]
     const text = "THOSE WHO HELPED CREATE OUR REVOLUTION:\n\n" + creditsList.join('\n');
 
   alert(text);
@@ -356,7 +361,7 @@ campaignTrail_temp.candidate_json = [
 			"color_hex": "#014d4e",
             "secondary_color_hex": "#41afa2",
             "is_active": 1,
-            "image_url": "https://i.imgur.com/MQOF55p.jpeg",
+            "image_url": "https://i.imgur.com/VzQE3pp.jpeg",
             "electoral_victory_message": "Placeholder!",
             "electoral_loss_message": "Placeholder!",
             "no_electoral_majority_message": "Placeholder!",
@@ -437,9 +442,9 @@ jet_data = {
 }
 HistHexcolour=["#184794","#910c0c","#D3AF41","#4EAF41","#014d4e"];
 HistName=["Bernie Sanders","Doug Burgum","Robert F. Kennedy Jr.","Dean Phillips","Jill Stein"];
-HistEV=[315,223,0,0,0];
-HistPV=["73,559,216","69,597,074","21,156,735","3,359,140","1,418,860"];
-HistPVP=["43.5%","41.1%","12.5%","2.0%","0.8%"];
+HistEV=[329,209,0,0,0];
+HistPV=["80,700,126","71,688,651","13,073,789","2,951,431","1,118,653"];
+HistPVP=["47.6%","42.3%","7.7%","1.7%","0.7%"];
 
 
 //#startcode
@@ -471,7 +476,8 @@ quotes = ["''What happens in Congress in the next few months will determine the 
 customquote = quotes[Math.floor((Math.random() * quotes.length))]
 corrr=`\n<h2>OUR REVOLUTION</h2><font id='wittyquote' size='3' color='white'><em>`+customquote+`</em></font>`
 campaignTrail_temp.modBoxTheme = { "header_color": "#242d80", "header_image_url": "https://files.catbox.moe/1kkpbb.png", "header_text_color": "#ffffff", "description_text_color": "#000000", "description_background_color": "#4d82e3", "main_color": "#0650ac", "secondary_color": "#242d80", "ui_text_color": "#FFFFFF" }
-$("#dynamic-favicon").attr("href", "https://i.imgur.com/lBOui3k.jpeg");
+// Custom favicon
+$("#dynamic-favicon").attr("href", "https://files.catbox.moe/nv7m0s.png");
 
 const customStyling = document.createElement("style");
 customStyling.innerHTML = `#map_container {
@@ -590,7 +596,7 @@ document.head.appendChild(customStyling);
       "https://audio.jukehost.co.uk/m578B1oFyTzSjaxiXpbBfZN7I5RHpeBi"
     );
   
-    const song3 = new Song(
+    const song3 = new Song( //recommended by Skittie
       "Bread And Roses",
       "Judy Collins",
       "https://i.imgur.com/FFyGJFl.jpeg",
@@ -625,7 +631,7 @@ document.head.appendChild(customStyling);
       "https://audio.jukehost.co.uk/eOuTV1mb4d0t7vhHqSEv7UArns2UKUHO"
     );
 	
-    const song8 = new Song(
+    const song8 = new Song( //recommended by Tannenberg
       "Masters Of War",
       "Bob Dylan",
       "https://files.catbox.moe/7zvbve.jpg",
@@ -646,14 +652,14 @@ document.head.appendChild(customStyling);
       "https://audio.jukehost.co.uk/BS0xqlokE9fZPQfEIdMVOzjmf43QWHEQ"
     );
 	
-    const song11 = new Song(
+    const song11 = new Song( //recommended by Tannenberg
       "Diamonds And Rust",
       "Joan Baez",
       "https://i.imgur.com/TiMajND.jpeg",
       "https://audio.jukehost.co.uk/YZ8150OYHEFp6jmmSX8rFdimeijOf99p"
     );
   
-    const song12 = new Song(
+    const song12 = new Song( //this version recommended by Skittie (previously Seeger.)
       "Solidarity Forever",
       "Tom Morello",
       "https://i.imgur.com/HMzKtUt.jpeg",
@@ -704,7 +710,7 @@ document.head.appendChild(customStyling);
 	  "https://i.imgur.com/ATV9Mq4.jpeg",
 	  "https://audio.jukehost.co.uk/MfK4n21okxhZK7m9Nn9VYu8SvvzgFHVO"
 	);
-	const Ksong5 = new Song(
+	const Ksong5 = new Song( //recommended by sailor_neptune_9
 	  "Von Dutch",
 	  "Charli XCX",
 	  "https://i.imgur.com/jqXerdq.jpeg",
@@ -723,6 +729,20 @@ document.head.appendChild(customStyling);
 	  "https://i.imgur.com/9jXjMLt.jpeg",
 	  "https://audio.jukehost.co.uk/RrWmyZRgRkFCE3ceDd7ym8zCl0g8xXA9"
 	);
+	
+	const Ksong8 = new Song( //recommended by Skittie.
+	  "We The People",
+	  "The Staple Singers",
+	  "https://i.imgur.com/dhWQr5O.jpeg",
+	  "https://audio.jukehost.co.uk/t6txpvU9hdEf5F1CsmvFQMfjJqvyRuU0"
+	);
+	
+	const Ksong9 = new Song( //recommended by Skittie.
+	  "If You Dare",
+	  "Jazmine Sullivan",
+	  "https://i.imgur.com/L6u1yYp.jpeg",
+	  "https://audio.jukehost.co.uk/zX2IJVH11Qv8KWOg2vHYFq0DUb52BKPt"
+	);
 	KPlaylist.addSong(Ksong1);
 	KPlaylist.addSong(Ksong2);
 	KPlaylist.addSong(Ksong3);
@@ -730,6 +750,8 @@ document.head.appendChild(customStyling);
 	KPlaylist.addSong(Ksong5);
 	KPlaylist.addSong(Ksong6);
 	KPlaylist.addSong(Ksong7);
+	KPlaylist.addSong(Ksong8);
+	KPlaylist.addSong(Ksong9);
   
     const playerContainer = document.createElement("div");
     playerContainer.id = "player";
@@ -1346,13 +1368,42 @@ tooltipList = [
 	{searchString: "your arms embargo", explanationText: "<img src=https://i.imgur.com/N7JRZhn.jpeg><br><b>You received this question due to disarming Israel early and maintaining the disarmament.</b><br><i> You've stopped offensive arms shipments to Israel for the whole of your Presidency, citing their human rights violations under Section 503 of the Foreign Assistance Act. Yet your advisors believe that Israel has responded only by pausing the air war in favor of home-produced artillery bombardments - dumb bombardments with far more collateral damage than American precision munitions. Bereft of leverage, you've been hard-pressed to convince Israel to let any humanitarian aid in; a mass famine is reportedly undergoing in Gaza with estimates of thousands dead.</i>", color: "darkblue"},
 	{searchString: "Special counsel Jack Smith", explanationText: "<img src=https://i.imgur.com/lUsrkwE.jpeg><br><b>You received this question due to successfully prosecuting Trump.</b><br><i>When you asked Attorney General Vanita Gupta to ensure accountability for the January 6 attacks, it was Jack Smith who saw that translated into action, preventing our nation from falling into the sway of a dictator in the making. It's thanks to him that justice was done, that we proved once and for all that no one is above the law. No One.</i>", color: "darkblue"},
 	{searchString: "will invade Taiwan in April.", explanationText: "<img src=https://i.imgur.com/VNspaiB.jpeg><br><b>You received this question due to allowing Russian conquest of Ukraine and being extremely pro-peace.</b><br><i>The intelligence briefing is as crushing as it is clear: China believes you're so reluctant for war that you won't intervene to protect Taiwan. To Xi Jinping, this is a fleeting opportunity to achieve reunification without American intervention. They claim that China is unprepared and unready, gambling on your unwillingness to fight; that if America fights, she will win.</i>", color: "darkblue"}, 
-	{searchString: "They're saying you're senile", explanationText: "<img src=https://i.imgur.com/5ai9WZS.jpeg><br><b>You received this question due to low Fervor. Fervor increases by picking in-character answers; it decreases slowly over time and rapidly by picking answers very out-of-character. This result is guaranteed with Fervor -10 or less; it will never happen when Fervor i 0 or higher. (If randomness is off, it will always happen when fervor is <-5, and never otherwise.)</b><br><i>You, senile? You're not senile - just tired. Who wouldn't be? You've spent your whole life fighting the same battles, carrying the same dreams. Your mind still works; it's just… slower sometimes. The words, they're still there, even if they stumble on the way out. That doesn't mean you've lost your way. You remember why you're here - what you stand for, even if sometimes you wonder why you've made the sacrifices you've made along the way as President.</i>", color: "darkblue"},
+	{searchString: "They're saying you're senile", explanationText: "<img src=https://i.imgur.com/5ai9WZS.jpeg><br><b>You received this question due to low Fervor. Fervor increases by picking in-character answers; it decreases slowly over time and rapidly by picking answers very out-of-character. This result is guaranteed with Fervor -10 or less; it will never happen when Fervor is non-negative. (If randomness is off, it will always happen when fervor is <-5, and never otherwise.)</b><br><i>You, senile? You're not senile - just tired. Who wouldn't be? You've spent your whole life fighting the same battles, carrying the same dreams. Your mind still works; it's just… slower sometimes. The words, they're still there, even if they stumble on the way out. That doesn't mean you've lost your way. You remember why you're here - what you stand for, even if sometimes you wonder why you've made the sacrifices you've made along the way as President.</i>", color: "darkblue"},
 	{searchString: "The reports from Gaza are heartbreaking", explanationText: "<img src=https://i.imgur.com/uYsUeTl.jpeg><br><b>You received this question due to convincing Sinema to switch parties</b><br><i>Without the Senate, your domestic agenda is dead and buried. So you pivot abroad, because peace and justice doesn't stop at America's borders</i>", color: "darkblue"}, 
 	{searchString: "threatening the full faith and credit of the United States", explanationText: "<img src=https://i.imgur.com/eQF2GTg.jpeg><br><b>You received this question due to convincing Sinema to switch parties</b><br><i>Senate Republicans - Sinema included - demand massive spending cuts for a debt ceiling hike. They say that programs keeping workers afloat are 'unprecedented' and need to be cut to tame inflation. You say that it's a pack of lies, that they're just seeking to do the bidding of the 1%.</i>", color: "darkblue"},
 	{searchString: "a global economy in ruins.", explanationText: "<img src=https://i.imgur.com/QwZpEsR.jpeg><br><b>With the Taiwanese microchip factories damaged, the world - including America - will suffer serious economic damage.</b><br><i>The Taiwanese microchip plants took direct hits from PRC missiles. Some lie in ruins, others barely salvageable, and the shockwaves will ripple for years.</i>", color: "darkblue"},
 	{searchString: "Taiwan's defenders fight bravely", explanationText: "<img src=https://i.imgur.com/QwZpEsR.jpeg><br><b>With the Taiwanese microchip factories gone, the world - including America - will suffer catastrophic economic damage.</b><br><i>As Chinese troops closed in, Taiwan's defenders triggered the self-destruct protocols wired into every chip factory, choosing ashes over surrender. Billions in machinery, years of innovation - gone in minutes.</i>", color: "darkblue"},
 	{searchString: "FSB losing control", explanationText: "<img src=https://i.imgur.com/eH3fCyh.jpeg><br><b>Russian loss of the Donbas has a 25% random chance of causing an escalation. Russian loss of Crimea has a 50% chance. If randomness is off, this will never trigger.</b><br><i>Decades of simmering frustrations, finally boiling over into incadescent rage, past the point repression can stop. The Russian people are no longer silent.</i>", color: "darkblue"},
-	{searchString: "Beijing refuses to yield", explanationText: "<img src=https://i.imgur.com/UUyfVsl.jpeg><br><b>The PRC has a 25% chance to reject peace and escalate if asked to renounce reunification by force; 50% if also asked to return the Penghus. If randomness is off, this will never trigger.</b><br><i>Beaten and bloodied, the PRC refuses to submit to yet another Unequal Treaty - while beneath, the people rise, crying for an end to the madness.</i>", color: "darkblue"},
+	{searchString: "Beijing refuses to yield", explanationText: "<img src=https://i.imgur.com/dGsQMq0.jpeg><br><b>The PRC has a 25% chance to reject peace and escalate if asked to renounce reunification by force; 50% if also asked to return the Penghus. If randomness is off, this will never trigger.</b><br><i>Beaten and bloodied, the PRC refuses to submit to yet another Unequal Treaty - while beneath, the people rise, crying for an end to the madness.</i>", color: "darkblue"},
+	
+	
+	//placeholder tooltips missing flavortext; flavortext to be filled in later by others
+	
+	//the following context for why you're getting this question had the flavor text written by u/Macrohistorian. Thanks to them!
+	{searchString: "broken through on negotiations", explanationText: "<img src=https://i.imgur.com/Xdykzor.jpeg><br><b>You received this question due to having positive political capital and controlling Congress.</b><br><i>You've ground your teeth at every concession and sacrifice, but for more than half a trillion invested in clean energy, it'll be worth it. For any climate action at all, it has to be.</i>", color: "darkblue"},
+	{searchString: "your agenda has been stymied", explanationText: "<img src=https://i.imgur.com/mftWx3i.jpeg><br><b>You received this question due to lacking political capital or failing to control Congress.</b><br><i>So-called 'moderates' have made it abundantly clear they won't give an inch on clean energy investment. They talk about fiscal responsibility, but you know they answer to the fossil fuel lobby. Either you primary these obstructionists, or accept two more years of legislative paralysis.</i>", color: "darkblue"},
+	
+	//the following context for why you're getting this question had the flavor text written by sabrinacarpenterfan333. Thanks to them!
+	{searchString: "recent moves have been a bridge too far", explanationText: "<img src=https://i.imgur.com/Xtu1nEs.png><br><b>You received this question due to having political capital<2, party unity<2, or by alienating Rs by being too partisan.</b><br><i>Perhaps it was never meant to last. The freedom caucus wants Speaker Upton's head, and despite your best efforts to convince members of the Progressive Caucus that Upton is the best we're going to get, they seem unreceptive to once again propping up Upton in a Speaker vote.  Perhaps this bargain was doomed to begin with.</i>", color: "darkblue"},
+	
+	{searchString: "in protest over your 'open-border' immigration policy", explanationText: "<img src=https://i.imgur.com/NrZY4YP.png><br><b>You received this question due to taking a lenient approach on immigration.</b><br><i>You were committed to turning the page from Obama and Trump's draconian immigration policies when you got into office, and the resulting humane reforms to immigration enforcement have led to record levels of immigration - an estimated twenty million undocumented migrants, levels you never expected. You were ready for the cries of a 'great replacement' from the Republicans, but the complaints from top labor union officials from the country that your immigration policy is depressing wages and hurting workers? Those sting. Now, Abbott has taken measures into his own hand, building wires on the border in direct disobedience of federal orders.</i>", color: "darkblue"},
+	
+	{searchString: "your humane migrant policy was overwhelmed by a vast flood of asylum-seekers.", explanationText: "<img src=https://i.imgur.com/W4SFodp.png><br><b>You received this question due to attempting to balance immigration leniency with enforcement.</b><br><i>You came into office with a vision to balance a humane immigration policy with proper enforcement of America's borders and America's laws, but your generous TPS grants as well as humanitarian parole programs for Central American countries have lead to an explosion of legal immigration, while your reforms to Title 42 and the Remain in Mexico protocol have lead to a large buildup of refugees right on the southern border - many opting to attempt illegal entry. Republicans are claiming your policies are leading to an 'invasion', while progressives decry the humanitarian crisis caused by the backload of immigrants at the border.</i>", color: "darkblue"},
+	
+	{searchString: "slammed the door on their countrymen to appease racists", explanationText: "<img src=https://i.imgur.com/hiNxeaA.jpeg><br><b>You received this question due to harshly cracking down on the flow of immigrants.</b><br><i>You ramped up immigration enforcement at the beginning of your term - not for the sake of cruelty, but to protect American wages and prevent the 1% from exploiting immigrants to avoid paying Americans fair wages. Your policies have been successful thus far, though its caused anger in the Latino community. They paraded the Bernie that slammed Obama and Trump's disastrous immigration policies, but now they see you as no different. In addition, while unions appreciate your commitment to protecting Americans wages from being depressed, economic reports are showing that a lack of immigrants is causing labor shortages, holding the economy back.</i>", color: "darkblue"},
+	
+	{searchString: "Trump declares himself their Retribution", explanationText: "<img src=https://i.imgur.com/kbkZPf8.png><br><b>You received this question as Trump is free and the interest group with the highest approval does not approve of you.</b><br><i>You watched as Donald Trump attempted a coup in broad daylight back in 2021. Now you can't help but sit in disbelief as he sweeps 49 states against a series of hapless opponents just a few years later. He's parading around J.D. Vance, another fraudster populist that cashes fat checks from the very elite he claims to be rallying against. Vance does very little to broaden Trump's appeal, suggesting he's very confident in his current chances to win. </i>", color: "darkblue"},
+	
+	{searchString: "Trump promises to drill, baby, drill.", explanationText: "<img src=https://i.imgur.com/eeH7Ud5.png><br><b>You received this question as Trump is free, workers have the highest approval, and workers approve of you.</b><br><i>You watched as Donald Trump attempted a coup in broad daylight back in 2021. Now you can't help but sit in disbelief as he sweeps 49 states against a series of hapless opponents just a few years later. He's parading around Doug Burgum, adding a second billionaire to the ticket. The selection of Burgum seems to suggest that Trump is attempting to appeal to the suburbs and businesses, trying to convince them that your pro-labor policies has exacerbated inflation and held the economy back from its full potential.</i>", color: "darkblue"},
+	
+	{searchString: "Trump declares that he will defend America's interests", explanationText: "<img src=https://i.imgur.com/dUY65oh.png><br><b>You received this question as Trump is free, doves have the highest approval, and doves approve of you.</b><br><i>You watched as Donald Trump attempted a coup in broad daylight back in 2021. Now you can't help but sit in disbelief as he sweeps 49 states against a series of hapless opponents just a few years later. He's parading around Marco Rubio, who slams your supposed failures to protect America's interests abroad. It seems that Trump has dropped the mask of being different from the neoconservatives, attempting to contrast your dovish foreign policy with Rubio's 'foreign policy expertise'.</i>", color: "darkblue"},
+	
+	{searchString: "Trump promises an end to your divisive coddling of illegals", explanationText: "<img src=https://i.imgur.com/p9h7xwZ.png><br><b>You received this question as Trump is free, Latinos have the highest approval, and Latinos approve of you.</b><br><i>You watched as Donald Trump attempted a coup in broad daylight back in 2021. Now you can't help but sit in disbelief as he sweeps 49 states against a series of hapless opponents just a few years later. He's parading around Tim Scott; their dog whistles about restoring 'American pride' seem aimed at accusing your administration's pro-Latino policies of leaving everyone else in the dirt.</i>", color: "darkblue"},
+	
+	{searchString: "Trump Jr promises an end to your 'political purges'", explanationText: "<img src=https://i.imgur.com/HgnIoYt.png><br><b>You received this question as Trump is jailed and doves have the lowest approval.</b><br><i>They couldn't nominate his father, so they went with the closest next choice. Trump Jr. saw success running on a uniquely isolationist foreign policy vision, winning the nomination by attacking your 'globalist' foreign policy agenda and promising to put Americans first - helped by tricking many of your former anti-war supporters with his nonsense.</i>", color: "darkblue"},
+	{searchString: "DeSantis promises to lead a rejuvenation of American strength", explanationText: "<img src=https://i.imgur.com/nCgsOUv.png><br><b>You received this question as Trump is jailed and Latinos have the lowest approval.</b><br><i>Propelled by a split of the MAGA vote by Hawley and Trump Jr, Ron DeSantis won the Republican nomination on a culture war platform aimed squarely at social conservatives. His platform of border security, social conservatism, and pocketbook issues seems to have unique appeal to your former Latino supporters, many of whom supported him in the primary.</i>", color: "darkblue"},
+	
+	{searchString: "Hawley promises to protect the working class from liberal elites", explanationText: "<img src=https://i.imgur.com/EecZNUL.png><br><b>You received this question as Trump is jailed and workers have the lowest approval.</b><br><i>Trump's jailing seems to have only strengthened the populist wing of the Republican party. You watch in utter shock as Hawley takes the nomination on claims that your administration has failed workers across the country; his pro-union posturing convincing many of your former working-class supporters to flock to him in the primary. No worker should seriously believe that Hawley has their best interests in mine. Yet, the polls among union workers - especially the Teamsters - are showing shocking gains for the right amongst the very people you've fought for your whole life. </i>", color: "darkblue"},
 	
 	
 	//Information from advisors
@@ -1370,7 +1421,7 @@ tooltipList = [
 	//the next one is more of a guess, but based on Bernie's real-world stance, which usually seems to follow Duss pretty strongly.
 	{searchString: "This crisis in the Red Sea is yet another indication", explanationText: "<img src=https://i.imgur.com/3n1glp7.jpeg><br><b>Matt Duss advises strongly against this option.</b><br> <i>Mr. President, I hate what Israel is doing too, but we can't ignore what the Houthis are doing here. They're not just striking Israeli-linked ships - they're striking ships from half of the world. It's indiscriminate violence with a fig leaf of revolutionary liberation. If we let this keep going, we're not just endangering lives and our own supply chains - we're also straining our relationship with Europe, including a swath of nations that don't supply Israel. If we want peace, let's focus on withholding arms from Israel and pressing for a ceasefire - not giving others cover to expand the conflict even further.</i>", color: "darkred"},
 	{searchString: "he's not getting anything, not one more bullet,", explanationText: "<img src=https://i.imgur.com/3n1glp7.jpeg><br><b>Matt Duss advises you to consider this option.</b><br> <i>Mr. President, sending even one more weapon is one too many. We've got to stop the weapons, make it clear to Israel that U.S. support isn't unconditional. There's a moral line, and they've already crossed it.</i>", color: "darkgreen"},
-	{searchString: "A no-fly zone is a serious commitment,", explanationText: "<img src=https://i.imgur.com/3n1glp7.jpeg><br><b>Matt Duss is shouting and begging you not to do this.</b><br> <i>A no-fly zone isn't just a serious commitment, it's insanity. President, you <b>must not</b> do this. Do you know what a no-fly zone means? It means American pilots shooting down Russian jets, targeting Russian bases in Russia, Russia retaliating against our bases in Poland or Germany. That's World War Three, with a nuclear-armed state. You're playing chicken with the entirety of human civilization!</i>", color: "darkred"},
+	{searchString: "A no-fly zone is a serious commitment,", explanationText: "<img src=https://i.imgur.com/3n1glp7.jpeg><br><b>Matt Duss is shouting and begging you not to do this.</b><br> <i>A no-fly zone isn't just a serious commitment, it's insanity. Mr. President, you <b>must not</b> do this. Do you know what a no-fly zone means? It means American pilots shooting down Russian jets, targeting Russian bases in Russia, Russia retaliating against our bases in Poland or Germany. That's World War Three, with a nuclear-armed state. You're playing chicken with the entirety of human civilization!</i>", color: "darkred"},
 	{searchString: "Ukraine not crossing the pre-invasion Minsk II", explanationText: "<img src=https://i.imgur.com/3n1glp7.jpeg><br><b>Matt Duss advises extremely strongly for this option and not pressing Russia further.</b><br> <i>Mr. President, I wish we could go further, but it's too risky. You push him further, you go into Donbas, especially into Crimea... if he feels cornered, he might take the whole world down with him.</i>", color: "darkgreen"},
 	{searchString: "renounce the idea of reunification", explanationText: "<img src=https://i.imgur.com/3n1glp7.jpeg><br><b>Matt Duss advises extremely strongly against this option.</b><br> <i>You've won, Bernie, but don't push too much. Don't make them eat dirt on the world stage. You force them to renounce the idea of reunification by force - to them, that's a demand that they kneel, a return to the Century of Humiliation. When Mao declared the People's Republic of China, he declared that China would no longer be subject to insult or humiliation, that China had stood up. If you demand Xi be the General Secretary who forced China to prostrate herself once again... he just might choose the abyss instead. Not because he thinks he can win, but because he can't bear to lose.</i>", color: "darkred"},
 	
@@ -1470,7 +1521,7 @@ campaignTrail_temp.achievements = {
         "description" : "Have the Vice Presidency sit empty for multiple years",
     },
     "Wait, What?" : {
-        "image" : "https://i.imgur.com/dILqtUZ.jpeg", //placeholder
+        "image" : "https://i.imgur.com/IotnMSf.jpeg",
         "description" : "Win the Senate but not the House in 2024",
     },
     "罢免独裁国贼习近平" : {
@@ -1482,15 +1533,15 @@ campaignTrail_temp.achievements = {
         "description" : "Ukraine ends the game with Crimea reconquered",
     },
     "Good politics, bad strategy" : { //done by making a show of force to intimidate China or get them to fire the first shot, and have that show of force destroyed
-        "image" : "https://i.imgur.com/gja4ZiA.jpeg", //placeholder
+        "image" : "https://i.imgur.com/bGhda4o.jpeg",
         "description" : "Have a show of force backfire",
     },
     "The Riskiest Game of Chicken" : {
-        "image" : "https://i.imgur.com/dzq0zWD.jpeg", //placeholder
+        "image" : "https://i.imgur.com/OMIhD4E.jpeg",
         "description" : "Careen over the debt ceiling",
     },
     "Definition of Insanity" : {
-        "image" : "https://i.imgur.com/p8Dqnis.jpeg", //placeholder
+        "image" : "https://i.imgur.com/5RYCBgH.jpeg",
         "description" : "Try to go over the debt ceiling a second time",
     },
     "Soak the Rich" : {
@@ -1578,7 +1629,7 @@ campaignTrail_temp.achievements = {
         "description" : "Defeat the Donald Trump/Marco Rubio ticket",
     },
     "Mr. Trump, Tear Down This Wall" : {
-        "image" : "https://i.imgur.com/U8qhFD7.jpeg", //placeholder
+        "image" : "https://i.imgur.com/Xe3ZG1H.jpeg", //placeholder
         "description" : "Defeat the Donald Trump/Tim Scott ticket",
     },
     "Like Father, Like Son" : {


### PR DESCRIPTION
Changelog for update to 2024-OR ("1.01")


Bug fixes: 

- Denying October 7 atrocities now gives +1 dove approval if you previously disarmed Israel (thanks u/macrohistorian)
- Center splinter parties accidentally had a soft-floor at ~4-5% upon which they would stop losing support, due to a bug.
- As Kamala, progressive anger is now green in the variable notepad when 0.

Mechanical changes
The tl;dr of the below is "the game will be a bit easier" (AZ,NM,NV easier to win; Latinos easier to please; Bernie's Q38 and Q42 campaign questions improved.)



- Increased all 3rd party decay by 33% (Now up 100% from initially.) In normal competitive election situations, third parties should end up in the 1%-6% range generally
- Vance/Cotton ticket hit with nerfbat (moved from -0.4 social -> -0.45 social; -0.6 immigration -> -0.65 immigration.)
- Doubled ability of Bernie campaigning questions on Q38 and Q42 to define the opponent. Motive is to incentivize the player to keep Bernie around
- Improved bipartisan border bill and reduced its difficulty. It was almost impossible before and completely unrewarding.
- Manchin 3rd-party ticket moved from 0.2 econ -> 0.4 econ (he's fairly populist - for PRO Act and taxing the rich)
- Sinema 3rd-party ticket moved from 0.2 immigration -> 0 immigration (she put a lot of emphasis on securing the border.)

Rebalanced a number of states:
- Shored up player slightly in CA and IL; they were a little too wobbly and easy to lose.
- AZ moved from 0.952 -> 0.975 state multiplier, -0.1 -> 0.1 econ, 0.4 -> 0.32 globalism, 1 -> 0.9 inflation importance.
- NM moved to the left on immigration; NM moved from 0.3 -> 0.35 econ, 0.2 -> 0 globalism, 0.2 -> 0.3 social issues. Inflation importance moved from 1.5->1.2. State multiplier moved from 1.11->1.068.
- NV moved from 0.35->0.42 econ, -0.35-> -0.47 globalism, 0.16 -> 0.35 social issues, 0.16-> -0.15 immigration. Inflation importance moved from 1.4->1.0.
- AR, ID, OK, SD, TN, WY moved to the right on immigration based on polling; same starting position but should be a little less static now. It may even be possible to win AR now.
- ND moved to the right on econ to assure that Burgum doesn't underperform in his home state.
- Moved LA econ issue weight 0.75->1; D state multiplier 1.82 -> 1.86. It's been more swingy and prone to recent populist D victory (John Bel Edwards) than the other Deep South states so it's a little less static now.
- Moved MS econ -0.1 -> -0.2.
Notes on the rebalance of AZ,NV,NM which were getting results that felt wrong:
Overall, Arizona has moved 2 points to the left for Bernie's issues (while staying the same against establishment Ds.) Biden's issue scores now perform ~3% better in AZ compared to Bernie's issue scores (was previously 5%); this is motivated by the belief that AZ was too red (overcalibrated to 2008-2012 when AZ was uniquely conservative) and 2020 polling showing Biden doing 3-4% better in AZ than Bernie. In the average player's game it will probably be 1-3% more Democratic. NM should be shored up by 2-3% in the average game while keeping the starting position identical. It should now be consistently likely D when the popular vote is tied. NV should be shored up by 3-5% in the average game while keeping the starting position identical. When the popular vote is tied, it should usually be lean D/tossup against most opponents.

- Adjusted the campaign-in-state answers (Q36.0, Q44.0, Q44.1) to reflect the updated issue scores in each state. Some were out of date.

Rebalanced Latinos:
- Progressive domestic cabinet now gives +2 to worker and Latino approval. This had been intended to be a desirable pick but was not as good in practice.
- High/low immigration variants of Q31 (Eagle pass, protesters) no longer drop Latino approval upon receiving the question. They still adjust issue importance and worker approval.
- Pushing for anything other than "votes on measures with broad public support" after Roe v Wade is overturned will give -1 Latino approval (you're being socially progressive and devout Catholics don't like it.)

Net result is that you can now net +2 Latino approval from the cabinet+immigration questions, and that you can now do so from either the lenient or the crackdown path. (The lenient path however will cost you a lot of worker approval.) Intent is to make it less absurdly difficult to make Latinos like you (they were intended to be finicky and annoying, not almost-impossible.)

- Made it so that variable decay happens after answer effects rather than before answer effects (thx u/macrohistorian)


Rebalance of DeSantis/Burgum ticket from -0.4 -> -0.35 econ, and from -0.2 -> -0.45 immigration. He should stay roughly the same difficulty, but his appeal to states like NM and Latinos should be considerably reduced.


Visual changes:
code1
- Rewrote A24301 feedback (thanks u/macrohistorian.) Added u/macrohistorian to credits.
- Adjusted favicon (thanks Skittie)
- Adjusted Jill Stein poster picture (thanks Skittie)
- Typo fix for tooltip explaining why you got the bad debate
- Updated Vance/Cotton stats as well as Manchin and Sinema 3rd-party stats in author notes
- Added full list of what you can get with political capital in author notes. Minor other adjustments to author notes.
- Updated the "historical" result to the current result of following the True Ending guide in the author notes.
- Replaced 4 placeholder achievement images with finished images (thanks, Tannenberg.)
- Replaced Trump/Scott defeated achievement placeholder image with a different placeholder image (previous one did not fit correctly)
- Adding "why are you getting this question" to 13 more question splits with help (thanks u/macrohistorian and sabrinacarpenterfan333 for flavor text! Both in credits now.)

code2
- Differentiated feedback for Bernie being maimed vs killed in assassination (player request.)
- New Bernie advisor picture for nuclear war endings (thanks Skittie)
- Fixed Jimi Hendrix and Beyoncé artist names (thanks Skittie)
- Revised Q28 (Houthis) and Q35.4 (debate vs Hawley) to make it clear that your answers are you speaking (hence the 1st person)
- Typo fix for Q1 (how did I not notice this before)
- Typo fix for Q17: Woman's Health Protection Act -> Women's Health Protection Act. 
- Adding color hexes changes for different opponents (Kamala, and each of the R presidential nominees now has a different one.) Thanks Skittie!
- Adding punctuation to ends of quotes when missing, as appropriate (Thanks Skittie!)
- Changed Tannenberg credits mention to acknowledge that achievement images were partially done and not TBD
- Added more descriptiveness to variable hovertext to explain variable decay and the thresholds for variable checks.
- Fixed Glenn Elliott's name (thanks Wahguy)
- Grammar fix for when a single held seat was decided by <5% ("1 seat that did not change parties were" -> "1 seat that did not change parties was")



Audio changes:
- Added We The People (The Staple Singers) and If You Dare (Jazmine Sullivan) to Kamala playlist
- Added ending song: I Just Threw Out the Love of my Dreams (Weezer) if you win as Kamala and Left Anger is 6+
- Added Bernie loss songs for each opponent. Loss songs only play if playing as Bernie and it isn't a landslide.
- Added Bernie win songs for each opponent. Opponent-specific win songs only play if playing as Bernie and you win 
- Added Ghost of Tom Joad as loss song if you have 38 EVs or fewer (i.e. opponents have 500+ EVs.)
- Added Our Revolution (Tony Tig) as victory song if you achieve M4A on Hard or harder ("True Ending" achievement.)
- Added win and loss music for winning and losing with PRC defeated militarily, and losing with Taiwan abandoned. Added win music for winning with Ukraine fully liberated.
- Added music (AI Trump Macarena) if you lose as Kamala vs Trump/Vance who gets 312 EVs (IRL numbers.)

Backend code changes:
Made roundToDecimals function work for negative numbers too.