### PR TITLE
Basic but actual optrng implementation instead of flat boost

### DIFF
--- a/static/js/consoleCheats.js
+++ b/static/js/consoleCheats.js
@@ -1113,32 +1113,17 @@ const useConsoleCheats = () => {
     terminalBody.scrollTop(terminalBody.prop("scrollHeight"));
   }
 
-  const ORIGINAL_GLOBAL_VARIANCE =
-    e.global_parameter_json[0].fields.global_variance;
+  // const ORIGINAL_GLOBAL_VARIANCE = e.global_parameter_json[0].fields.global_variance;
+  const ORIGINAL_MARSAGLIA = randomNormal;
   let optrng_enabled = false;
   function set_optimal_rng(enabled) {
     if (enabled && !optrng_enabled) {
-      e.global_parameter_json[0].fields.global_variance = 0;
-      add_global_modifier(e.candidate_id, 0.025);
-      for (const state_pk of e.states_json.map((e) => e.pk)) {
-        cmt_set(
-          e.candidate_id,
-          state_pk,
-          cmt_get(e.candidate_id, state_pk) - 0.05,
-        );
-      }
+      // e.global_parameter_json[0].fields.global_variance = 0;
+      randomNormal = (cand) => cand === e.candidate_id ? 3 : -3; // Values beyond 3 are rare
       optrng_enabled = true;
     } else if (!enabled && optrng_enabled) {
-      e.global_parameter_json[0].fields.global_variance =
-        ORIGINAL_GLOBAL_VARIANCE;
-      add_global_modifier(e.candidate_id, -0.05);
-      for (const state_pk of e.states_json.map((e) => e.pk)) {
-        cmt_set(
-          e.candidate_id,
-          state_pk,
-          cmt_get(e.candidate_id, state_pk) + 0.05,
-        );
-      }
+      // e.global_parameter_json[0].fields.global_variance = ORIGINAL_GLOBAL_VARIANCE;
+      randomNormal = ORIGINAL_MARSAGLIA;
       optrng_enabled = false;
     }
   }


### PR DESCRIPTION
The implementation is very basic—it modifies randomNormal to return 3 if the candidate is e.candidate_id, otherwise -3.

Why 3? Because the chances of getting any value greater than 3 sort of tapers off. Of course you can still get values past that, but it would be rare.

Things related to global variance are commented out. This is because setting global_variance to 0 effectively nullifies the effects of optimal RNG. The image below explains why. 0.97 is the difficulty multiplier used for Normal.

![The Maths](https://quicklatex.com/cache3/3e/ql_61b87e166b5d527b191f7c457b5bd93e_l3.png)