### PR TITLE
e.player_answers fix

### DIFF
--- a/static/js/campaign_trail.js
+++ b/static/js/campaign_trail.js
@@ -1908,17 +1908,19 @@ function answerEffects(t) {
     const numT = Number(t);
     const numCand = Number(e.candidate_id);
 
+    const tToUse = typeof t === 'string' && Number.isNaN(numT) ? t : numT;
+
     debugConsole(`Applying answer effects for answer pk ${t}`);
-    e.player_answers.push(t);
+    e.player_answers.push(tToUse);
     // const electIndex = findFromPK(e.election_json, e.election_id);
     const election = e.election_json.find((f) => Number(f.pk) === Number(e.election_id));
     if (e.answer_feedback_flg === 1) {
         const hasFeedback = e.answer_feedback_json.some(
-            (f) => f.fields.answer === numT && f.fields.candidate === numCand,
+            (f) => f.fields.answer === tToUse && f.fields.candidate === numCand,
         );
         if (hasFeedback) {
             const feedback = e.answer_feedback_json.find(
-                (f) => f.fields.answer === numT && f.fields.candidate === numCand,
+                (f) => f.fields.answer === tToUse && f.fields.candidate === numCand,
             );
             const n = `
                 <div class="overlay" id="visit_overlay"></div>


### PR DESCRIPTION
The `Array.prototype.includes()` method on Arrays uses the SameValueZero algorithm, which is basically strict equality except that it treats `NaN` as equivalent.

Since some CYOA mods use `e.player_answers.includes(answer)`, this will cause some bugs if the answer pushed is a String, and the answers are usually expected to be Number literals.

This fixes it by just checking whether t is a String and numT is NaN and if it is, it uses just t. Otherwise, it uses the coerced version of T. Since this is a ternary, it doesn't take into account other primitive values and non-primitive values like Objects. But who even uses Objects for PK generation?