### PR TITLE
Automatic space insertion in historical results

### DIFF
--- a/static/js/campaign_trail.js
+++ b/static/js/campaign_trail.js
@@ -3521,8 +3521,8 @@ function overallDetailsHtml() {
     const spaceToUse = HistName.find(spaceFunction)?.match(/^[\s\u2800]+/)?.[0] ?? ' ';
 
     const histRes = HistName.map((name, i) => {
-        const hasSpace = spaceFunction(name);
-        const nameToUse = hasSpace ? name : `${spaceToUse}${name}`;
+        const needsSpace = !(name === "" || spaceFunction(name));
+        const nameToUse = needsSpace ? `${spaceToUse}${name}` : name;
 
         return `
             <tr>


### PR DESCRIPTION
The lack of spaces between the color boxes and the candidate names in some mods has mildly infuriated me for a while now. This is because some mods forget to put a space at the start of each entry in HistName.