### PR TITLE
Fixed font issues for mod loader tabs

### DIFF
--- a/static/css/community.css
+++ b/static/css/community.css
@@ -17,6 +17,7 @@
 }
 
 .tablinks {
+  font-family: Arial, sans-serif;
   font-size: 10px;
 }
 
@@ -381,6 +382,7 @@
 }
 
 .mode-button {
+  font-family: Arial, sans-serif;
   font-size: medium;
   font-weight: bolder;
   flex-grow: 1;


### PR DESCRIPTION
Most browsers display Arial, though some Tahoma and others Verdana (which causes the mod categories to overflow to the next line). We should prefer Arial here and (in the event it's not available) fallback to sans-serif