### PR TITLE
skip decodeaudio in all the way if browser is brave

### DIFF
--- a/static/mods/1968 - All The Way_init.html
+++ b/static/mods/1968 - All The Way_init.html
@@ -667,8 +667,18 @@ window.updateUI=updateUI
 
 let getAudioAmplitude = (time) => 0;
 
+async function isBraveBrowser() {
+  if (window.navigator.brave && await window.navigator.brave.isBrave()) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 async function decodeAudio(audioSrc) {
 try {
+  if (await isBraveBrowser()) return null; 
+
   const audioContext = new AudioContext();
   const response = await fetch(audioSrc);
   const arrayBuffer = await response.arrayBuffer();


### PR DESCRIPTION
Brave's anti-fingerprinting shield extension blocks the `audioContext` in All the Way, causing `decodeAudio` to hang and freeze the tab - also reported on [reddit](https://www.reddit.com/r/thecampaigntrail/comments/1jzfzaw/all_the_way_doesnt_work_on_brave/). This detects if the current browser is Brave and exits `decodeAudio` to prevent the tab from freezing.