### PR TITLE
Update display year format for ROC 2004 Bian

### DIFF
--- a/static/mods/ROC 2004 Bian._init.html
+++ b/static/mods/ROC 2004 Bian._init.html
@@ -182,7 +182,7 @@ campaignTrail_temp.temp_election_list = [
         "id": 20,
         "year": 2004,
         "is_premium": 0,
-        "display_year": "ROC'04 Bian."
+        "display_year": "ROC 2004 Bian."
     }
 ]
 e.collect_results = true;


### PR DESCRIPTION
Fix the year to prevent the 2004 entry from being unsearchable/unfindable in the game.