### PR TITLE
Rename ROC'04 Bian._Lien ChanSong Chu-Yu.html

### DIFF
--- a/static/mods/ROC 2004 Bian._Lien ChanSong Chu-Yu.html
+++ b/static/mods/ROC 2004 Bian._Lien ChanSong Chu-Yu.html
@@ -1,4 +1,4 @@
-e=campaignTrail_temp // this is redundant, but Decstar uses this because it looks nicer in the code.
+ROC 2004 Bian.e=campaignTrail_temp // this is redundant, but Decstar uses this because it looks nicer in the code.
 campaignTrail_temp.multiple_endings=true
 campaignTrail_temp.cyoa = true
 if(campaignTrail_temp.candidate_id===68){


### PR DESCRIPTION
Fix the year to prevent the 2004 entry from being unsearchable/unfindable in the game.