### PR TITLE
Readability improvements to the achievements tab

### DIFF
--- a/static/js/achievements.js
+++ b/static/js/achievements.js
@@ -206,8 +206,15 @@ function getContrastingTextColor(bgColor) {
   if (!bgColor) return '#000000';
   if (colorContrastCache.has(bgColor)) return colorContrastCache.get(bgColor);
 
-  const color = (bgColor.charAt(0) === '#') ? bgColor.substring(1, 7) : bgColor;
-  if (color.length < 6) return '#000000';
+  let color = (bgColor.charAt(0) === '#') ? bgColor.substring(1) : bgColor;
+  
+  // handle 3-character hex codes (e.g., #000 becomes #000000)
+  if (color.length === 3) {
+    color = color[0] + color[0] + color[1] + color[1] + color[2] + color[2];
+  }
+  
+  // fallback if the color is an invalid hex or a CSS color name
+  if (color.length !== 6) return '#000000';
 
   const r = parseInt(color.substring(0, 2), 16);
   const g = parseInt(color.substring(2, 4), 16);
@@ -219,6 +226,83 @@ function getContrastingTextColor(bgColor) {
 
   colorContrastCache.set(bgColor, result);
   return result;
+}
+
+function enhanceUnlockColor(hexColor) {
+  if (!hexColor) return hexColor;
+  
+  // strip hash
+  let color = hexColor.charAt(0) === '#' ? hexColor.substring(1, 7) : hexColor;
+  if (color.length !== 6) return hexColor;
+
+  // convert HEX to RGB
+  let r = parseInt(color.substring(0, 2), 16) / 255;
+  let g = parseInt(color.substring(2, 4), 16) / 255;
+  let b = parseInt(color.substring(4, 6), 16) / 255;
+
+  // convert RGB to HSL
+  let max = Math.max(r, g, b), min = Math.min(r, g, b);
+  let h, s, l = (max + min) / 2;
+
+  if (max === min) {
+    h = s = 0; // achromatic (pure gray)
+  } else {
+    let d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r: h = (g - b) / d + (g < b ? 6 : 0); break;
+      case g: h = (b - r) / d + 2; break;
+      case b: h = (r - g) / d + 4; break;
+    }
+    h /= 6;
+  }
+
+  let adjusted = false;
+
+  // if it is very dark, boost the lightness so it doesn't look grayed/dimmed out
+  if (l < 0.25) {
+    l = Math.min(1, l + 0.15); // bump lightness up by 15%
+    adjusted = true;
+  }
+
+  // if it is extremely desaturated (gray?)
+  if (s < 0.15) {
+    l = Math.min(1, l + 0.10); // slight lightness bump
+    if (s === 0) h = 0.6; // some saturation - but default to a cool blue if pure gray
+    s = 0.20; 
+    adjusted = true;
+  }
+
+  // if it's already colorful and bright, return the original color
+  if (!adjusted) return hexColor;
+
+  // convert adjusted HSL back to RGB
+  let r1, g1, b1;
+  if (s === 0) {
+    r1 = g1 = b1 = l;
+  } else {
+    const hue2rgb = (p, q, t) => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1/6) return p + (q - p) * 6 * t;
+      if (t < 1/2) return q;
+      if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
+      return p;
+    };
+    let q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    let p = 2 * l - q;
+    r1 = hue2rgb(p, q, h + 1/3);
+    g1 = hue2rgb(p, q, h);
+    b1 = hue2rgb(p, q, h - 1/3);
+  }
+
+  // convert back to HEX
+  const toHex = x => {
+    const hex = Math.round(x * 255).toString(16);
+    return hex.length === 1 ? '0' + hex : hex;
+  };
+
+  return `#${toHex(r1)}${toHex(g1)}${toHex(b1)}`;
 }
 
 // Returns true if the achievement is unlocked
@@ -237,8 +321,18 @@ function addAchivement(achName, achData, parent, theme, lazyLoad = false) {
     borderColor: "",
   };
   if (theme) {
-    if (theme.main_color) {
-      const idealTextColor = getContrastingTextColor(theme.main_color);
+    let mainColor = theme.main_color;
+    let descBgColor = theme.description_background_color;
+    let secondaryColor = theme.secondary_color;
+
+    if (!locked) {
+      if (mainColor) mainColor = enhanceUnlockColor(mainColor);
+      if (descBgColor) descBgColor = enhanceUnlockColor(descBgColor);
+      if (secondaryColor) secondaryColor = enhanceUnlockColor(secondaryColor);
+    }
+
+    if (mainColor) {
+      const idealTextColor = getContrastingTextColor(mainColor);
       themeStyles.titleColor = `color: ${idealTextColor};`;
     } else {
       themeStyles.titleColor = theme.header_text_color
@@ -246,14 +340,14 @@ function addAchivement(achName, achData, parent, theme, lazyLoad = false) {
         : "";
     }
 
-    themeStyles.textBg = theme.description_background_color
-      ? `background-color:${theme.description_background_color}`
+    themeStyles.textBg = descBgColor
+      ? `background-color:${descBgColor}`
       : "";
     themeStyles.textColor = theme.description_text_color
       ? `color:${theme.description_text_color}`
       : "";
-    themeStyles.mainBg = theme.main_color ? theme.main_color : "";
-    themeStyles.borderColor = theme.secondary_color ? theme.secondary_color : "";
+    themeStyles.mainBg = mainColor ? mainColor : "";
+    themeStyles.borderColor = secondaryColor ? secondaryColor : "";
   }
 
   const imgSrc = lazyLoad
@@ -617,11 +711,15 @@ function renderModList(modsToRender, useLazyLoading = false) {
       if (theme.label_background_image_url) {
         labelHolder.style.backgroundImage = `url("${theme.label_background_image_url}")`;
         labelHolder.style.backgroundColor = "";
+        labelHolder.style.color = theme.header_text_color ?? "";
+        labelHolder.style.textShadow = "0px 1px 3px rgba(0,0,0,0.85)";
       } else if (theme.header_color) {
         labelHolder.style.backgroundImage = "";
         labelHolder.style.backgroundColor = theme.header_color;
+        labelHolder.style.color = getContrastingTextColor(theme.header_color);
+      } else {
+        labelHolder.style.color = theme.header_text_color ?? "";
       }
-      labelHolder.style.color = theme.header_text_color ?? "";
     }
   }
 


### PR DESCRIPTION
Fixes a bunch of readability issues in mod achievement boxes, such as unreadable text in boxes for Four More Wars and GMS

This also fixes an issue with some mods (like Duke, who have a black & white color palette) showing locked and unlocked achievements the same way by changing their background and adding a very cool blue border to make the unlocked ones stand out