### PR TITLE
Rename `copy` to `copyObj`

### DIFF
--- a/static/js/campaign_trail.js
+++ b/static/js/campaign_trail.js
@@ -524,7 +524,7 @@ function evest() {
   window.swE.innerHTML = nnn;
 }
 
-function copy(mainObject) {
+function copyObj(mainObject) {
   const objectCopy = {}; // objectCopy will store a copy of the mainObject
   let key;
   for (key in mainObject) {
@@ -3810,7 +3810,7 @@ function A(t) {
       if (candId === e.candidate_id) {
         const runIssue = runningMateByIssue.get(issue);
         if (!runIssue) {
-              console.warn(`No running mate issue for issue ${issue}`);
+          console.warn(`No running mate issue for issue ${issue}`);
           return it;
         }
         rmScore = runIssue.fields.issue_score;


### PR DESCRIPTION
`copy` is an actual function that can be called in the dev console for copying things like stirngs from within the console. This renames the function previously called `copy` in `campaign_trail.js` to `copyObj` to avoid collision